### PR TITLE
Hygiene batch: S4 offline-mode completeness + H4 dead-test cleanup

### DIFF
--- a/src/deriva_ml/core/base.py
+++ b/src/deriva_ml/core/base.py
@@ -704,15 +704,22 @@ class DerivaML(
                     "Legacy manifest migration failed: %s",
                     exc,
                 )
-            # Build the local schema so the ORM is available. Refresh the
-            # catalog model first so the ORM reflects the actual catalog
-            # state at the time workspace is lazily first accessed — the
-            # model object captured at DerivaML.__init__ may have been
-            # constructed before later catalog mutations (e.g. the test
-            # harness calling ``add_dataset_element_type`` to create
-            # association tables). Without this refresh, the local schema
-            # misses tables that already exist in the catalog.
-            self.model.refresh_model()
+            # Build the local schema so the ORM is available. In online
+            # mode, refresh the catalog model first so the ORM reflects
+            # the actual catalog state at the time workspace is lazily
+            # first accessed — the model object captured at
+            # DerivaML.__init__ may have been constructed before later
+            # catalog mutations (e.g. the test harness calling
+            # ``add_dataset_element_type`` to create association tables).
+            # Without this refresh, the local schema misses tables that
+            # already exist in the catalog.
+            #
+            # In offline mode, the schema cache IS the authoritative
+            # model and refresh_model() would attempt a network call
+            # that CatalogStub refuses. Skip it — the cached model was
+            # loaded at __init__ time and is what offline callers want.
+            if self._mode is ConnectionMode.online:
+                self.model.refresh_model()
             self._workspace.build_local_schema(
                 model=self.model.model,  # the ERMrest Model object
                 schemas=[self.ml_schema, *self.domain_schemas],

--- a/tests/catalog/test_clone_subset_catalog.py
+++ b/tests/catalog/test_clone_subset_catalog.py
@@ -9,6 +9,8 @@ Tests cover:
 
 from __future__ import annotations
 
+import os
+
 import pytest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -516,7 +518,10 @@ class TestParseExportAnnotationTables:
 class TestCreateMlWorkspaceIntegration:
     """Integration tests for create_ml_workspace (requires running catalog)."""
 
-    @pytest.mark.skip(reason="Requires running catalog")
+    @pytest.mark.skipif(
+        not os.environ.get("DERIVA_HOST"),
+        reason="requires a live catalog at DERIVA_HOST",
+    )
     def test_create_workspace_basic(self, catalog_manager: CatalogManager, tmp_path: Path):
         """Test basic workspace creation from a dataset RID."""
         ml = catalog_manager.ensure_populated(tmp_path / "source")
@@ -567,7 +572,10 @@ class TestCreateMlWorkspaceIntegration:
         finally:
             self._delete_catalog(hostname, result.catalog_id)
 
-    @pytest.mark.skip(reason="Requires running catalog")
+    @pytest.mark.skipif(
+        not os.environ.get("DERIVA_HOST"),
+        reason="requires a live catalog at DERIVA_HOST",
+    )
     def test_create_workspace_with_associations(self, catalog_manager: CatalogManager, tmp_path: Path):
         """Test that association tables are automatically included."""
         ml = catalog_manager.ensure_populated(tmp_path / "source")

--- a/tests/dataset/test_denormalize.py
+++ b/tests/dataset/test_denormalize.py
@@ -646,26 +646,6 @@ class TestDuplicateAssociationTables:
         )
 
 
-class TestDenormalizeSqlGeneration:
-    """Test the SQL generation aspects of _denormalize."""
-
-    @pytest.mark.skip(
-        reason="bag._denormalize() was removed in Phase 2; behavior is now covered "
-        "by the public denormalize_as_dataframe tests which exercise the unified "
-        "denormalize() engine end-to-end."
-    )
-    def test_sql_select_structure(self, dataset_test, tmp_path):
-        """Legacy: tested the deleted _denormalize() private method on DatasetBag."""
-
-    @pytest.mark.skip(
-        reason="bag._denormalize() was removed in Phase 2; UNION behavior for "
-        "multi-path joins is now handled inside the unified denormalize() engine "
-        "and covered by TestDenormalize.test_simple_denormalize etc."
-    )
-    def test_union_for_multiple_paths(self, dataset_test, tmp_path):
-        """Legacy: tested the deleted _denormalize() private method on DatasetBag."""
-
-
 class TestCatalogDenormalize:
     """Test suite for catalog-based denormalization (Dataset class).
 

--- a/tests/execution/test_execution_registry.py
+++ b/tests/execution/test_execution_registry.py
@@ -117,11 +117,27 @@ def test_resume_execution_missing_raises(test_ml):
 
 
 def test_resume_execution_offline_skips_reconcile(catalog_manager, tmp_path):
-    """Offline resume must not contact the server."""
+    """Offline resume must not contact the server.
+
+    S4 made offline mode require a pre-populated schema cache; this
+    test now does a two-step setup — online run first to populate
+    <working_dir>/schema-cache.json, then offline run reads it.
+    """
     from deriva_ml import ConnectionMode, DerivaML
     from deriva_ml.execution.state_store import ExecutionStatus
 
     catalog_manager.reset()
+    # Step 1: online run populates the schema cache.
+    DerivaML(
+        catalog_manager.hostname,
+        catalog_manager.catalog_id,
+        default_schema=catalog_manager.domain_schema,
+        working_dir=tmp_path,
+        use_minid=False,
+        mode=ConnectionMode.online,
+    )
+    # Step 2: offline run reads the cache; resume_execution must not
+    # contact the server.
     ml = DerivaML(
         catalog_manager.hostname,
         catalog_manager.catalog_id,
@@ -341,12 +357,28 @@ def test_create_execution_rejects_mixed_forms(test_ml):
 
 
 def test_create_execution_offline_raises(catalog_manager, tmp_path):
+    """Offline create_execution must raise DerivaMLOfflineError.
+
+    S4 made offline mode require a pre-populated schema cache; this
+    test now does a two-step setup — online run first to populate
+    <working_dir>/schema-cache.json, then offline run reads it.
+    """
     import pytest
 
     from deriva_ml import ConnectionMode, DerivaML
     from deriva_ml.core.exceptions import DerivaMLOfflineError
 
     catalog_manager.reset()
+    # Step 1: online run populates the schema cache.
+    DerivaML(
+        catalog_manager.hostname,
+        catalog_manager.catalog_id,
+        default_schema=catalog_manager.domain_schema,
+        working_dir=tmp_path,
+        use_minid=False,
+        mode=ConnectionMode.online,
+    )
+    # Step 2: offline run reads the cache; create_execution must raise.
     ml_offline = DerivaML(
         catalog_manager.hostname,
         catalog_manager.catalog_id,

--- a/tests/execution/test_lease_orchestrator.py
+++ b/tests/execution/test_lease_orchestrator.py
@@ -316,51 +316,45 @@ def test_workspace_open_reconciles_leases(test_ml, monkeypatch):
 
 
 def test_offline_workspace_skips_lease_reconcile(monkeypatch, tmp_path):
-    """In offline mode there's no server to query — skip the sweep."""
+    """In offline mode there's no server to query — skip the sweep.
+
+    S4 implemented real offline mode: ``DerivaML(mode=offline)`` reads
+    a pre-populated schema cache at ``<working_dir>/schema-cache.json``
+    and sets ``self.catalog = CatalogStub()``. The lease-reconcile
+    hook in ``__init__`` is gated on ``self._mode is online``, so in
+    offline mode it simply isn't called. This test plants a minimal
+    cache file, constructs offline, and asserts the spy was never hit.
+
+    No network stubs needed — offline mode doesn't touch
+    ``DerivaServer``, ``get_credential``, or ``DerivaModel.from_catalog``.
+    """
     from deriva_ml.execution import lease_orchestrator
     calls: list[str | None] = []
     def _spy(**_kw): calls.append(_kw.get("execution_rid"))
     monkeypatch.setattr(lease_orchestrator, "reconcile_pending_leases", _spy)
 
-    # DerivaML.__init__ still contacts the server regardless of mode
-    # (model reflection, credential discovery). Stub the network-bound
-    # bits so we can exercise the offline-skip branch of the lease hook
-    # without a live catalog. See spec §2.1 — true offline init is a
-    # future task; for now we verify only that the hook's online gate
-    # does the right thing.
-    import deriva_ml.core.base as base_mod
-
-    class _FakeModel:
-        schemas = {}
-        annotations: dict = {}
-        def apply(self): pass
-
-    class _FakeCatalog:
-        catalog_id = "1"
-        def getCatalogModel(self): return _FakeModel()
-
-    class _FakeServer:
-        def __init__(self, *a, **kw): pass
-        def get_authn_session(self): return None
-        def connect_ermrest(self, cid): return _FakeCatalog()
-
-    # Stub DerivaServer constructor and credential lookup so init
-    # doesn't hit the network.
-    monkeypatch.setattr(base_mod, "DerivaServer", _FakeServer)
-    monkeypatch.setattr(base_mod, "get_credential", lambda hostname: {})
-
-    # Stub DerivaModel so schema introspection doesn't run.
-    from deriva_ml.model import catalog as catalog_mod
-
-    class _FakeDerivaModel:
-        def __init__(self, *a, **kw):
-            self.domain_schemas = frozenset()
-            self.default_schema = None
-            self.ml_schema = kw.get("ml_schema", "deriva-ml")
-            self.schemas = {}
-        def refresh_model(self): pass
-
-    monkeypatch.setattr(catalog_mod, "DerivaModel", _FakeDerivaModel)
+    # Plant a minimal schema cache so offline init succeeds without
+    # a live catalog. The schema just needs to parse; no tables needed.
+    from deriva_ml.core.schema_cache import SchemaCache
+    cache = SchemaCache(tmp_path)
+    cache.write(
+        snapshot_id="fake-snap",
+        hostname="offline.example",
+        catalog_id="1",
+        ml_schema="deriva-ml",
+        schema={
+            "schemas": {
+                "deriva-ml": {
+                    "schema_name": "deriva-ml",
+                    "tables": {},
+                    "annotations": {},
+                    "comment": None,
+                },
+            },
+            "acls": {},
+            "annotations": {},
+        },
+    )
 
     from deriva_ml import ConnectionMode, DerivaML
     DerivaML(


### PR DESCRIPTION
## Summary

A small bundle of three related hygiene items that surfaced during S4 execution:

### 1. Source fix: `DerivaML.workspace` calls `refresh_model()` in offline mode

When `self.workspace` is first accessed in offline mode, it was calling `self.model.refresh_model()` unconditionally. `refresh_model()` calls `self.catalog.getCatalogModel()`, which the S4 `CatalogStub` correctly refuses in offline mode. The bug was visible whenever offline code touched the workspace (`resume_execution`, `create_execution`, registry ops).

**Fix:** gate the `refresh_model()` call on `self._mode is ConnectionMode.online`. In offline mode the cached model IS the authoritative model; refreshing makes no sense and would never succeed.

### 2. S4-residual offline tests

Three tests in `tests/execution/` were left failing after S4 (missed in the S4 regression audit):

| Test | Problem | Fix |
|---|---|---|
| `test_execution_registry.py::test_resume_execution_offline_skips_reconcile` | Constructs `DerivaML(mode=offline)` in fresh `tmp_path` — no cache | Two-step: online first to populate cache, then offline |
| `test_execution_registry.py::test_create_execution_offline_raises` | Same | Same |
| `test_lease_orchestrator.py::test_offline_workspace_skips_lease_reconcile` | Used ~45 lines of `DerivaServer`/`get_credential`/`DerivaModel` stubs that pre-dated S4 | Replaced with a 20-line `SchemaCache.write(...)` call that plants a minimal schema; no stubs needed |

All three now pass against `DERIVA_HOST=localhost`. The two-step pattern is the same one I applied in S4 itself for `tests/core/test_connection_mode.py`.

### 3. H4 dead-skip cleanup

Two unconditional `@pytest.mark.skip` sites cleaned up:

- **`tests/dataset/test_denormalize.py`** — deleted the `TestDenormalizeSqlGeneration` class entirely. Its two tests were tombstones for `bag._denormalize()`, a private method removed in Phase 2. The skip messages already said the behavior moved to the unified `denormalize()` engine and is covered by existing tests. Dead code.
- **`tests/catalog/test_clone_subset_catalog.py`** — converted two `@pytest.mark.skip(reason="Requires running catalog")` decorators to the project's standard `@pytest.mark.skipif(not os.environ.get("DERIVA_HOST"), ...)` pattern. Both tests run fine against `DERIVA_HOST=localhost` now (one passes, one internally skips when the fresh test catalog has no datasets — existing design).

## Commits

- `20a02ea` — `fix(base): skip refresh_model() in offline mode; fix 3 offline tests` (Items 1+2: source fix + 3 test fixes)
- `71fcfc8` — `test: clean up leftover @pytest.mark.skip sites (H4)` (Item 3: H4 cleanup)

## Test Plan

- [x] **`tests/execution/` against `DERIVA_HOST=localhost`:** 269 passed, 1 skipped, 1 xfailed — no failures. The 3 S4-residual tests pass; no regressions.
- [x] **The 3 unskipped catalog tests:** `test_create_workspace_with_associations` passes, `test_create_workspace_basic` internally skips (no datasets in fresh reset catalog — pre-existing design). The original `@pytest.mark.skip` hid both tests regardless; now the first is exercised against live catalogs, and the second's internal skip is visible.
- [x] **No regressions elsewhere.** The source change is strictly more conservative (adds a mode gate to an existing call); online behavior is unchanged.

## Also — in-scope housekeeping that didn't need a commit

Removed the stale `/Users/carl/github/deriva-ml/.claude/worktrees/heuristic-engelbart-922156` worktree (branch at `f2528ec`, whose commit content is already on `main` as `1c1abe2` from the S1b merge). No remote impact — worktree + local branch only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)