### PR TITLE
Phase 2 Subsystem 0: deriva-ml schema doc as source of truth

### DIFF
--- a/.github/workflows/validate-schema.yml
+++ b/.github/workflows/validate-schema.yml
@@ -1,0 +1,23 @@
+name: Validate deriva-ml schema doc
+
+on:
+  pull_request:
+  push:
+    branches: [main, master]
+
+jobs:
+  validate-schema:
+    name: schema.md ↔ create_schema.py
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+      - name: Sync deps
+        run: uv sync
+      - name: Run validator
+        run: uv run deriva-ml-validate-schema

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 All notable changes to this project are documented here.
 
+## Unreleased — Phase 2 Subsystem 0: Schema-doc source of truth
+
+### New
+
+- **`docs/reference/schema.md`** — authoritative description of the `deriva-ml` schema (tables, columns, FKs, vocabulary seeded terms). Edit this file **first** when changing the schema, then update `src/deriva_ml/schema/create_schema.py` to match.
+- **`deriva-ml-validate-schema`** CLI (`src/deriva_ml/tools/validate_schema_doc.py`) — asserts the doc and code agree on structure and seeded terms. Exit 0 on match, 1 on mismatch, 2 on parse error.
+- **CI workflow** `.github/workflows/validate-schema.yml` — runs the validator on every PR and push to main.
+- **`docs/reference/README.md`** — developer workflow instructions for doc-first schema changes.
+
+### Changed
+
+- Schema changes now **require editing two files together**: `docs/reference/schema.md` and `src/deriva_ml/schema/create_schema.py`. CI enforces they agree.
+
+### Known limitations
+
+- The validator's static AST walker cannot extract dynamically-named tables created via parameterized calls like `create_asset_table(asset_name=...)`. These tables (`Asset`, `File`, `Execution_Execution`, `Execution_Metadata`, `Execution_Asset`) exist at runtime but aren't cross-validated against the doc. The exemption is documented in `tests/tools/test_schema_doc_structure.py`.
+- `referenced_schema` in FKs is often written as a parameter (`sname`) or attribute (`schema.name`) in the code. The validator resolves these to a `<dynamic>` sentinel and treats them as matching any doc-side value.
+
+### Not yet supported (filed follow-ups)
+
+- Direction 2: `deriva-ml-validate-schema --against=catalog` for live-catalog drift detection.
+- Description validation (table/column prose on doc vs `comment=` on code).
+- Annotation validation (display configs, `curie_template`, indexes).
+- Ordering-convention test (warn-not-fail on section ordering violations in schema.md).
+
+---
+
 ## Unreleased — Phase 1: SQLite-backed execution state
 
 ### Breaking changes

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -1,0 +1,14 @@
+# Reference docs
+
+## schema.md
+
+Authoritative description of the `deriva-ml` schema.
+
+To change the schema:
+
+1. Edit `schema.md` to describe the intended state.
+2. Edit `src/deriva_ml/schema/create_schema.py` to match.
+3. Run `uv run deriva-ml-validate-schema` locally.
+4. Commit both files together.
+
+See `schema.md` for what is and isn't validated.

--- a/docs/reference/schema.md
+++ b/docs/reference/schema.md
@@ -1,0 +1,287 @@
+# deriva-ml Schema Reference
+
+This document is the authoritative description of the `deriva-ml` schema. It is kept in sync with `src/deriva_ml/schema/create_schema.py` by the `deriva-ml-validate-schema` CI check.
+
+## Editing this doc
+
+Schema changes are **doc-first** per Phase-2-Subsystem-0. To change the schema:
+
+1. Edit the relevant `## <Table>` section below (or add a new one).
+2. Edit `src/deriva_ml/schema/create_schema.py` to match.
+3. Run `uv run deriva-ml-validate-schema` locally to verify agreement.
+4. Commit both files together. CI re-runs the validator.
+
+## What is and isn't validated
+
+The validator enforces: **table names, columns (name + type), foreign keys, vocabulary seeded terms, and association-table endpoints.**
+
+The validator does NOT enforce: descriptions (narrative on both sides), ERMrest annotations, `curie_template` values, indexes, or display configs. These may differ between doc and code without CI failure.
+
+The `referenced_schema` field in foreign keys is often written in the code as a parameter (`sname`) or attribute (`schema.name`). The validator's AST parser resolves these to a `<dynamic>` sentinel and treats them as matching any doc-side value. In this doc we write the literal schema name (`deriva-ml`) for clarity.
+
+See `docs/superpowers/specs/2026-04-21-schema-doc-source-of-truth-design.md` for the full rationale.
+
+## Table of contents
+
+Ordered as: **core entities**, then **vocabularies**, then **association tables**.
+
+**Core entities**: [Dataset](#dataset), [Dataset_Version](#dataset_version), [Execution](#execution), [Workflow](#workflow)
+**Vocabularies**: [Dataset_Type](#dataset_type), [Workflow_Type](#workflow_type), [Feature_Name](#feature_name), [Asset_Type](#asset_type), [Asset_Role](#asset_role)
+**Associations**: [Dataset_Dataset_Type](#dataset_dataset_type), [Dataset_Nested_Dataset](#dataset_nested_dataset), [Dataset_Execution](#dataset_execution), [Dataset_File](#dataset_file), [Execution_Nested_Execution](#execution_nested_execution), [Workflow_Workflow_Type](#workflow_workflow_type)
+
+---
+
+## Dataset
+
+A versioned collection of records identified for training, validation, testing, or other ML purposes. The primary grouping unit for ML data.
+
+```yaml
+table: Dataset
+kind: table
+columns:
+- name: Description
+  type: markdown
+- name: Deleted
+  type: boolean
+foreign_keys: []
+```
+
+## Dataset_Version
+
+Version history for a `Dataset`. Each row records one semantic version (MAJOR.MINOR.PATCH) of a dataset, pinned to a catalog snapshot and optionally a MINID for durable external reference.
+
+```yaml
+table: Dataset_Version
+kind: table
+columns:
+- name: Version
+  type: text
+- name: Description
+  type: markdown
+- name: Dataset
+  type: text
+- name: Execution
+  type: text
+- name: Minid
+  type: text
+- name: Minid_Spec_Hash
+  type: text
+- name: Snapshot
+  type: text
+foreign_keys:
+- columns:
+  - Dataset
+  referenced_schema: deriva-ml
+  referenced_table: Dataset
+  referenced_columns:
+  - RID
+- columns:
+  - Execution
+  referenced_schema: deriva-ml
+  referenced_table: Execution
+  referenced_columns:
+  - RID
+```
+
+## Execution
+
+Per-execution lifecycle row. Created once per workflow run; status transitions (Created → Running → Stopped → Pending_Upload → Uploaded or Failed) are managed by the Phase-1 state machine in `src/deriva_ml/execution/state_machine.py`. `Status` and `Status_Detail` are plain text fields today; Subsystem 1 will tighten `Status` to a controlled vocabulary.
+
+```yaml
+table: Execution
+kind: table
+columns:
+- name: Workflow
+  type: text
+- name: Description
+  type: markdown
+- name: Duration
+  type: text
+- name: Status
+  type: text
+- name: Status_Detail
+  type: text
+foreign_keys:
+- columns:
+  - Workflow
+  referenced_schema: deriva-ml
+  referenced_table: Workflow
+  referenced_columns:
+  - RID
+```
+
+## Workflow
+
+A computational pipeline or procedure definition — the "program" an `Execution` runs. Identified by `Checksum` (content hash of the code) for deduplication.
+
+```yaml
+table: Workflow
+kind: table
+columns:
+- name: Name
+  type: text
+- name: Description
+  type: markdown
+- name: URL
+  type: ermrest_uri
+- name: Checksum
+  type: text
+- name: Version
+  type: text
+foreign_keys: []
+```
+
+## Dataset_Type
+
+Controlled vocabulary classifying a `Dataset`'s purpose. Multiple types can apply (e.g., Training + Labeled). Terms are orthogonal tags.
+
+```yaml
+table: Dataset_Type
+kind: vocabulary
+terms:
+- name: Complete
+- name: File
+- name: Training
+- name: Testing
+- name: Validation
+- name: Split
+- name: Labeled
+- name: Unlabeled
+```
+
+## Workflow_Type
+
+Controlled vocabulary classifying a `Workflow` by its computational purpose.
+
+```yaml
+table: Workflow_Type
+kind: vocabulary
+terms:
+- name: Training
+- name: Testing
+- name: Prediction
+- name: Feature_Creation
+- name: Visualization
+- name: Analysis
+- name: Ingest
+- name: Data_Cleaning
+- name: Embedding
+- name: Dataset_Management
+- name: VGG19
+- name: RETFound
+- name: Multimodal
+```
+
+## Feature_Name
+
+Controlled vocabulary of feature identifiers. Each domain-specific Feature table references its name here. No starter terms — projects define their own.
+
+```yaml
+table: Feature_Name
+kind: vocabulary
+```
+
+## Asset_Type
+
+Controlled vocabulary classifying file assets by purpose. Drives which upload-spec regex applies and which `Execution_*` association table an asset flows into.
+
+```yaml
+table: Asset_Type
+kind: vocabulary
+terms:
+- name: Execution_Config
+- name: Runtime_Env
+- name: Hydra_Config
+- name: Deriva_Config
+- name: Execution_Metadata
+- name: Execution_Asset
+- name: File
+- name: Input_File
+- name: Output_File
+- name: Model_File
+- name: Notebook_Output
+```
+
+## Asset_Role
+
+Controlled vocabulary classifying an asset's role in an `Execution` — input data or output artifact.
+
+```yaml
+table: Asset_Role
+kind: vocabulary
+terms:
+- name: Input
+- name: Output
+```
+
+## Dataset_Dataset_Type
+
+Association linking a `Dataset` to its zero-or-more `Dataset_Type` classifications.
+
+```yaml
+table: Dataset_Dataset_Type
+kind: association
+associates:
+- table: Dataset
+- table: Dataset_Type
+```
+
+## Dataset_Nested_Dataset
+
+Self-association: one `Dataset` can contain nested `Dataset` children (e.g., a Split dataset has Training/Testing/Validation children).
+
+```yaml
+table: Dataset_Nested_Dataset
+kind: association
+associates:
+- table: Dataset
+- table: Nested_Dataset
+```
+
+## Dataset_Execution
+
+Association linking a `Dataset` to the `Execution`(s) that produced or consumed it. Drives provenance queries.
+
+```yaml
+table: Dataset_Execution
+kind: association
+associates:
+- table: Dataset
+- table: Execution
+```
+
+## Dataset_File
+
+Association linking a `Dataset` to raw `File` members (files that aren't tracked as catalog `Asset` rows).
+
+```yaml
+table: Dataset_File
+kind: association
+associates:
+- table: Dataset
+- table: File
+```
+
+## Execution_Nested_Execution
+
+Self-association for hierarchical runs: a sweep/multirun `Execution` is the parent; individual trials are children. The optional `Sequence` column records ordering (null for parallel).
+
+```yaml
+table: Execution_Nested_Execution
+kind: association
+associates:
+- table: Execution
+- table: Nested_Execution
+```
+
+## Workflow_Workflow_Type
+
+Association linking a `Workflow` to its zero-or-more `Workflow_Type` classifications.
+
+```yaml
+table: Workflow_Workflow_Type
+kind: association
+associates:
+- table: Workflow
+- table: Workflow_Type
+```

--- a/docs/superpowers/plans/2026-04-21-schema-doc-source-of-truth.md
+++ b/docs/superpowers/plans/2026-04-21-schema-doc-source-of-truth.md
@@ -1,0 +1,2873 @@
+# deriva-ml Schema Doc Source-of-Truth Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Establish `docs/reference/schema.md` as the authoritative description of the deriva-ml schema, with a CI validator that asserts the doc and `src/deriva_ml/schema/create_schema.py` agree on tables, columns, FKs, and vocabulary seeded terms.
+
+**Architecture:** New dev-tool module `src/deriva_ml/tools/validate_schema_doc.py` exposes `SchemaModel`, two loaders (`load_from_doc` for Markdown + YAML, `load_from_code` for AST-parsed Python), and a `diff_schemas` comparator. CLI entry point `deriva-ml-validate-schema` runs the code↔doc comparison. GitHub Actions workflow runs the CLI on every PR. Bootstrap: generate initial doc from the existing `create_schema.py`, then hand-add prose and ordering.
+
+**Tech Stack:** Python 3.12+, `ast` stdlib, PyYAML (already a direct dep), pytest, GitHub Actions.
+
+**Spec:** `docs/superpowers/specs/2026-04-21-schema-doc-source-of-truth-design.md`
+
+---
+
+## Conventions referenced throughout this plan
+
+- **Worktree root:** `/Users/carl/github/deriva-ml/.claude/worktrees/phase2-status-enum/`. All paths below are relative to it.
+- **Environment:** `export PATH="/Users/carl/.local/bin:$PATH"` if `uv` not found. `DERIVA_ML_ALLOW_DIRTY=true` for tests. The validator itself needs NO catalog — pure static analysis + YAML parsing.
+- **Module layout:** tool lives at `src/deriva_ml/tools/validate_schema_doc.py` (a new sub-package of `deriva_ml`). Tests live at `tests/tools/test_*.py`. This matches how `src/deriva_ml/cli/upload.py` is structured (dev tool shipped in the wheel).
+- **Enum shortcuts:** `MLTable` and `MLVocab` are `StrEnum`s in `src/deriva_ml/core/enums.py`. They are safe to import at validator runtime — no catalog, no network calls. `load_from_code` imports them rather than AST-parsing their definitions.
+- **`create_schema.py` AST patterns:** the validator recognizes these call patterns in `src/deriva_ml/schema/create_schema.py`:
+  - `TableDef(name=..., columns=[...], foreign_keys=[...])` → table
+  - `VocabularyTableDef(name=..., curie_template=...)` → vocab table
+  - `Table.define_association(associates=[...], metadata=[...])` → association table
+  - `ColumnDef(name, type, ...)` → column inside a TableDef
+  - `ForeignKeyDef(columns=[...], referenced_schema=..., referenced_table=..., referenced_columns=[...])` → FK inside a TableDef
+  - `_ensure_terms(vocab_name, [{"Name": ..., ...}, ...])` → seeded terms list for a vocab
+  - Call sites may reference `MLTable.xxx` / `MLVocab.xxx`; the validator resolves these via imported enum lookup.
+
+---
+
+## Task Group overview
+
+Seven task groups, ordered so the tool builds bottom-up then the doc/CI integrate with it.
+
+| Group | Scope | Tasks |
+|---|---|---|
+| **A** | `SchemaModel` dataclass hierarchy + empty scaffold | 2 tasks |
+| **B** | `load_from_doc` (Markdown + YAML parser) | 3 tasks |
+| **C** | `load_from_code` (AST-based code parser) | 4 tasks |
+| **D** | `diff_schemas` comparator | 4 tasks |
+| **E** | CLI entry point + output format | 3 tasks |
+| **F** | Bootstrap: generate initial `docs/reference/schema.md` + hand-edit + commit | 2 tasks |
+| **G** | CI workflow + `CHANGELOG` + final review | 3 tasks |
+
+Total: ~21 bite-sized tasks.
+
+---
+
+## Task Group A — `SchemaModel` dataclass hierarchy
+
+Build the in-memory representation that both loaders produce and the comparator consumes. Pure data; no I/O.
+
+### Task A1: Create the `tools` sub-package
+
+**Files:**
+- Create: `src/deriva_ml/tools/__init__.py`
+- Create: `tests/tools/__init__.py`
+- Create: `tests/tools/test_validate_schema_doc.py` (initially empty; tests accumulate through the plan)
+
+- [ ] **Step 1: Create the package init files**
+
+```bash
+mkdir -p src/deriva_ml/tools tests/tools
+touch src/deriva_ml/tools/__init__.py
+touch tests/tools/__init__.py
+```
+
+Create `tests/tools/test_validate_schema_doc.py`:
+
+```python
+"""Tests for the schema-doc validator (spec §6)."""
+
+from __future__ import annotations
+```
+
+- [ ] **Step 2: Verify package is importable**
+
+```bash
+DERIVA_ML_ALLOW_DIRTY=true uv run python -c "import deriva_ml.tools"
+```
+
+Expected: no output (successful import).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/deriva_ml/tools/__init__.py tests/tools/__init__.py tests/tools/test_validate_schema_doc.py
+git commit -m "$(cat <<'EOF'
+chore(tools): scaffold deriva_ml.tools sub-package + tests/tools
+
+Empty sub-package for dev-tooling modules (schema validator, future
+ones). Matches src/deriva_ml/cli/ pattern.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task A2: Add `SchemaModel` + sub-dataclasses
+
+**Files:**
+- Create: `src/deriva_ml/tools/validate_schema_doc.py`
+- Modify: `tests/tools/test_validate_schema_doc.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `tests/tools/test_validate_schema_doc.py`:
+
+```python
+def test_schema_model_fields():
+    from deriva_ml.tools.validate_schema_doc import (
+        SchemaModel,
+        TableModel,
+    )
+    m = SchemaModel(tables=[])
+    assert m.tables == []
+
+    t = TableModel(
+        name="Dataset",
+        kind="table",
+        columns=[],
+        foreign_keys=[],
+        terms=[],
+        associates=[],
+        metadata=[],
+    )
+    assert t.name == "Dataset"
+    assert t.kind == "table"
+
+
+def test_column_model_fields():
+    from deriva_ml.tools.validate_schema_doc import ColumnModel
+    c = ColumnModel(name="Status", type="text")
+    assert c.name == "Status"
+    assert c.type == "text"
+
+
+def test_fk_model_fields():
+    from deriva_ml.tools.validate_schema_doc import ForeignKeyModel
+    fk = ForeignKeyModel(
+        columns=["Workflow"],
+        referenced_schema="deriva-ml",
+        referenced_table="Workflow",
+        referenced_columns=["RID"],
+    )
+    assert fk.columns == ["Workflow"]
+    assert fk.referenced_table == "Workflow"
+
+
+def test_vocabulary_term_model():
+    from deriva_ml.tools.validate_schema_doc import VocabularyTermModel
+    term = VocabularyTermModel(name="Running")
+    assert term.name == "Running"
+
+
+def test_mismatch_kinds_defined():
+    """Enum of mismatch kinds is present."""
+    from deriva_ml.tools.validate_schema_doc import MismatchKind
+    assert MismatchKind.MISSING_TABLE.value == "missing_table"
+    assert MismatchKind.COLUMN_MISMATCH.value == "column_mismatch"
+    assert MismatchKind.FK_MISMATCH.value == "fk_mismatch"
+    assert MismatchKind.VOCAB_TERMS_MISMATCH.value == "vocab_terms_mismatch"
+```
+
+- [ ] **Step 2: Run to verify failures**
+
+```bash
+DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/tools/test_validate_schema_doc.py -v
+```
+
+Expected: 5 FAIL with `ModuleNotFoundError: No module named 'deriva_ml.tools.validate_schema_doc'`.
+
+- [ ] **Step 3: Implement the dataclasses**
+
+Create `src/deriva_ml/tools/validate_schema_doc.py`:
+
+```python
+"""Validator: assert docs/reference/schema.md and create_schema.py agree.
+
+Path-1 architecture (per spec §2): both files are maintained by developers.
+The doc describes intended schema; the code defines it at runtime. This
+validator compares the two.
+
+Runs in CI via the deriva-ml-validate-schema entry point.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+
+
+@dataclass(frozen=True)
+class ColumnModel:
+    """Column definition (name + ERMrest type)."""
+    name: str
+    type: str
+
+
+@dataclass(frozen=True)
+class ForeignKeyModel:
+    """FK from a set of columns to a referenced table's columns."""
+    columns: list[str]
+    referenced_schema: str
+    referenced_table: str
+    referenced_columns: list[str]
+
+
+@dataclass(frozen=True)
+class VocabularyTermModel:
+    """One seeded term in a vocabulary table."""
+    name: str
+
+
+@dataclass(frozen=True)
+class AssociationEndpointModel:
+    """One endpoint of an association table."""
+    table: str
+    role: str | None = None
+
+
+@dataclass(frozen=True)
+class TableModel:
+    """One table in the schema — plain, vocabulary, or association."""
+    name: str
+    kind: str  # "table", "vocabulary", "association"
+    columns: list[ColumnModel] = field(default_factory=list)
+    foreign_keys: list[ForeignKeyModel] = field(default_factory=list)
+    terms: list[VocabularyTermModel] = field(default_factory=list)
+    associates: list[AssociationEndpointModel] = field(default_factory=list)
+    metadata: list[ColumnModel] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class SchemaModel:
+    """The full schema — one list of tables."""
+    tables: list[TableModel]
+
+
+class MismatchKind(StrEnum):
+    """Categories of doc↔code mismatch."""
+    MISSING_TABLE = "missing_table"
+    EXTRA_TABLE = "extra_table"
+    COLUMN_MISMATCH = "column_mismatch"
+    FK_MISMATCH = "fk_mismatch"
+    VOCAB_TERMS_MISMATCH = "vocab_terms_mismatch"
+    ASSOCIATION_MISMATCH = "association_mismatch"
+```
+
+Note: `TableModel` cannot be frozen if it contains mutable `list` defaults via `field(default_factory=list)`. Python's `@dataclass(frozen=True)` actually DOES allow `field(default_factory=list)` — the instance's attributes are immutable references, but the lists themselves are mutable. This matches the intended semantics (compare-by-value; don't let anyone reassign `.tables` but DO allow building the list incrementally during parsing).
+
+Wait — `frozen=True` disallows attribute assignment AFTER construction, but construction itself populates via the field default factories. That's fine. Keep `frozen=True` on all of them.
+
+- [ ] **Step 4: Run tests**
+
+```bash
+DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/tools/test_validate_schema_doc.py -v
+```
+
+Expected: 5 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/deriva_ml/tools/validate_schema_doc.py tests/tools/test_validate_schema_doc.py
+git commit -m "$(cat <<'EOF'
+feat(tools): SchemaModel dataclass hierarchy for schema-doc validator
+
+Data shape both loaders (doc, code) produce and diff_schemas consumes.
+Frozen dataclasses with list fields (defaults via field(default_factory)).
+
+Includes MismatchKind StrEnum for diff outputs.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task Group B — `load_from_doc`
+
+Parse the Markdown file. Find fenced `yaml` code blocks. Deserialize each into a `TableModel`.
+
+### Task B1: Markdown YAML-block extraction
+
+**Files:**
+- Modify: `src/deriva_ml/tools/validate_schema_doc.py`
+- Modify: `tests/tools/test_validate_schema_doc.py`
+
+- [ ] **Step 1: Write failing test**
+
+Append to `tests/tools/test_validate_schema_doc.py`:
+
+```python
+def test_extract_yaml_blocks_basic(tmp_path):
+    """Extracts YAML-fenced blocks and parses each into a dict."""
+    from deriva_ml.tools.validate_schema_doc import _extract_yaml_blocks
+
+    doc = tmp_path / "schema.md"
+    doc.write_text(
+        "# Intro\n"
+        "\n"
+        "## Dataset\n"
+        "\n"
+        "```yaml\n"
+        "table: Dataset\n"
+        "kind: table\n"
+        "columns:\n"
+        "  - name: Name\n"
+        "    type: text\n"
+        "```\n"
+        "\n"
+        "More prose.\n"
+        "\n"
+        "```yaml\n"
+        "table: Workflow\n"
+        "kind: table\n"
+        "```\n"
+    )
+
+    blocks = _extract_yaml_blocks(doc)
+    assert len(blocks) == 2
+    assert blocks[0]["table"] == "Dataset"
+    assert blocks[0]["columns"][0]["name"] == "Name"
+    assert blocks[1]["table"] == "Workflow"
+
+
+def test_extract_yaml_blocks_ignores_non_yaml_fences(tmp_path):
+    """Code blocks fenced as other languages are not parsed as YAML."""
+    from deriva_ml.tools.validate_schema_doc import _extract_yaml_blocks
+
+    doc = tmp_path / "schema.md"
+    doc.write_text(
+        "```python\n"
+        "x = 1\n"
+        "```\n"
+        "\n"
+        "```yaml\n"
+        "table: Dataset\n"
+        "kind: table\n"
+        "```\n"
+    )
+
+    blocks = _extract_yaml_blocks(doc)
+    assert len(blocks) == 1
+    assert blocks[0]["table"] == "Dataset"
+```
+
+- [ ] **Step 2: Run to verify failures**
+
+```bash
+DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/tools/test_validate_schema_doc.py -v -k extract_yaml_blocks
+```
+
+Expected: 2 FAIL with ImportError on `_extract_yaml_blocks`.
+
+- [ ] **Step 3: Implement `_extract_yaml_blocks`**
+
+Append to `src/deriva_ml/tools/validate_schema_doc.py`:
+
+```python
+import re
+from pathlib import Path
+
+import yaml
+
+_YAML_FENCE_RE = re.compile(
+    r"^```yaml\s*$(.*?)^```\s*$",
+    re.MULTILINE | re.DOTALL,
+)
+
+
+def _extract_yaml_blocks(path: Path) -> list[dict]:
+    """Extract YAML-fenced code blocks from a Markdown file.
+
+    Args:
+        path: Path to the Markdown file.
+
+    Returns:
+        List of dicts, one per ```yaml block, in file order.
+
+    Raises:
+        SchemaDocError: If any block fails to parse as YAML.
+    """
+    text = path.read_text()
+    blocks: list[dict] = []
+    for match in _YAML_FENCE_RE.finditer(text):
+        body = match.group(1)
+        line_number = text[: match.start()].count("\n") + 1
+        try:
+            parsed = yaml.safe_load(body)
+        except yaml.YAMLError as exc:
+            raise SchemaDocError(
+                f"YAML parse error in {path}:{line_number}: {exc}"
+            ) from exc
+        if parsed is None:
+            continue
+        if not isinstance(parsed, dict):
+            raise SchemaDocError(
+                f"{path}:{line_number}: expected a mapping, got {type(parsed).__name__}"
+            )
+        blocks.append(parsed)
+    return blocks
+
+
+class SchemaDocError(Exception):
+    """Raised when the schema doc can't be parsed or is malformed."""
+```
+
+Add `import yaml` to the module-level imports at the top of the file (above the `from dataclasses` line).
+
+- [ ] **Step 4: Run tests**
+
+```bash
+DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/tools/test_validate_schema_doc.py -v -k extract_yaml_blocks
+```
+
+Expected: 2 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/deriva_ml/tools/validate_schema_doc.py tests/tools/test_validate_schema_doc.py
+git commit -m "$(cat <<'EOF'
+feat(tools): _extract_yaml_blocks for Markdown with YAML fences
+
+Reads the doc, extracts fenced ```yaml code blocks, parses each via
+yaml.safe_load. Non-YAML fences (e.g. python) are skipped. Malformed
+YAML raises SchemaDocError with the Markdown line number.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task B2: `load_from_doc` — dict → `SchemaModel`
+
+**Files:**
+- Modify: `src/deriva_ml/tools/validate_schema_doc.py`
+- Modify: `tests/tools/test_validate_schema_doc.py`
+
+- [ ] **Step 1: Write failing test**
+
+Append to `tests/tools/test_validate_schema_doc.py`:
+
+```python
+def test_load_from_doc_plain_table(tmp_path):
+    """A plain table becomes a TableModel with kind='table'."""
+    from deriva_ml.tools.validate_schema_doc import load_from_doc
+
+    doc = tmp_path / "schema.md"
+    doc.write_text(
+        "```yaml\n"
+        "table: Dataset\n"
+        "kind: table\n"
+        "description: A data collection.\n"
+        "columns:\n"
+        "  - name: Name\n"
+        "    type: text\n"
+        "  - name: Description\n"
+        "    type: markdown\n"
+        "foreign_keys: []\n"
+        "```\n"
+    )
+    model = load_from_doc(doc)
+    assert len(model.tables) == 1
+    t = model.tables[0]
+    assert t.name == "Dataset"
+    assert t.kind == "table"
+    assert len(t.columns) == 2
+    assert t.columns[0].name == "Name"
+    assert t.columns[0].type == "text"
+
+
+def test_load_from_doc_vocabulary(tmp_path):
+    """A vocabulary table gets terms populated."""
+    from deriva_ml.tools.validate_schema_doc import load_from_doc
+
+    doc = tmp_path / "schema.md"
+    doc.write_text(
+        "```yaml\n"
+        "table: Asset_Type\n"
+        "kind: vocabulary\n"
+        "terms:\n"
+        "  - name: Execution_Config\n"
+        "  - name: Runtime_Env\n"
+        "```\n"
+    )
+    model = load_from_doc(doc)
+    t = model.tables[0]
+    assert t.kind == "vocabulary"
+    assert len(t.terms) == 2
+    assert [term.name for term in t.terms] == ["Execution_Config", "Runtime_Env"]
+
+
+def test_load_from_doc_association(tmp_path):
+    """An association table gets associates populated."""
+    from deriva_ml.tools.validate_schema_doc import load_from_doc
+
+    doc = tmp_path / "schema.md"
+    doc.write_text(
+        "```yaml\n"
+        "table: Dataset_Execution\n"
+        "kind: association\n"
+        "associates:\n"
+        "  - table: Dataset\n"
+        "  - table: Execution\n"
+        "```\n"
+    )
+    model = load_from_doc(doc)
+    t = model.tables[0]
+    assert t.kind == "association"
+    assert [a.table for a in t.associates] == ["Dataset", "Execution"]
+
+
+def test_load_from_doc_foreign_keys(tmp_path):
+    """FKs parse correctly."""
+    from deriva_ml.tools.validate_schema_doc import load_from_doc
+
+    doc = tmp_path / "schema.md"
+    doc.write_text(
+        "```yaml\n"
+        "table: Execution\n"
+        "kind: table\n"
+        "columns:\n"
+        "  - name: Workflow\n"
+        "    type: text\n"
+        "foreign_keys:\n"
+        "  - columns: [Workflow]\n"
+        "    referenced_schema: deriva-ml\n"
+        "    referenced_table: Workflow\n"
+        "    referenced_columns: [RID]\n"
+        "```\n"
+    )
+    model = load_from_doc(doc)
+    fk = model.tables[0].foreign_keys[0]
+    assert fk.columns == ["Workflow"]
+    assert fk.referenced_table == "Workflow"
+    assert fk.referenced_columns == ["RID"]
+
+
+def test_load_from_doc_invalid_kind_raises(tmp_path):
+    """Unknown 'kind:' value raises SchemaDocError."""
+    import pytest
+    from deriva_ml.tools.validate_schema_doc import SchemaDocError, load_from_doc
+
+    doc = tmp_path / "schema.md"
+    doc.write_text(
+        "```yaml\n"
+        "table: Bogus\n"
+        "kind: not-a-real-kind\n"
+        "```\n"
+    )
+    with pytest.raises(SchemaDocError, match="unknown kind"):
+        load_from_doc(doc)
+
+
+def test_load_from_doc_missing_required_key_raises(tmp_path):
+    """Missing required key 'kind' raises SchemaDocError."""
+    import pytest
+    from deriva_ml.tools.validate_schema_doc import SchemaDocError, load_from_doc
+
+    doc = tmp_path / "schema.md"
+    doc.write_text(
+        "```yaml\n"
+        "table: Bogus\n"
+        "```\n"
+    )
+    with pytest.raises(SchemaDocError, match="missing required key"):
+        load_from_doc(doc)
+```
+
+- [ ] **Step 2: Run to verify failures**
+
+```bash
+DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/tools/test_validate_schema_doc.py -v -k load_from_doc
+```
+
+Expected: 6 FAIL with ImportError on `load_from_doc`.
+
+- [ ] **Step 3: Implement `load_from_doc`**
+
+Append to `src/deriva_ml/tools/validate_schema_doc.py`:
+
+```python
+_VALID_KINDS = frozenset({"table", "vocabulary", "association"})
+
+
+def load_from_doc(path: Path) -> SchemaModel:
+    """Parse a schema doc Markdown file into a SchemaModel.
+
+    Args:
+        path: Path to docs/reference/schema.md or equivalent.
+
+    Returns:
+        SchemaModel with one TableModel per ```yaml block.
+
+    Raises:
+        SchemaDocError: If any block is malformed (unknown kind, missing
+            required keys, parse error).
+    """
+    blocks = _extract_yaml_blocks(path)
+    tables: list[TableModel] = []
+    for block in blocks:
+        if "table" not in block:
+            raise SchemaDocError(
+                f"{path}: block missing required key 'table': {block}"
+            )
+        if "kind" not in block:
+            raise SchemaDocError(
+                f"{path}: block missing required key 'kind' for table "
+                f"{block['table']!r}"
+            )
+        kind = block["kind"]
+        if kind not in _VALID_KINDS:
+            raise SchemaDocError(
+                f"{path}: table {block['table']!r} has unknown kind {kind!r}; "
+                f"expected one of {sorted(_VALID_KINDS)}"
+            )
+        columns = [
+            ColumnModel(name=c["name"], type=c["type"])
+            for c in block.get("columns", [])
+        ]
+        foreign_keys = [
+            ForeignKeyModel(
+                columns=fk["columns"],
+                referenced_schema=fk["referenced_schema"],
+                referenced_table=fk["referenced_table"],
+                referenced_columns=fk["referenced_columns"],
+            )
+            for fk in block.get("foreign_keys", [])
+        ]
+        terms = [
+            VocabularyTermModel(name=t["name"])
+            for t in block.get("terms", [])
+        ]
+        associates = [
+            AssociationEndpointModel(table=a["table"], role=a.get("role"))
+            for a in block.get("associates", [])
+        ]
+        metadata = [
+            ColumnModel(name=m["name"], type=m["type"])
+            for m in block.get("metadata", [])
+        ]
+        tables.append(TableModel(
+            name=block["table"],
+            kind=kind,
+            columns=columns,
+            foreign_keys=foreign_keys,
+            terms=terms,
+            associates=associates,
+            metadata=metadata,
+        ))
+    return SchemaModel(tables=tables)
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/tools/test_validate_schema_doc.py -v
+```
+
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/deriva_ml/tools/validate_schema_doc.py tests/tools/test_validate_schema_doc.py
+git commit -m "$(cat <<'EOF'
+feat(tools): load_from_doc — parse Markdown YAML blocks → SchemaModel
+
+Handles plain tables, vocabularies, and association tables. Validates
+required keys ('table', 'kind') and rejects unknown kinds. Raises
+SchemaDocError with path context on malformed blocks.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task B3: Handle descriptions in doc (narrative-only)
+
+**Files:**
+- Modify: `src/deriva_ml/tools/validate_schema_doc.py`
+- Modify: `tests/tools/test_validate_schema_doc.py`
+
+Per spec §2, descriptions are doc-side narrative and NOT validated. But `load_from_doc` should accept them without error — the parser currently doesn't look at the `description:` key, so it's already tolerated. We just need a test that asserts this.
+
+- [ ] **Step 1: Write test**
+
+Append to `tests/tools/test_validate_schema_doc.py`:
+
+```python
+def test_load_from_doc_accepts_descriptions(tmp_path):
+    """Descriptions on tables and columns are tolerated (doc-side only)."""
+    from deriva_ml.tools.validate_schema_doc import load_from_doc
+
+    doc = tmp_path / "schema.md"
+    doc.write_text(
+        "```yaml\n"
+        "table: Dataset\n"
+        "kind: table\n"
+        "description: A collection of records.\n"
+        "columns:\n"
+        "  - name: Name\n"
+        "    type: text\n"
+        "    description: Human-readable label.\n"
+        "```\n"
+    )
+    model = load_from_doc(doc)
+    # Description text is NOT preserved in the model (doc-side only).
+    t = model.tables[0]
+    assert t.name == "Dataset"
+    assert t.columns[0].name == "Name"
+    # ColumnModel has no description field.
+    assert not hasattr(t.columns[0], "description")
+```
+
+- [ ] **Step 2: Run**
+
+```bash
+DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/tools/test_validate_schema_doc.py::test_load_from_doc_accepts_descriptions -v
+```
+
+Expected: PASS (nothing new to implement — the existing parser already ignores the `description:` key).
+
+- [ ] **Step 3: Commit (test addition only)**
+
+```bash
+git add tests/tools/test_validate_schema_doc.py
+git commit -m "test(tools): confirm load_from_doc tolerates descriptions as narrative"
+```
+
+---
+
+## Task Group C — `load_from_code`
+
+AST-parse `create_schema.py` without executing it. Walk the call tree for `TableDef`, `VocabularyTableDef`, `Table.define_association`, `ColumnDef`, `ForeignKeyDef`, `_ensure_terms`. Resolve `MLTable.xxx` / `MLVocab.xxx` references via imported enum lookup.
+
+### Task C1: Skeleton `load_from_code` with enum-ref resolver
+
+**Files:**
+- Modify: `src/deriva_ml/tools/validate_schema_doc.py`
+- Modify: `tests/tools/test_validate_schema_doc.py`
+
+- [ ] **Step 1: Write failing test**
+
+Append to `tests/tools/test_validate_schema_doc.py`:
+
+```python
+def test_resolve_enum_ref_mltable():
+    """Resolver returns the enum value for MLTable.execution."""
+    from deriva_ml.tools.validate_schema_doc import _resolve_enum_ref
+
+    assert _resolve_enum_ref("MLTable", "execution") == "Execution"
+    assert _resolve_enum_ref("MLTable", "dataset") == "Dataset"
+
+
+def test_resolve_enum_ref_mlvocab():
+    from deriva_ml.tools.validate_schema_doc import _resolve_enum_ref
+
+    assert _resolve_enum_ref("MLVocab", "workflow_type") == "Workflow_Type"
+    assert _resolve_enum_ref("MLVocab", "asset_type") == "Asset_Type"
+
+
+def test_resolve_enum_ref_unknown_raises():
+    import pytest
+    from deriva_ml.tools.validate_schema_doc import SchemaCodeError, _resolve_enum_ref
+
+    with pytest.raises(SchemaCodeError, match="unknown enum"):
+        _resolve_enum_ref("UnknownEnum", "whatever")
+
+
+def test_resolve_enum_ref_unknown_member_raises():
+    import pytest
+    from deriva_ml.tools.validate_schema_doc import SchemaCodeError, _resolve_enum_ref
+
+    with pytest.raises(SchemaCodeError, match="has no member"):
+        _resolve_enum_ref("MLTable", "no_such_member")
+```
+
+- [ ] **Step 2: Run to verify failures**
+
+```bash
+DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/tools/test_validate_schema_doc.py -v -k resolve_enum_ref
+```
+
+Expected: 4 FAIL with ImportError.
+
+- [ ] **Step 3: Implement resolver + exception**
+
+Append to `src/deriva_ml/tools/validate_schema_doc.py`:
+
+```python
+class SchemaCodeError(Exception):
+    """Raised when create_schema.py contains a pattern the validator can't extract."""
+
+
+# Enum lookup for resolving MLTable.xxx / MLVocab.xxx references.
+# Populated lazily via _resolve_enum_ref to avoid circular-import risk.
+_ENUM_LOOKUP: dict[str, dict[str, str]] = {}
+
+
+def _load_enum_lookup() -> dict[str, dict[str, str]]:
+    """Build {enum_name: {member_name: value}} for MLTable and MLVocab."""
+    global _ENUM_LOOKUP
+    if _ENUM_LOOKUP:
+        return _ENUM_LOOKUP
+    from deriva_ml.core.enums import MLTable, MLVocab
+
+    _ENUM_LOOKUP = {
+        "MLTable": {m.name: m.value for m in MLTable},
+        "MLVocab": {m.name: m.value for m in MLVocab},
+    }
+    return _ENUM_LOOKUP
+
+
+def _resolve_enum_ref(enum_name: str, member: str) -> str:
+    """Resolve an enum-member reference like MLTable.execution → 'Execution'."""
+    lookup = _load_enum_lookup()
+    if enum_name not in lookup:
+        raise SchemaCodeError(
+            f"unknown enum {enum_name!r}; expected one of {sorted(lookup)}"
+        )
+    members = lookup[enum_name]
+    if member not in members:
+        raise SchemaCodeError(
+            f"{enum_name} has no member {member!r}; known: {sorted(members)}"
+        )
+    return members[member]
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/tools/test_validate_schema_doc.py -v -k resolve_enum_ref
+```
+
+Expected: 4 PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/deriva_ml/tools/validate_schema_doc.py tests/tools/test_validate_schema_doc.py
+git commit -m "$(cat <<'EOF'
+feat(tools): _resolve_enum_ref for MLTable/MLVocab references in AST
+
+The validator's load_from_code needs to resolve MLTable.execution →
+'Execution' when walking the AST. Builds a lookup on first call via
+runtime enum import (safe — StrEnum, no catalog required).
+
+SchemaCodeError is raised for unknown enums or members.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task C2: AST-parse `ColumnDef` / `ForeignKeyDef` / `TableDef`
+
+**Files:**
+- Modify: `src/deriva_ml/tools/validate_schema_doc.py`
+- Modify: `tests/tools/test_validate_schema_doc.py`
+
+- [ ] **Step 1: Write failing test**
+
+Append to `tests/tools/test_validate_schema_doc.py`:
+
+```python
+def test_load_from_code_simple_tabledef(tmp_path):
+    """A fixture module with one TableDef call produces a TableModel."""
+    from deriva_ml.tools.validate_schema_doc import load_from_code
+
+    fixture = tmp_path / "fixture_schema.py"
+    fixture.write_text(
+        'from deriva.core.typed import TableDef, ColumnDef, ForeignKeyDef, BuiltinType\n'
+        'from deriva_ml.core.definitions import MLTable\n'
+        '\n'
+        'def create_execution_table(schema):\n'
+        '    schema.create_table(TableDef(\n'
+        '        name=MLTable.execution,\n'
+        '        columns=[\n'
+        '            ColumnDef("Workflow", BuiltinType.text),\n'
+        '            ColumnDef("Description", BuiltinType.markdown),\n'
+        '            ColumnDef("Status", BuiltinType.text),\n'
+        '        ],\n'
+        '        foreign_keys=[\n'
+        '            ForeignKeyDef(\n'
+        '                columns=["Workflow"],\n'
+        '                referenced_schema="deriva-ml",\n'
+        '                referenced_table="Workflow",\n'
+        '                referenced_columns=["RID"],\n'
+        '            )\n'
+        '        ],\n'
+        '    ))\n'
+    )
+    model = load_from_code(fixture)
+    assert len(model.tables) == 1
+    t = model.tables[0]
+    assert t.name == "Execution"
+    assert t.kind == "table"
+    assert [c.name for c in t.columns] == ["Workflow", "Description", "Status"]
+    assert [c.type for c in t.columns] == ["text", "markdown", "text"]
+    assert len(t.foreign_keys) == 1
+    assert t.foreign_keys[0].columns == ["Workflow"]
+    assert t.foreign_keys[0].referenced_table == "Workflow"
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+```bash
+DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/tools/test_validate_schema_doc.py::test_load_from_code_simple_tabledef -v
+```
+
+Expected: FAIL with ImportError on `load_from_code`.
+
+- [ ] **Step 3: Implement AST walker**
+
+Append to `src/deriva_ml/tools/validate_schema_doc.py`:
+
+```python
+import ast
+
+
+def _extract_ast_str(node: ast.AST) -> str:
+    """Extract a string from an ast.Constant or return the ast.unparse repr."""
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    # Attribute access like BuiltinType.text → "text"
+    if isinstance(node, ast.Attribute):
+        return node.attr
+    raise SchemaCodeError(
+        f"expected string constant or attribute, got {ast.dump(node)}"
+    )
+
+
+def _extract_ast_name_or_enum(node: ast.AST) -> str:
+    """Extract a table-name string from a literal, enum ref, or attr access."""
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    if isinstance(node, ast.Attribute):
+        # Expect: MLTable.execution or MLVocab.workflow_type
+        if isinstance(node.value, ast.Name):
+            return _resolve_enum_ref(node.value.id, node.attr)
+    raise SchemaCodeError(
+        f"expected string literal or enum reference, got {ast.dump(node)}"
+    )
+
+
+def _extract_ast_str_list(node: ast.AST) -> list[str]:
+    """Extract a list[str] from an ast.List node."""
+    if not isinstance(node, ast.List):
+        raise SchemaCodeError(
+            f"expected list literal, got {ast.dump(node)}"
+        )
+    return [_extract_ast_str(elt) for elt in node.elts]
+
+
+def _extract_column(node: ast.Call) -> ColumnModel:
+    """Extract a ColumnDef(...) call into a ColumnModel."""
+    # Positional or keyword args: ColumnDef("Name", BuiltinType.text)
+    name: str | None = None
+    type_: str | None = None
+    if node.args:
+        name = _extract_ast_str(node.args[0])
+        if len(node.args) > 1:
+            type_ = _extract_ast_str(node.args[1])
+    for kw in node.keywords:
+        if kw.arg == "name":
+            name = _extract_ast_str(kw.value)
+        elif kw.arg == "type":
+            type_ = _extract_ast_str(kw.value)
+    if name is None or type_ is None:
+        raise SchemaCodeError(
+            f"ColumnDef missing name or type: {ast.dump(node)}"
+        )
+    return ColumnModel(name=name, type=type_)
+
+
+def _extract_fk(node: ast.Call) -> ForeignKeyModel:
+    """Extract a ForeignKeyDef(...) call into a ForeignKeyModel."""
+    columns: list[str] = []
+    referenced_schema: str = ""
+    referenced_table: str = ""
+    referenced_columns: list[str] = []
+    for kw in node.keywords:
+        if kw.arg == "columns":
+            columns = _extract_ast_str_list(kw.value)
+        elif kw.arg == "referenced_schema":
+            referenced_schema = _extract_ast_str(kw.value)
+        elif kw.arg == "referenced_table":
+            referenced_table = _extract_ast_str(kw.value)
+        elif kw.arg == "referenced_columns":
+            referenced_columns = _extract_ast_str_list(kw.value)
+    return ForeignKeyModel(
+        columns=columns,
+        referenced_schema=referenced_schema,
+        referenced_table=referenced_table,
+        referenced_columns=referenced_columns,
+    )
+
+
+def _extract_tabledef(node: ast.Call) -> TableModel:
+    """Extract a TableDef(name=..., columns=[...], foreign_keys=[...]) call."""
+    name: str = ""
+    columns: list[ColumnModel] = []
+    foreign_keys: list[ForeignKeyModel] = []
+    for kw in node.keywords:
+        if kw.arg == "name":
+            name = _extract_ast_name_or_enum(kw.value)
+        elif kw.arg == "columns":
+            if isinstance(kw.value, ast.List):
+                columns = [
+                    _extract_column(elt)
+                    for elt in kw.value.elts
+                    if isinstance(elt, ast.Call) and _callable_name(elt) == "ColumnDef"
+                ]
+        elif kw.arg == "foreign_keys":
+            if isinstance(kw.value, ast.List):
+                foreign_keys = [
+                    _extract_fk(elt)
+                    for elt in kw.value.elts
+                    if isinstance(elt, ast.Call) and _callable_name(elt) == "ForeignKeyDef"
+                ]
+    return TableModel(
+        name=name,
+        kind="table",
+        columns=columns,
+        foreign_keys=foreign_keys,
+    )
+
+
+def _callable_name(node: ast.Call) -> str:
+    """Return the callable's name: 'TableDef', 'Foo.bar', etc."""
+    if isinstance(node.func, ast.Name):
+        return node.func.id
+    if isinstance(node.func, ast.Attribute):
+        parts = []
+        cur: ast.AST = node.func
+        while isinstance(cur, ast.Attribute):
+            parts.insert(0, cur.attr)
+            cur = cur.value
+        if isinstance(cur, ast.Name):
+            parts.insert(0, cur.id)
+        return ".".join(parts)
+    return ""
+
+
+def load_from_code(path: Path) -> SchemaModel:
+    """Parse create_schema.py AST into a SchemaModel.
+
+    Walks the tree looking for TableDef, VocabularyTableDef,
+    Table.define_association, and _ensure_terms calls.
+
+    Args:
+        path: Path to create_schema.py or a fixture module.
+
+    Returns:
+        SchemaModel with one TableModel per table definition found.
+
+    Raises:
+        SchemaCodeError: If a call pattern can't be statically extracted.
+    """
+    tree = ast.parse(path.read_text(), filename=str(path))
+    tables: list[TableModel] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        name = _callable_name(node)
+        if name == "TableDef":
+            tables.append(_extract_tabledef(node))
+        # Vocabulary / association / _ensure_terms handled in C3 / C4.
+    return SchemaModel(tables=tables)
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/tools/test_validate_schema_doc.py::test_load_from_code_simple_tabledef -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/deriva_ml/tools/validate_schema_doc.py tests/tools/test_validate_schema_doc.py
+git commit -m "$(cat <<'EOF'
+feat(tools): load_from_code AST parser — TableDef + ColumnDef + ForeignKeyDef
+
+Walks the AST of create_schema.py-like modules, extracts TableDef
+calls and their column/FK lists. Resolves MLTable.xxx enum references
+via _resolve_enum_ref.
+
+Vocabulary/association/_ensure_terms handling comes in C3/C4.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task C3: AST-parse `VocabularyTableDef` + `_ensure_terms`
+
+**Files:**
+- Modify: `src/deriva_ml/tools/validate_schema_doc.py`
+- Modify: `tests/tools/test_validate_schema_doc.py`
+
+- [ ] **Step 1: Write failing test**
+
+Append to `tests/tools/test_validate_schema_doc.py`:
+
+```python
+def test_load_from_code_vocabulary_with_terms(tmp_path):
+    """A VocabularyTableDef plus _ensure_terms yields a vocabulary TableModel."""
+    from deriva_ml.tools.validate_schema_doc import load_from_code
+
+    fixture = tmp_path / "fixture_vocab.py"
+    fixture.write_text(
+        'from deriva.core.typed import VocabularyTableDef\n'
+        'from deriva_ml.core.definitions import MLVocab\n'
+        '\n'
+        'def create():\n'
+        '    schema.create_table(\n'
+        '        VocabularyTableDef(name=MLVocab.workflow_type, curie_template="x:{RID}")\n'
+        '    )\n'
+        '\n'
+        'def seed():\n'
+        '    _ensure_terms(MLVocab.workflow_type, [\n'
+        '        {"Name": "Training", "Description": "Train a model"},\n'
+        '        {"Name": "Testing", "Description": "Evaluate a model"},\n'
+        '    ])\n'
+    )
+    model = load_from_code(fixture)
+    assert len(model.tables) == 1
+    t = model.tables[0]
+    assert t.name == "Workflow_Type"
+    assert t.kind == "vocabulary"
+    assert [term.name for term in t.terms] == ["Training", "Testing"]
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+```bash
+DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/tools/test_validate_schema_doc.py::test_load_from_code_vocabulary_with_terms -v
+```
+
+Expected: FAIL — VocabularyTableDef not extracted yet.
+
+- [ ] **Step 3: Extend `load_from_code` to handle vocabulary + terms**
+
+In `src/deriva_ml/tools/validate_schema_doc.py`, add helpers and extend `load_from_code`:
+
+```python
+def _extract_vocabulary(node: ast.Call) -> TableModel:
+    """Extract a VocabularyTableDef(name=..., curie_template=...) call."""
+    name: str = ""
+    for kw in node.keywords:
+        if kw.arg == "name":
+            name = _extract_ast_name_or_enum(kw.value)
+    return TableModel(name=name, kind="vocabulary")
+
+
+def _extract_ensure_terms(node: ast.Call) -> tuple[str, list[VocabularyTermModel]]:
+    """Extract (vocab_name, terms) from an _ensure_terms(vocab, [...]) call."""
+    if len(node.args) < 2:
+        raise SchemaCodeError(
+            f"_ensure_terms expects 2 positional args, got {len(node.args)}"
+        )
+    vocab_name = _extract_ast_name_or_enum(node.args[0])
+    terms_list = node.args[1]
+    if not isinstance(terms_list, ast.List):
+        raise SchemaCodeError(
+            f"_ensure_terms second arg must be a list literal, got "
+            f"{ast.dump(terms_list)}"
+        )
+    terms: list[VocabularyTermModel] = []
+    for elt in terms_list.elts:
+        if not isinstance(elt, ast.Dict):
+            raise SchemaCodeError(
+                f"_ensure_terms term must be a dict literal, got "
+                f"{ast.dump(elt)}"
+            )
+        name_val: str | None = None
+        for k, v in zip(elt.keys, elt.values, strict=True):
+            if (
+                isinstance(k, ast.Constant)
+                and k.value == "Name"
+                and isinstance(v, ast.Constant)
+                and isinstance(v.value, str)
+            ):
+                name_val = v.value
+        if name_val is None:
+            raise SchemaCodeError(
+                f"_ensure_terms term missing 'Name': {ast.dump(elt)}"
+            )
+        terms.append(VocabularyTermModel(name=name_val))
+    return vocab_name, terms
+```
+
+Rewrite `load_from_code` to include vocab + ensure_terms handling:
+
+```python
+def load_from_code(path: Path) -> SchemaModel:
+    """Parse create_schema.py AST into a SchemaModel.
+
+    Walks the tree for:
+      - TableDef(...)              → plain table
+      - VocabularyTableDef(...)    → vocabulary table (terms populated below)
+      - Table.define_association(...) → association table (C4)
+      - _ensure_terms(vocab, [...]) → seed terms for a vocab table
+
+    After walking, vocab tables have their terms populated by matching
+    _ensure_terms vocab_name to TableModel.name.
+
+    Args:
+        path: Path to create_schema.py or a fixture.
+
+    Returns:
+        SchemaModel with all discovered TableModels, vocab terms filled in.
+
+    Raises:
+        SchemaCodeError: If a call pattern can't be statically extracted.
+    """
+    tree = ast.parse(path.read_text(), filename=str(path))
+    tables: list[TableModel] = []
+    # Map from vocab table name → list of VocabularyTermModel to apply later.
+    terms_by_vocab: dict[str, list[VocabularyTermModel]] = {}
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        name = _callable_name(node)
+        if name == "TableDef":
+            tables.append(_extract_tabledef(node))
+        elif name == "VocabularyTableDef":
+            tables.append(_extract_vocabulary(node))
+        elif name == "_ensure_terms":
+            vocab_name, terms = _extract_ensure_terms(node)
+            terms_by_vocab.setdefault(vocab_name, []).extend(terms)
+
+    # Apply accumulated terms to matching vocab tables.
+    tables_with_terms: list[TableModel] = []
+    for t in tables:
+        if t.kind == "vocabulary" and t.name in terms_by_vocab:
+            tables_with_terms.append(TableModel(
+                name=t.name,
+                kind=t.kind,
+                columns=t.columns,
+                foreign_keys=t.foreign_keys,
+                terms=terms_by_vocab[t.name],
+                associates=t.associates,
+                metadata=t.metadata,
+            ))
+        else:
+            tables_with_terms.append(t)
+    return SchemaModel(tables=tables_with_terms)
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/tools/test_validate_schema_doc.py -v
+```
+
+Expected: all PASS (C1-C3 tests plus earlier A/B tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/deriva_ml/tools/validate_schema_doc.py tests/tools/test_validate_schema_doc.py
+git commit -m "$(cat <<'EOF'
+feat(tools): load_from_code handles VocabularyTableDef + _ensure_terms
+
+Extracts vocabulary tables and their seeded terms. Terms are collected
+across the entire module and then grafted onto the matching vocab
+TableModel by name.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task C4: AST-parse `Table.define_association`
+
+**Files:**
+- Modify: `src/deriva_ml/tools/validate_schema_doc.py`
+- Modify: `tests/tools/test_validate_schema_doc.py`
+
+- [ ] **Step 1: Write failing test**
+
+Append to `tests/tools/test_validate_schema_doc.py`:
+
+```python
+def test_load_from_code_association_table(tmp_path):
+    """Table.define_association produces a TableModel with kind='association'."""
+    from deriva_ml.tools.validate_schema_doc import load_from_code
+
+    fixture = tmp_path / "fixture_assoc.py"
+    fixture.write_text(
+        'from deriva.core.ermrest_model import Table\n'
+        'from deriva.core.typed import ColumnDef, BuiltinType\n'
+        '\n'
+        'def create():\n'
+        '    schema.create_table(\n'
+        '        Table.define_association(\n'
+        '            associates=[\n'
+        '                ("Execution", execution_table),\n'
+        '                ("Nested_Execution", execution_table),\n'
+        '            ],\n'
+        '            metadata=[\n'
+        '                ColumnDef(name="Sequence", type="int4", nullok=True),\n'
+        '            ],\n'
+        '        )\n'
+        '    )\n'
+    )
+    model = load_from_code(fixture)
+    assert len(model.tables) == 1
+    t = model.tables[0]
+    assert t.kind == "association"
+    # Name isn't given directly; derived from the associates pair.
+    # We expect "Execution_Nested_Execution" as the default-constructed name.
+    assert t.name == "Execution_Nested_Execution"
+    assert [a.table for a in t.associates] == ["Execution", "Nested_Execution"]
+    assert [m.name for m in t.metadata] == ["Sequence"]
+```
+
+**Note**: `Table.define_association` is actually a factory method from deriva-py that returns a `TableDef` with a derived name. We can't know the derived name without executing code. Two options:
+
+(a) Have the test fixture and the doc agree that association-table names are derived as `"{assoc1}_{assoc2}"` (the common convention used by define_association). Document this as a convention.
+
+(b) Require an explicit `name=` kwarg on the `Table.define_association(...)` call in the doc comparison context. Since the underlying code doesn't pass `name=`, the validator derives the name from `associates`.
+
+Going with (a) — simpler and matches deriva-py's actual behavior. Most cases pass an explicit pair like `("Dataset", dataset_table), ("Dataset_Type", dataset_type)` and the library builds `"Dataset_Dataset_Type"` from them.
+
+- [ ] **Step 2: Run to verify failure**
+
+```bash
+DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/tools/test_validate_schema_doc.py::test_load_from_code_association_table -v
+```
+
+Expected: FAIL — association not extracted yet.
+
+- [ ] **Step 3: Extend `load_from_code` for associations**
+
+In `src/deriva_ml/tools/validate_schema_doc.py`:
+
+```python
+def _extract_association(node: ast.Call) -> TableModel:
+    """Extract Table.define_association(associates=[...], metadata=[...])."""
+    associates: list[AssociationEndpointModel] = []
+    metadata: list[ColumnModel] = []
+    for kw in node.keywords:
+        if kw.arg == "associates":
+            if not isinstance(kw.value, ast.List):
+                raise SchemaCodeError(
+                    f"define_association associates must be a list, got "
+                    f"{ast.dump(kw.value)}"
+                )
+            for elt in kw.value.elts:
+                if not isinstance(elt, ast.Tuple) or len(elt.elts) < 1:
+                    raise SchemaCodeError(
+                        f"associates entry must be a tuple (name, table), got "
+                        f"{ast.dump(elt)}"
+                    )
+                table_name = _extract_ast_name_or_enum(elt.elts[0])
+                associates.append(AssociationEndpointModel(table=table_name))
+        elif kw.arg == "metadata":
+            if isinstance(kw.value, ast.List):
+                for m_elt in kw.value.elts:
+                    if isinstance(m_elt, ast.Call) and _callable_name(m_elt) == "ColumnDef":
+                        metadata.append(_extract_column(m_elt))
+    # Association name: derived from associates — '{first}_{second}'.
+    derived_name = "_".join(a.table for a in associates)
+    return TableModel(
+        name=derived_name,
+        kind="association",
+        associates=associates,
+        metadata=metadata,
+    )
+```
+
+Add a branch in `load_from_code`'s walker:
+
+```python
+elif name == "Table.define_association":
+    tables.append(_extract_association(node))
+```
+
+Place this branch alongside the TableDef / VocabularyTableDef branches.
+
+- [ ] **Step 4: Run tests**
+
+```bash
+DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/tools/test_validate_schema_doc.py -v
+```
+
+Expected: all PASS (C1-C4 plus earlier).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/deriva_ml/tools/validate_schema_doc.py tests/tools/test_validate_schema_doc.py
+git commit -m "$(cat <<'EOF'
+feat(tools): load_from_code handles Table.define_association
+
+Extracts association-table definitions. The derived name follows
+deriva-py's convention: '{first_associate}_{second_associate}'.
+Metadata columns are extracted as ColumnModels.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task Group D — `diff_schemas` comparator
+
+Compare two `SchemaModel` instances; emit a list of typed mismatches. No I/O.
+
+### Task D1: `Mismatch` dataclass + empty-diff case
+
+**Files:**
+- Modify: `src/deriva_ml/tools/validate_schema_doc.py`
+- Modify: `tests/tools/test_validate_schema_doc.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `tests/tools/test_validate_schema_doc.py`:
+
+```python
+def test_mismatch_dataclass_fields():
+    from deriva_ml.tools.validate_schema_doc import Mismatch, MismatchKind
+    m = Mismatch(
+        kind=MismatchKind.MISSING_TABLE,
+        table="Execution_Status",
+        detail="declared in doc but not in code",
+    )
+    assert m.kind == MismatchKind.MISSING_TABLE
+    assert m.table == "Execution_Status"
+
+
+def test_diff_identical_schemas_empty():
+    from deriva_ml.tools.validate_schema_doc import (
+        ColumnModel,
+        SchemaModel,
+        TableModel,
+        diff_schemas,
+    )
+    s1 = SchemaModel(tables=[
+        TableModel(
+            name="Dataset",
+            kind="table",
+            columns=[ColumnModel(name="Name", type="text")],
+        ),
+    ])
+    s2 = SchemaModel(tables=[
+        TableModel(
+            name="Dataset",
+            kind="table",
+            columns=[ColumnModel(name="Name", type="text")],
+        ),
+    ])
+    assert diff_schemas(expected=s1, actual=s2) == []
+```
+
+- [ ] **Step 2: Run to verify failures**
+
+```bash
+DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/tools/test_validate_schema_doc.py -v -k "Mismatch or identical"
+```
+
+Expected: FAIL with ImportError.
+
+- [ ] **Step 3: Implement Mismatch + empty diff**
+
+Append to `src/deriva_ml/tools/validate_schema_doc.py`:
+
+```python
+@dataclass(frozen=True)
+class Mismatch:
+    """One discrepancy between expected and actual schemas."""
+    kind: "MismatchKind"
+    table: str | None
+    detail: str
+
+
+def diff_schemas(*, expected: SchemaModel, actual: SchemaModel) -> list[Mismatch]:
+    """Compare two schemas; return list of Mismatches.
+
+    Args:
+        expected: The "expected" schema — typically the doc side.
+        actual: The "actual" schema — typically the code side.
+
+    Returns:
+        Empty list if schemas match. Otherwise one Mismatch per discrepancy.
+    """
+    mismatches: list[Mismatch] = []
+    expected_tables = {t.name: t for t in expected.tables}
+    actual_tables = {t.name: t for t in actual.tables}
+
+    # Missing from actual (in doc but not in code).
+    for name in sorted(expected_tables.keys() - actual_tables.keys()):
+        mismatches.append(Mismatch(
+            kind=MismatchKind.MISSING_TABLE,
+            table=name,
+            detail=f"table {name!r} is in the doc but not in the code",
+        ))
+    # Extra in actual (in code but not in doc).
+    for name in sorted(actual_tables.keys() - expected_tables.keys()):
+        mismatches.append(Mismatch(
+            kind=MismatchKind.EXTRA_TABLE,
+            table=name,
+            detail=f"table {name!r} is in the code but not in the doc",
+        ))
+    # Tables in both: D2-D4 extend this loop.
+    for name in sorted(expected_tables.keys() & actual_tables.keys()):
+        _compare_tables(mismatches, expected_tables[name], actual_tables[name])
+    return mismatches
+
+
+def _compare_tables(
+    mismatches: list[Mismatch],
+    expected: TableModel,
+    actual: TableModel,
+) -> None:
+    """Compare two same-named TableModels; append any differences."""
+    # D2-D4 populate this. Skeleton only for D1.
+    pass
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/tools/test_validate_schema_doc.py -v -k "Mismatch or identical"
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/deriva_ml/tools/validate_schema_doc.py tests/tools/test_validate_schema_doc.py
+git commit -m "$(cat <<'EOF'
+feat(tools): diff_schemas skeleton — Mismatch dataclass + missing/extra table
+
+Empty-diff case works: two identical SchemaModels return []. Missing
+tables (doc-only) and extra tables (code-only) emit Mismatches.
+Per-table column/FK/term comparison comes in D2-D4.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task D2: Compare columns (name + type)
+
+**Files:**
+- Modify: `src/deriva_ml/tools/validate_schema_doc.py`
+- Modify: `tests/tools/test_validate_schema_doc.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `tests/tools/test_validate_schema_doc.py`:
+
+```python
+def test_diff_column_missing_in_actual():
+    from deriva_ml.tools.validate_schema_doc import (
+        ColumnModel, MismatchKind, SchemaModel, TableModel, diff_schemas,
+    )
+    expected = SchemaModel(tables=[TableModel(
+        name="Dataset", kind="table",
+        columns=[ColumnModel(name="Name", type="text"), ColumnModel(name="Extra", type="text")],
+    )])
+    actual = SchemaModel(tables=[TableModel(
+        name="Dataset", kind="table",
+        columns=[ColumnModel(name="Name", type="text")],
+    )])
+    mismatches = diff_schemas(expected=expected, actual=actual)
+    assert len(mismatches) == 1
+    assert mismatches[0].kind == MismatchKind.COLUMN_MISMATCH
+    assert "Extra" in mismatches[0].detail
+
+
+def test_diff_column_type_mismatch():
+    from deriva_ml.tools.validate_schema_doc import (
+        ColumnModel, MismatchKind, SchemaModel, TableModel, diff_schemas,
+    )
+    expected = SchemaModel(tables=[TableModel(
+        name="Dataset", kind="table",
+        columns=[ColumnModel(name="Name", type="text")],
+    )])
+    actual = SchemaModel(tables=[TableModel(
+        name="Dataset", kind="table",
+        columns=[ColumnModel(name="Name", type="markdown")],
+    )])
+    mismatches = diff_schemas(expected=expected, actual=actual)
+    assert any(
+        m.kind == MismatchKind.COLUMN_MISMATCH
+        and "text" in m.detail and "markdown" in m.detail
+        for m in mismatches
+    )
+```
+
+- [ ] **Step 2: Run to verify failures**
+
+Expected: FAIL — `_compare_tables` is a pass-through currently.
+
+- [ ] **Step 3: Populate column comparison in `_compare_tables`**
+
+Modify `_compare_tables` in `src/deriva_ml/tools/validate_schema_doc.py`:
+
+```python
+def _compare_tables(
+    mismatches: list[Mismatch],
+    expected: TableModel,
+    actual: TableModel,
+) -> None:
+    """Compare two same-named TableModels; append any differences."""
+    _compare_columns(mismatches, expected, actual)
+    # D3 adds _compare_fks; D4 adds _compare_terms / _compare_associates.
+
+
+def _compare_columns(
+    mismatches: list[Mismatch],
+    expected: TableModel,
+    actual: TableModel,
+) -> None:
+    """Column-by-column diff."""
+    expected_cols = {c.name: c for c in expected.columns}
+    actual_cols = {c.name: c for c in actual.columns}
+    for col_name in sorted(expected_cols.keys() - actual_cols.keys()):
+        mismatches.append(Mismatch(
+            kind=MismatchKind.COLUMN_MISMATCH,
+            table=expected.name,
+            detail=f"column {col_name!r} in doc but not in code",
+        ))
+    for col_name in sorted(actual_cols.keys() - expected_cols.keys()):
+        mismatches.append(Mismatch(
+            kind=MismatchKind.COLUMN_MISMATCH,
+            table=expected.name,
+            detail=f"column {col_name!r} in code but not in doc",
+        ))
+    for col_name in sorted(expected_cols.keys() & actual_cols.keys()):
+        exp_c = expected_cols[col_name]
+        act_c = actual_cols[col_name]
+        if exp_c.type != act_c.type:
+            mismatches.append(Mismatch(
+                kind=MismatchKind.COLUMN_MISMATCH,
+                table=expected.name,
+                detail=(
+                    f"column {col_name!r}: doc type {exp_c.type!r} "
+                    f"vs code type {act_c.type!r}"
+                ),
+            ))
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/tools/test_validate_schema_doc.py -v
+```
+
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/deriva_ml/tools/validate_schema_doc.py tests/tools/test_validate_schema_doc.py
+git commit -m "$(cat <<'EOF'
+feat(tools): diff_schemas — column name + type comparison
+
+_compare_columns yields COLUMN_MISMATCH Mismatches for columns
+present in one model but not the other, or present in both with
+differing types.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task D3: Compare FKs
+
+**Files:**
+- Modify: `src/deriva_ml/tools/validate_schema_doc.py`
+- Modify: `tests/tools/test_validate_schema_doc.py`
+
+- [ ] **Step 1: Write failing test**
+
+Append to `tests/tools/test_validate_schema_doc.py`:
+
+```python
+def test_diff_fk_target_mismatch():
+    from deriva_ml.tools.validate_schema_doc import (
+        ColumnModel, ForeignKeyModel, MismatchKind, SchemaModel, TableModel, diff_schemas,
+    )
+    expected = SchemaModel(tables=[TableModel(
+        name="Execution", kind="table",
+        columns=[ColumnModel(name="Workflow", type="text")],
+        foreign_keys=[ForeignKeyModel(
+            columns=["Workflow"],
+            referenced_schema="deriva-ml",
+            referenced_table="Workflow",
+            referenced_columns=["RID"],
+        )],
+    )])
+    actual = SchemaModel(tables=[TableModel(
+        name="Execution", kind="table",
+        columns=[ColumnModel(name="Workflow", type="text")],
+        foreign_keys=[ForeignKeyModel(
+            columns=["Workflow"],
+            referenced_schema="deriva-ml",
+            referenced_table="SomeOtherTable",
+            referenced_columns=["RID"],
+        )],
+    )])
+    mismatches = diff_schemas(expected=expected, actual=actual)
+    assert any(m.kind == MismatchKind.FK_MISMATCH for m in mismatches)
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Expected: FAIL — FK comparison not implemented.
+
+- [ ] **Step 3: Add FK comparison**
+
+In `src/deriva_ml/tools/validate_schema_doc.py`:
+
+```python
+def _compare_fks(
+    mismatches: list[Mismatch],
+    expected: TableModel,
+    actual: TableModel,
+) -> None:
+    """FK comparison — by tuple (columns, referenced_table, referenced_columns).
+
+    FKs are matched by their source columns tuple. If a doc FK and a code
+    FK share columns, their referenced_* must match.
+    """
+    def key(fk: ForeignKeyModel) -> tuple[str, ...]:
+        return tuple(fk.columns)
+
+    expected_fks = {key(fk): fk for fk in expected.foreign_keys}
+    actual_fks = {key(fk): fk for fk in actual.foreign_keys}
+
+    for k in sorted(expected_fks.keys() - actual_fks.keys()):
+        fk = expected_fks[k]
+        mismatches.append(Mismatch(
+            kind=MismatchKind.FK_MISMATCH,
+            table=expected.name,
+            detail=f"FK on {list(k)} in doc but not in code",
+        ))
+    for k in sorted(actual_fks.keys() - expected_fks.keys()):
+        fk = actual_fks[k]
+        mismatches.append(Mismatch(
+            kind=MismatchKind.FK_MISMATCH,
+            table=expected.name,
+            detail=f"FK on {list(k)} in code but not in doc",
+        ))
+    for k in sorted(expected_fks.keys() & actual_fks.keys()):
+        exp_fk = expected_fks[k]
+        act_fk = actual_fks[k]
+        if (exp_fk.referenced_schema, exp_fk.referenced_table, tuple(exp_fk.referenced_columns)) != (
+            act_fk.referenced_schema, act_fk.referenced_table, tuple(act_fk.referenced_columns)
+        ):
+            mismatches.append(Mismatch(
+                kind=MismatchKind.FK_MISMATCH,
+                table=expected.name,
+                detail=(
+                    f"FK on {list(k)} differs: "
+                    f"doc → {exp_fk.referenced_schema}.{exp_fk.referenced_table}{exp_fk.referenced_columns}; "
+                    f"code → {act_fk.referenced_schema}.{act_fk.referenced_table}{act_fk.referenced_columns}"
+                ),
+            ))
+```
+
+Extend `_compare_tables` to call `_compare_fks`:
+
+```python
+def _compare_tables(
+    mismatches: list[Mismatch],
+    expected: TableModel,
+    actual: TableModel,
+) -> None:
+    _compare_columns(mismatches, expected, actual)
+    _compare_fks(mismatches, expected, actual)
+    # D4 adds _compare_terms / _compare_associates.
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/tools/test_validate_schema_doc.py -v
+```
+
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/deriva_ml/tools/validate_schema_doc.py tests/tools/test_validate_schema_doc.py
+git commit -m "$(cat <<'EOF'
+feat(tools): diff_schemas — FK comparison by column tuple + target
+
+_compare_fks matches FKs by their source-column tuple. Emits
+FK_MISMATCH for presence differences and for shared-key differences
+in referenced_schema/table/columns.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task D4: Compare vocabulary terms + associations
+
+**Files:**
+- Modify: `src/deriva_ml/tools/validate_schema_doc.py`
+- Modify: `tests/tools/test_validate_schema_doc.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `tests/tools/test_validate_schema_doc.py`:
+
+```python
+def test_diff_vocab_terms_differ():
+    from deriva_ml.tools.validate_schema_doc import (
+        MismatchKind, SchemaModel, TableModel, VocabularyTermModel, diff_schemas,
+    )
+    expected = SchemaModel(tables=[TableModel(
+        name="Asset_Type",
+        kind="vocabulary",
+        terms=[
+            VocabularyTermModel(name="Execution_Config"),
+            VocabularyTermModel(name="Extra_DocOnly_Term"),
+        ],
+    )])
+    actual = SchemaModel(tables=[TableModel(
+        name="Asset_Type",
+        kind="vocabulary",
+        terms=[
+            VocabularyTermModel(name="Execution_Config"),
+            VocabularyTermModel(name="Extra_CodeOnly_Term"),
+        ],
+    )])
+    mismatches = diff_schemas(expected=expected, actual=actual)
+    assert any(
+        m.kind == MismatchKind.VOCAB_TERMS_MISMATCH
+        and "Extra_DocOnly_Term" in m.detail
+        and "Extra_CodeOnly_Term" in m.detail
+        for m in mismatches
+    )
+
+
+def test_diff_association_endpoints_differ():
+    from deriva_ml.tools.validate_schema_doc import (
+        AssociationEndpointModel, MismatchKind, SchemaModel, TableModel, diff_schemas,
+    )
+    expected = SchemaModel(tables=[TableModel(
+        name="Dataset_Execution",
+        kind="association",
+        associates=[
+            AssociationEndpointModel(table="Dataset"),
+            AssociationEndpointModel(table="Execution"),
+        ],
+    )])
+    actual = SchemaModel(tables=[TableModel(
+        name="Dataset_Execution",
+        kind="association",
+        associates=[
+            AssociationEndpointModel(table="Dataset"),
+            AssociationEndpointModel(table="Workflow"),  # differs
+        ],
+    )])
+    mismatches = diff_schemas(expected=expected, actual=actual)
+    assert any(m.kind == MismatchKind.ASSOCIATION_MISMATCH for m in mismatches)
+```
+
+- [ ] **Step 2: Run to verify failures**
+
+Expected: FAIL.
+
+- [ ] **Step 3: Add vocab + associates comparison**
+
+In `src/deriva_ml/tools/validate_schema_doc.py`:
+
+```python
+def _compare_terms(
+    mismatches: list[Mismatch],
+    expected: TableModel,
+    actual: TableModel,
+) -> None:
+    """Compare vocabulary seeded terms (by Name)."""
+    expected_terms = {t.name for t in expected.terms}
+    actual_terms = {t.name for t in actual.terms}
+    if expected_terms != actual_terms:
+        doc_only = sorted(expected_terms - actual_terms)
+        code_only = sorted(actual_terms - expected_terms)
+        mismatches.append(Mismatch(
+            kind=MismatchKind.VOCAB_TERMS_MISMATCH,
+            table=expected.name,
+            detail=f"doc-only: {doc_only}; code-only: {code_only}",
+        ))
+
+
+def _compare_associates(
+    mismatches: list[Mismatch],
+    expected: TableModel,
+    actual: TableModel,
+) -> None:
+    """Compare association-table endpoints (by table name)."""
+    expected_assoc = [a.table for a in expected.associates]
+    actual_assoc = [a.table for a in actual.associates]
+    if expected_assoc != actual_assoc:
+        mismatches.append(Mismatch(
+            kind=MismatchKind.ASSOCIATION_MISMATCH,
+            table=expected.name,
+            detail=f"associates doc {expected_assoc} vs code {actual_assoc}",
+        ))
+```
+
+Extend `_compare_tables`:
+
+```python
+def _compare_tables(
+    mismatches: list[Mismatch],
+    expected: TableModel,
+    actual: TableModel,
+) -> None:
+    _compare_columns(mismatches, expected, actual)
+    _compare_fks(mismatches, expected, actual)
+    if expected.kind == "vocabulary" or actual.kind == "vocabulary":
+        _compare_terms(mismatches, expected, actual)
+    if expected.kind == "association" or actual.kind == "association":
+        _compare_associates(mismatches, expected, actual)
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/tools/test_validate_schema_doc.py -v
+```
+
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/deriva_ml/tools/validate_schema_doc.py tests/tools/test_validate_schema_doc.py
+git commit -m "$(cat <<'EOF'
+feat(tools): diff_schemas — vocabulary terms + association endpoints
+
+_compare_terms emits VOCAB_TERMS_MISMATCH with doc-only and code-only
+term-name sets. _compare_associates compares associate-table-name
+sequences; emits ASSOCIATION_MISMATCH on any divergence.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task Group E — CLI entry point + output format
+
+### Task E1: CLI `main(argv)` function
+
+**Files:**
+- Modify: `src/deriva_ml/tools/validate_schema_doc.py`
+- Modify: `tests/tools/test_validate_schema_doc.py`
+
+- [ ] **Step 1: Write failing test**
+
+Append to `tests/tools/test_validate_schema_doc.py`:
+
+```python
+def test_cli_match_returns_0(tmp_path, capsys):
+    """Identical schemas: exit 0, success message."""
+    from deriva_ml.tools.validate_schema_doc import main
+
+    doc = tmp_path / "schema.md"
+    doc.write_text(
+        "```yaml\n"
+        "table: X\n"
+        "kind: table\n"
+        "columns: []\n"
+        "foreign_keys: []\n"
+        "```\n"
+    )
+    code = tmp_path / "code.py"
+    code.write_text(
+        'from deriva.core.typed import TableDef\n'
+        'schema.create_table(TableDef(name="X", columns=[], foreign_keys=[]))\n'
+    )
+
+    exit_code = main(["--doc", str(doc), "--code", str(code)])
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "agree" in captured.out
+
+
+def test_cli_mismatch_returns_1(tmp_path, capsys):
+    """Divergent schemas: exit 1, mismatch lines."""
+    from deriva_ml.tools.validate_schema_doc import main
+
+    doc = tmp_path / "schema.md"
+    doc.write_text(
+        "```yaml\n"
+        "table: X\n"
+        "kind: table\n"
+        "columns:\n"
+        "  - name: A\n"
+        "    type: text\n"
+        "foreign_keys: []\n"
+        "```\n"
+    )
+    code = tmp_path / "code.py"
+    code.write_text(
+        'from deriva.core.typed import TableDef, ColumnDef, BuiltinType\n'
+        'schema.create_table(TableDef(\n'
+        '    name="X",\n'
+        '    columns=[ColumnDef("B", BuiltinType.text)],\n'
+        '    foreign_keys=[],\n'
+        '))\n'
+    )
+
+    exit_code = main(["--doc", str(doc), "--code", str(code)])
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "COLUMN MISMATCH" in captured.out or "column" in captured.out.lower()
+
+
+def test_cli_parse_error_returns_2(tmp_path, capsys):
+    """Malformed doc: exit 2."""
+    from deriva_ml.tools.validate_schema_doc import main
+
+    doc = tmp_path / "schema.md"
+    doc.write_text(
+        "```yaml\n"
+        "table: X\n"
+        "kind: invalid-kind\n"
+        "```\n"
+    )
+    code = tmp_path / "code.py"
+    code.write_text("")
+
+    exit_code = main(["--doc", str(doc), "--code", str(code)])
+    assert exit_code == 2
+```
+
+- [ ] **Step 2: Run to verify failures**
+
+Expected: FAIL — `main` not defined.
+
+- [ ] **Step 3: Implement `main` + formatted output**
+
+Append to `src/deriva_ml/tools/validate_schema_doc.py`:
+
+```python
+import argparse
+import sys
+from collections import defaultdict
+
+
+def _format_mismatches(mismatches: list[Mismatch]) -> str:
+    """Render mismatches in the §5.5 format."""
+    if not mismatches:
+        return "deriva-ml-validate-schema: schema.md and create_schema.py agree.\n"
+
+    buckets: dict[MismatchKind, list[Mismatch]] = defaultdict(list)
+    for m in mismatches:
+        buckets[m.kind].append(m)
+
+    lines = [
+        "deriva-ml-validate-schema: schema.md and create_schema.py disagree.",
+        "",
+    ]
+
+    def add_section(title: str, kind: MismatchKind) -> None:
+        lines.append(f"{title}:")
+        if kind in buckets:
+            for m in buckets[kind]:
+                lines.append(f"  - {m.detail}")
+        else:
+            lines.append("  (none)")
+        lines.append("")
+
+    add_section("MISSING FROM CODE", MismatchKind.MISSING_TABLE)
+    add_section("EXTRA IN CODE", MismatchKind.EXTRA_TABLE)
+    add_section("COLUMN MISMATCH", MismatchKind.COLUMN_MISMATCH)
+    add_section("FOREIGN KEY MISMATCH", MismatchKind.FK_MISMATCH)
+    add_section("VOCABULARY TERMS MISMATCH", MismatchKind.VOCAB_TERMS_MISMATCH)
+    add_section("ASSOCIATION MISMATCH", MismatchKind.ASSOCIATION_MISMATCH)
+    return "\n".join(lines)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="deriva-ml-validate-schema",
+        description=(
+            "Validate that docs/reference/schema.md and "
+            "src/deriva_ml/schema/create_schema.py agree on tables, "
+            "columns, foreign keys, and vocabulary seeded terms."
+        ),
+    )
+    p.add_argument(
+        "--doc",
+        default="docs/reference/schema.md",
+        help="Path to the schema doc (default: docs/reference/schema.md).",
+    )
+    p.add_argument(
+        "--code",
+        default="src/deriva_ml/schema/create_schema.py",
+        help="Path to create_schema.py (default: src/deriva_ml/schema/create_schema.py).",
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point: compare doc vs code.
+
+    Returns:
+        0 if schemas agree.
+        1 if they differ.
+        2 if parsing failed on either side.
+    """
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        expected = load_from_doc(Path(args.doc))
+    except (SchemaDocError, FileNotFoundError) as exc:
+        print(f"error loading doc: {exc}", file=sys.stderr)
+        return 2
+
+    try:
+        actual = load_from_code(Path(args.code))
+    except (SchemaCodeError, FileNotFoundError) as exc:
+        print(f"error loading code: {exc}", file=sys.stderr)
+        return 2
+
+    mismatches = diff_schemas(expected=expected, actual=actual)
+    print(_format_mismatches(mismatches))
+    return 1 if mismatches else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/tools/test_validate_schema_doc.py -v
+```
+
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/deriva_ml/tools/validate_schema_doc.py tests/tools/test_validate_schema_doc.py
+git commit -m "$(cat <<'EOF'
+feat(tools): main() CLI — exit codes 0/1/2, formatted mismatch output
+
+main(argv) parses --doc and --code args (default to production paths),
+runs load_from_doc + load_from_code + diff_schemas, prints either the
+'agree' single-liner or the bucketed mismatch report. Exit codes
+0 (match), 1 (mismatch), 2 (parse error).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task E2: Register `deriva-ml-validate-schema` entry point
+
+**Files:**
+- Modify: `pyproject.toml`
+
+- [ ] **Step 1: Read the current scripts section**
+
+```bash
+grep -B1 -A15 "\[project\.scripts\]" pyproject.toml
+```
+
+- [ ] **Step 2: Add the new entry**
+
+Append to the `[project.scripts]` section (matching existing `deriva-ml-*` naming):
+
+```toml
+deriva-ml-validate-schema = "deriva_ml.tools.validate_schema_doc:main"
+```
+
+Place it alphabetically with the others (after `deriva-ml-upload`).
+
+- [ ] **Step 3: Verify the entry is usable via `uv run`**
+
+```bash
+DERIVA_ML_ALLOW_DIRTY=true uv run python -m deriva_ml.tools.validate_schema_doc --help
+```
+
+Expected: argparse `--help` output listing `--doc` and `--code` flags.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add pyproject.toml
+git commit -m "$(cat <<'EOF'
+build(scripts): register deriva-ml-validate-schema entry point
+
+The schema-doc validator is now runnable as a first-class CLI via the
+project's [project.scripts] section.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task E3: `SchemaModel.to_doc_markdown()` helper for bootstrap
+
+**Files:**
+- Modify: `src/deriva_ml/tools/validate_schema_doc.py`
+- Modify: `tests/tools/test_validate_schema_doc.py`
+
+Per spec §8: ship a helper that renders a `SchemaModel` to the doc Markdown format. Used for the F1 bootstrap and as an "emergency regenerate from code" tool.
+
+- [ ] **Step 1: Write failing test**
+
+Append to `tests/tools/test_validate_schema_doc.py`:
+
+```python
+def test_to_doc_markdown_roundtrip(tmp_path):
+    """A SchemaModel rendered to Markdown can be loaded back losslessly."""
+    from deriva_ml.tools.validate_schema_doc import (
+        AssociationEndpointModel, ColumnModel, ForeignKeyModel,
+        SchemaModel, TableModel, VocabularyTermModel,
+        load_from_doc, to_doc_markdown,
+    )
+    original = SchemaModel(tables=[
+        TableModel(
+            name="Dataset",
+            kind="table",
+            columns=[ColumnModel(name="Name", type="text")],
+            foreign_keys=[],
+        ),
+        TableModel(
+            name="Workflow_Type",
+            kind="vocabulary",
+            terms=[VocabularyTermModel(name="Training")],
+        ),
+        TableModel(
+            name="Dataset_Dataset_Type",
+            kind="association",
+            associates=[
+                AssociationEndpointModel(table="Dataset"),
+                AssociationEndpointModel(table="Dataset_Type"),
+            ],
+        ),
+    ])
+    md = to_doc_markdown(original)
+    doc = tmp_path / "schema.md"
+    doc.write_text(md)
+    roundtripped = load_from_doc(doc)
+
+    assert len(roundtripped.tables) == 3
+    assert [t.name for t in roundtripped.tables] == [
+        "Dataset", "Workflow_Type", "Dataset_Dataset_Type",
+    ]
+    assert roundtripped.tables[0].columns[0].name == "Name"
+    assert roundtripped.tables[1].terms[0].name == "Training"
+    assert roundtripped.tables[2].associates[0].table == "Dataset"
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Expected: FAIL — `to_doc_markdown` not defined.
+
+- [ ] **Step 3: Implement `to_doc_markdown`**
+
+Append to `src/deriva_ml/tools/validate_schema_doc.py`:
+
+```python
+def to_doc_markdown(model: SchemaModel) -> str:
+    """Render a SchemaModel to the docs/reference/schema.md format.
+
+    Used for bootstrap (generate an initial doc from the code) and for
+    emergency regeneration. The output is round-trip identical with
+    load_from_doc.
+
+    Args:
+        model: SchemaModel instance.
+
+    Returns:
+        Multi-section Markdown string.
+    """
+    sections: list[str] = []
+    for t in model.tables:
+        header = f"## {t.name}\n"
+        yaml_body: dict = {
+            "table": t.name,
+            "kind": t.kind,
+        }
+        if t.columns:
+            yaml_body["columns"] = [
+                {"name": c.name, "type": c.type} for c in t.columns
+            ]
+        if t.foreign_keys:
+            yaml_body["foreign_keys"] = [
+                {
+                    "columns": list(fk.columns),
+                    "referenced_schema": fk.referenced_schema,
+                    "referenced_table": fk.referenced_table,
+                    "referenced_columns": list(fk.referenced_columns),
+                }
+                for fk in t.foreign_keys
+            ]
+        elif t.kind == "table":
+            yaml_body["foreign_keys"] = []
+        if t.terms:
+            yaml_body["terms"] = [{"name": term.name} for term in t.terms]
+        if t.associates:
+            yaml_body["associates"] = [
+                {"table": a.table} for a in t.associates
+            ]
+        if t.metadata:
+            yaml_body["metadata"] = [
+                {"name": m.name, "type": m.type} for m in t.metadata
+            ]
+        yaml_text = yaml.safe_dump(
+            yaml_body, sort_keys=False, default_flow_style=False,
+        )
+        block = "```yaml\n" + yaml_text + "```\n"
+        sections.append(header + "\n" + block)
+    return "\n".join(sections)
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/tools/test_validate_schema_doc.py -v
+```
+
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/deriva_ml/tools/validate_schema_doc.py tests/tools/test_validate_schema_doc.py
+git commit -m "$(cat <<'EOF'
+feat(tools): to_doc_markdown — render SchemaModel back to Markdown
+
+Used by the F1 bootstrap task and as an emergency regeneration helper.
+Roundtrip through load_from_doc is lossless.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task Group F — Bootstrap the doc
+
+### Task F1: Generate initial `docs/reference/schema.md` from code
+
+**Files:**
+- Create: `docs/reference/schema.md`
+- Create: `docs/reference/README.md`
+
+- [ ] **Step 1: Generate the initial doc from the real `create_schema.py`**
+
+```bash
+mkdir -p docs/reference
+DERIVA_ML_ALLOW_DIRTY=true uv run python -c "
+from pathlib import Path
+from deriva_ml.tools.validate_schema_doc import load_from_code, to_doc_markdown
+
+model = load_from_code(Path('src/deriva_ml/schema/create_schema.py'))
+print(to_doc_markdown(model))
+" > docs/reference/schema.md
+```
+
+This produces a pure-generated doc with no prose. The validator should run clean against it.
+
+- [ ] **Step 2: Run validator against the generated doc**
+
+```bash
+DERIVA_ML_ALLOW_DIRTY=true uv run deriva-ml-validate-schema
+```
+
+Expected: `deriva-ml-validate-schema: schema.md and create_schema.py agree.` Exit 0.
+
+If mismatches appear, they fall into two buckets:
+
+1. **Validator bugs** — a pattern in `create_schema.py` the validator misparses. Fix the validator; re-generate.
+2. **Intentional code-side dynamic patterns** — e.g., f-strings in `curie_template` — these are out of scope per spec §2. Document in the doc's top-of-file narrative which code patterns are ignored.
+
+Iterate Step 1 + Step 2 until clean.
+
+- [ ] **Step 3: Hand-edit — add top-of-file prose**
+
+Prepend to `docs/reference/schema.md`:
+
+```markdown
+# deriva-ml Schema Reference
+
+This document is the authoritative description of the deriva-ml schema. It is kept in sync with `src/deriva_ml/schema/create_schema.py` by the `deriva-ml-validate-schema` CI check.
+
+## Editing this doc
+
+Schema changes are **doc-first** per Phase-2-Subsystem-0. To change the schema:
+
+1. Edit the relevant `## <Table>` section below (or add a new one).
+2. Edit `src/deriva_ml/schema/create_schema.py` to match.
+3. Run `uv run deriva-ml-validate-schema` locally to verify agreement.
+4. Commit both files together. CI re-runs the validator.
+
+## What is and isn't validated
+
+The validator enforces: **table names, columns (name + type), foreign keys, vocabulary seeded terms, and association-table endpoints.**
+
+The validator does NOT enforce: descriptions (narrative on both sides), ERMrest annotations (dynamic Python in the code), `curie_template` values (dynamic f-strings), indexes, or display configs. These may differ between doc and code without CI failure.
+
+See `docs/superpowers/specs/2026-04-21-schema-doc-source-of-truth-design.md` for the full rationale.
+
+## Table of contents
+
+(Ordered as: core entities, then vocabularies, then association tables.)
+
+---
+```
+
+- [ ] **Step 4: Hand-edit — add per-table descriptions**
+
+For each `## <Table>` section, add a short paragraph of description text between the header and the YAML block. Example:
+
+~~~markdown
+## Execution
+
+Per-execution lifecycle row. Created once per workflow run; status transitions through the Phase-1 state machine (`src/deriva_ml/execution/state_machine.py`).
+
+```yaml
+table: Execution
+kind: table
+...
+```
+~~~
+
+Do this for every table. Keep descriptions short (1-3 sentences). Avoid restating the YAML's structural content.
+
+- [ ] **Step 5: Verify validator still passes**
+
+```bash
+DERIVA_ML_ALLOW_DIRTY=true uv run deriva-ml-validate-schema
+```
+
+Expected: still clean (descriptions aren't validated).
+
+- [ ] **Step 6: Write `docs/reference/README.md`**
+
+Create `docs/reference/README.md`:
+
+```markdown
+# Reference docs
+
+## schema.md
+
+Authoritative description of the `deriva-ml` schema.
+
+To change the schema:
+
+1. Edit `schema.md` to describe the intended state.
+2. Edit `src/deriva_ml/schema/create_schema.py` to match.
+3. Run `uv run deriva-ml-validate-schema` locally.
+4. Commit both files together.
+
+See `schema.md` for what is and isn't validated.
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add docs/reference/
+git commit -m "$(cat <<'EOF'
+docs(reference): bootstrap schema.md from create_schema.py
+
+Initial generation via to_doc_markdown + hand-added prose and
+per-table descriptions. Validator runs clean.
+
+Adds docs/reference/README.md with the doc-first workflow instructions.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task F2: Doc-structure tests
+
+**Files:**
+- Create: `tests/tools/test_schema_doc_structure.py`
+
+- [ ] **Step 1: Write tests**
+
+Create `tests/tools/test_schema_doc_structure.py`:
+
+```python
+"""Structure tests for docs/reference/schema.md.
+
+These tests enforce invariants about the doc itself, separate from the
+doc-vs-code comparison:
+
+- Every MLTable and MLVocab enum member has a doc entry.
+- Every YAML block parses.
+- Tables are ordered: core entities → vocabularies → associations.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+DOC_PATH = Path(__file__).resolve().parent.parent.parent / "docs" / "reference" / "schema.md"
+
+
+def test_schema_doc_exists():
+    assert DOC_PATH.exists(), f"{DOC_PATH} does not exist"
+
+
+def test_schema_doc_yaml_blocks_all_valid():
+    """Every fenced YAML block parses as a dict."""
+    from deriva_ml.tools.validate_schema_doc import _extract_yaml_blocks
+    blocks = _extract_yaml_blocks(DOC_PATH)
+    assert len(blocks) > 0
+    for b in blocks:
+        assert isinstance(b, dict)
+        assert "table" in b
+        assert "kind" in b
+
+
+def test_schema_doc_has_entry_per_mltable_member():
+    """Every MLTable enum member appears as a table in the doc."""
+    from deriva_ml.core.enums import MLTable
+    from deriva_ml.tools.validate_schema_doc import load_from_doc
+
+    model = load_from_doc(DOC_PATH)
+    doc_names = {t.name for t in model.tables}
+    for member in MLTable:
+        assert member.value in doc_names, (
+            f"MLTable.{member.name} ({member.value!r}) is missing from "
+            f"{DOC_PATH.name}. Add a ## {member.value} section with a "
+            f"fenced yaml block."
+        )
+
+
+def test_schema_doc_has_entry_per_mlvocab_member():
+    """Every MLVocab enum member appears as a vocabulary table in the doc."""
+    from deriva_ml.core.enums import MLVocab
+    from deriva_ml.tools.validate_schema_doc import load_from_doc
+
+    model = load_from_doc(DOC_PATH)
+    vocab_names = {t.name for t in model.tables if t.kind == "vocabulary"}
+    for member in MLVocab:
+        assert member.value in vocab_names, (
+            f"MLVocab.{member.name} ({member.value!r}) is missing as a "
+            f"vocabulary table in {DOC_PATH.name}."
+        )
+```
+
+- [ ] **Step 2: Run**
+
+```bash
+DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/tools/test_schema_doc_structure.py -v
+```
+
+Expected: all PASS. If MLTable members are missing, F1's generated doc was incomplete — investigate (the generator may have skipped an AST pattern). Fix and regenerate.
+
+- [ ] **Step 3: Write the integration test for repo-scale validation**
+
+Create `tests/tools/test_validate_schema_doc_integration.py`:
+
+```python
+"""Integration tests — run the validator on the real repo files.
+
+If this test fails, docs/reference/schema.md has drifted from
+src/deriva_ml/schema/create_schema.py. Fix one or both.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+def test_validator_runs_clean_on_current_repo():
+    """The authoritative doc and code agree. This IS the CI gate."""
+    from deriva_ml.tools.validate_schema_doc import (
+        diff_schemas, load_from_code, load_from_doc,
+    )
+
+    doc_path = REPO_ROOT / "docs" / "reference" / "schema.md"
+    code_path = REPO_ROOT / "src" / "deriva_ml" / "schema" / "create_schema.py"
+
+    expected = load_from_doc(doc_path)
+    actual = load_from_code(code_path)
+    mismatches = diff_schemas(expected=expected, actual=actual)
+
+    assert mismatches == [], (
+        "schema.md and create_schema.py disagree:\n"
+        + "\n".join(f"  - {m.kind.value}: {m.detail}" for m in mismatches)
+    )
+
+
+def test_cli_exits_zero_on_current_repo():
+    """Invoking the CLI against the real paths returns exit 0."""
+    result = subprocess.run(
+        [sys.executable, "-m", "deriva_ml.tools.validate_schema_doc"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, (
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+    assert "agree" in result.stdout
+```
+
+- [ ] **Step 4: Run all tests**
+
+```bash
+DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/tools/ -v
+```
+
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/tools/test_schema_doc_structure.py tests/tools/test_validate_schema_doc_integration.py
+git commit -m "$(cat <<'EOF'
+test(tools): schema doc structure + integration tests
+
+test_schema_doc_structure.py asserts every MLTable / MLVocab enum
+member appears in the doc — catches 'added a table to the enum but
+forgot the doc.'
+
+test_validate_schema_doc_integration.py runs the full doc-vs-code
+diff on the real repo files. This IS the CI gate.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task Group G — CI workflow + CHANGELOG + final review
+
+### Task G1: Add GitHub Actions workflow
+
+**Files:**
+- Create: `.github/workflows/validate-schema.yml`
+
+- [ ] **Step 1: Write the workflow**
+
+Create `.github/workflows/validate-schema.yml`:
+
+```yaml
+name: Validate deriva-ml schema doc
+
+on:
+  pull_request:
+  push:
+    branches: [main, master]
+
+jobs:
+  validate-schema:
+    name: schema.md ↔ create_schema.py
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+      - name: Sync deps
+        run: uv sync
+      - name: Run validator
+        run: uv run deriva-ml-validate-schema
+```
+
+- [ ] **Step 2: Verify workflow locally with act (if available) or by lint-only**
+
+```bash
+# If actionlint is available:
+actionlint .github/workflows/validate-schema.yml 2>&1 || echo "actionlint not installed; skipping"
+# Or just visually review.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/validate-schema.yml
+git commit -m "$(cat <<'EOF'
+ci: add validate-schema workflow for every PR
+
+Runs uv run deriva-ml-validate-schema on each pull request and on
+pushes to main. Fails the build if docs/reference/schema.md and
+src/deriva_ml/schema/create_schema.py disagree.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task G2: CHANGELOG entry
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Insert new section**
+
+Near the top of `CHANGELOG.md`, above any existing Phase-2 entries:
+
+```markdown
+## Unreleased — Phase 2 Subsystem 0: Schema-doc source of truth
+
+### New
+
+- **`docs/reference/schema.md`** — authoritative description of the `deriva-ml` schema (tables, columns, FKs, vocabulary seeded terms). Edit this file **first** when changing the schema, then update `src/deriva_ml/schema/create_schema.py` to match.
+- **`deriva-ml-validate-schema`** CLI (`src/deriva_ml/tools/validate_schema_doc.py`) — asserts the doc and code agree on structure and seeded terms. Exit 0 on match, 1 on mismatch, 2 on parse error.
+- **CI workflow** `.github/workflows/validate-schema.yml` — runs the validator on every PR and push to main.
+- **`docs/reference/README.md`** — developer workflow instructions for doc-first schema changes.
+
+### Changed
+
+- Schema changes now **require editing two files together**: `docs/reference/schema.md` and `src/deriva_ml/schema/create_schema.py`. CI enforces they agree.
+
+### Not yet supported (filed follow-ups)
+
+- Direction 2: `deriva-ml-validate-schema --against=catalog` for live-catalog drift detection.
+- Description validation (table/column prose on doc vs `comment=` on code).
+- Annotation validation.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add CHANGELOG.md
+git commit -m "$(cat <<'EOF'
+docs(changelog): Phase 2 Subsystem 0 — schema-doc source of truth
+
+Announces the new doc-first workflow for schema changes, the
+deriva-ml-validate-schema CLI, and the CI workflow.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task G3: Final review + regression
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Full tool test run**
+
+```bash
+DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/tools/ -v
+```
+
+Expected: all PASS.
+
+- [ ] **Step 2: Verify the CLI runs clean**
+
+```bash
+DERIVA_ML_ALLOW_DIRTY=true uv run deriva-ml-validate-schema
+echo "exit=$?"
+```
+
+Expected: "agree" message, `exit=0`.
+
+- [ ] **Step 3: Regression across the rest of the suite**
+
+```bash
+DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/core/ tests/local_db/ -q 2>&1 | tail -5
+```
+
+Expected: no Phase-2-Subsystem-0-introduced regressions. (We haven't touched library code, only tools + docs.)
+
+- [ ] **Step 4: Ruff on new files**
+
+```bash
+uv run ruff check src/deriva_ml/tools/ tests/tools/
+```
+
+Expected: clean.
+
+- [ ] **Step 5: Dispatch a `superpowers:code-reviewer` subagent for final review**
+
+Per `superpowers:subagent-driven-development`:
+
+```
+Subagent: superpowers:code-reviewer
+Task: review the Phase 2 Subsystem 0 diff (commits A1 through G2) against
+spec docs/superpowers/specs/2026-04-21-schema-doc-source-of-truth-design.md.
+
+Check: spec coverage (§§1-11), Path-1 architecture correctness, validator
+behavior (structure-only per Q6/Q8), CI workflow shape, doc completeness.
+
+Report blockers, important issues, and nits. Implementer fixes blockers
+and important issues before merge.
+```
+
+- [ ] **Step 6: Address reviewer findings**
+
+Follow subagent-driven-development pattern: re-dispatch implementer for each fix, re-run reviewer until approved.
+
+- [ ] **Step 7: Finish branch**
+
+Once approved, invoke `superpowers:finishing-a-development-branch` to PR and merge.
+
+---
+
+*(End of Task Group G — Phase 2 Subsystem 0 complete.)*
+
+---
+
+## Deferred from spec
+
+- **Spec §6.3 test #18** (`test_schema_doc_table_order` — warn-not-fail on section-ordering violations): not implemented in this plan. Pytest's warn-not-fail semantics are fiddly, and the §4.1 ordering (core → vocab → association) is a readability convention that doesn't need CI enforcement. If the ordering drifts in practice, add this test as a follow-up.
+
+## Post-Subsystem-0
+
+After Subsystem 0 merges to main, resume **Subsystem 1 (status-enum reconciliation)**. The existing spec (`2026-04-21-status-enum-reconciliation-design.md`) is already written; the WIP plan (`2026-04-21-status-enum-reconciliation.md`) needs the following edits to reflect the Path-1 workflow:
+
+- Each task that modifies `src/deriva_ml/schema/create_schema.py` must also update `docs/reference/schema.md` in the same commit.
+- Subsystem 1's Q6 (vocab table shape — Execution_Status as a direct FK) is resolvable once Subsystem 0 merges: the schema doc's yaml shape for FK vs. association-table patterns is established, so the decision about Execution_Status becomes "which pattern does the doc describe?"
+
+Then: Subsystem 3 (upload engine), Subsystem 4 (hygiene), Subsystem 2 (feature-consistency, the real Phase 2).

--- a/docs/superpowers/specs/2026-04-21-schema-doc-source-of-truth-design.md
+++ b/docs/superpowers/specs/2026-04-21-schema-doc-source-of-truth-design.md
@@ -1,0 +1,345 @@
+# deriva-ml Schema Documentation — Source-of-Truth Design
+
+**Date:** 2026-04-21
+**Author:** Claude (with Carl)
+**Status:** Approved, ready for implementation-plan
+**Phase:** Phase 2, Subsystem 0 (of 5)
+**Related spec:** `2026-04-21-status-enum-reconciliation-design.md` (Subsystem 1; blocked on this)
+
+## 1. Motivation
+
+The `deriva-ml` schema (tables, columns, FKs, vocabulary terms) is defined programmatically in `src/deriva_ml/schema/create_schema.py`. That file is Python, executable at catalog-creation time via `create_ml_schema` / `initialize_ml_schema`. It is the authoritative source for what a freshly-created catalog contains.
+
+But there is no corresponding reviewable document describing the schema. The existing `docs/architecture.md` has a 5-row summary table and references `docs/assets/ERD.png` — an image that is 15+ months stale (last updated Jan 2025, well before Phase 1's SQLite-backed execution state and numerous other additions).
+
+Subsystem 1 (status-enum reconciliation) adds `Execution_Status` as a new vocabulary table. Reviewing that change, and every future schema change, is harder than it should be without a current-state reference.
+
+This spec establishes `docs/reference/schema.md` as the **authoritative document** for the `deriva-ml` schema structure and vocabulary seeding. A CI validator enforces that the document and `create_schema.py` agree.
+
+## 2. Decisions (from brainstorming)
+
+- **Path 1 (doc + code coexist, validator enforces agreement).** Both `docs/reference/schema.md` and `src/deriva_ml/schema/create_schema.py` are maintained by developers. The doc describes the intended schema; the code defines it at runtime. Neither is generated from the other. A validator asserts they match on structure and seeded terms.
+- **Scope**: `deriva-ml` schema only. Domain schemas (Subject, Image, test-schema, etc.) are user-defined and out of scope.
+- **Doc format**: single Markdown file `docs/reference/schema.md`, one section per table, with a fenced YAML block per section carrying the machine-readable structure.
+- **Validator scope**: enforces tables, columns (name + type), FKs, vocabulary seeded terms. Descriptions (both table-level and column-level) are narrative in the doc but NOT cross-validated against code comments. Annotations, display configs, indexes — skipped.
+- **When validation runs**: CI only. Local developers run `uv run deriva-ml-validate-schema` for faster feedback.
+- **Direction 1 ships (code ↔ doc)**; Direction 2 (doc ↔ live catalog) is a filed follow-up.
+
+## 3. Architecture
+
+The validator has three loaders producing one in-memory `SchemaModel` and one comparator:
+
+```
+  docs/reference/schema.md                                 schema.md ←→ create_schema.py
+      ├── Markdown sections per table                       [Direction 1, SHIPS NOW]
+      └── Fenced YAML blocks per section
+          │
+          ▼ load_from_doc(path) ─┐
+                                 │
+                                 │  ─────►  diff_schemas(expected, actual)
+                                 │              │
+  src/deriva_ml/schema/create_schema.py          ▼
+      ├── TableDef / VocabularyTableDef          list[Mismatch]
+      ├── ColumnDef / ForeignKeyDef              │
+      └── _ensure_terms(...)                     ▼
+          │                                   Exit 0 or 1
+          ▼ load_from_code(module) ─┘
+
+  (follow-up: load_from_catalog(catalog) for Direction 2)
+```
+
+All loaders produce the same `SchemaModel` shape. The comparator knows nothing about where the data came from.
+
+## 4. File layout
+
+### 4.1 `docs/reference/schema.md`
+
+Single Markdown file. Structure:
+
+- **Top-of-file prose** (~50-100 lines): overview, how to edit the doc + code together, schema-level invariants.
+- **Per-table sections**, ordered:
+  1. Core entity tables (Dataset, Execution, Workflow, Feature_Name, ...).
+  2. Vocabulary tables (Asset_Type, Dataset_Type, Workflow_Type, Execution_Status, ...).
+  3. Association tables (Dataset_Execution, Nested_Execution, ...).
+
+Each section:
+
+~~~markdown
+## Execution
+
+Per-execution lifecycle row. Created once per workflow run; updated as state transitions per Phase-1 spec §2.2.
+
+```yaml
+table: Execution
+kind: table
+description: Per-execution lifecycle row.
+columns:
+  - name: Workflow
+    type: text
+  - name: Description
+    type: markdown
+  - name: Duration
+    type: text
+  - name: Status
+    type: fk
+  - name: Status_Detail
+    type: text
+foreign_keys:
+  - columns: [Workflow]
+    referenced_schema: deriva-ml
+    referenced_table: Workflow
+    referenced_columns: [RID]
+  - columns: [Status]
+    referenced_schema: deriva-ml
+    referenced_table: Execution_Status
+    referenced_columns: [Name]
+```
+~~~
+
+Vocabulary tables also include a `terms:` list:
+
+~~~yaml
+table: Execution_Status
+kind: vocabulary
+description: Controlled vocabulary for Execution.Status lifecycle values.
+terms:
+  - name: Created
+  - name: Running
+  - name: Stopped
+  - name: Failed
+  - name: Pending_Upload
+  - name: Uploaded
+  - name: Aborted
+~~~
+
+Association tables have an `associates:` list:
+
+~~~yaml
+table: Nested_Execution
+kind: association
+description: Hierarchical execution nesting (parent → child).
+associates:
+  - table: Execution
+    role: parent
+  - table: Execution
+    role: child
+metadata:
+  - name: Sequence
+    type: int4
+    nullok: true
+~~~
+
+### 4.2 `tools/validate_schema_doc.py`
+
+Python module with:
+
+- `SchemaModel` dataclass (tables list).
+- `TableModel`, `ColumnModel`, `ForeignKeyModel`, `VocabularyTermModel`, `AssociationEndpointModel` sub-dataclasses.
+- `load_from_doc(path: Path) -> SchemaModel` — Markdown parser + YAML deserializer.
+- `load_from_code(module_path: Path) -> SchemaModel` — AST parser over `create_schema.py`.
+- `diff_schemas(expected: SchemaModel, actual: SchemaModel) -> list[Mismatch]` — comparator.
+- `Mismatch` dataclass with `kind`, `location`, `detail` fields.
+- `main(argv)` — CLI entry point.
+
+### 4.3 `pyproject.toml` entry point
+
+```toml
+[project.scripts]
+deriva-ml-validate-schema = "deriva_ml_tools.validate_schema_doc:main"
+```
+
+(Or similar path — consistent with existing `deriva-ml-*` scripts.)
+
+### 4.4 `.github/workflows/validate-schema.yml`
+
+GitHub Actions workflow (or step in existing test workflow):
+
+```yaml
+name: Validate deriva-ml schema doc
+on: [pull_request]
+jobs:
+  validate-schema:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+      - name: Run validator
+        run: uv run deriva-ml-validate-schema
+```
+
+### 4.5 `docs/reference/README.md`
+
+Short contributor doc explaining the doc-first workflow:
+
+```markdown
+# Reference docs
+
+`schema.md` is the authoritative description of the deriva-ml schema.
+To modify the schema:
+
+1. Edit `docs/reference/schema.md` to describe the intended state.
+2. Edit `src/deriva_ml/schema/create_schema.py` to match.
+3. Run `uv run deriva-ml-validate-schema` locally to verify agreement.
+4. Commit both files together. CI re-runs the validator.
+```
+
+## 5. Validator implementation
+
+### 5.1 `load_from_doc`
+
+Parse the Markdown. Find fenced code blocks with language `yaml`. Deserialize each block into a dict via `yaml.safe_load`. Build `SchemaModel` entries based on `table:` and `kind:` keys.
+
+Malformed YAML, missing required keys, unknown `kind:` → raise `SchemaDocError` with the Markdown line number. The CLI reports these as parse failures rather than mismatches.
+
+### 5.2 `load_from_code`
+
+AST-parse `create_schema.py` without executing it. Walk the tree looking for these call patterns:
+
+- `schema.create_table(TableDef(name=..., columns=[...], foreign_keys=[...]))` → table.
+- `schema.create_table(VocabularyTableDef(name=..., curie_template=...))` → vocab table.
+- `schema.create_table(Table.define_association(associates=[...], metadata=[...]))` → association table.
+- `_ensure_terms(vocab_name, [{"Name": ..., ...}, ...])` → seeded terms for a vocab.
+
+Enum references (`MLTable.execution`, `MLVocab.workflow_type`) are resolved by AST-parsing `src/deriva_ml/core/definitions.py` and building a `{enum_member: value}` lookup.
+
+Dynamic Python (f-strings in `curie_template`, conditional FKs, comprehensions building column lists) are intentionally out of scope. If a `ColumnDef(...)` or `ForeignKeyDef(...)` is inside a comprehension or conditional, the validator extracts it when the outer structure is still statically walkable; if not, it reports a `SchemaCodeError` with the code line number.
+
+### 5.3 `diff_schemas`
+
+Given expected (doc-side) and actual (code-side) `SchemaModel` instances:
+
+- For every table name in either: if present in both, recursively compare; if only in one, emit `MissingTable` mismatch.
+- For each table's columns: compare by name; mismatches on type emit `ColumnMismatch`.
+- For each table's FKs: compare by `(columns, referenced_table, referenced_columns)` tuple. Missing or extra FK → `ForeignKeyMismatch`.
+- For vocab tables: compare the set of `term.name` values. Symmetric difference → `VocabularyTermsMismatch`.
+- For association tables: compare `associates` endpoints (by target table name) and `metadata` columns.
+- Column/table descriptions skipped per §2.
+- Annotations, indexes, display configs skipped per §2.
+
+### 5.4 CLI
+
+```
+$ deriva-ml-validate-schema [--doc PATH] [--code PATH] [--definitions PATH]
+```
+
+Default paths: `docs/reference/schema.md`, `src/deriva_ml/schema/create_schema.py`, `src/deriva_ml/core/definitions.py` (resolved from the working directory).
+
+Output on mismatch: structured text (see §5.5 for format). Exit code 1.
+Output on match: single line `deriva-ml-validate-schema: schema.md and create_schema.py agree.` Exit code 0.
+Output on parse error: error location + message. Exit code 2.
+
+### 5.5 Mismatch output format
+
+```
+deriva-ml-validate-schema: schema.md and create_schema.py disagree.
+
+MISSING FROM CODE:
+  - table 'Execution_Status' declared in docs/reference/schema.md:142
+    but not found in src/deriva_ml/schema/create_schema.py.
+
+MISSING FROM DOC:
+  (none)
+
+COLUMN MISMATCH:
+  - Execution.Status
+    doc (schema.md:78):   type=fk
+    code (create_schema.py:149): type=text
+
+FOREIGN KEY MISMATCH:
+  (none)
+
+VOCABULARY TERMS MISMATCH:
+  - Asset_Type (schema.md:203; create_schema.py:395):
+    code-only: {Model_File, Notebook_Output}
+    doc-only:  {Execution_Config}
+
+Exit code: 1
+```
+
+## 6. Testing strategy
+
+### 6.1 Unit tests (`tests/tools/test_validate_schema_doc.py`)
+
+1. `test_load_from_doc_parses_yaml_blocks` — handcrafted fixture Markdown with two tables; verify `SchemaModel` fields populated.
+2. `test_load_from_code_parses_simple_tabledef` — fixture Python module with a `TableDef`; verify AST extraction matches.
+3. `test_load_from_code_parses_vocabulary_table` — fixture with `VocabularyTableDef`; verify.
+4. `test_load_from_code_parses_ensure_terms` — fixture with `_ensure_terms` calls; verify seeded-terms extraction.
+5. `test_load_from_code_resolves_mlvocab_enum_refs` — fixture that uses `MLVocab.workflow_type`; verify resolver maps to "Workflow_Type".
+6. `test_diff_identical_schemas_is_empty` — two identical models → zero mismatches.
+7. `test_diff_missing_table` — table in doc, missing in code → `MissingTable` mismatch.
+8. `test_diff_column_type_mismatch` — same column, different types → `ColumnMismatch`.
+9. `test_diff_fk_target_mismatch` — FK target differs → `ForeignKeyMismatch`.
+10. `test_diff_vocab_terms_differ` — extra term in code → `VocabularyTermsMismatch` with correct symmetric-difference.
+11. `test_diff_ignores_descriptions` — schemas identical except doc has descriptions → zero mismatches (per §2).
+12. `test_diff_ignores_annotations` — schemas identical except code has annotations → zero mismatches.
+
+### 6.2 Integration tests (`tests/tools/test_validate_schema_doc_integration.py`)
+
+13. `test_validator_runs_clean_on_current_repo` — load actual `docs/reference/schema.md` + actual `src/deriva_ml/schema/create_schema.py`; assert zero mismatches. This test IS the CI gate in test form — if the two drift, this fails.
+14. `test_cli_exit_codes` — subprocess invocation of `deriva-ml-validate-schema` on the real repo; assert exit 0.
+
+### 6.3 Doc structure tests (`tests/tools/test_schema_doc_structure.py`)
+
+15. `test_schema_doc_yaml_blocks_all_valid` — every fenced YAML block parses without error.
+16. `test_schema_doc_has_entry_per_mltable_member` — every member of `MLTable` enum has a corresponding `table:` entry in the doc. Catches "added a table to `MLTable` but forgot the doc."
+17. `test_schema_doc_has_entry_per_mlvocab_member` — parallel for `MLVocab`.
+18. `test_schema_doc_table_order` — core → vocabulary → association. Warns (not fails) on ordering violations; enforces the readability convention.
+
+### 6.4 CI
+
+GitHub Actions workflow runs `uv run deriva-ml-validate-schema` on every PR. Failure surfaces in the PR check. No extra setup — the validator is pure-Python + PyYAML (transitive) + stdlib `ast`.
+
+## 7. Error handling
+
+- **Parse errors in the doc** (malformed YAML, unknown `kind:`, missing required key): validator reports `SchemaDocError` with Markdown line number. Exit 2.
+- **Parse errors in the code** (call pattern inside a comprehension, enum member can't resolve): `SchemaCodeError` with code line number. Exit 2.
+- **Mismatch**: structured output per §5.5. Exit 1.
+- **Agreement**: single-line OK. Exit 0.
+
+Parse errors are a developer-facing signal: "the tool couldn't understand this section; refactor it or extend the validator."
+
+## 8. Bootstrap
+
+The initial `docs/reference/schema.md` is hand-written to match the current `create_schema.py` exactly. Implementation plan task 1:
+
+1. Run the validator's `load_from_code` on the current `create_schema.py` to produce a `SchemaModel`.
+2. Render that `SchemaModel` back to the doc format as a starting point.
+3. Hand-edit the result: add prose, add the top-of-file overview, add descriptions, re-order sections per §4.1.
+4. Commit the doc. Validator passes with zero mismatches.
+
+A one-shot "render SchemaModel to Markdown" helper (`SchemaModel.to_doc_markdown() -> str`) can ship as part of the tool — useful for bootstrap, handy for future "emergency regenerate" flows (reset the doc from code, re-add prose).
+
+## 9. Filed follow-ups
+
+These are deferred by design:
+
+1. **Direction 2 — live catalog validation.** Add `load_from_catalog(catalog: ErmrestCatalog) -> SchemaModel` loader and CLI flags `--against=catalog --hostname=X --catalog=N`. Enables operational "does my deployed catalog match the doc?" diagnostics. Separate subsystem; not Subsystem 0.
+2. **Descriptions validation.** Extend validator to enforce `comment=` ↔ `description:` matching (opt-in per-column). Requires bootstrap pass adding `comment=` to existing `ColumnDef` sites. Deferred per Q8-c decision.
+3. **Annotation validation.** `curie_template`, display annotations, FK annotations. Heavy; likely never worth it.
+4. **ERD image regeneration.** Replace stale `docs/assets/ERD.png`. Separate effort; could be driven from `docs/reference/schema.md` via Graphviz or similar.
+
+## 10. Non-goals
+
+- Domain schema documentation (Subject, Image, test-schema, etc.) — user-defined, not part of `create_schema.py`.
+- Generating `create_schema.py` from the doc — explicitly rejected (Path 2); loses Python expressiveness.
+- Replacing `docs/architecture.md` — different purpose (overview + concepts vs. structural reference). The two coexist.
+- Schema migration tooling for existing catalogs — Subsystem 1's concern.
+- Real-time schema drift monitoring — out of scope; Direction 2 is on-demand.
+
+## 11. Delivery order (for the plan)
+
+Rough sequence; the implementation plan will refine into bite-sized steps:
+
+1. Create `tools/validate_schema_doc.py` skeleton: `SchemaModel` dataclass hierarchy, loader/diff/CLI stubs.
+2. Implement `load_from_doc` with unit tests.
+3. Implement `load_from_code` (AST-based) with unit tests, including `MLTable` / `MLVocab` resolver.
+4. Implement `diff_schemas` with unit tests.
+5. Implement CLI (`main`) and the mismatch output format.
+6. Implement `SchemaModel.to_doc_markdown()` helper (bootstrap tool).
+7. Use (6) to generate an initial `docs/reference/schema.md`. Hand-edit prose + ordering.
+8. Register `deriva-ml-validate-schema` entry point in `pyproject.toml`.
+9. Add `docs/reference/README.md` with the doc-first workflow instructions.
+10. Add GitHub Actions workflow step.
+11. Run integration test (`test_validator_runs_clean_on_current_repo`) — green gate.
+12. CHANGELOG entry noting the new doc-first workflow for schema changes.

--- a/docs/superpowers/specs/2026-04-21-status-enum-reconciliation-design.md
+++ b/docs/superpowers/specs/2026-04-21-status-enum-reconciliation-design.md
@@ -152,24 +152,16 @@ Identified by grep (non-exhaustive — implementation will do a full sweep):
 
 ## 6. Schema seeding
 
-`src/deriva_ml/schema/create_schema.py` (or wherever `Execution_Status` vocabulary terms are seeded during `create_ml_schema`):
+**Correction from earlier draft:** `Execution.Status` is a plain `text` column (`src/deriva_ml/schema/create_schema.py:149`), NOT a foreign key to an `Execution_Status` vocabulary table. There is no vocab table to seed. The column holds whatever string the library writes.
 
-**Seed the full canonical set for new catalogs:**
-- `Created`
-- `Running`
-- `Stopped`         ← new (additive)
-- `Failed`
-- `Pending_Upload`  ← new (additive)
-- `Uploaded`        ← new (additive)
-- `Aborted`
+This simplifies §6 to nothing:
+- No vocabulary table exists.
+- No schema-init routine seeds `Execution_Status` terms.
+- No term-migration helper needed.
 
-**Remove from the seed list** (if currently present):
-- `Initializing`
-- `Pending`
+**The only discipline:** post-migration, `Execution.Status` values written to the catalog are constrained by the library to the 7 canonical title-case strings (the `ExecutionStatus` enum values). Historical rows with `"Initializing"` / `"Pending"` remain as free-text until the user manually updates them or they age out via `gc_executions`.
 
-Existing catalogs (if any) retain whatever terms they currently have in the `Execution_Status` vocabulary — we don't attempt to purge legacy terms from existing catalogs because that would orphan historical rows. New catalogs start clean with only the canonical 7.
-
-Dev catalogs get re-created from scratch during normal test runs, so no migration helper is needed.
+`Execution.Status_Detail` (a sibling text column on the catalog Execution table) stays unused by the library — it was a pre-existing column that legacy `update_status` would populate with the human-readable message. With M2 (drop status_message), this column is simply not written to. It may be removed from the schema in a future migration; not in scope here.
 
 ## 7. Error handling
 
@@ -222,18 +214,16 @@ The existing 627-test Phase-1 suite must pass post-migration. Any test that hard
 Rough task sequence; the implementation plan will refine into bite-sized steps:
 
 1. Update `ExecutionStatus` enum values (the 7-character strings).
-2. Update SQLite schema seeding (no column change — the seed string changes).
-3. Sweep `src/deriva_ml/` for lowercase status literals; rewrite.
-4. Update `create_ml_schema` vocabulary seeding to include new terms.
-5. Implement `Execution.update_status(target, *, error=None)`.
-6. Implement `ExecutionRecord.update_status(target, *, ml, error=None)`.
-7. Migrate every call site per §5's table.
-8. Delete `Status` enum + `DerivaML.status` attribute + `_initialize_execution`.
-9. Add test files (§8.1).
-10. Update existing tests (§8.2).
-11. Run the grep gate; address any remaining hits.
-12. Full regression: 627 unit + 2 integration must pass.
-13. CHANGELOG: add a "Phase 2 Subsystem 1" entry noting the breaking change and the dropped legacy terms.
+2. Sweep SQLite-written status string literals (if any hardcoded) — ensure they use the enum.
+3. Implement `Execution.update_status(target, *, error=None)`.
+4. Implement `ExecutionRecord.update_status(target, *, ml, error=None)`.
+5. Migrate every call site per §5's table.
+6. Delete `Status` enum + `DerivaML.status` attribute + `_initialize_execution` (verify no readers first).
+7. Add test files (§8.1).
+8. Update existing tests (§8.2).
+9. Run the grep gate; address any remaining hits.
+10. Full regression: 627 unit + 2 integration must pass.
+11. CHANGELOG: add a "Phase 2 Subsystem 1" entry noting the breaking change.
 
 ## 10. Non-goals
 
@@ -252,4 +242,4 @@ Explicitly out of scope; separate subsystems handle them:
 None at design freeze. Decisions made during brainstorming that might surface as follow-ups:
 
 - If an unexpected external consumer of the legacy `Status` enum surfaces post-merge, revert to Option C (shim). Unlikely given the current architecture, but noted.
-- The `Stopped` / `Pending_Upload` / `Uploaded` vocab terms need to be in the catalog's `Execution_Status` vocabulary before any execution can transition to them. New catalogs get them automatically via §6; existing catalogs (if any — none confirmed in production) need one-time `add_term` calls. A small `migrate_execution_status_vocabulary.py` helper may be worth shipping; flag for implementation triage.
+- (The earlier-drafted bullet about seeding an `Execution_Status` vocabulary is removed — §6 documents the correction: `Execution.Status` is a free-text column, not a vocab FK.)

--- a/docs/superpowers/specs/2026-04-21-status-enum-reconciliation-design.md
+++ b/docs/superpowers/specs/2026-04-21-status-enum-reconciliation-design.md
@@ -1,0 +1,255 @@
+# Status Enum Reconciliation — Design Spec
+
+**Date:** 2026-04-21
+**Author:** Claude (with Carl)
+**Status:** Approved, ready for implementation-plan
+**Phase:** Phase 2, Subsystem 1 (of 4)
+**Parent spec:** `2026-04-18-sqlite-execution-state-design.md` (Phase 1)
+
+## 1. Motivation
+
+Phase 1 shipped with two parallel execution-status vocabularies:
+
+- **Legacy** `Status` enum (`src/deriva_ml/core/enums.py`): title-case values `Initializing`, `Created`, `Pending`, `Running`, `Aborted`, `Completed`, `Failed`. Written to the catalog `Execution.Status` field and consumed by the catalog's `Execution_Status` vocabulary (terms match).
+- **Phase-1 new** `ExecutionStatus` enum (`src/deriva_ml/execution/state_store.py`): lowercase values `created`, `running`, `stopped`, `failed`, `pending_upload`, `uploaded`, `aborted`. Used by the state-machine module, SQLite registry, and Phase 1's public API (`list_executions`, `resume_execution`, etc.).
+
+`Execution._initialize_execution` and several other internal call sites still write the legacy title-case values to the catalog. Phase 1's `reconcile_with_catalog` reads those values and tries `ExecutionStatus(catalog_row["Status"])`, which raises `ValueError` (wrapped as `DerivaMLStateInconsistency`). The Phase-1 integration test (H2) had to work around this by reading SQLite directly instead of using `resume_execution`.
+
+The CHANGELOG flagged this as the "critical Phase 2 item." This spec is the fix.
+
+## 2. Decisions (already made during brainstorming)
+
+The brainstorming sessions settled these:
+
+- **Option A (full migration).** Delete the legacy `Status` enum and its consumers; rewrite every internal call site. Backwards compatibility is not a constraint because `update_status` is not called by users outside the library.
+- **W3 (title-case values).** Change `ExecutionStatus` values from lowercase to title-case to match the catalog `Execution_Status` vocabulary directly. No translation layer at the wire boundary; the in-memory enum *is* the wire format.
+- **Method name preserved: `Execution.update_status(...)`.** Keep the legacy method name — it reads cleanly on an Execution instance and existing call sites barely change. The Phase-1 state-machine module function `transition()` stays internal; `update_status` wraps it.
+- **M2 (drop status_message).** Legacy messages are split across three categories: progress chatter (→ `logger.info`), error context (→ existing `error` column), completion notes (redundant with the status value itself). No new `status_message` column on SQLite or the catalog.
+- **B1 (delete `DerivaML.status`).** The `self.status = Status.pending.value` line in `core/base.py:353` is vestigial. Grep confirmed no readers; delete.
+- **E1 (strict reconciliation).** Unknown legacy status values in catalog rows raise `DerivaMLStateInconsistency` — consistent with Phase 1. Users with historical rows migrate their data; the library doesn't silently accept unknown values.
+
+## 3. Semantic mappings
+
+The legacy `Status` → new `ExecutionStatus` mappings. These are binding for every call site:
+
+| Legacy                    | New action                              | Rationale                                                         |
+|---------------------------|-----------------------------------------|-------------------------------------------------------------------|
+| `Status.initializing`     | **Delete.** Replace with `logger.info`. | Not a lifecycle state — progress chatter during setup.            |
+| `Status.created`          | `ExecutionStatus.Created`               | 1:1.                                                              |
+| `Status.pending`          | **Delete.** Collapse into `Created`.    | Phase 1's state machine doesn't track a separate "pending" state. |
+| `Status.running`          | `ExecutionStatus.Running`               | 1:1.                                                              |
+| `Status.completed`        | **Split per call site.** See §4.        | Legacy conflated "algorithm done" with "data uploaded."           |
+| `Status.aborted`          | `ExecutionStatus.Aborted`               | 1:1.                                                              |
+| `Status.failed`           | `ExecutionStatus.Failed`                | 1:1.                                                              |
+
+### 3.1 The `Status.completed` split
+
+Each of the ~3 legacy `Status.completed` call sites maps to one of:
+
+- `ExecutionStatus.Stopped` — algorithm finished successfully, data not yet uploaded. The `Execution.__exit__` path.
+- `ExecutionStatus.Pending_Upload` — in-flight upload. Mid-`upload_execution_outputs` progress.
+- `ExecutionStatus.Uploaded` — upload finished successfully. Tail of `upload_execution_outputs`.
+
+Each call site gets its mapping decided explicitly during implementation. No blanket rule.
+
+## 4. API changes
+
+### 4.1 `ExecutionStatus` enum (value change)
+
+```python
+class ExecutionStatus(StrEnum):
+    """Lifecycle status for an Execution (see Phase 1 spec §2.2).
+
+    Values are title-case to match the catalog's Execution_Status
+    vocabulary — a catalog row's Status field can be parsed directly
+    via ExecutionStatus(row["Status"]).
+    """
+    Created = "Created"
+    Running = "Running"
+    Stopped = "Stopped"
+    Failed = "Failed"
+    Pending_Upload = "Pending_Upload"
+    Uploaded = "Uploaded"
+    Aborted = "Aborted"
+```
+
+Python identifier casing matches the enum's string value (so `ExecutionStatus.Running.name == "Running"` and `.value == "Running"`). This is a deviation from PEP 8's lowercase convention for enum members, but it optimizes for readability at call sites (`ExecutionStatus.Running` matches what appears in the catalog) and keeps identifier == value. Precedent: `http.HTTPStatus` in the stdlib uses uppercase identifiers matching HTTP-status names.
+
+### 4.2 `Execution.update_status`
+
+```python
+def update_status(
+    self,
+    target: ExecutionStatus,
+    *,
+    error: str | None = None,
+) -> None:
+    """Transition this execution to a new status.
+
+    Thin wrapper around state_machine.transition() that validates
+    against ALLOWED_TRANSITIONS, updates the SQLite registry, and
+    syncs to the catalog when online.
+
+    Args:
+        target: Target status.
+        error: For Failed/Aborted transitions, a human-readable
+            error message. Written to the `error` column. Ignored
+            (with a logger.warning) for non-terminal transitions.
+
+    Raises:
+        InvalidTransitionError: If the (current, target) pair is
+            not in ALLOWED_TRANSITIONS.
+        DerivaMLStateInconsistency: If state_machine reconciliation
+            detects catalog/SQLite divergence during the sync step.
+    """
+```
+
+### 4.3 `ExecutionRecord.update_status`
+
+```python
+def update_status(
+    self,
+    target: ExecutionStatus,
+    *,
+    ml: "DerivaML",
+    error: str | None = None,
+) -> None:
+    """Parallel to Execution.update_status; Records require an ml= kwarg."""
+```
+
+### 4.4 Deletions
+
+- `src/deriva_ml/core/enums.py::Status` — entire class deleted.
+- `Execution._initialize_execution` — legacy method deleted (its lifecycle work was already taken over by `create_catalog_execution` in Phase 1).
+- `DerivaML.status` attribute — the `self.status = Status.pending.value` in `core/base.py:353`. Verify no readers first.
+- Legacy `update_status(...)` signature accepting `Status` — the whole method body gets replaced per §4.2; no separate deletion.
+
+## 5. Internal call sites
+
+Identified by grep (non-exhaustive — implementation will do a full sweep):
+
+| File                                   | Line      | Legacy call                                         | New call                                              |
+|----------------------------------------|-----------|-----------------------------------------------------|-------------------------------------------------------|
+| `src/deriva_ml/core/base.py`           | 353       | `self.status = Status.pending.value`                | **Delete.**                                           |
+| `src/deriva_ml/core/base.py`           | 380–381   | `update_status(Status.aborted, "…")`                | `exe.update_status(Ex.Aborted, error="…")`            |
+| `src/deriva_ml/execution/execution.py` | 307       | `status=Status.created`                             | `status=Ex.Created`                                   |
+| `src/deriva_ml/execution/execution.py` | 514       | `update_status(Status.initializing, …)`             | `logger.info("Materialize bag %s…", dataset.rid)`     |
+| `src/deriva_ml/execution/execution.py` | 526       | `update_status(Status.running, "Downloading…")`     | `logger.info("Downloading assets…")` (progress)       |
+| `src/deriva_ml/execution/execution.py` | 583       | `update_status(Status.pending, "Init finished.")`   | **Delete.** (Already in `Created` post-Phase-1.)      |
+| `src/deriva_ml/execution/execution.py` | 980       | `update_status(Status.initializing, …)`             | `logger.info("Start execution…")`                     |
+| `src/deriva_ml/execution/execution.py` | 1020      | `update_status(Status.completed, "Algo ended.")`    | `update_status(Ex.Stopped)`                           |
+| `src/deriva_ml/execution/execution.py` | 1122      | `update_status(Status.running, "Uploading files…")` | `update_status(Ex.Pending_Upload)` (enter upload)     |
+| `src/deriva_ml/execution/execution.py` | 1134      | `update_status(Status.failed, error)`               | `update_status(Ex.Failed, error=error)`               |
+| `src/deriva_ml/execution/execution.py` | 1166      | `update_status(Status.running, "Updating feat…")`   | `logger.info("Updating features…")` (progress)        |
+| `src/deriva_ml/execution/execution.py` | 1177      | `update_status(Status.running, "Upload complete")`  | `logger.info("Upload assets complete")` (progress)    |
+| `src/deriva_ml/execution/execution.py` | 1378      | `update_status(Status.completed, "Success end.")`   | `update_status(Ex.Uploaded)`                          |
+| `src/deriva_ml/execution/execution.py` | 1384      | `update_status(Status.failed, error)`               | `update_status(Ex.Failed, error=error)`               |
+| `src/deriva_ml/dataset/dataset.py`     | 2666, 2672| `update_status(Status.running, msg)` via callback   | `logger.info(msg)` or keep callback with `Ex.Running` |
+
+`src/deriva_ml/execution/execution_record.py` — the field's type annotation is `Status`; rewrite to `ExecutionStatus`. The PrivateAttr default of `Status.created` becomes `ExecutionStatus.Created`.
+
+`src/deriva_ml/core/mixins/execution.py` — docstring examples mentioning `Status.completed` etc. update to `ExecutionStatus.Uploaded` where relevant.
+
+## 6. Schema seeding
+
+`src/deriva_ml/schema/create_schema.py` (or wherever `Execution_Status` vocabulary terms are seeded during `create_ml_schema`):
+
+**Seed the full canonical set for new catalogs:**
+- `Created`
+- `Running`
+- `Stopped`         ← new (additive)
+- `Failed`
+- `Pending_Upload`  ← new (additive)
+- `Uploaded`        ← new (additive)
+- `Aborted`
+
+**Remove from the seed list** (if currently present):
+- `Initializing`
+- `Pending`
+
+Existing catalogs (if any) retain whatever terms they currently have in the `Execution_Status` vocabulary — we don't attempt to purge legacy terms from existing catalogs because that would orphan historical rows. New catalogs start clean with only the canonical 7.
+
+Dev catalogs get re-created from scratch during normal test runs, so no migration helper is needed.
+
+## 7. Error handling
+
+(Covered in §5 of brainstorming; summarized here.)
+
+- **Invalid transition**: existing `InvalidTransitionError` from `state_machine.transition`. `update_status` surfaces it.
+- **Catalog sync failure (online mode)**: existing `sync_pending=True` soft-fail. No change.
+- **Offline mode**: writes SQLite only; sets `sync_pending=True`. No change.
+- **Unknown status from catalog during reconciliation** (E1): raises `DerivaMLStateInconsistency` with a message that names the offending value and the execution RID. Users clean up historical rows (documented in CHANGELOG).
+
+## 8. Testing
+
+### 8.1 New test files
+
+- `tests/execution/test_status_migration.py` — enum value correctness:
+  - All 7 `ExecutionStatus` members present with title-case values.
+  - `ExecutionStatus("Running")` succeeds.
+  - `ExecutionStatus("running")` raises `ValueError`.
+  - Round-trip: catalog row `{"Status": "Running"}` parses to `ExecutionStatus.Running`.
+
+- `tests/execution/test_update_status.py` — new public method:
+  - Valid transition updates SQLite status + syncs catalog (online).
+  - Invalid transition raises `InvalidTransitionError`.
+  - `error="…"` kwarg writes the `error` column on `Failed` / `Aborted`.
+  - `error="…"` on a non-terminal transition logs a warning via `logger.warning` and is otherwise ignored. (The kwarg is accepted silently to keep call-site patterns uniform; misuse is a logged-only soft error, not a raise.)
+  - Offline mode: SQLite updates, `sync_pending=True`, no catalog call.
+  - `ExecutionRecord.update_status(target, *, ml, error=None)` parallel coverage.
+
+- `tests/test_migration_complete.py` — grep gate:
+  - Greps `src/deriva_ml/` for remaining references to the legacy `Status` enum or its members. Fails if any match. Catches missed migrations before they ship.
+  - Specifically greps for: `class Status`, `Status.pending`, `Status.running`, `Status.completed`, `Status.initializing`, `Status.aborted`, `Status.failed`, `Status.created`, `from deriva_ml.core.enums import Status`, `from .enums import Status`.
+
+### 8.2 Existing test updates
+
+- `tests/execution/test_state_machine.py` — lowercase `"running"` literals → title-case `"Running"` or `ExecutionStatus.Running.value`.
+- `tests/execution/test_state_store.py` — same sweep.
+- `tests/execution/test_execution_registry.py` — same.
+- `tests/execution/test_execution_readthrough.py` — same.
+- `tests/execution/test_execution_hierarchy.py` — same.
+- `tests/integration/test_phase1_end_to_end.py`:
+  - `test_online_create_offline_stage_online_upload`: remove the "workaround: read SQLite directly" comment; tighten the final assertion to `exe_final.status is ExecutionStatus.Uploaded` via `resume_execution`.
+  - Tighten the `with exe.execute(): pass` post-assertion from `in (Stopped, Running)` to `is ExecutionStatus.Stopped`.
+
+### 8.3 Regression
+
+The existing 627-test Phase-1 suite must pass post-migration. Any test that hardcoded a lowercase value gets swept; any that incidentally checked `Status.something` gets rewritten.
+
+## 9. Delivery order (for the plan)
+
+Rough task sequence; the implementation plan will refine into bite-sized steps:
+
+1. Update `ExecutionStatus` enum values (the 7-character strings).
+2. Update SQLite schema seeding (no column change — the seed string changes).
+3. Sweep `src/deriva_ml/` for lowercase status literals; rewrite.
+4. Update `create_ml_schema` vocabulary seeding to include new terms.
+5. Implement `Execution.update_status(target, *, error=None)`.
+6. Implement `ExecutionRecord.update_status(target, *, ml, error=None)`.
+7. Migrate every call site per §5's table.
+8. Delete `Status` enum + `DerivaML.status` attribute + `_initialize_execution`.
+9. Add test files (§8.1).
+10. Update existing tests (§8.2).
+11. Run the grep gate; address any remaining hits.
+12. Full regression: 627 unit + 2 integration must pass.
+13. CHANGELOG: add a "Phase 2 Subsystem 1" entry noting the breaking change and the dropped legacy terms.
+
+## 10. Non-goals
+
+Explicitly out of scope; separate subsystems handle them:
+
+- Real `_invoke_deriva_py_uploader` implementation (Subsystem 3).
+- `parallel_files` / `bandwidth_limit_mbps` threading (Subsystem 3).
+- Offline-mode `DerivaML.__init__` network-I/O skip (Subsystem 4).
+- `UploadJob._state_lock` race-fixing (Subsystem 4).
+- Full `TableHandle` / `AssetTableHandle` surface (Subsystem 2, the real Phase 2).
+- Metric / Param as first-class concepts (Subsystem 2).
+- Deprecation warnings for the legacy `Status` enum. We're deleting it outright; there are no external users to warn.
+
+## 11. Open questions
+
+None at design freeze. Decisions made during brainstorming that might surface as follow-ups:
+
+- If an unexpected external consumer of the legacy `Status` enum surfaces post-merge, revert to Option C (shim). Unlikely given the current architecture, but noted.
+- The `Stopped` / `Pending_Upload` / `Uploaded` vocab terms need to be in the catalog's `Execution_Status` vocabulary before any execution can transition to them. New catalogs get them automatically via §6; existing catalogs (if any — none confirmed in production) need one-time `add_term` calls. A small `migrate_execution_status_vocabulary.py` helper may be worth shipping; flag for implementation triage.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ deriva-ml-check-catalog-schema = "deriva_ml.schema.check_schema:main"
 deriva-ml-split-dataset = "deriva_ml.dataset.split:main"
 deriva-ml-storage = "deriva_ml.cache_tui:main"
 deriva-ml-upload = "deriva_ml.cli.upload:main"
+deriva-ml-validate-schema = "deriva_ml.tools.validate_schema_doc:main"
 
 [project.optional-dependencies]
 

--- a/src/deriva_ml/tools/__init__.py
+++ b/src/deriva_ml/tools/__init__.py
@@ -1,0 +1,1 @@
+"""Tools for DerivaML validation and utility tasks."""

--- a/src/deriva_ml/tools/validate_schema_doc.py
+++ b/src/deriva_ml/tools/validate_schema_doc.py
@@ -1,0 +1,70 @@
+"""Validator: assert docs/reference/schema.md and create_schema.py agree.
+
+Path-1 architecture (per spec §2): both files are maintained by developers.
+The doc describes intended schema; the code defines it at runtime. This
+validator compares the two.
+
+Runs in CI via the deriva-ml-validate-schema entry point.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+
+
+@dataclass(frozen=True)
+class ColumnModel:
+    """Column definition (name + ERMrest type)."""
+    name: str
+    type: str
+
+
+@dataclass(frozen=True)
+class ForeignKeyModel:
+    """FK from a set of columns to a referenced table's columns."""
+    columns: list[str]
+    referenced_schema: str
+    referenced_table: str
+    referenced_columns: list[str]
+
+
+@dataclass(frozen=True)
+class VocabularyTermModel:
+    """One seeded term in a vocabulary table."""
+    name: str
+
+
+@dataclass(frozen=True)
+class AssociationEndpointModel:
+    """One endpoint of an association table."""
+    table: str
+    role: str | None = None
+
+
+@dataclass(frozen=True)
+class TableModel:
+    """One table in the schema — plain, vocabulary, or association."""
+    name: str
+    kind: str  # "table", "vocabulary", "association"
+    columns: list[ColumnModel] = field(default_factory=list)
+    foreign_keys: list[ForeignKeyModel] = field(default_factory=list)
+    terms: list[VocabularyTermModel] = field(default_factory=list)
+    associates: list[AssociationEndpointModel] = field(default_factory=list)
+    metadata: list[ColumnModel] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class SchemaModel:
+    """The full schema — one list of tables."""
+    tables: list[TableModel]
+
+
+class MismatchKind(StrEnum):
+    """Categories of doc↔code mismatch."""
+    MISSING_TABLE = "missing_table"
+    EXTRA_TABLE = "extra_table"
+    COLUMN_MISMATCH = "column_mismatch"
+    FK_MISMATCH = "fk_mismatch"
+    VOCAB_TERMS_MISMATCH = "vocab_terms_mismatch"
+    ASSOCIATION_MISMATCH = "association_mismatch"

--- a/src/deriva_ml/tools/validate_schema_doc.py
+++ b/src/deriva_ml/tools/validate_schema_doc.py
@@ -397,6 +397,40 @@ def _extract_ensure_terms(node: ast.Call) -> tuple[str, list[VocabularyTermModel
     return vocab_name, terms
 
 
+def _extract_association(node: ast.Call) -> TableModel:
+    """Extract Table.define_association(associates=[...], metadata=[...])."""
+    associates: list[AssociationEndpointModel] = []
+    metadata: list[ColumnModel] = []
+    for kw in node.keywords:
+        if kw.arg == "associates":
+            if not isinstance(kw.value, ast.List):
+                raise SchemaCodeError(
+                    f"define_association associates must be a list, got "
+                    f"{ast.dump(kw.value)}"
+                )
+            for elt in kw.value.elts:
+                if not isinstance(elt, ast.Tuple) or len(elt.elts) < 1:
+                    raise SchemaCodeError(
+                        f"associates entry must be a tuple (name, table), got "
+                        f"{ast.dump(elt)}"
+                    )
+                table_name = _extract_ast_name_or_enum(elt.elts[0])
+                associates.append(AssociationEndpointModel(table=table_name))
+        elif kw.arg == "metadata":
+            if isinstance(kw.value, ast.List):
+                for m_elt in kw.value.elts:
+                    if isinstance(m_elt, ast.Call) and _callable_name(m_elt) == "ColumnDef":
+                        metadata.append(_extract_column(m_elt))
+    # Association name: derived from associates — '{first}_{second}'.
+    derived_name = "_".join(a.table for a in associates)
+    return TableModel(
+        name=derived_name,
+        kind="association",
+        associates=associates,
+        metadata=metadata,
+    )
+
+
 def load_from_code(path: Path) -> SchemaModel:
     """Parse create_schema.py AST into a SchemaModel.
 
@@ -434,6 +468,8 @@ def load_from_code(path: Path) -> SchemaModel:
         elif name == "_ensure_terms":
             vocab_name, terms = _extract_ensure_terms(node)
             terms_by_vocab.setdefault(vocab_name, []).extend(terms)
+        elif name == "Table.define_association":
+            tables.append(_extract_association(node))
 
     # Apply accumulated terms to matching vocab tables.
     tables_with_terms: list[TableModel] = []

--- a/src/deriva_ml/tools/validate_schema_doc.py
+++ b/src/deriva_ml/tools/validate_schema_doc.py
@@ -9,8 +9,11 @@ Runs in CI via the deriva-ml-validate-schema entry point.
 
 from __future__ import annotations
 
+import argparse
 import ast
 import re
+import sys
+from collections import defaultdict
 from dataclasses import dataclass, field
 from enum import StrEnum
 from pathlib import Path
@@ -656,3 +659,89 @@ def _compare_associates(
             table=expected.name,
             detail=f"associates doc {expected_assoc} vs code {actual_assoc}",
         ))
+
+
+def _format_mismatches(mismatches: list[Mismatch]) -> str:
+    """Render mismatches in the §5.5 format."""
+    if not mismatches:
+        return "deriva-ml-validate-schema: schema.md and create_schema.py agree.\n"
+
+    buckets: dict[MismatchKind, list[Mismatch]] = defaultdict(list)
+    for m in mismatches:
+        buckets[m.kind].append(m)
+
+    lines = [
+        "deriva-ml-validate-schema: schema.md and create_schema.py disagree.",
+        "",
+    ]
+
+    def add_section(title: str, kind: MismatchKind) -> None:
+        lines.append(f"{title}:")
+        if kind in buckets:
+            for m in buckets[kind]:
+                lines.append(f"  - {m.detail}")
+        else:
+            lines.append("  (none)")
+        lines.append("")
+
+    add_section("MISSING FROM CODE", MismatchKind.MISSING_TABLE)
+    add_section("EXTRA IN CODE", MismatchKind.EXTRA_TABLE)
+    add_section("COLUMN MISMATCH", MismatchKind.COLUMN_MISMATCH)
+    add_section("FOREIGN KEY MISMATCH", MismatchKind.FK_MISMATCH)
+    add_section("VOCABULARY TERMS MISMATCH", MismatchKind.VOCAB_TERMS_MISMATCH)
+    add_section("ASSOCIATION MISMATCH", MismatchKind.ASSOCIATION_MISMATCH)
+    return "\n".join(lines)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="deriva-ml-validate-schema",
+        description=(
+            "Validate that docs/reference/schema.md and "
+            "src/deriva_ml/schema/create_schema.py agree on tables, "
+            "columns, foreign keys, and vocabulary seeded terms."
+        ),
+    )
+    p.add_argument(
+        "--doc",
+        default="docs/reference/schema.md",
+        help="Path to the schema doc (default: docs/reference/schema.md).",
+    )
+    p.add_argument(
+        "--code",
+        default="src/deriva_ml/schema/create_schema.py",
+        help="Path to create_schema.py (default: src/deriva_ml/schema/create_schema.py).",
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point: compare doc vs code.
+
+    Returns:
+        0 if schemas agree.
+        1 if they differ.
+        2 if parsing failed on either side.
+    """
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        expected = load_from_doc(Path(args.doc))
+    except (SchemaDocError, FileNotFoundError) as exc:
+        print(f"error loading doc: {exc}", file=sys.stderr)
+        return 2
+
+    try:
+        actual = load_from_code(Path(args.code))
+    except (SchemaCodeError, FileNotFoundError) as exc:
+        print(f"error loading code: {exc}", file=sys.stderr)
+        return 2
+
+    mismatches = diff_schemas(expected=expected, actual=actual)
+    print(_format_mismatches(mismatches))
+    return 1 if mismatches else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/deriva_ml/tools/validate_schema_doc.py
+++ b/src/deriva_ml/tools/validate_schema_doc.py
@@ -720,7 +720,7 @@ def _compare_associates(
     expected: TableModel,
     actual: TableModel,
 ) -> None:
-    """Compare association-table endpoints (by table name)."""
+    """Compare association-table endpoints (by table name) + metadata columns."""
     expected_assoc = [a.table for a in expected.associates]
     actual_assoc = [a.table for a in actual.associates]
     if expected_assoc != actual_assoc:
@@ -728,6 +728,18 @@ def _compare_associates(
             kind=MismatchKind.ASSOCIATION_MISMATCH,
             table=expected.name,
             detail=f"associates doc {expected_assoc} vs code {actual_assoc}",
+        ))
+    # Association tables may carry metadata columns (e.g. Execution_Nested_Execution.Sequence).
+    # Diff by (name, type) tuples — same semantics as the regular column diff.
+    expected_meta = {(m.name, m.type) for m in expected.metadata}
+    actual_meta = {(m.name, m.type) for m in actual.metadata}
+    if expected_meta != actual_meta:
+        doc_only = sorted(expected_meta - actual_meta)
+        code_only = sorted(actual_meta - expected_meta)
+        mismatches.append(Mismatch(
+            kind=MismatchKind.ASSOCIATION_MISMATCH,
+            table=expected.name,
+            detail=f"metadata doc-only {doc_only} vs code-only {code_only}",
         ))
 
 

--- a/src/deriva_ml/tools/validate_schema_doc.py
+++ b/src/deriva_ml/tools/validate_schema_doc.py
@@ -537,5 +537,39 @@ def _compare_tables(
     actual: TableModel,
 ) -> None:
     """Compare two same-named TableModels; append any differences."""
-    # D2-D4 populate this. Skeleton only for D1.
-    pass
+    _compare_columns(mismatches, expected, actual)
+    # D3 adds _compare_fks; D4 adds _compare_terms / _compare_associates.
+
+
+def _compare_columns(
+    mismatches: list[Mismatch],
+    expected: TableModel,
+    actual: TableModel,
+) -> None:
+    """Column-by-column diff."""
+    expected_cols = {c.name: c for c in expected.columns}
+    actual_cols = {c.name: c for c in actual.columns}
+    for col_name in sorted(expected_cols.keys() - actual_cols.keys()):
+        mismatches.append(Mismatch(
+            kind=MismatchKind.COLUMN_MISMATCH,
+            table=expected.name,
+            detail=f"column {col_name!r} in doc but not in code",
+        ))
+    for col_name in sorted(actual_cols.keys() - expected_cols.keys()):
+        mismatches.append(Mismatch(
+            kind=MismatchKind.COLUMN_MISMATCH,
+            table=expected.name,
+            detail=f"column {col_name!r} in code but not in doc",
+        ))
+    for col_name in sorted(expected_cols.keys() & actual_cols.keys()):
+        exp_c = expected_cols[col_name]
+        act_c = actual_cols[col_name]
+        if exp_c.type != act_c.type:
+            mismatches.append(Mismatch(
+                kind=MismatchKind.COLUMN_MISMATCH,
+                table=expected.name,
+                detail=(
+                    f"column {col_name!r}: doc type {exp_c.type!r} "
+                    f"vs code type {act_c.type!r}"
+                ),
+            ))

--- a/src/deriva_ml/tools/validate_schema_doc.py
+++ b/src/deriva_ml/tools/validate_schema_doc.py
@@ -9,6 +9,7 @@ Runs in CI via the deriva-ml-validate-schema entry point.
 
 from __future__ import annotations
 
+import ast
 import re
 from dataclasses import dataclass, field
 from enum import StrEnum
@@ -224,3 +225,154 @@ def _resolve_enum_ref(enum_name: str, member: str) -> str:
             f"{enum_name} has no member {member!r}; known: {sorted(members)}"
         )
     return members[member]
+
+
+def _extract_ast_str(node: ast.AST) -> str:
+    """Extract a string from an ast.Constant or return the ast.unparse repr."""
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    # Attribute access like BuiltinType.text → "text"
+    if isinstance(node, ast.Attribute):
+        return node.attr
+    raise SchemaCodeError(
+        f"expected string constant or attribute, got {ast.dump(node)}"
+    )
+
+
+def _extract_ast_name_or_enum(node: ast.AST) -> str:
+    """Extract a table-name string from a literal, enum ref, or attr access."""
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    if isinstance(node, ast.Attribute):
+        # Expect: MLTable.execution or MLVocab.workflow_type
+        if isinstance(node.value, ast.Name):
+            return _resolve_enum_ref(node.value.id, node.attr)
+    raise SchemaCodeError(
+        f"expected string literal or enum reference, got {ast.dump(node)}"
+    )
+
+
+def _extract_ast_str_list(node: ast.AST) -> list[str]:
+    """Extract a list[str] from an ast.List node."""
+    if not isinstance(node, ast.List):
+        raise SchemaCodeError(
+            f"expected list literal, got {ast.dump(node)}"
+        )
+    return [_extract_ast_str(elt) for elt in node.elts]
+
+
+def _extract_column(node: ast.Call) -> ColumnModel:
+    """Extract a ColumnDef(...) call into a ColumnModel."""
+    # Positional or keyword args: ColumnDef("Name", BuiltinType.text)
+    name: str | None = None
+    type_: str | None = None
+    if node.args:
+        name = _extract_ast_str(node.args[0])
+        if len(node.args) > 1:
+            type_ = _extract_ast_str(node.args[1])
+    for kw in node.keywords:
+        if kw.arg == "name":
+            name = _extract_ast_str(kw.value)
+        elif kw.arg == "type":
+            type_ = _extract_ast_str(kw.value)
+    if name is None or type_ is None:
+        raise SchemaCodeError(
+            f"ColumnDef missing name or type: {ast.dump(node)}"
+        )
+    return ColumnModel(name=name, type=type_)
+
+
+def _extract_fk(node: ast.Call) -> ForeignKeyModel:
+    """Extract a ForeignKeyDef(...) call into a ForeignKeyModel."""
+    columns: list[str] = []
+    referenced_schema: str = ""
+    referenced_table: str = ""
+    referenced_columns: list[str] = []
+    for kw in node.keywords:
+        if kw.arg == "columns":
+            columns = _extract_ast_str_list(kw.value)
+        elif kw.arg == "referenced_schema":
+            referenced_schema = _extract_ast_str(kw.value)
+        elif kw.arg == "referenced_table":
+            referenced_table = _extract_ast_str(kw.value)
+        elif kw.arg == "referenced_columns":
+            referenced_columns = _extract_ast_str_list(kw.value)
+    return ForeignKeyModel(
+        columns=columns,
+        referenced_schema=referenced_schema,
+        referenced_table=referenced_table,
+        referenced_columns=referenced_columns,
+    )
+
+
+def _extract_tabledef(node: ast.Call) -> TableModel:
+    """Extract a TableDef(name=..., columns=[...], foreign_keys=[...]) call."""
+    name: str = ""
+    columns: list[ColumnModel] = []
+    foreign_keys: list[ForeignKeyModel] = []
+    for kw in node.keywords:
+        if kw.arg == "name":
+            name = _extract_ast_name_or_enum(kw.value)
+        elif kw.arg == "columns":
+            if isinstance(kw.value, ast.List):
+                columns = [
+                    _extract_column(elt)
+                    for elt in kw.value.elts
+                    if isinstance(elt, ast.Call) and _callable_name(elt) == "ColumnDef"
+                ]
+        elif kw.arg == "foreign_keys":
+            if isinstance(kw.value, ast.List):
+                foreign_keys = [
+                    _extract_fk(elt)
+                    for elt in kw.value.elts
+                    if isinstance(elt, ast.Call) and _callable_name(elt) == "ForeignKeyDef"
+                ]
+    return TableModel(
+        name=name,
+        kind="table",
+        columns=columns,
+        foreign_keys=foreign_keys,
+    )
+
+
+def _callable_name(node: ast.Call) -> str:
+    """Return the callable's name: 'TableDef', 'Foo.bar', etc."""
+    if isinstance(node.func, ast.Name):
+        return node.func.id
+    if isinstance(node.func, ast.Attribute):
+        parts = []
+        cur: ast.AST = node.func
+        while isinstance(cur, ast.Attribute):
+            parts.insert(0, cur.attr)
+            cur = cur.value
+        if isinstance(cur, ast.Name):
+            parts.insert(0, cur.id)
+        return ".".join(parts)
+    return ""
+
+
+def load_from_code(path: Path) -> SchemaModel:
+    """Parse create_schema.py AST into a SchemaModel.
+
+    Walks the tree looking for TableDef, VocabularyTableDef,
+    Table.define_association, and _ensure_terms calls.
+
+    Args:
+        path: Path to create_schema.py or a fixture module.
+
+    Returns:
+        SchemaModel with one TableModel per table definition found.
+
+    Raises:
+        SchemaCodeError: If a call pattern can't be statically extracted.
+    """
+    tree = ast.parse(path.read_text(), filename=str(path))
+    tables: list[TableModel] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        name = _callable_name(node)
+        if name == "TableDef":
+            tables.append(_extract_tabledef(node))
+        # Vocabulary / association / _ensure_terms handled in C3 / C4.
+    return SchemaModel(tables=tables)

--- a/src/deriva_ml/tools/validate_schema_doc.py
+++ b/src/deriva_ml/tools/validate_schema_doc.py
@@ -250,6 +250,9 @@ def _extract_ast_str(node: ast.AST) -> str:
     )
 
 
+_KNOWN_TYPE_HOLDERS = frozenset({"BuiltinType"})
+
+
 def _extract_ast_str_tolerant(node: ast.AST) -> str:
     """Like _extract_ast_str, but returns DYNAMIC_VALUE for unknown patterns.
 
@@ -257,22 +260,26 @@ def _extract_ast_str_tolerant(node: ast.AST) -> str:
     attribute chain (e.g., FK referenced_schema = sname or schema.name).
     The diff comparator treats DYNAMIC_VALUE as matching any counterpart.
 
-    For attribute references like `MLVocab.dataset_type`, resolves via the
-    enum lookup first (→ "Dataset_Type"); falls back to `.attr` only if the
-    enum is unknown.
+    Resolution order for ast.Attribute nodes:
+      - MLTable / MLVocab enum reference → resolved via _resolve_enum_ref.
+      - BuiltinType.text → ".text" (type-like attribute).
+      - Anything else (schema.name, self.catalog) → DYNAMIC_VALUE.
     """
     if isinstance(node, ast.Constant) and isinstance(node.value, str):
         return node.value
     if isinstance(node, ast.Attribute):
-        # Try enum resolution: MLVocab.dataset_type → "Dataset_Type".
         if isinstance(node.value, ast.Name):
+            # Enum-backed attr: MLVocab.dataset_type → "Dataset_Type".
             try:
                 return _resolve_enum_ref(node.value.id, node.attr)
             except SchemaCodeError:
-                # Not an enum we know about (e.g., BuiltinType.text); fall
-                # back to the attr name.
+                pass
+            # Known type holders: BuiltinType.text → "text".
+            if node.value.id in _KNOWN_TYPE_HOLDERS:
                 return node.attr
-        return node.attr
+        # Dotted access on a local value (schema.name, self.catalog, …)
+        # can't be resolved statically.
+        return DYNAMIC_VALUE
     # ast.Name (parameter reference), ast.Call, etc.: treat as dynamic.
     return DYNAMIC_VALUE
 

--- a/src/deriva_ml/tools/validate_schema_doc.py
+++ b/src/deriva_ml/tools/validate_schema_doc.py
@@ -351,28 +351,103 @@ def _callable_name(node: ast.Call) -> str:
     return ""
 
 
+def _extract_vocabulary(node: ast.Call) -> TableModel:
+    """Extract a VocabularyTableDef(name=..., curie_template=...) call."""
+    name: str = ""
+    for kw in node.keywords:
+        if kw.arg == "name":
+            name = _extract_ast_name_or_enum(kw.value)
+    return TableModel(name=name, kind="vocabulary")
+
+
+def _extract_ensure_terms(node: ast.Call) -> tuple[str, list[VocabularyTermModel]]:
+    """Extract (vocab_name, terms) from an _ensure_terms(vocab, [...]) call."""
+    if len(node.args) < 2:
+        raise SchemaCodeError(
+            f"_ensure_terms expects 2 positional args, got {len(node.args)}"
+        )
+    vocab_name = _extract_ast_name_or_enum(node.args[0])
+    terms_list = node.args[1]
+    if not isinstance(terms_list, ast.List):
+        raise SchemaCodeError(
+            f"_ensure_terms second arg must be a list literal, got "
+            f"{ast.dump(terms_list)}"
+        )
+    terms: list[VocabularyTermModel] = []
+    for elt in terms_list.elts:
+        if not isinstance(elt, ast.Dict):
+            raise SchemaCodeError(
+                f"_ensure_terms term must be a dict literal, got "
+                f"{ast.dump(elt)}"
+            )
+        name_val: str | None = None
+        for k, v in zip(elt.keys, elt.values, strict=True):
+            if (
+                isinstance(k, ast.Constant)
+                and k.value == "Name"
+                and isinstance(v, ast.Constant)
+                and isinstance(v.value, str)
+            ):
+                name_val = v.value
+        if name_val is None:
+            raise SchemaCodeError(
+                f"_ensure_terms term missing 'Name': {ast.dump(elt)}"
+            )
+        terms.append(VocabularyTermModel(name=name_val))
+    return vocab_name, terms
+
+
 def load_from_code(path: Path) -> SchemaModel:
     """Parse create_schema.py AST into a SchemaModel.
 
-    Walks the tree looking for TableDef, VocabularyTableDef,
-    Table.define_association, and _ensure_terms calls.
+    Walks the tree for:
+      - TableDef(...)              → plain table
+      - VocabularyTableDef(...)    → vocabulary table (terms populated below)
+      - Table.define_association(...) → association table (C4)
+      - _ensure_terms(vocab, [...]) → seed terms for a vocab table
+
+    After walking, vocab tables have their terms populated by matching
+    _ensure_terms vocab_name to TableModel.name.
 
     Args:
-        path: Path to create_schema.py or a fixture module.
+        path: Path to create_schema.py or a fixture.
 
     Returns:
-        SchemaModel with one TableModel per table definition found.
+        SchemaModel with all discovered TableModels, vocab terms filled in.
 
     Raises:
         SchemaCodeError: If a call pattern can't be statically extracted.
     """
     tree = ast.parse(path.read_text(), filename=str(path))
     tables: list[TableModel] = []
+    # Map from vocab table name → list of VocabularyTermModel to apply later.
+    terms_by_vocab: dict[str, list[VocabularyTermModel]] = {}
+
     for node in ast.walk(tree):
         if not isinstance(node, ast.Call):
             continue
         name = _callable_name(node)
         if name == "TableDef":
             tables.append(_extract_tabledef(node))
-        # Vocabulary / association / _ensure_terms handled in C3 / C4.
-    return SchemaModel(tables=tables)
+        elif name == "VocabularyTableDef":
+            tables.append(_extract_vocabulary(node))
+        elif name == "_ensure_terms":
+            vocab_name, terms = _extract_ensure_terms(node)
+            terms_by_vocab.setdefault(vocab_name, []).extend(terms)
+
+    # Apply accumulated terms to matching vocab tables.
+    tables_with_terms: list[TableModel] = []
+    for t in tables:
+        if t.kind == "vocabulary" and t.name in terms_by_vocab:
+            tables_with_terms.append(TableModel(
+                name=t.name,
+                kind=t.kind,
+                columns=t.columns,
+                foreign_keys=t.foreign_keys,
+                terms=terms_by_vocab[t.name],
+                associates=t.associates,
+                metadata=t.metadata,
+            ))
+        else:
+            tables_with_terms.append(t)
+    return SchemaModel(tables=tables_with_terms)

--- a/src/deriva_ml/tools/validate_schema_doc.py
+++ b/src/deriva_ml/tools/validate_schema_doc.py
@@ -186,3 +186,41 @@ def load_from_doc(path: Path) -> SchemaModel:
             metadata=metadata,
         ))
     return SchemaModel(tables=tables)
+
+
+class SchemaCodeError(Exception):
+    """Raised when create_schema.py contains a pattern the validator can't extract."""
+
+
+# Enum lookup for resolving MLTable.xxx / MLVocab.xxx references.
+# Populated lazily via _resolve_enum_ref to avoid circular-import risk.
+_ENUM_LOOKUP: dict[str, dict[str, str]] = {}
+
+
+def _load_enum_lookup() -> dict[str, dict[str, str]]:
+    """Build {enum_name: {member_name: value}} for MLTable and MLVocab."""
+    global _ENUM_LOOKUP
+    if _ENUM_LOOKUP:
+        return _ENUM_LOOKUP
+    from deriva_ml.core.enums import MLTable, MLVocab
+
+    _ENUM_LOOKUP = {
+        "MLTable": {m.name: m.value for m in MLTable},
+        "MLVocab": {m.name: m.value for m in MLVocab},
+    }
+    return _ENUM_LOOKUP
+
+
+def _resolve_enum_ref(enum_name: str, member: str) -> str:
+    """Resolve an enum-member reference like MLTable.execution → 'Execution'."""
+    lookup = _load_enum_lookup()
+    if enum_name not in lookup:
+        raise SchemaCodeError(
+            f"unknown enum {enum_name!r}; expected one of {sorted(lookup)}"
+        )
+    members = lookup[enum_name]
+    if member not in members:
+        raise SchemaCodeError(
+            f"{enum_name} has no member {member!r}; known: {sorted(members)}"
+        )
+    return members[member]

--- a/src/deriva_ml/tools/validate_schema_doc.py
+++ b/src/deriva_ml/tools/validate_schema_doc.py
@@ -487,3 +487,55 @@ def load_from_code(path: Path) -> SchemaModel:
         else:
             tables_with_terms.append(t)
     return SchemaModel(tables=tables_with_terms)
+
+
+@dataclass(frozen=True)
+class Mismatch:
+    """One discrepancy between expected and actual schemas."""
+    kind: "MismatchKind"
+    table: str | None
+    detail: str
+
+
+def diff_schemas(*, expected: SchemaModel, actual: SchemaModel) -> list[Mismatch]:
+    """Compare two schemas; return list of Mismatches.
+
+    Args:
+        expected: The "expected" schema — typically the doc side.
+        actual: The "actual" schema — typically the code side.
+
+    Returns:
+        Empty list if schemas match. Otherwise one Mismatch per discrepancy.
+    """
+    mismatches: list[Mismatch] = []
+    expected_tables = {t.name: t for t in expected.tables}
+    actual_tables = {t.name: t for t in actual.tables}
+
+    # Missing from actual (in doc but not in code).
+    for name in sorted(expected_tables.keys() - actual_tables.keys()):
+        mismatches.append(Mismatch(
+            kind=MismatchKind.MISSING_TABLE,
+            table=name,
+            detail=f"table {name!r} is in the doc but not in the code",
+        ))
+    # Extra in actual (in code but not in doc).
+    for name in sorted(actual_tables.keys() - expected_tables.keys()):
+        mismatches.append(Mismatch(
+            kind=MismatchKind.EXTRA_TABLE,
+            table=name,
+            detail=f"table {name!r} is in the code but not in the doc",
+        ))
+    # Tables in both: D2-D4 extend this loop.
+    for name in sorted(expected_tables.keys() & actual_tables.keys()):
+        _compare_tables(mismatches, expected_tables[name], actual_tables[name])
+    return mismatches
+
+
+def _compare_tables(
+    mismatches: list[Mismatch],
+    expected: TableModel,
+    actual: TableModel,
+) -> None:
+    """Compare two same-named TableModels; append any differences."""
+    # D2-D4 populate this. Skeleton only for D1.
+    pass

--- a/src/deriva_ml/tools/validate_schema_doc.py
+++ b/src/deriva_ml/tools/validate_schema_doc.py
@@ -230,6 +230,14 @@ def _resolve_enum_ref(enum_name: str, member: str) -> str:
     return members[member]
 
 
+# Sentinel for AST values the validator can't resolve statically — parameter
+# names, attribute chains like `schema.name`, etc. When either side of a diff
+# has this sentinel, comparison treats it as "any match." Used chiefly for
+# referenced_schema in FKs where create_schema.py passes `sname` / `schema.name`
+# as a parameter rather than a literal.
+DYNAMIC_VALUE = "<dynamic>"
+
+
 def _extract_ast_str(node: ast.AST) -> str:
     """Extract a string from an ast.Constant or return the ast.unparse repr."""
     if isinstance(node, ast.Constant) and isinstance(node.value, str):
@@ -240,6 +248,33 @@ def _extract_ast_str(node: ast.AST) -> str:
     raise SchemaCodeError(
         f"expected string constant or attribute, got {ast.dump(node)}"
     )
+
+
+def _extract_ast_str_tolerant(node: ast.AST) -> str:
+    """Like _extract_ast_str, but returns DYNAMIC_VALUE for unknown patterns.
+
+    Used for fields whose code-side value is commonly a parameter or
+    attribute chain (e.g., FK referenced_schema = sname or schema.name).
+    The diff comparator treats DYNAMIC_VALUE as matching any counterpart.
+
+    For attribute references like `MLVocab.dataset_type`, resolves via the
+    enum lookup first (→ "Dataset_Type"); falls back to `.attr` only if the
+    enum is unknown.
+    """
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    if isinstance(node, ast.Attribute):
+        # Try enum resolution: MLVocab.dataset_type → "Dataset_Type".
+        if isinstance(node.value, ast.Name):
+            try:
+                return _resolve_enum_ref(node.value.id, node.attr)
+            except SchemaCodeError:
+                # Not an enum we know about (e.g., BuiltinType.text); fall
+                # back to the attr name.
+                return node.attr
+        return node.attr
+    # ast.Name (parameter reference), ast.Call, etc.: treat as dynamic.
+    return DYNAMIC_VALUE
 
 
 def _extract_ast_name_or_enum(node: ast.AST) -> str:
@@ -295,7 +330,7 @@ def _extract_fk(node: ast.Call) -> ForeignKeyModel:
         if kw.arg == "columns":
             columns = _extract_ast_str_list(kw.value)
         elif kw.arg == "referenced_schema":
-            referenced_schema = _extract_ast_str(kw.value)
+            referenced_schema = _extract_ast_str_tolerant(kw.value)
         elif kw.arg == "referenced_table":
             referenced_table = _extract_ast_str(kw.value)
         elif kw.arg == "referenced_columns":
@@ -400,31 +435,49 @@ def _extract_ensure_terms(node: ast.Call) -> tuple[str, list[VocabularyTermModel
     return vocab_name, terms
 
 
-def _extract_association(node: ast.Call) -> TableModel:
-    """Extract Table.define_association(associates=[...], metadata=[...])."""
+def _extract_association(node: ast.Call) -> TableModel | None:
+    """Extract Table.define_association(associates, metadata=[...]).
+
+    `associates` may be passed positionally (first positional arg) or as a
+    keyword. Endpoint-name references that are parameters (e.g., `asset_name`
+    in `create_asset_table`) are dynamic — if either endpoint can't be
+    resolved statically, the helper returns None and the caller skips it.
+    """
     associates: list[AssociationEndpointModel] = []
     metadata: list[ColumnModel] = []
+    assoc_list_node: ast.AST | None = None
+
+    # associates as positional (first arg).
+    if node.args:
+        assoc_list_node = node.args[0]
+
+    # Or associates= kwarg overrides.
     for kw in node.keywords:
         if kw.arg == "associates":
-            if not isinstance(kw.value, ast.List):
-                raise SchemaCodeError(
-                    f"define_association associates must be a list, got "
-                    f"{ast.dump(kw.value)}"
-                )
-            for elt in kw.value.elts:
-                if not isinstance(elt, ast.Tuple) or len(elt.elts) < 1:
-                    raise SchemaCodeError(
-                        f"associates entry must be a tuple (name, table), got "
-                        f"{ast.dump(elt)}"
-                    )
-                table_name = _extract_ast_name_or_enum(elt.elts[0])
-                associates.append(AssociationEndpointModel(table=table_name))
+            assoc_list_node = kw.value
         elif kw.arg == "metadata":
             if isinstance(kw.value, ast.List):
                 for m_elt in kw.value.elts:
                     if isinstance(m_elt, ast.Call) and _callable_name(m_elt) == "ColumnDef":
                         metadata.append(_extract_column(m_elt))
-    # Association name: derived from associates — '{first}_{second}'.
+
+    if not isinstance(assoc_list_node, ast.List):
+        # Can't resolve associates list → skip this table rather than fail.
+        return None
+
+    for elt in assoc_list_node.elts:
+        if not isinstance(elt, ast.Tuple) or len(elt.elts) < 1:
+            return None  # unexpected shape — skip silently
+        table_name = _extract_ast_str_tolerant(elt.elts[0])
+        if table_name == DYNAMIC_VALUE:
+            # Endpoint name is a parameter like `asset_name` — skip this
+            # association since we can't derive a table name.
+            return None
+        associates.append(AssociationEndpointModel(table=table_name))
+
+    if not associates:
+        return None
+
     derived_name = "_".join(a.table for a in associates)
     return TableModel(
         name=derived_name,
@@ -472,7 +525,9 @@ def load_from_code(path: Path) -> SchemaModel:
             vocab_name, terms = _extract_ensure_terms(node)
             terms_by_vocab.setdefault(vocab_name, []).extend(terms)
         elif name == "Table.define_association":
-            tables.append(_extract_association(node))
+            assoc = _extract_association(node)
+            if assoc is not None:
+                tables.append(assoc)
 
     # Apply accumulated terms to matching vocab tables.
     tables_with_terms: list[TableModel] = []
@@ -613,8 +668,16 @@ def _compare_fks(
     for k in sorted(expected_fks.keys() & actual_fks.keys()):
         exp_fk = expected_fks[k]
         act_fk = actual_fks[k]
-        if (exp_fk.referenced_schema, exp_fk.referenced_table, tuple(exp_fk.referenced_columns)) != (
-            act_fk.referenced_schema, act_fk.referenced_table, tuple(act_fk.referenced_columns)
+        # DYNAMIC_VALUE on either side of referenced_schema matches anything —
+        # create_schema.py frequently passes `sname` / `schema.name` which the
+        # AST extractor can't resolve statically.
+        schemas_match = (
+            exp_fk.referenced_schema == DYNAMIC_VALUE
+            or act_fk.referenced_schema == DYNAMIC_VALUE
+            or exp_fk.referenced_schema == act_fk.referenced_schema
+        )
+        if not schemas_match or (exp_fk.referenced_table, tuple(exp_fk.referenced_columns)) != (
+            act_fk.referenced_table, tuple(act_fk.referenced_columns)
         ):
             mismatches.append(Mismatch(
                 kind=MismatchKind.FK_MISMATCH,

--- a/src/deriva_ml/tools/validate_schema_doc.py
+++ b/src/deriva_ml/tools/validate_schema_doc.py
@@ -743,5 +743,59 @@ def main(argv: list[str] | None = None) -> int:
     return 1 if mismatches else 0
 
 
+def to_doc_markdown(model: SchemaModel) -> str:
+    """Render a SchemaModel to the docs/reference/schema.md format.
+
+    Used for bootstrap (generate an initial doc from the code) and for
+    emergency regeneration. The output is round-trip identical with
+    load_from_doc.
+
+    Args:
+        model: SchemaModel instance.
+
+    Returns:
+        Multi-section Markdown string.
+    """
+    sections: list[str] = []
+    for t in model.tables:
+        header = f"## {t.name}\n"
+        yaml_body: dict = {
+            "table": t.name,
+            "kind": t.kind,
+        }
+        if t.columns:
+            yaml_body["columns"] = [
+                {"name": c.name, "type": c.type} for c in t.columns
+            ]
+        if t.foreign_keys:
+            yaml_body["foreign_keys"] = [
+                {
+                    "columns": list(fk.columns),
+                    "referenced_schema": fk.referenced_schema,
+                    "referenced_table": fk.referenced_table,
+                    "referenced_columns": list(fk.referenced_columns),
+                }
+                for fk in t.foreign_keys
+            ]
+        elif t.kind == "table":
+            yaml_body["foreign_keys"] = []
+        if t.terms:
+            yaml_body["terms"] = [{"name": term.name} for term in t.terms]
+        if t.associates:
+            yaml_body["associates"] = [
+                {"table": a.table} for a in t.associates
+            ]
+        if t.metadata:
+            yaml_body["metadata"] = [
+                {"name": m.name, "type": m.type} for m in t.metadata
+            ]
+        yaml_text = yaml.safe_dump(
+            yaml_body, sort_keys=False, default_flow_style=False,
+        )
+        block = "```yaml\n" + yaml_text + "```\n"
+        sections.append(header + "\n" + block)
+    return "\n".join(sections)
+
+
 if __name__ == "__main__":
     sys.exit(main())

--- a/src/deriva_ml/tools/validate_schema_doc.py
+++ b/src/deriva_ml/tools/validate_schema_doc.py
@@ -9,8 +9,12 @@ Runs in CI via the deriva-ml-validate-schema entry point.
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass, field
 from enum import StrEnum
+from pathlib import Path
+
+import yaml
 
 
 @dataclass(frozen=True)
@@ -68,3 +72,46 @@ class MismatchKind(StrEnum):
     FK_MISMATCH = "fk_mismatch"
     VOCAB_TERMS_MISMATCH = "vocab_terms_mismatch"
     ASSOCIATION_MISMATCH = "association_mismatch"
+
+
+class SchemaDocError(Exception):
+    """Raised when the schema doc can't be parsed or is malformed."""
+
+
+_YAML_FENCE_RE = re.compile(
+    r"^```yaml\s*$(.*?)^```\s*$",
+    re.MULTILINE | re.DOTALL,
+)
+
+
+def _extract_yaml_blocks(path: Path) -> list[dict]:
+    """Extract YAML-fenced code blocks from a Markdown file.
+
+    Args:
+        path: Path to the Markdown file.
+
+    Returns:
+        List of dicts, one per ```yaml block, in file order.
+
+    Raises:
+        SchemaDocError: If any block fails to parse as YAML.
+    """
+    text = path.read_text()
+    blocks: list[dict] = []
+    for match in _YAML_FENCE_RE.finditer(text):
+        body = match.group(1)
+        line_number = text[: match.start()].count("\n") + 1
+        try:
+            parsed = yaml.safe_load(body)
+        except yaml.YAMLError as exc:
+            raise SchemaDocError(
+                f"YAML parse error in {path}:{line_number}: {exc}"
+            ) from exc
+        if parsed is None:
+            continue
+        if not isinstance(parsed, dict):
+            raise SchemaDocError(
+                f"{path}:{line_number}: expected a mapping, got {type(parsed).__name__}"
+            )
+        blocks.append(parsed)
+    return blocks

--- a/src/deriva_ml/tools/validate_schema_doc.py
+++ b/src/deriva_ml/tools/validate_schema_doc.py
@@ -115,3 +115,74 @@ def _extract_yaml_blocks(path: Path) -> list[dict]:
             )
         blocks.append(parsed)
     return blocks
+
+
+_VALID_KINDS = frozenset({"table", "vocabulary", "association"})
+
+
+def load_from_doc(path: Path) -> SchemaModel:
+    """Parse a schema doc Markdown file into a SchemaModel.
+
+    Args:
+        path: Path to docs/reference/schema.md or equivalent.
+
+    Returns:
+        SchemaModel with one TableModel per ```yaml block.
+
+    Raises:
+        SchemaDocError: If any block is malformed (unknown kind, missing
+            required keys, parse error).
+    """
+    blocks = _extract_yaml_blocks(path)
+    tables: list[TableModel] = []
+    for block in blocks:
+        if "table" not in block:
+            raise SchemaDocError(
+                f"{path}: block missing required key 'table': {block}"
+            )
+        if "kind" not in block:
+            raise SchemaDocError(
+                f"{path}: block missing required key 'kind' for table "
+                f"{block['table']!r}"
+            )
+        kind = block["kind"]
+        if kind not in _VALID_KINDS:
+            raise SchemaDocError(
+                f"{path}: table {block['table']!r} has unknown kind {kind!r}; "
+                f"expected one of {sorted(_VALID_KINDS)}"
+            )
+        columns = [
+            ColumnModel(name=c["name"], type=c["type"])
+            for c in block.get("columns", [])
+        ]
+        foreign_keys = [
+            ForeignKeyModel(
+                columns=fk["columns"],
+                referenced_schema=fk["referenced_schema"],
+                referenced_table=fk["referenced_table"],
+                referenced_columns=fk["referenced_columns"],
+            )
+            for fk in block.get("foreign_keys", [])
+        ]
+        terms = [
+            VocabularyTermModel(name=t["name"])
+            for t in block.get("terms", [])
+        ]
+        associates = [
+            AssociationEndpointModel(table=a["table"], role=a.get("role"))
+            for a in block.get("associates", [])
+        ]
+        metadata = [
+            ColumnModel(name=m["name"], type=m["type"])
+            for m in block.get("metadata", [])
+        ]
+        tables.append(TableModel(
+            name=block["table"],
+            kind=kind,
+            columns=columns,
+            foreign_keys=foreign_keys,
+            terms=terms,
+            associates=associates,
+            metadata=metadata,
+        ))
+    return SchemaModel(tables=tables)

--- a/src/deriva_ml/tools/validate_schema_doc.py
+++ b/src/deriva_ml/tools/validate_schema_doc.py
@@ -539,7 +539,10 @@ def _compare_tables(
     """Compare two same-named TableModels; append any differences."""
     _compare_columns(mismatches, expected, actual)
     _compare_fks(mismatches, expected, actual)
-    # D4 adds _compare_terms / _compare_associates.
+    if expected.kind == "vocabulary" or actual.kind == "vocabulary":
+        _compare_terms(mismatches, expected, actual)
+    if expected.kind == "association" or actual.kind == "association":
+        _compare_associates(mismatches, expected, actual)
 
 
 def _compare_columns(
@@ -619,3 +622,37 @@ def _compare_fks(
                     f"code → {act_fk.referenced_schema}.{act_fk.referenced_table}{act_fk.referenced_columns}"
                 ),
             ))
+
+
+def _compare_terms(
+    mismatches: list[Mismatch],
+    expected: TableModel,
+    actual: TableModel,
+) -> None:
+    """Compare vocabulary seeded terms (by Name)."""
+    expected_terms = {t.name for t in expected.terms}
+    actual_terms = {t.name for t in actual.terms}
+    if expected_terms != actual_terms:
+        doc_only = sorted(expected_terms - actual_terms)
+        code_only = sorted(actual_terms - expected_terms)
+        mismatches.append(Mismatch(
+            kind=MismatchKind.VOCAB_TERMS_MISMATCH,
+            table=expected.name,
+            detail=f"doc-only: {doc_only}; code-only: {code_only}",
+        ))
+
+
+def _compare_associates(
+    mismatches: list[Mismatch],
+    expected: TableModel,
+    actual: TableModel,
+) -> None:
+    """Compare association-table endpoints (by table name)."""
+    expected_assoc = [a.table for a in expected.associates]
+    actual_assoc = [a.table for a in actual.associates]
+    if expected_assoc != actual_assoc:
+        mismatches.append(Mismatch(
+            kind=MismatchKind.ASSOCIATION_MISMATCH,
+            table=expected.name,
+            detail=f"associates doc {expected_assoc} vs code {actual_assoc}",
+        ))

--- a/src/deriva_ml/tools/validate_schema_doc.py
+++ b/src/deriva_ml/tools/validate_schema_doc.py
@@ -538,7 +538,8 @@ def _compare_tables(
 ) -> None:
     """Compare two same-named TableModels; append any differences."""
     _compare_columns(mismatches, expected, actual)
-    # D3 adds _compare_fks; D4 adds _compare_terms / _compare_associates.
+    _compare_fks(mismatches, expected, actual)
+    # D4 adds _compare_terms / _compare_associates.
 
 
 def _compare_columns(
@@ -571,5 +572,50 @@ def _compare_columns(
                 detail=(
                     f"column {col_name!r}: doc type {exp_c.type!r} "
                     f"vs code type {act_c.type!r}"
+                ),
+            ))
+
+
+def _compare_fks(
+    mismatches: list[Mismatch],
+    expected: TableModel,
+    actual: TableModel,
+) -> None:
+    """FK comparison — by tuple (columns, referenced_table, referenced_columns).
+
+    FKs are matched by their source columns tuple. If a doc FK and a code
+    FK share columns, their referenced_* must match.
+    """
+    def key(fk: ForeignKeyModel) -> tuple[str, ...]:
+        return tuple(fk.columns)
+
+    expected_fks = {key(fk): fk for fk in expected.foreign_keys}
+    actual_fks = {key(fk): fk for fk in actual.foreign_keys}
+
+    for k in sorted(expected_fks.keys() - actual_fks.keys()):
+        mismatches.append(Mismatch(
+            kind=MismatchKind.FK_MISMATCH,
+            table=expected.name,
+            detail=f"FK on {list(k)} in doc but not in code",
+        ))
+    for k in sorted(actual_fks.keys() - expected_fks.keys()):
+        mismatches.append(Mismatch(
+            kind=MismatchKind.FK_MISMATCH,
+            table=expected.name,
+            detail=f"FK on {list(k)} in code but not in doc",
+        ))
+    for k in sorted(expected_fks.keys() & actual_fks.keys()):
+        exp_fk = expected_fks[k]
+        act_fk = actual_fks[k]
+        if (exp_fk.referenced_schema, exp_fk.referenced_table, tuple(exp_fk.referenced_columns)) != (
+            act_fk.referenced_schema, act_fk.referenced_table, tuple(act_fk.referenced_columns)
+        ):
+            mismatches.append(Mismatch(
+                kind=MismatchKind.FK_MISMATCH,
+                table=expected.name,
+                detail=(
+                    f"FK on {list(k)} differs: "
+                    f"doc → {exp_fk.referenced_schema}.{exp_fk.referenced_table}{exp_fk.referenced_columns}; "
+                    f"code → {act_fk.referenced_schema}.{act_fk.referenced_table}{act_fk.referenced_columns}"
                 ),
             ))

--- a/tests/tools/test_schema_doc_structure.py
+++ b/tests/tools/test_schema_doc_structure.py
@@ -1,0 +1,67 @@
+"""Structure tests for docs/reference/schema.md.
+
+These tests enforce invariants about the doc itself, separate from the
+doc-vs-code comparison:
+
+- Every MLTable and MLVocab enum member has a doc entry.
+- Every YAML block parses.
+- Tables are ordered: core entities → vocabularies → associations.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+DOC_PATH = Path(__file__).resolve().parent.parent.parent / "docs" / "reference" / "schema.md"
+
+# MLTable members that are dynamically-named (not extractable from static
+# AST analysis of create_schema.py). These exist at runtime but aren't
+# cross-validated. Skipped to keep the doc-vs-MLTable check focused on
+# statically-declared tables.
+_DYNAMIC_MLTABLE_EXEMPT = {"File", "Asset", "Execution_Execution", "Execution_Metadata", "Execution_Asset"}
+
+
+def test_schema_doc_exists():
+    assert DOC_PATH.exists(), f"{DOC_PATH} does not exist"
+
+
+def test_schema_doc_yaml_blocks_all_valid():
+    """Every fenced YAML block parses as a dict."""
+    from deriva_ml.tools.validate_schema_doc import _extract_yaml_blocks
+    blocks = _extract_yaml_blocks(DOC_PATH)
+    assert len(blocks) > 0
+    for b in blocks:
+        assert isinstance(b, dict)
+        assert "table" in b
+        assert "kind" in b
+
+
+def test_schema_doc_has_entry_per_mltable_member():
+    """Every MLTable enum member appears as a table in the doc."""
+    from deriva_ml.core.enums import MLTable
+    from deriva_ml.tools.validate_schema_doc import load_from_doc
+
+    model = load_from_doc(DOC_PATH)
+    doc_names = {t.name for t in model.tables}
+    for member in MLTable:
+        if member.value in _DYNAMIC_MLTABLE_EXEMPT:
+            continue
+        assert member.value in doc_names, (
+            f"MLTable.{member.name} ({member.value!r}) is missing from "
+            f"{DOC_PATH.name}. Add a ## {member.value} section with a "
+            f"fenced yaml block."
+        )
+
+
+def test_schema_doc_has_entry_per_mlvocab_member():
+    """Every MLVocab enum member appears as a vocabulary table in the doc."""
+    from deriva_ml.core.enums import MLVocab
+    from deriva_ml.tools.validate_schema_doc import load_from_doc
+
+    model = load_from_doc(DOC_PATH)
+    vocab_names = {t.name for t in model.tables if t.kind == "vocabulary"}
+    for member in MLVocab:
+        assert member.value in vocab_names, (
+            f"MLVocab.{member.name} ({member.value!r}) is missing as a "
+            f"vocabulary table in {DOC_PATH.name}."
+        )

--- a/tests/tools/test_validate_schema_doc.py
+++ b/tests/tools/test_validate_schema_doc.py
@@ -210,6 +210,7 @@ def test_load_from_doc_foreign_keys(tmp_path):
 def test_load_from_doc_invalid_kind_raises(tmp_path):
     """Unknown 'kind:' value raises SchemaDocError."""
     import pytest
+
     from deriva_ml.tools.validate_schema_doc import SchemaDocError, load_from_doc
 
     doc = tmp_path / "schema.md"
@@ -226,6 +227,7 @@ def test_load_from_doc_invalid_kind_raises(tmp_path):
 def test_load_from_doc_missing_required_key_raises(tmp_path):
     """Missing required key 'kind' raises SchemaDocError."""
     import pytest
+
     from deriva_ml.tools.validate_schema_doc import SchemaDocError, load_from_doc
 
     doc = tmp_path / "schema.md"
@@ -280,6 +282,7 @@ def test_resolve_enum_ref_mlvocab():
 
 def test_resolve_enum_ref_unknown_raises():
     import pytest
+
     from deriva_ml.tools.validate_schema_doc import SchemaCodeError, _resolve_enum_ref
 
     with pytest.raises(SchemaCodeError, match="unknown enum"):
@@ -288,6 +291,7 @@ def test_resolve_enum_ref_unknown_raises():
 
 def test_resolve_enum_ref_unknown_member_raises():
     import pytest
+
     from deriva_ml.tools.validate_schema_doc import SchemaCodeError, _resolve_enum_ref
 
     with pytest.raises(SchemaCodeError, match="has no member"):
@@ -431,7 +435,11 @@ def test_diff_identical_schemas_empty():
 
 def test_diff_column_missing_in_actual():
     from deriva_ml.tools.validate_schema_doc import (
-        ColumnModel, MismatchKind, SchemaModel, TableModel, diff_schemas,
+        ColumnModel,
+        MismatchKind,
+        SchemaModel,
+        TableModel,
+        diff_schemas,
     )
     expected = SchemaModel(tables=[TableModel(
         name="Dataset", kind="table",
@@ -449,7 +457,11 @@ def test_diff_column_missing_in_actual():
 
 def test_diff_column_type_mismatch():
     from deriva_ml.tools.validate_schema_doc import (
-        ColumnModel, MismatchKind, SchemaModel, TableModel, diff_schemas,
+        ColumnModel,
+        MismatchKind,
+        SchemaModel,
+        TableModel,
+        diff_schemas,
     )
     expected = SchemaModel(tables=[TableModel(
         name="Dataset", kind="table",
@@ -469,7 +481,12 @@ def test_diff_column_type_mismatch():
 
 def test_diff_fk_target_mismatch():
     from deriva_ml.tools.validate_schema_doc import (
-        ColumnModel, ForeignKeyModel, MismatchKind, SchemaModel, TableModel, diff_schemas,
+        ColumnModel,
+        ForeignKeyModel,
+        MismatchKind,
+        SchemaModel,
+        TableModel,
+        diff_schemas,
     )
     expected = SchemaModel(tables=[TableModel(
         name="Execution", kind="table",
@@ -497,7 +514,11 @@ def test_diff_fk_target_mismatch():
 
 def test_diff_vocab_terms_differ():
     from deriva_ml.tools.validate_schema_doc import (
-        MismatchKind, SchemaModel, TableModel, VocabularyTermModel, diff_schemas,
+        MismatchKind,
+        SchemaModel,
+        TableModel,
+        VocabularyTermModel,
+        diff_schemas,
     )
     expected = SchemaModel(tables=[TableModel(
         name="Asset_Type",
@@ -526,7 +547,11 @@ def test_diff_vocab_terms_differ():
 
 def test_diff_association_endpoints_differ():
     from deriva_ml.tools.validate_schema_doc import (
-        AssociationEndpointModel, MismatchKind, SchemaModel, TableModel, diff_schemas,
+        AssociationEndpointModel,
+        MismatchKind,
+        SchemaModel,
+        TableModel,
+        diff_schemas,
     )
     expected = SchemaModel(tables=[TableModel(
         name="Dataset_Execution",
@@ -625,9 +650,13 @@ def test_cli_parse_error_returns_2(tmp_path, capsys):
 def test_to_doc_markdown_roundtrip(tmp_path):
     """A SchemaModel rendered to Markdown can be loaded back losslessly."""
     from deriva_ml.tools.validate_schema_doc import (
-        AssociationEndpointModel, ColumnModel, ForeignKeyModel,
-        SchemaModel, TableModel, VocabularyTermModel,
-        load_from_doc, to_doc_markdown,
+        AssociationEndpointModel,
+        ColumnModel,
+        SchemaModel,
+        TableModel,
+        VocabularyTermModel,
+        load_from_doc,
+        to_doc_markdown,
     )
     original = SchemaModel(tables=[
         TableModel(

--- a/tests/tools/test_validate_schema_doc.py
+++ b/tests/tools/test_validate_schema_doc.py
@@ -1,0 +1,3 @@
+"""Tests for the schema-doc validator (spec §6)."""
+
+from __future__ import annotations

--- a/tests/tools/test_validate_schema_doc.py
+++ b/tests/tools/test_validate_schema_doc.py
@@ -493,3 +493,56 @@ def test_diff_fk_target_mismatch():
     )])
     mismatches = diff_schemas(expected=expected, actual=actual)
     assert any(m.kind == MismatchKind.FK_MISMATCH for m in mismatches)
+
+
+def test_diff_vocab_terms_differ():
+    from deriva_ml.tools.validate_schema_doc import (
+        MismatchKind, SchemaModel, TableModel, VocabularyTermModel, diff_schemas,
+    )
+    expected = SchemaModel(tables=[TableModel(
+        name="Asset_Type",
+        kind="vocabulary",
+        terms=[
+            VocabularyTermModel(name="Execution_Config"),
+            VocabularyTermModel(name="Extra_DocOnly_Term"),
+        ],
+    )])
+    actual = SchemaModel(tables=[TableModel(
+        name="Asset_Type",
+        kind="vocabulary",
+        terms=[
+            VocabularyTermModel(name="Execution_Config"),
+            VocabularyTermModel(name="Extra_CodeOnly_Term"),
+        ],
+    )])
+    mismatches = diff_schemas(expected=expected, actual=actual)
+    assert any(
+        m.kind == MismatchKind.VOCAB_TERMS_MISMATCH
+        and "Extra_DocOnly_Term" in m.detail
+        and "Extra_CodeOnly_Term" in m.detail
+        for m in mismatches
+    )
+
+
+def test_diff_association_endpoints_differ():
+    from deriva_ml.tools.validate_schema_doc import (
+        AssociationEndpointModel, MismatchKind, SchemaModel, TableModel, diff_schemas,
+    )
+    expected = SchemaModel(tables=[TableModel(
+        name="Dataset_Execution",
+        kind="association",
+        associates=[
+            AssociationEndpointModel(table="Dataset"),
+            AssociationEndpointModel(table="Execution"),
+        ],
+    )])
+    actual = SchemaModel(tables=[TableModel(
+        name="Dataset_Execution",
+        kind="association",
+        associates=[
+            AssociationEndpointModel(table="Dataset"),
+            AssociationEndpointModel(table="Workflow"),  # differs
+        ],
+    )])
+    mismatches = diff_schemas(expected=expected, actual=actual)
+    assert any(m.kind == MismatchKind.ASSOCIATION_MISMATCH for m in mismatches)

--- a/tests/tools/test_validate_schema_doc.py
+++ b/tests/tools/test_validate_schema_doc.py
@@ -110,3 +110,129 @@ def test_extract_yaml_blocks_ignores_non_yaml_fences(tmp_path):
     blocks = _extract_yaml_blocks(doc)
     assert len(blocks) == 1
     assert blocks[0]["table"] == "Dataset"
+
+
+def test_load_from_doc_plain_table(tmp_path):
+    """A plain table becomes a TableModel with kind='table'."""
+    from deriva_ml.tools.validate_schema_doc import load_from_doc
+
+    doc = tmp_path / "schema.md"
+    doc.write_text(
+        "```yaml\n"
+        "table: Dataset\n"
+        "kind: table\n"
+        "description: A data collection.\n"
+        "columns:\n"
+        "  - name: Name\n"
+        "    type: text\n"
+        "  - name: Description\n"
+        "    type: markdown\n"
+        "foreign_keys: []\n"
+        "```\n"
+    )
+    model = load_from_doc(doc)
+    assert len(model.tables) == 1
+    t = model.tables[0]
+    assert t.name == "Dataset"
+    assert t.kind == "table"
+    assert len(t.columns) == 2
+    assert t.columns[0].name == "Name"
+    assert t.columns[0].type == "text"
+
+
+def test_load_from_doc_vocabulary(tmp_path):
+    """A vocabulary table gets terms populated."""
+    from deriva_ml.tools.validate_schema_doc import load_from_doc
+
+    doc = tmp_path / "schema.md"
+    doc.write_text(
+        "```yaml\n"
+        "table: Asset_Type\n"
+        "kind: vocabulary\n"
+        "terms:\n"
+        "  - name: Execution_Config\n"
+        "  - name: Runtime_Env\n"
+        "```\n"
+    )
+    model = load_from_doc(doc)
+    t = model.tables[0]
+    assert t.kind == "vocabulary"
+    assert len(t.terms) == 2
+    assert [term.name for term in t.terms] == ["Execution_Config", "Runtime_Env"]
+
+
+def test_load_from_doc_association(tmp_path):
+    """An association table gets associates populated."""
+    from deriva_ml.tools.validate_schema_doc import load_from_doc
+
+    doc = tmp_path / "schema.md"
+    doc.write_text(
+        "```yaml\n"
+        "table: Dataset_Execution\n"
+        "kind: association\n"
+        "associates:\n"
+        "  - table: Dataset\n"
+        "  - table: Execution\n"
+        "```\n"
+    )
+    model = load_from_doc(doc)
+    t = model.tables[0]
+    assert t.kind == "association"
+    assert [a.table for a in t.associates] == ["Dataset", "Execution"]
+
+
+def test_load_from_doc_foreign_keys(tmp_path):
+    """FKs parse correctly."""
+    from deriva_ml.tools.validate_schema_doc import load_from_doc
+
+    doc = tmp_path / "schema.md"
+    doc.write_text(
+        "```yaml\n"
+        "table: Execution\n"
+        "kind: table\n"
+        "columns:\n"
+        "  - name: Workflow\n"
+        "    type: text\n"
+        "foreign_keys:\n"
+        "  - columns: [Workflow]\n"
+        "    referenced_schema: deriva-ml\n"
+        "    referenced_table: Workflow\n"
+        "    referenced_columns: [RID]\n"
+        "```\n"
+    )
+    model = load_from_doc(doc)
+    fk = model.tables[0].foreign_keys[0]
+    assert fk.columns == ["Workflow"]
+    assert fk.referenced_table == "Workflow"
+    assert fk.referenced_columns == ["RID"]
+
+
+def test_load_from_doc_invalid_kind_raises(tmp_path):
+    """Unknown 'kind:' value raises SchemaDocError."""
+    import pytest
+    from deriva_ml.tools.validate_schema_doc import SchemaDocError, load_from_doc
+
+    doc = tmp_path / "schema.md"
+    doc.write_text(
+        "```yaml\n"
+        "table: Bogus\n"
+        "kind: not-a-real-kind\n"
+        "```\n"
+    )
+    with pytest.raises(SchemaDocError, match="unknown kind"):
+        load_from_doc(doc)
+
+
+def test_load_from_doc_missing_required_key_raises(tmp_path):
+    """Missing required key 'kind' raises SchemaDocError."""
+    import pytest
+    from deriva_ml.tools.validate_schema_doc import SchemaDocError, load_from_doc
+
+    doc = tmp_path / "schema.md"
+    doc.write_text(
+        "```yaml\n"
+        "table: Bogus\n"
+        "```\n"
+    )
+    with pytest.raises(SchemaDocError, match="missing required key"):
+        load_from_doc(doc)

--- a/tests/tools/test_validate_schema_doc.py
+++ b/tests/tools/test_validate_schema_doc.py
@@ -392,3 +392,38 @@ def test_load_from_code_association_table(tmp_path):
     assert t.name == "Execution_Nested_Execution"
     assert [a.table for a in t.associates] == ["Execution", "Nested_Execution"]
     assert [m.name for m in t.metadata] == ["Sequence"]
+
+
+def test_mismatch_dataclass_fields():
+    from deriva_ml.tools.validate_schema_doc import Mismatch, MismatchKind
+    m = Mismatch(
+        kind=MismatchKind.MISSING_TABLE,
+        table="Execution_Status",
+        detail="declared in doc but not in code",
+    )
+    assert m.kind == MismatchKind.MISSING_TABLE
+    assert m.table == "Execution_Status"
+
+
+def test_diff_identical_schemas_empty():
+    from deriva_ml.tools.validate_schema_doc import (
+        ColumnModel,
+        SchemaModel,
+        TableModel,
+        diff_schemas,
+    )
+    s1 = SchemaModel(tables=[
+        TableModel(
+            name="Dataset",
+            kind="table",
+            columns=[ColumnModel(name="Name", type="text")],
+        ),
+    ])
+    s2 = SchemaModel(tables=[
+        TableModel(
+            name="Dataset",
+            kind="table",
+            columns=[ColumnModel(name="Name", type="text")],
+        ),
+    ])
+    assert diff_schemas(expected=s1, actual=s2) == []

--- a/tests/tools/test_validate_schema_doc.py
+++ b/tests/tools/test_validate_schema_doc.py
@@ -465,3 +465,31 @@ def test_diff_column_type_mismatch():
         and "text" in m.detail and "markdown" in m.detail
         for m in mismatches
     )
+
+
+def test_diff_fk_target_mismatch():
+    from deriva_ml.tools.validate_schema_doc import (
+        ColumnModel, ForeignKeyModel, MismatchKind, SchemaModel, TableModel, diff_schemas,
+    )
+    expected = SchemaModel(tables=[TableModel(
+        name="Execution", kind="table",
+        columns=[ColumnModel(name="Workflow", type="text")],
+        foreign_keys=[ForeignKeyModel(
+            columns=["Workflow"],
+            referenced_schema="deriva-ml",
+            referenced_table="Workflow",
+            referenced_columns=["RID"],
+        )],
+    )])
+    actual = SchemaModel(tables=[TableModel(
+        name="Execution", kind="table",
+        columns=[ColumnModel(name="Workflow", type="text")],
+        foreign_keys=[ForeignKeyModel(
+            columns=["Workflow"],
+            referenced_schema="deriva-ml",
+            referenced_table="SomeOtherTable",
+            referenced_columns=["RID"],
+        )],
+    )])
+    mismatches = diff_schemas(expected=expected, actual=actual)
+    assert any(m.kind == MismatchKind.FK_MISMATCH for m in mismatches)

--- a/tests/tools/test_validate_schema_doc.py
+++ b/tests/tools/test_validate_schema_doc.py
@@ -427,3 +427,41 @@ def test_diff_identical_schemas_empty():
         ),
     ])
     assert diff_schemas(expected=s1, actual=s2) == []
+
+
+def test_diff_column_missing_in_actual():
+    from deriva_ml.tools.validate_schema_doc import (
+        ColumnModel, MismatchKind, SchemaModel, TableModel, diff_schemas,
+    )
+    expected = SchemaModel(tables=[TableModel(
+        name="Dataset", kind="table",
+        columns=[ColumnModel(name="Name", type="text"), ColumnModel(name="Extra", type="text")],
+    )])
+    actual = SchemaModel(tables=[TableModel(
+        name="Dataset", kind="table",
+        columns=[ColumnModel(name="Name", type="text")],
+    )])
+    mismatches = diff_schemas(expected=expected, actual=actual)
+    assert len(mismatches) == 1
+    assert mismatches[0].kind == MismatchKind.COLUMN_MISMATCH
+    assert "Extra" in mismatches[0].detail
+
+
+def test_diff_column_type_mismatch():
+    from deriva_ml.tools.validate_schema_doc import (
+        ColumnModel, MismatchKind, SchemaModel, TableModel, diff_schemas,
+    )
+    expected = SchemaModel(tables=[TableModel(
+        name="Dataset", kind="table",
+        columns=[ColumnModel(name="Name", type="text")],
+    )])
+    actual = SchemaModel(tables=[TableModel(
+        name="Dataset", kind="table",
+        columns=[ColumnModel(name="Name", type="markdown")],
+    )])
+    mismatches = diff_schemas(expected=expected, actual=actual)
+    assert any(
+        m.kind == MismatchKind.COLUMN_MISMATCH
+        and "text" in m.detail and "markdown" in m.detail
+        for m in mismatches
+    )

--- a/tests/tools/test_validate_schema_doc.py
+++ b/tests/tools/test_validate_schema_doc.py
@@ -359,3 +359,36 @@ def test_load_from_code_vocabulary_with_terms(tmp_path):
     assert t.name == "Workflow_Type"
     assert t.kind == "vocabulary"
     assert [term.name for term in t.terms] == ["Training", "Testing"]
+
+
+def test_load_from_code_association_table(tmp_path):
+    """Table.define_association produces a TableModel with kind='association'."""
+    from deriva_ml.tools.validate_schema_doc import load_from_code
+
+    fixture = tmp_path / "fixture_assoc.py"
+    fixture.write_text(
+        'from deriva.core.ermrest_model import Table\n'
+        'from deriva.core.typed import ColumnDef, BuiltinType\n'
+        '\n'
+        'def create():\n'
+        '    schema.create_table(\n'
+        '        Table.define_association(\n'
+        '            associates=[\n'
+        '                ("Execution", execution_table),\n'
+        '                ("Nested_Execution", execution_table),\n'
+        '            ],\n'
+        '            metadata=[\n'
+        '                ColumnDef(name="Sequence", type="int4", nullok=True),\n'
+        '            ],\n'
+        '        )\n'
+        '    )\n'
+    )
+    model = load_from_code(fixture)
+    assert len(model.tables) == 1
+    t = model.tables[0]
+    assert t.kind == "association"
+    # Name isn't given directly; derived from the associates pair.
+    # We expect "Execution_Nested_Execution" as the default-constructed name.
+    assert t.name == "Execution_Nested_Execution"
+    assert [a.table for a in t.associates] == ["Execution", "Nested_Execution"]
+    assert [m.name for m in t.metadata] == ["Sequence"]

--- a/tests/tools/test_validate_schema_doc.py
+++ b/tests/tools/test_validate_schema_doc.py
@@ -56,3 +56,57 @@ def test_mismatch_kinds_defined():
     assert MismatchKind.COLUMN_MISMATCH.value == "column_mismatch"
     assert MismatchKind.FK_MISMATCH.value == "fk_mismatch"
     assert MismatchKind.VOCAB_TERMS_MISMATCH.value == "vocab_terms_mismatch"
+
+
+def test_extract_yaml_blocks_basic(tmp_path):
+    """Extracts YAML-fenced blocks and parses each into a dict."""
+    from deriva_ml.tools.validate_schema_doc import _extract_yaml_blocks
+
+    doc = tmp_path / "schema.md"
+    doc.write_text(
+        "# Intro\n"
+        "\n"
+        "## Dataset\n"
+        "\n"
+        "```yaml\n"
+        "table: Dataset\n"
+        "kind: table\n"
+        "columns:\n"
+        "  - name: Name\n"
+        "    type: text\n"
+        "```\n"
+        "\n"
+        "More prose.\n"
+        "\n"
+        "```yaml\n"
+        "table: Workflow\n"
+        "kind: table\n"
+        "```\n"
+    )
+
+    blocks = _extract_yaml_blocks(doc)
+    assert len(blocks) == 2
+    assert blocks[0]["table"] == "Dataset"
+    assert blocks[0]["columns"][0]["name"] == "Name"
+    assert blocks[1]["table"] == "Workflow"
+
+
+def test_extract_yaml_blocks_ignores_non_yaml_fences(tmp_path):
+    """Code blocks fenced as other languages are not parsed as YAML."""
+    from deriva_ml.tools.validate_schema_doc import _extract_yaml_blocks
+
+    doc = tmp_path / "schema.md"
+    doc.write_text(
+        "```python\n"
+        "x = 1\n"
+        "```\n"
+        "\n"
+        "```yaml\n"
+        "table: Dataset\n"
+        "kind: table\n"
+        "```\n"
+    )
+
+    blocks = _extract_yaml_blocks(doc)
+    assert len(blocks) == 1
+    assert blocks[0]["table"] == "Dataset"

--- a/tests/tools/test_validate_schema_doc.py
+++ b/tests/tools/test_validate_schema_doc.py
@@ -691,3 +691,117 @@ def test_to_doc_markdown_roundtrip(tmp_path):
     assert roundtripped.tables[0].columns[0].name == "Name"
     assert roundtripped.tables[1].terms[0].name == "Training"
     assert roundtripped.tables[2].associates[0].table == "Dataset"
+
+
+def test_dynamic_value_fk_schema_matches_any():
+    """DYNAMIC_VALUE on either side of referenced_schema matches anything.
+
+    When create_schema.py writes `referenced_schema=sname` (a parameter),
+    the AST extractor stores DYNAMIC_VALUE. The doc side writes the literal
+    schema name (e.g. "deriva-ml"). These must compare as equal.
+    """
+    from deriva_ml.tools.validate_schema_doc import (
+        DYNAMIC_VALUE,
+        ColumnModel,
+        ForeignKeyModel,
+        SchemaModel,
+        TableModel,
+        diff_schemas,
+    )
+    expected = SchemaModel(tables=[TableModel(
+        name="Execution",
+        kind="table",
+        columns=[ColumnModel(name="Workflow", type="text")],
+        foreign_keys=[ForeignKeyModel(
+            columns=["Workflow"],
+            referenced_schema="deriva-ml",  # doc-side literal
+            referenced_table="Workflow",
+            referenced_columns=["RID"],
+        )],
+    )])
+    actual = SchemaModel(tables=[TableModel(
+        name="Execution",
+        kind="table",
+        columns=[ColumnModel(name="Workflow", type="text")],
+        foreign_keys=[ForeignKeyModel(
+            columns=["Workflow"],
+            referenced_schema=DYNAMIC_VALUE,  # code-side unresolvable
+            referenced_table="Workflow",
+            referenced_columns=["RID"],
+        )],
+    )])
+    mismatches = diff_schemas(expected=expected, actual=actual)
+    assert mismatches == [], f"Expected no mismatches; got {mismatches}"
+
+
+def test_dynamic_value_does_not_mask_other_fk_differences():
+    """DYNAMIC_VALUE matches referenced_schema, but other FK fields still diff."""
+    from deriva_ml.tools.validate_schema_doc import (
+        DYNAMIC_VALUE,
+        ColumnModel,
+        ForeignKeyModel,
+        MismatchKind,
+        SchemaModel,
+        TableModel,
+        diff_schemas,
+    )
+    expected = SchemaModel(tables=[TableModel(
+        name="Execution",
+        kind="table",
+        columns=[ColumnModel(name="Workflow", type="text")],
+        foreign_keys=[ForeignKeyModel(
+            columns=["Workflow"],
+            referenced_schema="deriva-ml",
+            referenced_table="Workflow",
+            referenced_columns=["RID"],
+        )],
+    )])
+    actual = SchemaModel(tables=[TableModel(
+        name="Execution",
+        kind="table",
+        columns=[ColumnModel(name="Workflow", type="text")],
+        foreign_keys=[ForeignKeyModel(
+            columns=["Workflow"],
+            referenced_schema=DYNAMIC_VALUE,
+            referenced_table="DifferentTable",  # differs
+            referenced_columns=["RID"],
+        )],
+    )])
+    mismatches = diff_schemas(expected=expected, actual=actual)
+    assert any(m.kind == MismatchKind.FK_MISMATCH for m in mismatches)
+
+
+def test_compare_associates_detects_metadata_mismatch():
+    """Association-table metadata columns diff when they differ."""
+    from deriva_ml.tools.validate_schema_doc import (
+        AssociationEndpointModel,
+        ColumnModel,
+        MismatchKind,
+        SchemaModel,
+        TableModel,
+        diff_schemas,
+    )
+    expected = SchemaModel(tables=[TableModel(
+        name="X_Y",
+        kind="association",
+        associates=[
+            AssociationEndpointModel(table="X"),
+            AssociationEndpointModel(table="Y"),
+        ],
+        metadata=[ColumnModel(name="Sequence", type="int4")],
+    )])
+    actual = SchemaModel(tables=[TableModel(
+        name="X_Y",
+        kind="association",
+        associates=[
+            AssociationEndpointModel(table="X"),
+            AssociationEndpointModel(table="Y"),
+        ],
+        metadata=[],  # code is missing the metadata column
+    )])
+    mismatches = diff_schemas(expected=expected, actual=actual)
+    assert any(
+        m.kind == MismatchKind.ASSOCIATION_MISMATCH
+        and "metadata" in m.detail
+        for m in mismatches
+    ), f"Expected metadata mismatch; got {mismatches}"

--- a/tests/tools/test_validate_schema_doc.py
+++ b/tests/tools/test_validate_schema_doc.py
@@ -292,3 +292,42 @@ def test_resolve_enum_ref_unknown_member_raises():
 
     with pytest.raises(SchemaCodeError, match="has no member"):
         _resolve_enum_ref("MLTable", "no_such_member")
+
+
+def test_load_from_code_simple_tabledef(tmp_path):
+    """A fixture module with one TableDef call produces a TableModel."""
+    from deriva_ml.tools.validate_schema_doc import load_from_code
+
+    fixture = tmp_path / "fixture_schema.py"
+    fixture.write_text(
+        'from deriva.core.typed import TableDef, ColumnDef, ForeignKeyDef, BuiltinType\n'
+        'from deriva_ml.core.definitions import MLTable\n'
+        '\n'
+        'def create_execution_table(schema):\n'
+        '    schema.create_table(TableDef(\n'
+        '        name=MLTable.execution,\n'
+        '        columns=[\n'
+        '            ColumnDef("Workflow", BuiltinType.text),\n'
+        '            ColumnDef("Description", BuiltinType.markdown),\n'
+        '            ColumnDef("Status", BuiltinType.text),\n'
+        '        ],\n'
+        '        foreign_keys=[\n'
+        '            ForeignKeyDef(\n'
+        '                columns=["Workflow"],\n'
+        '                referenced_schema="deriva-ml",\n'
+        '                referenced_table="Workflow",\n'
+        '                referenced_columns=["RID"],\n'
+        '            )\n'
+        '        ],\n'
+        '    ))\n'
+    )
+    model = load_from_code(fixture)
+    assert len(model.tables) == 1
+    t = model.tables[0]
+    assert t.name == "Execution"
+    assert t.kind == "table"
+    assert [c.name for c in t.columns] == ["Workflow", "Description", "Status"]
+    assert [c.type for c in t.columns] == ["text", "markdown", "text"]
+    assert len(t.foreign_keys) == 1
+    assert t.foreign_keys[0].columns == ["Workflow"]
+    assert t.foreign_keys[0].referenced_table == "Workflow"

--- a/tests/tools/test_validate_schema_doc.py
+++ b/tests/tools/test_validate_schema_doc.py
@@ -1,3 +1,58 @@
 """Tests for the schema-doc validator (spec §6)."""
 
 from __future__ import annotations
+
+
+def test_schema_model_fields():
+    from deriva_ml.tools.validate_schema_doc import (
+        SchemaModel,
+        TableModel,
+    )
+    m = SchemaModel(tables=[])
+    assert m.tables == []
+
+    t = TableModel(
+        name="Dataset",
+        kind="table",
+        columns=[],
+        foreign_keys=[],
+        terms=[],
+        associates=[],
+        metadata=[],
+    )
+    assert t.name == "Dataset"
+    assert t.kind == "table"
+
+
+def test_column_model_fields():
+    from deriva_ml.tools.validate_schema_doc import ColumnModel
+    c = ColumnModel(name="Status", type="text")
+    assert c.name == "Status"
+    assert c.type == "text"
+
+
+def test_fk_model_fields():
+    from deriva_ml.tools.validate_schema_doc import ForeignKeyModel
+    fk = ForeignKeyModel(
+        columns=["Workflow"],
+        referenced_schema="deriva-ml",
+        referenced_table="Workflow",
+        referenced_columns=["RID"],
+    )
+    assert fk.columns == ["Workflow"]
+    assert fk.referenced_table == "Workflow"
+
+
+def test_vocabulary_term_model():
+    from deriva_ml.tools.validate_schema_doc import VocabularyTermModel
+    term = VocabularyTermModel(name="Running")
+    assert term.name == "Running"
+
+
+def test_mismatch_kinds_defined():
+    """Enum of mismatch kinds is present."""
+    from deriva_ml.tools.validate_schema_doc import MismatchKind
+    assert MismatchKind.MISSING_TABLE.value == "missing_table"
+    assert MismatchKind.COLUMN_MISMATCH.value == "column_mismatch"
+    assert MismatchKind.FK_MISMATCH.value == "fk_mismatch"
+    assert MismatchKind.VOCAB_TERMS_MISMATCH.value == "vocab_terms_mismatch"

--- a/tests/tools/test_validate_schema_doc.py
+++ b/tests/tools/test_validate_schema_doc.py
@@ -331,3 +331,31 @@ def test_load_from_code_simple_tabledef(tmp_path):
     assert len(t.foreign_keys) == 1
     assert t.foreign_keys[0].columns == ["Workflow"]
     assert t.foreign_keys[0].referenced_table == "Workflow"
+
+
+def test_load_from_code_vocabulary_with_terms(tmp_path):
+    """A VocabularyTableDef plus _ensure_terms yields a vocabulary TableModel."""
+    from deriva_ml.tools.validate_schema_doc import load_from_code
+
+    fixture = tmp_path / "fixture_vocab.py"
+    fixture.write_text(
+        'from deriva.core.typed import VocabularyTableDef\n'
+        'from deriva_ml.core.definitions import MLVocab\n'
+        '\n'
+        'def create():\n'
+        '    schema.create_table(\n'
+        '        VocabularyTableDef(name=MLVocab.workflow_type, curie_template="x:{RID}")\n'
+        '    )\n'
+        '\n'
+        'def seed():\n'
+        '    _ensure_terms(MLVocab.workflow_type, [\n'
+        '        {"Name": "Training", "Description": "Train a model"},\n'
+        '        {"Name": "Testing", "Description": "Evaluate a model"},\n'
+        '    ])\n'
+    )
+    model = load_from_code(fixture)
+    assert len(model.tables) == 1
+    t = model.tables[0]
+    assert t.name == "Workflow_Type"
+    assert t.kind == "vocabulary"
+    assert [term.name for term in t.terms] == ["Training", "Testing"]

--- a/tests/tools/test_validate_schema_doc.py
+++ b/tests/tools/test_validate_schema_doc.py
@@ -236,3 +236,28 @@ def test_load_from_doc_missing_required_key_raises(tmp_path):
     )
     with pytest.raises(SchemaDocError, match="missing required key"):
         load_from_doc(doc)
+
+
+def test_load_from_doc_accepts_descriptions(tmp_path):
+    """Descriptions on tables and columns are tolerated (doc-side only)."""
+    from deriva_ml.tools.validate_schema_doc import load_from_doc
+
+    doc = tmp_path / "schema.md"
+    doc.write_text(
+        "```yaml\n"
+        "table: Dataset\n"
+        "kind: table\n"
+        "description: A collection of records.\n"
+        "columns:\n"
+        "  - name: Name\n"
+        "    type: text\n"
+        "    description: Human-readable label.\n"
+        "```\n"
+    )
+    model = load_from_doc(doc)
+    # Description text is NOT preserved in the model (doc-side only).
+    t = model.tables[0]
+    assert t.name == "Dataset"
+    assert t.columns[0].name == "Name"
+    # ColumnModel has no description field.
+    assert not hasattr(t.columns[0], "description")

--- a/tests/tools/test_validate_schema_doc.py
+++ b/tests/tools/test_validate_schema_doc.py
@@ -261,3 +261,34 @@ def test_load_from_doc_accepts_descriptions(tmp_path):
     assert t.columns[0].name == "Name"
     # ColumnModel has no description field.
     assert not hasattr(t.columns[0], "description")
+
+
+def test_resolve_enum_ref_mltable():
+    """Resolver returns the enum value for MLTable.execution."""
+    from deriva_ml.tools.validate_schema_doc import _resolve_enum_ref
+
+    assert _resolve_enum_ref("MLTable", "execution") == "Execution"
+    assert _resolve_enum_ref("MLTable", "dataset") == "Dataset"
+
+
+def test_resolve_enum_ref_mlvocab():
+    from deriva_ml.tools.validate_schema_doc import _resolve_enum_ref
+
+    assert _resolve_enum_ref("MLVocab", "workflow_type") == "Workflow_Type"
+    assert _resolve_enum_ref("MLVocab", "asset_type") == "Asset_Type"
+
+
+def test_resolve_enum_ref_unknown_raises():
+    import pytest
+    from deriva_ml.tools.validate_schema_doc import SchemaCodeError, _resolve_enum_ref
+
+    with pytest.raises(SchemaCodeError, match="unknown enum"):
+        _resolve_enum_ref("UnknownEnum", "whatever")
+
+
+def test_resolve_enum_ref_unknown_member_raises():
+    import pytest
+    from deriva_ml.tools.validate_schema_doc import SchemaCodeError, _resolve_enum_ref
+
+    with pytest.raises(SchemaCodeError, match="has no member"):
+        _resolve_enum_ref("MLTable", "no_such_member")

--- a/tests/tools/test_validate_schema_doc.py
+++ b/tests/tools/test_validate_schema_doc.py
@@ -620,3 +620,45 @@ def test_cli_parse_error_returns_2(tmp_path, capsys):
 
     exit_code = main(["--doc", str(doc), "--code", str(code)])
     assert exit_code == 2
+
+
+def test_to_doc_markdown_roundtrip(tmp_path):
+    """A SchemaModel rendered to Markdown can be loaded back losslessly."""
+    from deriva_ml.tools.validate_schema_doc import (
+        AssociationEndpointModel, ColumnModel, ForeignKeyModel,
+        SchemaModel, TableModel, VocabularyTermModel,
+        load_from_doc, to_doc_markdown,
+    )
+    original = SchemaModel(tables=[
+        TableModel(
+            name="Dataset",
+            kind="table",
+            columns=[ColumnModel(name="Name", type="text")],
+            foreign_keys=[],
+        ),
+        TableModel(
+            name="Workflow_Type",
+            kind="vocabulary",
+            terms=[VocabularyTermModel(name="Training")],
+        ),
+        TableModel(
+            name="Dataset_Dataset_Type",
+            kind="association",
+            associates=[
+                AssociationEndpointModel(table="Dataset"),
+                AssociationEndpointModel(table="Dataset_Type"),
+            ],
+        ),
+    ])
+    md = to_doc_markdown(original)
+    doc = tmp_path / "schema.md"
+    doc.write_text(md)
+    roundtripped = load_from_doc(doc)
+
+    assert len(roundtripped.tables) == 3
+    assert [t.name for t in roundtripped.tables] == [
+        "Dataset", "Workflow_Type", "Dataset_Dataset_Type",
+    ]
+    assert roundtripped.tables[0].columns[0].name == "Name"
+    assert roundtripped.tables[1].terms[0].name == "Training"
+    assert roundtripped.tables[2].associates[0].table == "Dataset"

--- a/tests/tools/test_validate_schema_doc.py
+++ b/tests/tools/test_validate_schema_doc.py
@@ -546,3 +546,77 @@ def test_diff_association_endpoints_differ():
     )])
     mismatches = diff_schemas(expected=expected, actual=actual)
     assert any(m.kind == MismatchKind.ASSOCIATION_MISMATCH for m in mismatches)
+
+
+def test_cli_match_returns_0(tmp_path, capsys):
+    """Identical schemas: exit 0, success message."""
+    from deriva_ml.tools.validate_schema_doc import main
+
+    doc = tmp_path / "schema.md"
+    doc.write_text(
+        "```yaml\n"
+        "table: X\n"
+        "kind: table\n"
+        "columns: []\n"
+        "foreign_keys: []\n"
+        "```\n"
+    )
+    code = tmp_path / "code.py"
+    code.write_text(
+        'from deriva.core.typed import TableDef\n'
+        'schema.create_table(TableDef(name="X", columns=[], foreign_keys=[]))\n'
+    )
+
+    exit_code = main(["--doc", str(doc), "--code", str(code)])
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "agree" in captured.out
+
+
+def test_cli_mismatch_returns_1(tmp_path, capsys):
+    """Divergent schemas: exit 1, mismatch lines."""
+    from deriva_ml.tools.validate_schema_doc import main
+
+    doc = tmp_path / "schema.md"
+    doc.write_text(
+        "```yaml\n"
+        "table: X\n"
+        "kind: table\n"
+        "columns:\n"
+        "  - name: A\n"
+        "    type: text\n"
+        "foreign_keys: []\n"
+        "```\n"
+    )
+    code = tmp_path / "code.py"
+    code.write_text(
+        'from deriva.core.typed import TableDef, ColumnDef, BuiltinType\n'
+        'schema.create_table(TableDef(\n'
+        '    name="X",\n'
+        '    columns=[ColumnDef("B", BuiltinType.text)],\n'
+        '    foreign_keys=[],\n'
+        '))\n'
+    )
+
+    exit_code = main(["--doc", str(doc), "--code", str(code)])
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "COLUMN MISMATCH" in captured.out or "column" in captured.out.lower()
+
+
+def test_cli_parse_error_returns_2(tmp_path, capsys):
+    """Malformed doc: exit 2."""
+    from deriva_ml.tools.validate_schema_doc import main
+
+    doc = tmp_path / "schema.md"
+    doc.write_text(
+        "```yaml\n"
+        "table: X\n"
+        "kind: invalid-kind\n"
+        "```\n"
+    )
+    code = tmp_path / "code.py"
+    code.write_text("")
+
+    exit_code = main(["--doc", str(doc), "--code", str(code)])
+    assert exit_code == 2

--- a/tests/tools/test_validate_schema_doc_integration.py
+++ b/tests/tools/test_validate_schema_doc_integration.py
@@ -16,7 +16,9 @@ REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 def test_validator_runs_clean_on_current_repo():
     """The authoritative doc and code agree. This IS the CI gate."""
     from deriva_ml.tools.validate_schema_doc import (
-        diff_schemas, load_from_code, load_from_doc,
+        diff_schemas,
+        load_from_code,
+        load_from_doc,
     )
 
     doc_path = REPO_ROOT / "docs" / "reference" / "schema.md"

--- a/tests/tools/test_validate_schema_doc_integration.py
+++ b/tests/tools/test_validate_schema_doc_integration.py
@@ -1,0 +1,47 @@
+"""Integration tests — run the validator on the real repo files.
+
+If this test fails, docs/reference/schema.md has drifted from
+src/deriva_ml/schema/create_schema.py. Fix one or both.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+def test_validator_runs_clean_on_current_repo():
+    """The authoritative doc and code agree. This IS the CI gate."""
+    from deriva_ml.tools.validate_schema_doc import (
+        diff_schemas, load_from_code, load_from_doc,
+    )
+
+    doc_path = REPO_ROOT / "docs" / "reference" / "schema.md"
+    code_path = REPO_ROOT / "src" / "deriva_ml" / "schema" / "create_schema.py"
+
+    expected = load_from_doc(doc_path)
+    actual = load_from_code(code_path)
+    mismatches = diff_schemas(expected=expected, actual=actual)
+
+    assert mismatches == [], (
+        "schema.md and create_schema.py disagree:\n"
+        + "\n".join(f"  - {m.kind.value}: {m.detail}" for m in mismatches)
+    )
+
+
+def test_cli_exits_zero_on_current_repo():
+    """Invoking the CLI against the real paths returns exit 0."""
+    result = subprocess.run(
+        [sys.executable, "-m", "deriva_ml.tools.validate_schema_doc"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, (
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+    assert "agree" in result.stdout


### PR DESCRIPTION
## Summary

Establishes `docs/reference/schema.md` as the authoritative description of the deriva-ml schema, enforced by a CI validator that asserts doc and `src/deriva_ml/schema/create_schema.py` agree on tables, columns, foreign keys, and vocabulary seeded terms.

**Why:** Preparing for Subsystem 1 (status-enum reconciliation, which adds `Execution_Status` and other schema changes) — we want a reviewable, structured description of the current schema so reviewers can see "before" and "after" states explicitly instead of reading AST-level diffs.

**Architecture (Path 1, per spec §2):** Both files coexist and are maintained by developers — doc describes intended schema, code defines it at runtime, validator enforces agreement. Neither is generated from the other. Doc is a single Markdown file with fenced YAML blocks per table.

**Spec:** `docs/superpowers/specs/2026-04-21-schema-doc-source-of-truth-design.md`
**Plan:** `docs/superpowers/plans/2026-04-21-schema-doc-source-of-truth.md`

### What ships

- `src/deriva_ml/tools/validate_schema_doc.py` — validator module (`SchemaModel` dataclass hierarchy, `load_from_doc`, `load_from_code` AST walker, `diff_schemas` comparator, `main` CLI, `to_doc_markdown` helper for bootstrap).
- `docs/reference/schema.md` — authoritative 14-table schema description with prose and fenced YAML blocks.
- `docs/reference/README.md` — doc-first workflow instructions.
- `deriva-ml-validate-schema` CLI entry point registered in pyproject.toml.
- `.github/workflows/validate-schema.yml` — runs validator on every PR.
- 41 new unit + integration + structure tests in `tests/tools/`.
- CHANGELOG entry with known limitations and filed follow-ups.

### Known limitations (documented in CHANGELOG)

- Dynamically-named asset tables (`Asset`, `File`, `Execution_Execution`, `Execution_Metadata`, `Execution_Asset`) are not extractable from the static AST walker. They exist at runtime but aren't cross-validated; exemption list in `tests/tools/test_schema_doc_structure.py`.
- `referenced_schema` in FKs is often a parameter (`sname`) or attribute (`schema.name`). The validator resolves these to a `DYNAMIC_VALUE` sentinel and treats them as matching any doc-side value.

### Also included

The Subsystem 1 (status-enum reconciliation) design spec is committed here as `docs/superpowers/specs/2026-04-21-status-enum-reconciliation-design.md` — it's docs-only preparatory work; the corresponding implementation plan and code changes will come in a separate PR after this merges.

## Test Plan

- [x] 41 tests pass in `tests/tools/` (unit + doc-structure + integration)
- [x] `uv run deriva-ml-validate-schema` exits 0 on the real repo
- [x] Regression: 333 passed / 3 skipped in `tests/core/` + `tests/local_db/`
- [x] Ruff clean on all new files (src/deriva_ml/tools/, tests/tools/, docs/reference/, .github/workflows/)
- [x] Final reviewer pass (superpowers:code-reviewer) — verdict READY TO SHIP; 2 Important items addressed in `e9a63de` (DYNAMIC_VALUE unit tests + association metadata diff)
- [ ] Reviewer sanity-check: the CHANGELOG's "known limitations" section accurately describes the dynamic-named-table exemption
- [ ] Reviewer sanity-check: the spec for Subsystem 1 is clearly marked as docs-only preparatory work, not part of this subsystem's deliverables

## Filed follow-ups

See CHANGELOG "Not yet supported" section:
- Direction 2: live-catalog validation (`--against=catalog`)
- Description cross-validation (currently narrative-only)
- Annotation validation
- Section-ordering convention test (warn-not-fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)