### PR TITLE
fix(Bug E.2): asset uploads honor pre-leased RIDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 All notable changes to this project are documented here.
 
+## Unreleased — Bug E.2: asset uploads honor pre-leased RIDs
+
+### Fixed
+
+- **Asset-table catalog inserts now use the caller-supplied pre-leased RID** instead of silently accepting a server-generated one. Previously, the plain-row drain path honored `pending_rows.rid` but the asset-row path (via deriva-py's `GenericUploader`) looked up or created rows by MD5+Filename, discarding the pre-leased RID. Any client code that captured the pre-leased RID (e.g., for FK references within the same upload batch) ended up with a dangling pointer.
+
+The fix spans two repos:
+
+- **deriva-py** (PRs #206, #207, #208, #209 merged to `2.0-dev`): new opt-in `use_pre_allocated_rid: true` flag on asset mappings, new `_createFileRecordWithRid` method, `nondefaults=RID` support in `_catalogRecordCreate`, and a new ERMrest tag `tag:isrd.isi.edu,2026:strict-preallocated-rid` in the tag enum. Default behavior is **soft**: on MD5+Filename match with a different existing RID, the existing row's RID is adopted (legacy semantics preserved). Tables annotated with `{"strict": true}` opt into **strict** mode where mismatch raises `DerivaUploadCatalogCreateError`.
+- **deriva-ml**: `asset_table_upload_spec` emits `use_pre_allocated_rid=True` and adds `(?P<RID>[-A-Z0-9]+)` to the `file_pattern`; staging path-builders append the pre-leased RID as the final directory segment; `lease_manifest_pending_assets` ensures every pending manifest entry has a RID before staging begins; `_validate_pending_asset_leases` catches stale SQLite state at pre-flight.
+
+### Added
+
+- **`DerivaML.set_strict_preallocated_rid(table, strict=True)`** — opt an asset table into strict-RID mode. Raises `DerivaMLTableTypeError` for non-asset tables. Call `apply_annotations()` to commit.
+- **`DerivaML.is_strict_preallocated_rid(table) -> bool`** — query whether a table has the strict annotation.
+- **`STRICT_PREALLOCATED_RID_TAG = "tag:isrd.isi.edu,2026:strict-preallocated-rid"`** — constant in `deriva_ml.core.mixins.annotation`.
+- **`_validate_pending_asset_leases(catalog, entries)`** — pre-flight validator in `deriva_ml.execution.rid_lease`. Batch-queries `public:ERMrest_RID_Lease` and raises an aggregated `DerivaMLValidationError` listing missing RIDs.
+- **`lease_manifest_pending_assets(catalog, manifest)`** — helper in `deriva_ml.execution.manifest_lease` that leases RIDs for any manifest entries with `rid is None`.
+- **`AssetManifest.set_asset_rid(key, rid)`** — new method for assigning a pre-leased RID without flipping status.
+
+### External-caller impact
+
+**No action required for existing callers.** Soft mode is the default, which preserves legacy `_getFileRecord` semantics: uploading the same file twice yields the same catalog RID (driven by MD5+Filename dedup + `URL UNIQUE` constraints).
+
+**New capability for FK-critical batches.** Callers who upload a batch of assets referenced by FK columns in the same batch can annotate the target table with `{"strict": true}` to get hard failures on unexpected RID reassignments. Without this annotation, soft fallback continues to apply.
+
+**Edge case:** if a pre-leased RID has been cleared from `ERMrest_RID_Lease` (e.g., by manual cleanup), the upload is refused at pre-flight by `_validate_pending_asset_leases` with a clear error message. Restart the execution to re-lease.
+
 ## Unreleased — Bug C: asset metadata None-stringification
 
 ### Fixed

--- a/docs/superpowers/plans/2026-04-22-bug-e2-preallocated-rid.md
+++ b/docs/superpowers/plans/2026-04-22-bug-e2-preallocated-rid.md
@@ -1,0 +1,1549 @@
+# Bug E.2: Pre-Allocated RID Upload — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the pre-S3 architectural gap where deriva-py's asset uploader ignores pre-allocated RIDs from the lease system. Catalog inserts for asset rows must honor the caller-supplied RID.
+
+**Architecture:** Two-repo change. **deriva-py** gains an opt-in `use_pre_allocated_rid` config flag on asset mappings and a new `_createFileRecordWithRid` method (with idempotency pre-check) that bypasses the MD5+Filename lookup. **deriva-ml** emits the flag in `asset_table_upload_spec`, appends the pre-leased RID as the final directory segment in the staging tree, and adds a pre-flight validator that confirms every pre-leased RID is live in `ERMrest_RID_Lease` before any upload work starts.
+
+**Tech Stack:** Python ≥3.12, Pydantic v2 (deriva-ml validator output matches Bug C's aggregated-error shape), deriva-py's `GenericUploader` extension point, pytest. Built on the existing lease infrastructure (`rid_lease.py`, `lease_orchestrator.py`) and Bug C's validator pattern.
+
+**Reference spec:** `docs/superpowers/specs/2026-04-22-bug-e2-preallocated-rid-design.md`
+
+---
+
+## Repo coordination
+
+- **deriva-py** branch `2.0-dev` already tracked from deriva-ml's `pyproject.toml` as a git dep — no version bump needed.
+- **deriva-py** tasks (Phase 1) land first; CI for the deriva-ml PR will fail until deriva-py merges, then automatically picks up the new commit.
+- **deriva-ml** tasks (Phase 2) run against current `main` (which includes Bug C fixes).
+
+Both repos are checked out side-by-side on the same machine:
+- deriva-py: `/Users/carl/GitHub/deriva-py` (branch `2.0-dev`)
+- deriva-ml worktree: `/Users/carl/GitHub/deriva-ml/.worktrees/bug-e` (branch `claude/bug-e`)
+
+---
+
+## File Structure
+
+### deriva-py (Phase 1)
+
+- Modify: `deriva/transfer/upload/deriva_upload.py` — add fast-fail validation in `_initFileMetadata`, branch in `_uploadAsset` Step 7, new method `_createFileRecordWithRid`.
+- Create: `tests/deriva/transfer/upload/__init__.py` — test package marker.
+- Create: `tests/deriva/transfer/upload/test_pre_allocated_rid.py` — unit tests for the new flag and method.
+
+### deriva-ml (Phase 2)
+
+- Modify: `src/deriva_ml/execution/rid_lease.py` — add `_validate_pending_asset_leases` at end of file.
+- Modify: `src/deriva_ml/dataset/upload.py` — emit `use_pre_allocated_rid=True`, extend regex + column_map.
+- Modify: `src/deriva_ml/execution/upload_engine.py` — append RID to staging path, call lease validator at `run_upload_engine`.
+- Modify: `src/deriva_ml/execution/execution.py` — append RID to staging path in `_build_upload_staging`, call lease validator at `_upload_execution_dirs`.
+- Modify: `src/deriva_ml/core/mixins/execution.py` — adapt caller of `asset_file_path` (line 229) to pass its known RID.
+- Create: `tests/execution/test_pending_asset_lease_validator.py` — 5 unit tests for the lease validator.
+- Modify: `tests/asset/test_null_sentinel_processor.py` — add 3 tests for the new upload-spec fields.
+- Create: `tests/execution/test_bug_e2_live_smoke.py` — 3 live-catalog integration tests.
+- Modify: `CHANGELOG.md` — Unreleased entry.
+
+---
+
+# Phase 1: deriva-py
+
+## Task 1: Add fast-fail validation in `_initFileMetadata`
+
+**Files:**
+- Modify: `deriva/transfer/upload/deriva_upload.py:829-831` (append after `self._updateFileMetadata(match_groupdict)`)
+- Create: `tests/deriva/transfer/upload/__init__.py` (empty, package marker)
+- Test: `tests/deriva/transfer/upload/test_pre_allocated_rid.py` (new file)
+
+Guard: if asset mapping has `use_pre_allocated_rid=true` but the regex didn't capture `RID`, raise `DerivaUploadConfigurationError` before any hatrac I/O.
+
+- [ ] **Step 1: Create test package marker**
+
+```bash
+cd /Users/carl/GitHub/deriva-py && mkdir -p tests/deriva/transfer/upload && touch tests/deriva/transfer/upload/__init__.py
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Create `tests/deriva/transfer/upload/test_pre_allocated_rid.py`:
+
+```python
+"""Unit tests for deriva-py's use_pre_allocated_rid asset-mapping flag.
+
+These tests exercise two narrowly-scoped changes on GenericUploader:
+
+1. A fast-fail validation in ``_initFileMetadata`` when the flag is
+   set but the regex didn't capture a RID group.
+2. A new ``_createFileRecordWithRid`` method that bypasses the
+   MD5+Filename lookup in ``_getFileRecord`` and creates (or
+   idempotently returns) a catalog row at the caller-supplied RID.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.fixture
+def uploader():
+    """Construct a GenericUploader with mocked catalog + identity."""
+    from deriva.transfer.upload.deriva_upload import GenericUploader
+    inst = GenericUploader.__new__(GenericUploader)
+    # Fill the attributes _initFileMetadata and _createFileRecordWithRid read.
+    inst.metadata = {}
+    inst.catalog = MagicMock()
+    inst.identity = {"id": "anon", "display_name": "a", "full_name": "A", "email": "a@b"}
+    inst.processor_output = {}
+    inst.cancelled = False
+    return inst
+
+
+def test_init_file_metadata_raises_when_flag_set_and_no_rid_captured(uploader):
+    from deriva.transfer.upload.deriva_upload import DerivaUploadConfigurationError
+    asset_mapping = {
+        "use_pre_allocated_rid": True,
+        "target_table": ["S", "T"],
+    }
+    # match_groupdict has NO 'RID' key — regex didn't capture it.
+    match_groupdict = {"schema": "S", "asset_table": "T"}
+    # Stub getCatalogTable to avoid needing a real catalog model.
+    uploader.getCatalogTable = MagicMock(return_value="S:T")
+    uploader.getFileDisplayName = MagicMock(return_value="f.bin")
+    uploader.getFileSize = MagicMock(return_value=123)
+
+    with pytest.raises(DerivaUploadConfigurationError) as ei:
+        uploader._initFileMetadata("/tmp/f.bin", asset_mapping, match_groupdict)
+    msg = str(ei.value)
+    assert "use_pre_allocated_rid" in msg
+    assert "RID" in msg
+
+
+def test_init_file_metadata_passes_when_flag_set_and_rid_captured(uploader):
+    asset_mapping = {
+        "use_pre_allocated_rid": True,
+        "target_table": ["S", "T"],
+    }
+    match_groupdict = {"schema": "S", "asset_table": "T", "RID": "1-ABC"}
+    uploader.getCatalogTable = MagicMock(return_value="S:T")
+    uploader.getFileDisplayName = MagicMock(return_value="f.bin")
+    uploader.getFileSize = MagicMock(return_value=123)
+
+    # Should not raise.
+    uploader._initFileMetadata("/tmp/f.bin", asset_mapping, match_groupdict)
+    assert uploader.metadata["RID"] == "1-ABC"
+
+
+def test_init_file_metadata_passes_when_flag_absent(uploader):
+    """Legacy callers (flag not set) see no behavior change — no RID check."""
+    asset_mapping = {"target_table": ["S", "T"]}
+    match_groupdict = {"schema": "S", "asset_table": "T"}
+    uploader.getCatalogTable = MagicMock(return_value="S:T")
+    uploader.getFileDisplayName = MagicMock(return_value="f.bin")
+    uploader.getFileSize = MagicMock(return_value=123)
+
+    # Should not raise — legacy path doesn't require RID.
+    uploader._initFileMetadata("/tmp/f.bin", asset_mapping, match_groupdict)
+    assert "RID" not in uploader.metadata
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `cd /Users/carl/GitHub/deriva-py && python -m pytest tests/deriva/transfer/upload/test_pre_allocated_rid.py -v`
+
+Expected: `test_init_file_metadata_raises_when_flag_set_and_no_rid_captured` FAILS with "DID NOT RAISE" because the validation doesn't exist yet. The other two tests pass trivially (no validation runs, so no raise).
+
+- [ ] **Step 4: Add the fast-fail validation**
+
+In `deriva/transfer/upload/deriva_upload.py`, locate `_initFileMetadata` (around line 829). After the line `self._updateFileMetadata(match_groupdict)` and before `self.metadata['target_table'] = self.getCatalogTable(...)`, insert:
+
+```python
+        # Fast-fail check for pre-allocated-RID asset mappings: the caller
+        # opted in via ``use_pre_allocated_rid: true`` and must supply the
+        # RID via a ``(?P<RID>...)`` named group in the file_pattern regex.
+        if stob(asset_mapping.get("use_pre_allocated_rid", False)):
+            if not self.metadata.get("RID"):
+                raise DerivaUploadConfigurationError(
+                    "Asset mapping has use_pre_allocated_rid=true but no RID "
+                    "was captured by the file_pattern regex. Ensure the pattern "
+                    "includes a (?P<RID>[A-Z0-9-]+) named group."
+                )
+```
+
+Verify `stob` and `DerivaUploadConfigurationError` are already imported (they should be — `stob` appears in `_uploadAsset`; `DerivaUploadConfigurationError` in `_getFileRecord`).
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd /Users/carl/GitHub/deriva-py && python -m pytest tests/deriva/transfer/upload/test_pre_allocated_rid.py -v`
+
+Expected: all 3 tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/carl/GitHub/deriva-py && git add tests/deriva/transfer/upload/__init__.py tests/deriva/transfer/upload/test_pre_allocated_rid.py deriva/transfer/upload/deriva_upload.py
+git commit -m "feat(upload): fast-fail when use_pre_allocated_rid flag has no RID"
+```
+
+---
+
+## Task 2: Add `_createFileRecordWithRid` with idempotency pre-check
+
+**Files:**
+- Modify: `deriva/transfer/upload/deriva_upload.py` — add new method after `_getFileRecord` (around line 820).
+- Test: `tests/deriva/transfer/upload/test_pre_allocated_rid.py` — append 2 tests.
+
+New private method that skips MD5+Filename lookup, does a RID-keyed existence check for idempotent retry, creates if absent.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/deriva/transfer/upload/test_pre_allocated_rid.py`:
+
+```python
+def test_create_file_record_with_rid_happy_path(uploader):
+    """No existing row with RID → _catalogRecordCreate called with RID in payload."""
+    asset_mapping = {
+        "use_pre_allocated_rid": True,
+        "column_map": {"MD5": "{md5}", "Filename": "{file_name}", "RID": "{RID}"},
+    }
+    uploader.metadata = {
+        "RID": "1-NEW",
+        "md5": "abc123",
+        "file_name": "f.bin",
+        "target_table": "S:T",
+    }
+
+    # Pre-check GET returns empty — row doesn't exist yet.
+    get_response = MagicMock()
+    get_response.json.return_value = []
+    uploader.catalog.get.return_value = get_response
+
+    # Stub _catalogRecordCreate to return a created-record shape.
+    uploader._catalogRecordCreate = MagicMock(
+        return_value=[{"RID": "1-NEW", "MD5": "abc123", "Filename": "f.bin"}]
+    )
+    uploader._updateFileMetadata = MagicMock()
+
+    record, result = uploader._createFileRecordWithRid(asset_mapping)
+
+    # Pre-check queried by RID.
+    uploader.catalog.get.assert_called_once_with("/entity/S:T/RID=1-NEW")
+    # Create called with RID in the row.
+    create_call = uploader._catalogRecordCreate.call_args
+    assert create_call[0][0] == "S:T"  # target_table
+    assert create_call[0][1]["RID"] == "1-NEW"
+    # Return shape mirrors _getFileRecord: (dict, record).
+    assert isinstance(record, dict)
+    assert result["RID"] == "1-NEW"
+
+
+def test_create_file_record_with_rid_idempotent_on_existing(uploader):
+    """RID already exists → skip create, return existing row."""
+    asset_mapping = {
+        "use_pre_allocated_rid": True,
+        "column_map": {"MD5": "{md5}", "Filename": "{file_name}", "RID": "{RID}"},
+    }
+    uploader.metadata = {
+        "RID": "1-OLD",
+        "md5": "abc123",
+        "file_name": "f.bin",
+        "target_table": "S:T",
+    }
+
+    existing_row = {"RID": "1-OLD", "MD5": "abc123", "Filename": "f.bin"}
+    get_response = MagicMock()
+    get_response.json.return_value = [existing_row]
+    uploader.catalog.get.return_value = get_response
+
+    # _catalogRecordCreate MUST NOT be called.
+    uploader._catalogRecordCreate = MagicMock()
+    uploader._updateFileMetadata = MagicMock()
+
+    record, result = uploader._createFileRecordWithRid(asset_mapping)
+
+    uploader._catalogRecordCreate.assert_not_called()
+    # Return shape: (pruned dict, existing record).
+    assert isinstance(record, dict)
+    assert result == existing_row
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/carl/GitHub/deriva-py && python -m pytest tests/deriva/transfer/upload/test_pre_allocated_rid.py -v`
+
+Expected: the 2 new tests FAIL with `AttributeError: 'GenericUploader' object has no attribute '_createFileRecordWithRid'`.
+
+- [ ] **Step 3: Add the method**
+
+In `deriva/transfer/upload/deriva_upload.py`, locate `_getFileRecord` (around line 793). Immediately AFTER that method (before `_urlEncodeMetadata` or whatever method comes next), insert:
+
+```python
+    def _createFileRecordWithRid(self, asset_mapping):
+        """Create a new record using a caller-supplied RID.
+
+        Used when asset_mapping has ``use_pre_allocated_rid: true``.
+        Skips the MD5+Filename lookup in ``_getFileRecord``; the caller
+        (via the scan-path regex) must have supplied an RID that was
+        pre-allocated from ``ERMrest_RID_Lease``.
+
+        Idempotency: if a row with the supplied RID already exists
+        (e.g., a prior upload landed the catalog row but the client
+        crashed before recording success), returns that row rather
+        than raising an RID-collision error. Callers can safely retry
+        after partial failures.
+
+        Returns:
+            Tuple of (row, record) mirroring ``_getFileRecord``'s
+            return shape.
+        """
+        column_map = asset_mapping.get("column_map", {})
+        allow_none_col_list = asset_mapping.get("allow_empty_columns_on_update", [])
+        target_table = self.metadata['target_table']
+        rid = self.metadata["RID"]
+
+        # Pre-check: does a row with this RID already exist?
+        existing = self.catalog.get("/entity/%s/RID=%s" % (target_table, rid)).json()
+        if existing:
+            record = existing[0]
+            self._updateFileMetadata(record, no_overwrite=True)
+            return self.pruneDict(record, column_map, allow_none_col_list), record
+
+        # Fresh create — RID goes into the payload via column_map.
+        row = self.interpolateDict(self.metadata, column_map, allow_none_col_list)
+        result = self._catalogRecordCreate(target_table, row)
+        record = result[0] if result else row
+        if record:
+            self._updateFileMetadata(record)
+        return self.interpolateDict(
+            self.metadata, column_map, allow_none_column_list=allow_none_col_list
+        ), record
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /Users/carl/GitHub/deriva-py && python -m pytest tests/deriva/transfer/upload/test_pre_allocated_rid.py -v`
+
+Expected: all 5 tests pass (3 from Task 1 + 2 new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/carl/GitHub/deriva-py && git add deriva/transfer/upload/deriva_upload.py tests/deriva/transfer/upload/test_pre_allocated_rid.py
+git commit -m "feat(upload): _createFileRecordWithRid bypasses MD5+Filename lookup"
+```
+
+---
+
+## Task 3: Wire `_createFileRecordWithRid` into `_uploadAsset`
+
+**Files:**
+- Modify: `deriva/transfer/upload/deriva_upload.py:736-738` (Step 7 of `_uploadAsset`)
+- Test: `tests/deriva/transfer/upload/test_pre_allocated_rid.py` — append 1 test.
+
+Route `_uploadAsset`'s Step 7 to `_createFileRecordWithRid` when the flag is set.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/deriva/transfer/upload/test_pre_allocated_rid.py`:
+
+```python
+def test_flag_off_uses_existing_md5_filename_path(uploader):
+    """When flag is absent, _getFileRecord (MD5+Filename path) is used."""
+    asset_mapping = {"target_table": ["S", "T"], "column_map": {"MD5": "{md5}"}}
+    uploader.metadata = {"md5": "abc", "file_name": "f.bin", "target_table": "S:T"}
+
+    uploader._getFileRecord = MagicMock(return_value=({}, {"RID": "SERVER-RID"}))
+    uploader._createFileRecordWithRid = MagicMock()
+
+    # Simulate what _uploadAsset Step 7 will do (see task step 2).
+    from deriva.transfer.upload.deriva_upload import stob
+    if stob(asset_mapping.get("use_pre_allocated_rid", False)):
+        record, result = uploader._createFileRecordWithRid(asset_mapping)
+    else:
+        record, result = uploader._getFileRecord(asset_mapping)
+
+    uploader._getFileRecord.assert_called_once()
+    uploader._createFileRecordWithRid.assert_not_called()
+    assert result["RID"] == "SERVER-RID"
+```
+
+- [ ] **Step 2: Update `_uploadAsset` Step 7**
+
+In `deriva/transfer/upload/deriva_upload.py`, locate `_uploadAsset` (line 660). Find Step 7 (around line 736-738):
+
+```python
+        # 7. Check for an existing record and create a new one if necessary
+        if not record:
+            record, result = self._getFileRecord(asset_mapping)
+```
+
+Replace with:
+
+```python
+        # 7. Check for an existing record and create a new one if necessary.
+        #    If use_pre_allocated_rid is set, skip the MD5+Filename lookup
+        #    and go straight to _createFileRecordWithRid (with idempotency
+        #    pre-check).
+        if not record:
+            if stob(asset_mapping.get("use_pre_allocated_rid", False)):
+                record, result = self._createFileRecordWithRid(asset_mapping)
+            else:
+                record, result = self._getFileRecord(asset_mapping)
+```
+
+Also check Step 5 (around line 690-693) — it has a similar `record = self._getFileRecord(asset_mapping)` call in the `create_record_before_upload` branch. For safety and symmetry, update it too:
+
+```python
+        # 5. If "create_record_before_upload" specified in asset_mapping, check for an existing record, creating a new
+        #    one if necessary. Otherwise, delay this logic until after the file upload.
+        result = record = None
+        if stob(asset_mapping.get("create_record_before_upload", False)):
+            if stob(asset_mapping.get("use_pre_allocated_rid", False)):
+                record = self._createFileRecordWithRid(asset_mapping)
+            else:
+                record = self._getFileRecord(asset_mapping)
+```
+
+Wait — the existing Step 5 returns only `record` (not a tuple). Let me leave Step 5 as is for now; `create_record_before_upload` isn't in deriva-ml's use case. Only update Step 7.
+
+Revert any Step 5 change; only Step 7 should be modified.
+
+- [ ] **Step 3: Run tests to verify they pass**
+
+Run: `cd /Users/carl/GitHub/deriva-py && python -m pytest tests/deriva/transfer/upload/test_pre_allocated_rid.py -v`
+
+Expected: all 6 tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/carl/GitHub/deriva-py && git add deriva/transfer/upload/deriva_upload.py tests/deriva/transfer/upload/test_pre_allocated_rid.py
+git commit -m "feat(upload): route _uploadAsset Step 7 to _createFileRecordWithRid when flag set"
+```
+
+---
+
+## Task 4: Push deriva-py branch and open PR
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+cd /Users/carl/GitHub/deriva-py && git checkout -b claude/bug-e2-preallocated-rid && git push -u origin claude/bug-e2-preallocated-rid
+```
+
+- [ ] **Step 2: Open a PR against `2.0-dev`**
+
+```bash
+cd /Users/carl/GitHub/deriva-py && gh pr create \
+  --base 2.0-dev \
+  --title "feat(upload): add use_pre_allocated_rid flag for caller-supplied RIDs" \
+  --body "$(cat <<'EOF'
+## Summary
+
+Add opt-in support for asset mappings that use caller-supplied RIDs instead of deriva-py's default MD5+Filename lookup/upsert.
+
+When an asset mapping sets \`use_pre_allocated_rid: true\`:
+
+- \`_initFileMetadata\` fast-fails with \`DerivaUploadConfigurationError\` if the file_pattern regex didn't capture a \`RID\` named group.
+- \`_uploadAsset\` Step 7 routes to a new \`_createFileRecordWithRid\` method that does a RID-keyed existence check for idempotent retry, then creates with the caller-supplied RID in the payload.
+
+Default (flag absent): legacy MD5+Filename behavior — no change.
+
+## Motivation
+
+deriva-ml's lease system (\`ERMrest_RID_Lease\`) pre-allocates RIDs so client code can reference them in FK columns before the target row exists. The existing upload path silently substitutes server-generated RIDs for asset rows, breaking this invariant. This flag lets opt-in callers honor pre-allocated RIDs.
+
+## Test Plan
+
+- [x] 6 unit tests in \`tests/deriva/transfer/upload/test_pre_allocated_rid.py\`:
+  - Fast-fail validation when flag set without RID
+  - Passthrough when flag set with RID captured
+  - No change when flag absent
+  - Happy path (no existing row → create with RID)
+  - Idempotent retry (existing row → return without re-create)
+  - Step 7 routing correctness
+
+## Backward Compatibility
+
+Strictly opt-in. No existing asset mapping has the flag, so no existing caller sees any behavior change.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Record the PR URL — deriva-ml Phase 2 can't merge until this one does.
+
+---
+
+# Phase 2: deriva-ml
+
+## Task 5: Add `_validate_pending_asset_leases` validator
+
+**Files:**
+- Modify: `src/deriva_ml/execution/rid_lease.py` — append new function at end of file.
+- Test: `tests/execution/test_pending_asset_lease_validator.py` (new file).
+
+Pre-flight validator that batch-queries `ERMrest_RID_Lease` and aggregates missing RIDs into a single `DerivaMLValidationError`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/execution/test_pending_asset_lease_validator.py`:
+
+```python
+"""Unit tests for _validate_pending_asset_leases."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _fake_catalog(found_rids: set[str]):
+    """Build a fake ErmrestCatalog whose .get() returns rows with
+    RIDs from ``found_rids`` that match the query's filter."""
+    catalog = MagicMock()
+
+    def fake_get(path: str):
+        # Parse "/entity/public:ERMrest_RID_Lease/RID=r1;RID=r2;..."
+        response = MagicMock()
+        assert path.startswith("/entity/public:ERMrest_RID_Lease/")
+        filter_part = path.split("/entity/public:ERMrest_RID_Lease/", 1)[1]
+        queried = []
+        for clause in filter_part.split(";"):
+            key, _, value = clause.partition("=")
+            if key == "RID":
+                queried.append(value)
+        response.json.return_value = [
+            {"RID": rid, "ID": f"token-{rid}"}
+            for rid in queried
+            if rid in found_rids
+        ]
+        return response
+
+    catalog.get.side_effect = fake_get
+    return catalog
+
+
+def test_empty_entries_returns_none():
+    from deriva_ml.execution.rid_lease import _validate_pending_asset_leases
+    catalog = MagicMock()
+    assert _validate_pending_asset_leases(catalog, []) is None
+    catalog.get.assert_not_called()
+
+
+def test_all_leases_valid_passes():
+    from deriva_ml.execution.rid_lease import _validate_pending_asset_leases
+    catalog = _fake_catalog({"1-ABC", "1-DEF"})
+    entries = [("Image/a.png", "1-ABC"), ("Image/b.png", "1-DEF")]
+    assert _validate_pending_asset_leases(catalog, entries) is None
+
+
+def test_single_missing_lease_raises():
+    from deriva_ml.execution.rid_lease import _validate_pending_asset_leases
+    from deriva_ml.core.exceptions import DerivaMLValidationError
+    catalog = _fake_catalog({"1-ABC"})  # 1-DEF NOT there
+    entries = [("Image/a.png", "1-ABC"), ("Image/b.png", "1-DEF")]
+    with pytest.raises(DerivaMLValidationError) as ei:
+        _validate_pending_asset_leases(catalog, entries)
+    msg = str(ei.value)
+    assert "Image/b.png" in msg
+    assert "1-DEF" in msg
+    assert "Image/a.png" not in msg  # the valid one isn't listed
+
+
+def test_multiple_missing_leases_aggregated():
+    from deriva_ml.execution.rid_lease import _validate_pending_asset_leases
+    from deriva_ml.core.exceptions import DerivaMLValidationError
+    catalog = _fake_catalog(set())  # nothing found
+    entries = [
+        ("Image/z.png", "1-ZZZ"),
+        ("Image/a.png", "1-AAA"),
+    ]
+    with pytest.raises(DerivaMLValidationError) as ei:
+        _validate_pending_asset_leases(catalog, entries)
+    msg = str(ei.value)
+    assert "1-ZZZ" in msg
+    assert "1-AAA" in msg
+    # Sorted by (key, rid) — 'a.png' before 'z.png'.
+    assert msg.index("Image/a.png") < msg.index("Image/z.png")
+
+
+def test_batched_queries_use_chunk_size(monkeypatch):
+    """More entries than chunk size → multiple catalog.get calls."""
+    from deriva_ml.execution import rid_lease
+    from deriva_ml.execution.rid_lease import _validate_pending_asset_leases
+
+    # Set chunk size to 2 so 3 entries require 2 batched calls.
+    monkeypatch.setattr(rid_lease, "PENDING_ROWS_LEASE_CHUNK", 2)
+    catalog = _fake_catalog({"1-A", "1-B", "1-C"})
+    entries = [("k1", "1-A"), ("k2", "1-B"), ("k3", "1-C")]
+    _validate_pending_asset_leases(catalog, entries)
+    # Expect 2 calls: first batch of 2, second batch of 1.
+    assert catalog.get.call_count == 2
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/carl/GitHub/deriva-ml/.worktrees/bug-e && DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/execution/test_pending_asset_lease_validator.py -v`
+
+Expected: all 5 tests FAIL with `ImportError: cannot import name '_validate_pending_asset_leases'`.
+
+- [ ] **Step 3: Implement the validator**
+
+In `src/deriva_ml/execution/rid_lease.py`, append at the end of the file:
+
+```python
+def _validate_pending_asset_leases(
+    catalog: "ErmrestCatalog",
+    entries: "Iterable[tuple[str, str]]",
+) -> None:
+    """Confirm each (key, rid) pair's RID is still live in ERMrest_RID_Lease.
+
+    Queries the lease table in batches of ``PENDING_ROWS_LEASE_CHUNK``.
+    Aggregates missing RIDs and raises a single
+    :class:`DerivaMLValidationError` listing every failure in sorted
+    order. Returns ``None`` silently when every RID is present.
+
+    Args:
+        catalog: Live ErmrestCatalog for querying the lease table.
+        entries: Iterable of (key, rid) tuples. Key is a
+            human-readable identifier used in the error message.
+
+    Raises:
+        DerivaMLValidationError: If one or more RIDs are not found
+            in ``ERMrest_RID_Lease``.
+    """
+    from deriva_ml.core.exceptions import DerivaMLValidationError
+
+    entries_list = list(entries)
+    if not entries_list:
+        return
+
+    # Build a reverse map so we can attribute a missing RID back to
+    # its caller-supplied key. If the same RID appears under two keys
+    # (shouldn't happen in practice), the last one wins in the reverse
+    # map — missing-list below iterates the forward list.
+    rid_to_keys: dict[str, list[str]] = {}
+    for key, rid in entries_list:
+        rid_to_keys.setdefault(rid, []).append(key)
+
+    all_rids = list(rid_to_keys.keys())
+    found_rids: set[str] = set()
+
+    for i in range(0, len(all_rids), PENDING_ROWS_LEASE_CHUNK):
+        chunk = all_rids[i : i + PENDING_ROWS_LEASE_CHUNK]
+        filter_clause = ";".join(f"RID={rid}" for rid in chunk)
+        path = f"/entity/public:ERMrest_RID_Lease/{filter_clause}"
+        response = catalog.get(path)
+        for row in response.json():
+            found_rids.add(row["RID"])
+
+    missing: list[tuple[str, str]] = []
+    for key, rid in entries_list:
+        if rid not in found_rids:
+            missing.append((key, rid))
+    if not missing:
+        return
+
+    lines = [
+        f"Missing or invalid pre-allocated RIDs for "
+        f"{len(missing)} pending asset(s):"
+    ]
+    for key, rid in sorted(missing):
+        lines.append(f"  - {key}: RID {rid} not found in ERMrest_RID_Lease")
+    lines.append(
+        "A pre-leased RID has become invalid (e.g., cleared from the "
+        "lease table or never successfully POSTed). Restart the "
+        "execution to re-lease, or investigate lease-table state."
+    )
+    raise DerivaMLValidationError("\n".join(lines))
+```
+
+Also add `Iterable` to the `typing` imports at the top of `rid_lease.py` if not already present. Current imports block:
+
+```python
+from typing import TYPE_CHECKING
+```
+
+becomes:
+
+```python
+from typing import TYPE_CHECKING, Iterable
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /Users/carl/GitHub/deriva-ml/.worktrees/bug-e && DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/execution/test_pending_asset_lease_validator.py -v`
+
+Expected: all 5 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/carl/GitHub/deriva-ml/.worktrees/bug-e && git add src/deriva_ml/execution/rid_lease.py tests/execution/test_pending_asset_lease_validator.py
+git commit -m "feat(rid_lease): _validate_pending_asset_leases for pre-flight lease-table check"
+```
+
+---
+
+## Task 6: Emit `use_pre_allocated_rid` in upload spec
+
+**Files:**
+- Modify: `src/deriva_ml/dataset/upload.py` — extend `asset_table_upload_spec()`.
+- Test: `tests/asset/test_null_sentinel_processor.py` — append 3 tests.
+
+Extend the regex with a RID capture group, add `RID` to `column_map`, emit the `use_pre_allocated_rid=True` flag.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/asset/test_null_sentinel_processor.py`:
+
+```python
+def test_asset_table_upload_spec_has_use_pre_allocated_rid_flag(test_ml):
+    from deriva.core.ermrest_model import builtin_types
+    from deriva_ml.core.definitions import ColumnDefinition
+    from deriva_ml.dataset.upload import asset_table_upload_spec
+
+    test_ml.create_asset(
+        "UsePreAllocatedFlagTest",
+        column_defs=[ColumnDefinition(name="foo", type=builtin_types.int4)],
+    )
+    spec = asset_table_upload_spec(test_ml.model, "UsePreAllocatedFlagTest")
+    assert spec.get("use_pre_allocated_rid") is True
+
+
+def test_asset_table_upload_spec_file_pattern_captures_rid(test_ml):
+    from deriva.core.ermrest_model import builtin_types
+    from deriva_ml.core.definitions import ColumnDefinition
+    from deriva_ml.dataset.upload import asset_table_upload_spec
+
+    test_ml.create_asset(
+        "UsePreAllocatedRegexTest",
+        column_defs=[ColumnDefinition(name="foo", type=builtin_types.int4)],
+    )
+    spec = asset_table_upload_spec(test_ml.model, "UsePreAllocatedRegexTest")
+    pattern = spec["file_pattern"]
+    # Regex must contain a (?P<RID>...) named group.
+    assert "(?P<RID>" in pattern, f"file_pattern missing RID capture: {pattern}"
+
+
+def test_asset_table_upload_spec_column_map_includes_rid(test_ml):
+    from deriva.core.ermrest_model import builtin_types
+    from deriva_ml.core.definitions import ColumnDefinition
+    from deriva_ml.dataset.upload import asset_table_upload_spec
+
+    test_ml.create_asset(
+        "UsePreAllocatedColumnMapTest",
+        column_defs=[ColumnDefinition(name="foo", type=builtin_types.int4)],
+    )
+    spec = asset_table_upload_spec(test_ml.model, "UsePreAllocatedColumnMapTest")
+    assert spec["column_map"].get("RID") == "{RID}"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/carl/GitHub/deriva-ml/.worktrees/bug-e && DERIVA_ML_ALLOW_DIRTY=true DERIVA_HOST=localhost uv run pytest tests/asset/test_null_sentinel_processor.py -v`
+
+Expected: the 3 new tests FAIL (flag, regex group, and column_map entry all absent).
+
+- [ ] **Step 3: Extend `asset_table_upload_spec`**
+
+In `src/deriva_ml/dataset/upload.py`, locate `asset_table_upload_spec()` (around line 276). Find the block that builds `asset_path`:
+
+```python
+    metadata_path = "/".join([rf"(?P<{c}>[-:._ \w]+)" for c in metadata_columns])
+    asset_path = f"{exec_dir_regex}/asset/{schema}/{asset_table.name}/{metadata_path}/{asset_file_regex}"
+```
+
+Replace with:
+
+```python
+    metadata_path = "/".join([rf"(?P<{c}>[-:._ \w]+)" for c in metadata_columns])
+    # Bug E.2: capture pre-allocated RID as an additional path segment
+    # after metadata columns and before the filename.
+    rid_path = r"(?P<RID>[-A-Z0-9]+)"
+    parts = [metadata_path, rid_path] if metadata_path else [rid_path]
+    asset_path = (
+        f"{exec_dir_regex}/asset/{schema}/{asset_table.name}/"
+        f"{'/'.join(parts)}/{asset_file_regex}"
+    )
+```
+
+Then find the `spec = {...}` dict. Extend `column_map` to include `RID`:
+
+Current:
+```python
+        "column_map": {
+            "MD5": "{md5}",
+            "URL": "{URI}",
+            "Length": "{file_size}",
+            "Filename": "{file_name}",
+        }
+        | {c: f"{{{c}}}" for c in metadata_columns},
+```
+
+Change to:
+```python
+        "column_map": {
+            "MD5": "{md5}",
+            "URL": "{URI}",
+            "Length": "{file_size}",
+            "Filename": "{file_name}",
+            "RID": "{RID}",  # Bug E.2: pre-allocated RID
+        }
+        | {c: f"{{{c}}}" for c in metadata_columns},
+```
+
+Finally, add the `use_pre_allocated_rid` flag to the spec dict. Find the end of the spec dict (after `record_query_template`) and add:
+
+```python
+    spec = {
+        ...existing fields...
+        "record_query_template": "/entity/{target_table}/MD5={md5}&Filename={file_name}",
+        "use_pre_allocated_rid": True,  # Bug E.2: use caller-supplied RID
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /Users/carl/GitHub/deriva-ml/.worktrees/bug-e && DERIVA_ML_ALLOW_DIRTY=true DERIVA_HOST=localhost uv run pytest tests/asset/test_null_sentinel_processor.py -v`
+
+Expected: all tests pass (original 6 from Bug C + 3 new = 9).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/carl/GitHub/deriva-ml/.worktrees/bug-e && git add src/deriva_ml/dataset/upload.py tests/asset/test_null_sentinel_processor.py
+git commit -m "feat(dataset/upload): emit use_pre_allocated_rid + RID capture (Bug E.2)"
+```
+
+---
+
+## Task 7: Append RID to staging path in `_build_upload_staging`
+
+**Files:**
+- Modify: `src/deriva_ml/execution/execution.py` — `_build_upload_staging` around line 1074.
+
+Change the staging directory layout to append the pre-leased RID (from `entry.rid`) as the final segment before the filename.
+
+- [ ] **Step 1: Update `_build_upload_staging`**
+
+In `src/deriva_ml/execution/execution.py`, locate `_build_upload_staging` method (around line 1034). Find the block that builds `target_dir`:
+
+```python
+            all_metadata_cols = sorted(self._model.asset_metadata(asset_table_name))
+            metadata_parts = [
+                str(entry.metadata.get(k, NULL_SENTINEL)) for k in all_metadata_cols
+            ] if all_metadata_cols else []
+            target_dir = staging_root / entry.schema / asset_table_name
+            for part in metadata_parts:
+                target_dir = target_dir / part
+            target_dir.mkdir(parents=True, exist_ok=True)
+```
+
+Change to:
+
+```python
+            all_metadata_cols = sorted(self._model.asset_metadata(asset_table_name))
+            metadata_parts = [
+                str(entry.metadata.get(k, NULL_SENTINEL)) for k in all_metadata_cols
+            ] if all_metadata_cols else []
+            target_dir = staging_root / entry.schema / asset_table_name
+            for part in metadata_parts:
+                target_dir = target_dir / part
+            # Bug E.2: append pre-leased RID as the final path segment.
+            # asset_table_upload_spec's file_pattern expects to capture
+            # this as (?P<RID>[-A-Z0-9]+).
+            target_dir = target_dir / entry.rid
+            target_dir.mkdir(parents=True, exist_ok=True)
+```
+
+- [ ] **Step 2: Sanity import check**
+
+Run: `cd /Users/carl/GitHub/deriva-ml/.worktrees/bug-e && DERIVA_ML_ALLOW_DIRTY=true uv run python -c "from deriva_ml.execution.execution import Execution; print('ok')"`
+
+Expected: prints `ok`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/carl/GitHub/deriva-ml/.worktrees/bug-e && git add src/deriva_ml/execution/execution.py
+git commit -m "fix(execution): append pre-leased RID in _build_upload_staging (Bug E.2)"
+```
+
+---
+
+## Task 8: Append RID to staging path in `_invoke_deriva_py_uploader`
+
+**Files:**
+- Modify: `src/deriva_ml/execution/upload_engine.py` — `_invoke_deriva_py_uploader._path_for` around line 680.
+
+Same one-line addition for the engine-driven path.
+
+- [ ] **Step 1: Update `_path_for`**
+
+In `src/deriva_ml/execution/upload_engine.py`, locate `_invoke_deriva_py_uploader` (around line 562). Inside, find `_path_for`:
+
+```python
+        def _path_for(f: dict) -> Path:
+            """Compute the regex-expected path for one input file."""
+            src = Path(f["path"]).resolve()
+            metadata = f.get("metadata") or {}
+            target_dir = asset_root / schema_name / target_table
+            for col in metadata_cols:
+                target_dir = target_dir / str(metadata.get(col, NULL_SENTINEL))
+            return target_dir / src.name
+```
+
+Change to:
+
+```python
+        def _path_for(f: dict) -> Path:
+            """Compute the regex-expected path for one input file."""
+            src = Path(f["path"]).resolve()
+            metadata = f.get("metadata") or {}
+            target_dir = asset_root / schema_name / target_table
+            for col in metadata_cols:
+                target_dir = target_dir / str(metadata.get(col, NULL_SENTINEL))
+            # Bug E.2: pre-leased RID as the final segment before filename.
+            target_dir = target_dir / f["rid"]
+            return target_dir / src.name
+```
+
+- [ ] **Step 2: Sanity import check**
+
+Run: `cd /Users/carl/GitHub/deriva-ml/.worktrees/bug-e && DERIVA_ML_ALLOW_DIRTY=true uv run python -c "from deriva_ml.execution.upload_engine import run_upload_engine; print('ok')"`
+
+Expected: prints `ok`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/carl/GitHub/deriva-ml/.worktrees/bug-e && git add src/deriva_ml/execution/upload_engine.py
+git commit -m "fix(upload_engine): append pre-leased RID in _invoke_deriva_py_uploader (Bug E.2)"
+```
+
+---
+
+## Task 9: Update `asset_file_path` helper in `dataset/upload.py`
+
+**Files:**
+- Modify: `src/deriva_ml/dataset/upload.py` — `asset_file_path` function around line 657.
+- Modify: `src/deriva_ml/core/mixins/execution.py:229` — caller site.
+
+The module-level `asset_file_path` helper (not the Execution method) is used only by `core/mixins/execution.py:229` for `Execution_Metadata` configuration. It needs a new `rid` parameter since the staging regex now requires it.
+
+- [ ] **Step 1: Add `rid` parameter to `asset_file_path`**
+
+In `src/deriva_ml/dataset/upload.py`, locate the `asset_file_path` function (around line 657):
+
+```python
+def asset_file_path(
+    prefix: Path | str,
+    exec_rid: RID,
+    file_name: str | Path,
+    asset_table: Table,
+    metadata: dict | None = None,
+) -> Path:
+```
+
+Add a `rid` parameter:
+
+```python
+def asset_file_path(
+    prefix: Path | str,
+    exec_rid: RID,
+    file_name: str | Path,
+    asset_table: Table,
+    rid: RID,
+    metadata: dict | None = None,
+) -> Path:
+```
+
+And in the function body (around line 691), add the RID segment:
+
+```python
+    for m in asset_metadata:
+        path = path / str(metadata.get(m, NULL_SENTINEL))
+    # Bug E.2: append pre-allocated RID as final segment.
+    path = path / rid
+    path.mkdir(parents=True, exist_ok=True)
+    return path / file_name
+```
+
+- [ ] **Step 2: Update the caller in `core/mixins/execution.py`**
+
+In `src/deriva_ml/core/mixins/execution.py`, locate the call around line 229:
+
+```python
+        cfile = asset_file_path(
+            prefix=self.working_dir,
+            exec_rid=execution_rid,
+            file_name="configuration.json",
+            asset_table=self.model.name_to_table("Execution_Metadata"),
+            metadata={},
+        )
+```
+
+This call is reading an EXISTING configuration.json for an already-uploaded execution. The file's staging path on disk includes whatever RID it has — but we don't have that RID at this call site. We're trying to read it, not write it.
+
+Read the function's purpose in context — it's looking up a config file that was created during a previous run. The current behavior was: path ends at `/configuration.json` after the metadata dirs. With the RID segment added, we need to either:
+
+**A.** Glob under all RID dirs: `path / "*" / "configuration.json"` (ambiguous if multiple exist).
+**B.** Pass the known RID from the caller's context.
+**C.** Fall back to a wildcard-resolving helper specifically for this case.
+
+Let me check the broader context. What's this function called from?
+
+Reading lines around 229 in mixins/execution.py:
+
+The function is `bind_execution` or similar — it loads a configuration for a RESUMED execution. The caller has `execution_rid` but not the `configuration.json`'s RID (which would be the RID of the Execution_Metadata row recording that file).
+
+**The simplest compatible path:** for `Execution_Metadata` rows loaded this way, there's no metadata column and no pre-leased RID applicable — this is reading an existing on-disk file, not staging a new upload. Use a glob:
+
+```python
+        # Execution_Metadata for a resumed execution: the file lives under
+        # a RID-segment directory that was written by a prior run. Glob
+        # for it rather than requiring the caller to know the RID.
+        em_table = self.model.name_to_table("Execution_Metadata")
+        staging_base = (
+            Path(self.working_dir) / "deriva-ml" / "execution" / execution_rid
+            / "asset" / em_table.schema.name / em_table.name
+        )
+        candidates = list(staging_base.glob("*/configuration.json"))
+        cfile = candidates[0] if candidates else (staging_base / "configuration.json")
+```
+
+Actually this is getting complex for a helper meant to just compute a path. Let me reconsider.
+
+**Alternative simpler approach: don't change `asset_file_path`'s signature.** Instead, only callers that actually need the new RID segment (the two upload-side staging builders in Tasks 7 and 8) compute the path themselves. The `asset_file_path` helper stays as-is — it's no longer aligned with the upload regex, but it's not ON the upload path either.
+
+Confirm by checking: is `asset_file_path` called anywhere else in the upload pipeline?
+
+```bash
+grep -rn "from deriva_ml.dataset.upload import asset_file_path\|dataset.upload\.asset_file_path\| asset_file_path(" src/deriva_ml/ tests/
+```
+
+Expected: only `core/mixins/execution.py:229` calls it.
+
+If that's the only caller, and it's not part of the upload pipeline, we revert this task. The helper is then dead code with respect to the new regex, but still correctly finds the configuration.json it's looking for (since that file was saved BEFORE Bug E.2 with no RID segment).
+
+**Decision:** skip this task. Leave `asset_file_path` unchanged. Verify in step 3 that no other callers exist.
+
+- [ ] **Step 3: Verify `asset_file_path` has no other upload-path callers**
+
+Run: `cd /Users/carl/GitHub/deriva-ml/.worktrees/bug-e && grep -rn "asset_file_path" src/deriva_ml/ | grep -v "__pycache__" | grep -v "self\.asset_file_path\|exe\.asset_file_path\|execution\.asset_file_path"`
+
+Expected output: only the definition at `src/deriva_ml/dataset/upload.py:657` and the one caller at `src/deriva_ml/core/mixins/execution.py:229`.
+
+The `Execution.asset_file_path` method (different function, defined at `src/deriva_ml/execution/execution.py:1291`) uses the manifest + `_build_upload_staging` (Task 7) — that path IS covered.
+
+- [ ] **Step 4: No code change needed — leave Task 9 as a verification-only task**
+
+If step 3 confirms, this task is a no-op beyond the check. Commit nothing; log the decision:
+
+```bash
+cd /Users/carl/GitHub/deriva-ml/.worktrees/bug-e && git log --oneline -1
+```
+
+(If step 3 surfaces other callers, this task expands to include those updates. Default plan assumes no other callers.)
+
+---
+
+## Task 10: Call lease validator at `_upload_execution_dirs`
+
+**Files:**
+- Modify: `src/deriva_ml/execution/execution.py` — `_upload_execution_dirs` around line 1100.
+
+Add the lease validator call alongside the existing Bug C metadata validator.
+
+- [ ] **Step 1: Add the validator call**
+
+In `src/deriva_ml/execution/execution.py`, locate `_upload_execution_dirs` (around line 1100). Find the existing Bug C validator block:
+
+```python
+        # Bug C: refuse to upload if any pending asset is missing a
+        # required (NOT-NULL) metadata column. This raises a single
+        # DerivaMLValidationError that lists all failures at once.
+        from deriva_ml.asset.manifest import _validate_pending_asset_metadata
+        _validate_pending_asset_metadata(self._model, self._get_manifest())
+```
+
+Immediately after it, add:
+
+```python
+        # Bug E.2: confirm each pre-leased asset RID is still live in
+        # ERMrest_RID_Lease. Catches stale SQLite state and out-of-band
+        # lease-table edits before any hatrac I/O.
+        from deriva_ml.execution.rid_lease import _validate_pending_asset_leases
+        manifest = self._get_manifest()
+        lease_entries = [
+            (key, entry.rid)
+            for key, entry in manifest.pending_assets().items()
+            if entry.rid
+        ]
+        if lease_entries:
+            _validate_pending_asset_leases(
+                self._ml_object.catalog, lease_entries,
+            )
+```
+
+- [ ] **Step 2: Sanity import check**
+
+Run: `cd /Users/carl/GitHub/deriva-ml/.worktrees/bug-e && DERIVA_ML_ALLOW_DIRTY=true uv run python -c "from deriva_ml.execution.execution import Execution; print('ok')"`
+
+Expected: prints `ok`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/carl/GitHub/deriva-ml/.worktrees/bug-e && git add src/deriva_ml/execution/execution.py
+git commit -m "feat(execution): validate pre-leased RIDs at _upload_execution_dirs (Bug E.2)"
+```
+
+---
+
+## Task 11: Call lease validator at `run_upload_engine`
+
+**Files:**
+- Modify: `src/deriva_ml/execution/upload_engine.py` — `run_upload_engine` around line 290.
+
+- [ ] **Step 1: Add the validator call**
+
+In `src/deriva_ml/execution/upload_engine.py`, locate `run_upload_engine` (around line 236). The existing Bug C validator block iterates `list_pending_rows` once to build `validator_entries` and invokes `_validate_pending_asset_metadata_iter`. To avoid a second full iteration, restructure that block to collect both metadata entries AND lease entries in a single pass, then invoke both validators sequentially.
+
+**Before** (existing Bug C code):
+
+```python
+    import json as _json
+    from deriva_ml.asset.manifest import _validate_pending_asset_metadata_iter
+    store = ml.workspace.execution_state_store()
+    _statuses_to_validate = [
+        PendingRowStatus.staged,
+        PendingRowStatus.leasing,
+        PendingRowStatus.leased,
+        PendingRowStatus.uploading,
+    ]
+    if retry_failed:
+        _statuses_to_validate.append(PendingRowStatus.failed)
+    if execution_rids is None:
+        rids_for_validation = [row["rid"] for row in store.list_executions()]
+    else:
+        rids_for_validation = list(execution_rids)
+    validator_entries: list[tuple[str, str, str, dict]] = []
+    for rid in rids_for_validation:
+        for row in store.list_pending_rows(
+            execution_rid=rid, status=_statuses_to_validate,
+        ):
+            if not row.get("asset_file_path"):
+                continue
+            md = _json.loads(row["metadata_json"]) if row["metadata_json"] else {}
+            validator_entries.append((
+                f"{row['execution_rid']}/{row['target_table']}/{row['key']}",
+                row["target_schema"],
+                row["target_table"],
+                md,
+            ))
+    if validator_entries:
+        _validate_pending_asset_metadata_iter(ml.model, validator_entries)
+```
+
+**After** (Bug C + Bug E.2 combined in one iteration):
+
+```python
+    import json as _json
+    from deriva_ml.asset.manifest import _validate_pending_asset_metadata_iter
+    from deriva_ml.execution.rid_lease import _validate_pending_asset_leases
+    store = ml.workspace.execution_state_store()
+    _statuses_to_validate = [
+        PendingRowStatus.staged,
+        PendingRowStatus.leasing,
+        PendingRowStatus.leased,
+        PendingRowStatus.uploading,
+    ]
+    if retry_failed:
+        _statuses_to_validate.append(PendingRowStatus.failed)
+    if execution_rids is None:
+        rids_for_validation = [row["rid"] for row in store.list_executions()]
+    else:
+        rids_for_validation = list(execution_rids)
+    metadata_entries: list[tuple[str, str, str, dict]] = []
+    lease_entries: list[tuple[str, str]] = []
+    for rid in rids_for_validation:
+        for row in store.list_pending_rows(
+            execution_rid=rid, status=_statuses_to_validate,
+        ):
+            if not row.get("asset_file_path"):
+                continue
+            key_str = f"{row['execution_rid']}/{row['target_table']}/{row['key']}"
+            md = _json.loads(row["metadata_json"]) if row["metadata_json"] else {}
+            metadata_entries.append((
+                key_str,
+                row["target_schema"],
+                row["target_table"],
+                md,
+            ))
+            if row.get("rid"):
+                lease_entries.append((key_str, row["rid"]))
+    if metadata_entries:
+        _validate_pending_asset_metadata_iter(ml.model, metadata_entries)
+    if lease_entries:
+        _validate_pending_asset_leases(ml.catalog, lease_entries)
+```
+
+(`metadata_entries` is just a rename of `validator_entries` to be more specific.)
+
+- [ ] **Step 2: Sanity import check**
+
+Run: `cd /Users/carl/GitHub/deriva-ml/.worktrees/bug-e && DERIVA_ML_ALLOW_DIRTY=true uv run python -c "from deriva_ml.execution.upload_engine import run_upload_engine; print('ok')"`
+
+Expected: prints `ok`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/carl/GitHub/deriva-ml/.worktrees/bug-e && git add src/deriva_ml/execution/upload_engine.py
+git commit -m "feat(upload_engine): validate pre-leased RIDs at run_upload_engine (Bug E.2)"
+```
+
+---
+
+## Task 12: Live-catalog integration tests
+
+**Files:**
+- Create: `tests/execution/test_bug_e2_live_smoke.py` (new file).
+
+Three tests, all gated on `DERIVA_HOST`.
+
+- [ ] **Step 1: Write the tests**
+
+Create `tests/execution/test_bug_e2_live_smoke.py`:
+
+```python
+"""Live-catalog integration tests for Bug E.2 (pre-allocated RID upload).
+
+Gated on DERIVA_HOST. Three tests:
+
+1. Happy path — upload uses pre-leased RID.
+2. Missing-lease validation — RID not in ERMrest_RID_Lease raises.
+3. Retry idempotent — partial failure + retry produces same catalog row.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from datetime import datetime, timezone
+
+import pytest
+
+
+requires_catalog = pytest.mark.skipif(
+    not os.environ.get("DERIVA_HOST"),
+    reason="Bug E.2 live tests require DERIVA_HOST",
+)
+
+
+def _make_workflow(test_ml, name: str):
+    from deriva_ml import MLVocab as vc
+    test_ml.add_term(
+        vc.workflow_type,
+        "Test Workflow",
+        description="for Bug E.2 live tests",
+    )
+    return test_ml.create_workflow(
+        name=name,
+        workflow_type="Test Workflow",
+        description="for Bug E.2 live tests",
+    )
+
+
+def _lease_one_rid(test_ml) -> tuple[str, str]:
+    """POST a single lease to ERMrest_RID_Lease; return (token, rid)."""
+    from deriva_ml.execution.rid_lease import (
+        generate_lease_token, post_lease_batch,
+    )
+    token = generate_lease_token()
+    result = post_lease_batch(catalog=test_ml.catalog, tokens=[token])
+    return token, result[token]
+
+
+@requires_catalog
+def test_upload_asset_uses_pre_leased_rid(test_ml, tmp_path):
+    """End-to-end: stage an asset with a pre-leased RID; assert the
+    catalog row has that RID (not a server-generated one)."""
+    from deriva_ml.execution.state_store import PendingRowStatus
+
+    f = tmp_path / "bug-e2-happy.bin"
+    f.write_bytes(b"bug-e2 happy path " * 32)
+
+    # Pre-lease a RID.
+    token, leased_rid = _lease_one_rid(test_ml)
+
+    wf = _make_workflow(test_ml, "Bug E2 happy path")
+    exe = test_ml.create_execution(description="bug-e2-happy", workflow=wf)
+    store = test_ml.workspace.execution_state_store()
+    now = datetime.now(timezone.utc)
+
+    with exe.execute():
+        pass
+
+    # Stage a pending row with the pre-leased RID.
+    store.insert_pending_row(
+        execution_rid=exe.execution_rid,
+        key="k1",
+        target_schema="deriva-ml",
+        target_table="Execution_Asset",
+        metadata_json=json.dumps({}),
+        created_at=now,
+        rid=leased_rid,
+        status=PendingRowStatus.leased,
+        lease_token=token,
+        asset_file_path=str(f),
+    )
+
+    report = exe.upload_outputs()
+    assert report.total_failed == 0, f"failures: {report.errors}"
+    assert report.total_uploaded == 1
+
+    # Catalog row must have our pre-leased RID.
+    pb = test_ml.pathBuilder()
+    asset_path = pb.schemas["deriva-ml"].tables["Execution_Asset"]
+    rows = list(
+        asset_path.filter(asset_path.RID == leased_rid)
+        .entities().fetch()
+    )
+    assert len(rows) == 1, (
+        f"Execution_Asset row with RID={leased_rid} not found; "
+        f"got {len(rows)} results. Bug E.2 regression: server "
+        f"substituted its own RID instead of honoring our lease."
+    )
+    # Sanity: MD5 matches what we uploaded.
+    expected_md5 = hashlib.md5(f.read_bytes()).hexdigest()
+    assert rows[0]["MD5"] == expected_md5
+
+
+@requires_catalog
+def test_upload_asset_raises_validation_when_lease_missing(test_ml, tmp_path):
+    """Staging an asset with a bogus RID (never in ERMrest_RID_Lease)
+    must raise DerivaMLValidationError before any hatrac I/O."""
+    from deriva_ml.core.exceptions import DerivaMLValidationError
+    from deriva_ml.execution.state_store import PendingRowStatus
+
+    f = tmp_path / "bug-e2-missing.bin"
+    f.write_bytes(b"bug-e2 missing lease " * 32)
+
+    # A plausible-looking RID that was never leased.
+    bogus_rid = "0-FAKEFAKE"
+
+    wf = _make_workflow(test_ml, "Bug E2 missing lease")
+    exe = test_ml.create_execution(description="bug-e2-missing", workflow=wf)
+    store = test_ml.workspace.execution_state_store()
+    now = datetime.now(timezone.utc)
+
+    with exe.execute():
+        pass
+
+    store.insert_pending_row(
+        execution_rid=exe.execution_rid,
+        key="k2",
+        target_schema="deriva-ml",
+        target_table="Execution_Asset",
+        metadata_json=json.dumps({}),
+        created_at=now,
+        rid=bogus_rid,
+        status=PendingRowStatus.leased,
+        lease_token="bogus-token",
+        asset_file_path=str(f),
+    )
+
+    with pytest.raises(DerivaMLValidationError) as ei:
+        exe.upload_outputs()
+    msg = str(ei.value)
+    assert bogus_rid in msg
+    assert "ERMrest_RID_Lease" in msg
+
+
+@requires_catalog
+def test_upload_asset_retry_idempotent_with_existing_row(test_ml, tmp_path):
+    """Simulate partial success: pre-insert a row at the pre-leased RID.
+    A subsequent upload_outputs must detect the existing row and report
+    success without re-insert."""
+    from deriva_ml.execution.state_store import PendingRowStatus
+
+    f = tmp_path / "bug-e2-retry.bin"
+    f.write_bytes(b"bug-e2 retry " * 32)
+
+    token, leased_rid = _lease_one_rid(test_ml)
+
+    wf = _make_workflow(test_ml, "Bug E2 retry")
+    exe = test_ml.create_execution(description="bug-e2-retry", workflow=wf)
+    store = test_ml.workspace.execution_state_store()
+    now = datetime.now(timezone.utc)
+
+    with exe.execute():
+        pass
+
+    # Pre-populate a catalog row at the pre-leased RID, simulating a
+    # prior successful insert that the client didn't record locally.
+    expected_md5 = hashlib.md5(f.read_bytes()).hexdigest()
+    pb = test_ml.pathBuilder()
+    asset_path = pb.schemas["deriva-ml"].tables["Execution_Asset"]
+    asset_path.insert([{
+        "RID": leased_rid,
+        "Filename": "bug-e2-retry.bin",
+        "MD5": expected_md5,
+        "Length": f.stat().st_size,
+        "URL": "/hatrac/fake-pre-existing-uri",
+    }])
+
+    # Now stage the row as pending with the SAME RID.
+    store.insert_pending_row(
+        execution_rid=exe.execution_rid,
+        key="k3",
+        target_schema="deriva-ml",
+        target_table="Execution_Asset",
+        metadata_json=json.dumps({}),
+        created_at=now,
+        rid=leased_rid,
+        status=PendingRowStatus.leased,
+        lease_token=token,
+        asset_file_path=str(f),
+    )
+
+    # Retry must succeed (idempotency pre-check finds the existing row).
+    report = exe.upload_outputs()
+    assert report.total_failed == 0, f"retry failures: {report.errors}"
+    # At least one row reported uploaded (exact count semantics depend on
+    # whether deriva-py counts "existing" as uploaded, which is fine).
+    assert report.total_uploaded >= 1
+
+    # Exactly ONE catalog row for this RID — no duplicates.
+    rows = list(
+        asset_path.filter(asset_path.RID == leased_rid)
+        .entities().fetch()
+    )
+    assert len(rows) == 1
+```
+
+- [ ] **Step 2: Run the tests**
+
+Run: `cd /Users/carl/GitHub/deriva-ml/.worktrees/bug-e && DERIVA_ML_ALLOW_DIRTY=true DERIVA_HOST=localhost uv run pytest tests/execution/test_bug_e2_live_smoke.py -v`
+
+Expected: all 3 tests pass.
+
+**If the tests fail with `DerivaUploadConfigurationError: ...use_pre_allocated_rid=true but no RID...` or similar:** the deriva-py PR (Tasks 1-4) hasn't landed yet. Check `uv.lock` to see which commit of deriva-py is pinned; if it predates the Phase 1 merge, run `uv lock --upgrade-package deriva` to pick up the latest `2.0-dev` head.
+
+**If the tests fail with `Server substituted its own RID` in test #1:** deriva-ml's upload spec isn't emitting the flag OR the staging path doesn't include the RID segment. Verify Tasks 6-8 landed correctly.
+
+- [ ] **Step 3: Broader regression**
+
+Run: `cd /Users/carl/GitHub/deriva-ml/.worktrees/bug-e && DERIVA_ML_ALLOW_DIRTY=true DERIVA_HOST=localhost uv run pytest tests/asset/ tests/execution/test_bug_c_live_smoke.py tests/execution/test_bug_e2_live_smoke.py tests/execution/test_pending_asset_lease_validator.py -q`
+
+Expected: all tests pass (Bug C tests continue to pass — orthogonal fix).
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/carl/GitHub/deriva-ml/.worktrees/bug-e && git add tests/execution/test_bug_e2_live_smoke.py
+git commit -m "test(bug_e2): live-catalog integration (happy, missing-lease, retry-idempotent)"
+```
+
+---
+
+## Task 13: CHANGELOG entry
+
+**Files:**
+- Modify: `CHANGELOG.md` — prepend new Unreleased section.
+
+- [ ] **Step 1: Add CHANGELOG entry**
+
+In `CHANGELOG.md`, immediately after the title/preamble and BEFORE the first existing `## Unreleased —` section, insert:
+
+```markdown
+## Unreleased — Bug E.2: asset uploads honor pre-leased RIDs
+
+### Fixed
+
+- **Asset-table catalog inserts now use the caller-supplied pre-leased RID** instead of silently accepting a server-generated one. Previously, the plain-row drain path honored `pending_rows.rid` but the asset-row path (via deriva-py's `GenericUploader`) looked up or created rows by MD5+Filename, discarding the pre-leased RID. Any client code that captured the pre-leased RID (e.g., for FK references) ended up with a dangling pointer. Fix is a two-repo change:
+  - **deriva-py** (`2.0-dev`): new opt-in `use_pre_allocated_rid: true` flag on asset mappings. When set, `_uploadAsset` bypasses `_getFileRecord` (MD5+Filename lookup) and routes to a new `_createFileRecordWithRid` method that does a RID-keyed existence check for idempotent retry, then creates with the caller-supplied RID in the payload. Legacy callers (flag absent) see no change.
+  - **deriva-ml**: `asset_table_upload_spec` emits the new flag automatically, adds `(?P<RID>[-A-Z0-9]+)` to the `file_pattern` regex, and includes `"RID": "{RID}"` in the `column_map`. The two staging path-builders (`Execution._build_upload_staging`, `_invoke_deriva_py_uploader`) append the pre-leased RID as the final directory segment.
+
+### Added
+
+- **`_validate_pending_asset_leases(catalog, entries)`** — pre-flight validator in `deriva_ml.execution.rid_lease`. Batch-queries `public:ERMrest_RID_Lease` (chunked by `PENDING_ROWS_LEASE_CHUNK`) and raises an aggregated `DerivaMLValidationError` listing every pre-leased RID that is no longer present on the server. Called at the top of `Execution._upload_execution_dirs` and `run_upload_engine`, right after Bug C's metadata validator.
+
+### External-caller impact
+
+No action required. Any caller using the standard `asset_file_path` → `upload_execution_outputs` flow is automatically opted into pre-allocated-RID semantics. Callers who had captured a pre-leased RID for cross-references will find that RID now matches what's in the catalog after upload.
+
+Edge case: if a pre-leased RID has been cleared from `ERMrest_RID_Lease` (e.g., by manual cleanup or a dropped catalog), the upload is refused at pre-flight with a clear error message. Restart the execution to re-lease.
+```
+
+- [ ] **Step 2: Verify file still parses**
+
+Run: `cd /Users/carl/GitHub/deriva-ml/.worktrees/bug-e && head -40 CHANGELOG.md`
+
+Expected: new section appears between preamble and the first existing Unreleased section.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/carl/GitHub/deriva-ml/.worktrees/bug-e && git add CHANGELOG.md
+git commit -m "docs(changelog): Bug E.2 asset uploads honor pre-leased RIDs"
+```
+
+---
+
+## Final verification
+
+- [ ] **Step 1: deriva-py tests**
+
+Run: `cd /Users/carl/GitHub/deriva-py && python -m pytest tests/deriva/transfer/upload/test_pre_allocated_rid.py -v`
+
+Expected: 6/6 tests pass.
+
+- [ ] **Step 2: deriva-ml unit tier**
+
+Run: `cd /Users/carl/GitHub/deriva-ml/.worktrees/bug-e && DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/execution/test_pending_asset_lease_validator.py tests/asset/test_null_sentinel_processor.py tests/asset/test_metadata_validator.py tests/core/test_schema_cache.py tests/core/test_schema_diff.py tests/core/test_exceptions.py -q`
+
+Expected: all tests pass. (Some may skip without DERIVA_HOST — acceptable.)
+
+- [ ] **Step 3: deriva-ml live tier**
+
+Run: `cd /Users/carl/GitHub/deriva-ml/.worktrees/bug-e && DERIVA_ML_ALLOW_DIRTY=true DERIVA_HOST=localhost uv run pytest tests/asset/ tests/execution/test_bug_c_live_smoke.py tests/execution/test_bug_e2_live_smoke.py tests/execution/test_pending_asset_lease_validator.py -q`
+
+Expected: all tests pass.
+
+- [ ] **Step 4: Ruff check**
+
+Run: `cd /Users/carl/GitHub/deriva-ml/.worktrees/bug-e && uv run ruff check src/deriva_ml/execution/rid_lease.py src/deriva_ml/execution/execution.py src/deriva_ml/execution/upload_engine.py src/deriva_ml/dataset/upload.py`
+
+Expected: no new warnings on Bug E.2 changes. Pre-existing unrelated warnings are fine.
+
+---
+
+## Commit summary (expected)
+
+### deriva-py side (Phase 1)
+
+1. `docs(spec): Bug E.2 pre-allocated RID upload design` (already committed on deriva-ml worktree)
+2. `feat(upload): fast-fail when use_pre_allocated_rid flag has no RID`
+3. `feat(upload): _createFileRecordWithRid bypasses MD5+Filename lookup`
+4. `feat(upload): route _uploadAsset Step 7 to _createFileRecordWithRid when flag set`
+
+Then: PR against `2.0-dev`, merge.
+
+### deriva-ml side (Phase 2)
+
+5. `feat(rid_lease): _validate_pending_asset_leases for pre-flight lease-table check`
+6. `feat(dataset/upload): emit use_pre_allocated_rid + RID capture (Bug E.2)`
+7. `fix(execution): append pre-leased RID in _build_upload_staging (Bug E.2)`
+8. `fix(upload_engine): append pre-leased RID in _invoke_deriva_py_uploader (Bug E.2)`
+9. `feat(execution): validate pre-leased RIDs at _upload_execution_dirs (Bug E.2)`
+10. `feat(upload_engine): validate pre-leased RIDs at run_upload_engine (Bug E.2)`
+11. `test(bug_e2): live-catalog integration (happy, missing-lease, retry-idempotent)`
+12. `docs(changelog): Bug E.2 asset uploads honor pre-leased RIDs`
+
+Total: 3 deriva-py commits (after spec) + 8 deriva-ml commits = 11 implementation commits across the two repos.

--- a/docs/superpowers/specs/2026-04-22-bug-e2-preallocated-rid-design.md
+++ b/docs/superpowers/specs/2026-04-22-bug-e2-preallocated-rid-design.md
@@ -1,0 +1,380 @@
+# Bug E.2: Asset Uploads Honor Pre-Leased RIDs — Design
+
+**Status:** Draft · **Date:** 2026-04-22 · **Bug:** Pre-S3 architectural gap — deriva-py's asset uploader ignores pre-allocated RIDs
+
+## 1. Problem
+
+DerivaML's lease system (§2.6, `rid_lease.py` + `lease_orchestrator.py`) pre-allocates RIDs from `public:ERMrest_RID_Lease` so client code can reference those RIDs in FK columns **before** the target row exists in the catalog. The plain-row drain path honors pre-leased RIDs correctly: `metadata["RID"] = r["rid"]` + `tpath.insert(body)` (see `upload_engine.py` around line 573).
+
+The **asset-row path** does not. It delegates to deriva-py's `GenericUploader`, which uses `record_query_template: "/entity/{target_table}/MD5={md5}&Filename={file_name}"` to either look up an existing row (by MD5+Filename) or `_catalogRecordCreate` a new one with a **server-generated RID**. The pre-leased RID in `files[i]["rid"]` is never threaded into the insert payload.
+
+Consequences:
+- Any client code that captured the pre-leased RID (e.g., to build an FK-referencing row elsewhere) ends up with a dangling reference — the row in the asset table has a different RID.
+- SQLite's `pending_rows.rid` column becomes stale (diverged from catalog).
+- The whole point of the lease system — "client has a valid RID immediately, no round-trip per row" — is silently broken for asset tables.
+
+## 2. Goals & non-goals
+
+**In scope:**
+- Asset uploads must use the pre-leased RID for the catalog insert.
+- Upstream fix in deriva-py (branch `2.0-dev`): add opt-in config flag `use_pre_allocated_rid` to asset mappings.
+- Pre-flight validator in deriva-ml that confirms every pre-leased RID is still live in `ERMrest_RID_Lease` before the upload runs — raises an aggregated `DerivaMLValidationError` if any are missing.
+- Idempotent retry: if a partial failure leaves a catalog row at the pre-leased RID, a subsequent upload detects and skips the duplicate insert rather than raising an RID-collision error.
+
+**Explicitly out of scope:**
+- Any change to the plain-row drain path (already works).
+- Removing the MD5+Filename query for callers who don't opt into `use_pre_allocated_rid` (backward compatibility requirement).
+- Implementing a separate lease-release-on-success workflow — a successfully consumed lease stays in `ERMrest_RID_Lease` indefinitely (existing behavior).
+- Changes to the state-store's lease-acquisition protocol.
+- Cross-repo tooling automation. The deriva-py and deriva-ml PRs are coordinated manually.
+
+## 3. Design summary
+
+Four units across two repos:
+
+### 3.1 deriva-py (upstream, branch `2.0-dev`)
+
+- **New config flag** `use_pre_allocated_rid: true` on any asset mapping in the upload spec. Default `false` (legacy MD5+Filename behavior).
+- **Fast-fail validation** in `_initFileMetadata`: if flag is set and `match_groupdict` lacks `RID`, raise `DerivaUploadConfigurationError` before any hatrac I/O.
+- **New method** `_createFileRecordWithRid` replaces `_getFileRecord` when the flag is set. Does a pre-check GET by RID for idempotency; if no row exists, creates one with the caller-supplied RID in the payload.
+- Everything else (hatrac upload, regex, column_map, pre/post processors) unchanged.
+
+### 3.2 deriva-ml (downstream)
+
+- **New validator** `_validate_pending_asset_leases(catalog, entries)` in `rid_lease.py` — batch-queries `ERMrest_RID_Lease` and raises `DerivaMLValidationError` aggregating any missing RIDs.
+- **Upload entry points** (`Execution._upload_execution_dirs` and `run_upload_engine`) call the new validator alongside the existing `_validate_pending_asset_metadata`.
+- **Upload spec** (`asset_table_upload_spec`) emits `use_pre_allocated_rid=True`, adds `(?P<RID>[-A-Z0-9]+)` to `file_pattern`, and adds `"RID": "{RID}"` to `column_map`.
+- **Staging path builders** (`_invoke_deriva_py_uploader._path_for` and `Execution._build_upload_staging`) append the pre-leased RID as the final directory segment after the metadata columns: `.../Table/<col1>/<col2>/<RID>/<file>`.
+- **Dependency** bumps `deriva-py` in `pyproject.toml` to the release that ships the new flag.
+
+## 4. Components
+
+### 4.1 deriva-py — `use_pre_allocated_rid` flag
+
+**File:** `deriva/transfer/upload/deriva_upload.py`
+
+**Change A** — after `_initFileMetadata`'s `self._updateFileMetadata(match_groupdict)`:
+
+```python
+if stob(asset_mapping.get("use_pre_allocated_rid", False)):
+    if not self.metadata.get("RID"):
+        raise DerivaUploadConfigurationError(
+            "Asset mapping has use_pre_allocated_rid=true but no RID "
+            "was captured by the file_pattern regex. Ensure the pattern "
+            "includes a (?P<RID>[A-Z0-9-]+) named group."
+        )
+```
+
+**Change B** — in `_uploadAsset` Step 7 (`if not record:`):
+
+```python
+if not record:
+    if stob(asset_mapping.get("use_pre_allocated_rid", False)):
+        record, result = self._createFileRecordWithRid(asset_mapping)
+    else:
+        record, result = self._getFileRecord(asset_mapping)
+```
+
+**Change C** — new private method on `GenericUploader`:
+
+```python
+def _createFileRecordWithRid(self, asset_mapping):
+    """Create a new record using a caller-supplied RID.
+
+    Used when asset_mapping has ``use_pre_allocated_rid: true``.
+    Skips the MD5+Filename lookup in ``_getFileRecord``; the caller
+    (via the scan-path regex) must have supplied an RID that was
+    pre-allocated from ``ERMrest_RID_Lease``.
+
+    Idempotency: if a row with the supplied RID already exists
+    (e.g., a prior upload landed the catalog row but the client
+    crashed before recording success), returns that row rather
+    than raising an RID-collision error. Callers can safely retry
+    after partial failures.
+
+    Returns:
+        Tuple of (record, result) mirroring ``_getFileRecord``'s
+        return shape.
+    """
+    column_map = asset_mapping.get("column_map", {})
+    allow_none_col_list = asset_mapping.get("allow_empty_columns_on_update", [])
+    target_table = self.metadata['target_table']
+    rid = self.metadata["RID"]
+
+    existing = self.catalog.get(f"/entity/{target_table}/RID={rid}").json()
+    if existing:
+        record = existing[0]
+        self._updateFileMetadata(record, no_overwrite=True)
+        return self.pruneDict(record, column_map, allow_none_col_list), record
+
+    row = self.interpolateDict(self.metadata, column_map, allow_none_col_list)
+    result = self._catalogRecordCreate(target_table, row)
+    record = result[0] if result else row
+    if record:
+        self._updateFileMetadata(record)
+    return self.interpolateDict(
+        self.metadata, column_map, allow_none_column_list=allow_none_col_list
+    ), record
+```
+
+### 4.2 deriva-ml — `_validate_pending_asset_leases`
+
+**Location:** module-level private function at the end of `src/deriva_ml/execution/rid_lease.py`.
+
+```python
+def _validate_pending_asset_leases(
+    catalog: "ErmrestCatalog",
+    entries: "Iterable[tuple[str, str]]",
+) -> None:
+    """Confirm each (key, rid) pair's RID is still live in ERMrest_RID_Lease.
+
+    Queries the lease table in batches of ``PENDING_ROWS_LEASE_CHUNK``.
+    Aggregates missing RIDs and raises a single
+    :class:`DerivaMLValidationError` listing every failure in sorted
+    order. Returns ``None`` silently when every RID is present.
+
+    Args:
+        catalog: Live ErmrestCatalog for querying the lease table.
+        entries: Iterable of (key, rid) tuples. Key is a
+            human-readable identifier used in the error message.
+
+    Raises:
+        DerivaMLValidationError: If one or more RIDs are not found
+            in ``ERMrest_RID_Lease``.
+    """
+```
+
+Uses the existing `PENDING_ROWS_LEASE_CHUNK` constant for batch size.
+
+**Error-message shape:**
+
+```
+Missing or invalid pre-allocated RIDs for 2 pending asset(s):
+  - Image/acq001.png: RID 1-ABC not found in ERMrest_RID_Lease
+  - Image/acq002.png: RID 1-DEF not found in ERMrest_RID_Lease
+A pre-leased RID has become invalid (e.g., cleared from the lease
+table or never successfully POSTed). Restart the execution to
+re-lease, or investigate lease-table state.
+```
+
+### 4.3 deriva-ml — validator call sites
+
+**Call site 1 — `Execution._upload_execution_dirs`:**
+After the existing `_validate_pending_asset_metadata(self._model, self._get_manifest())` call, add:
+
+```python
+from deriva_ml.execution.rid_lease import _validate_pending_asset_leases
+manifest = self._get_manifest()
+lease_entries = [
+    (key, entry.rid)
+    for key, entry in manifest.pending_assets().items()
+    if entry.rid
+]
+if lease_entries:
+    _validate_pending_asset_leases(self._ml_object.catalog, lease_entries)
+```
+
+**Call site 2 — `run_upload_engine`:**
+After the existing metadata-validator block, reuse the row-iteration to build lease entries:
+
+```python
+from deriva_ml.execution.rid_lease import _validate_pending_asset_leases
+lease_entries = [
+    (key_str, row["rid"])
+    for key_str, row in <rows already iterated>
+    if row.get("rid") and row.get("asset_file_path")
+]
+if lease_entries:
+    _validate_pending_asset_leases(ml.catalog, lease_entries)
+```
+
+### 4.4 deriva-ml — upload spec changes
+
+In `asset_table_upload_spec()` (`src/deriva_ml/dataset/upload.py`):
+
+**Regex** — add RID capture group after metadata path, before filename:
+
+```python
+metadata_path = "/".join([rf"(?P<{c}>[-:._ \w]+)" for c in metadata_columns])
+rid_path = r"(?P<RID>[-A-Z0-9]+)"
+parts = [metadata_path, rid_path] if metadata_path else [rid_path]
+asset_path = (
+    f"{exec_dir_regex}/asset/{schema}/{asset_table.name}/"
+    f"{'/'.join(parts)}/{asset_file_regex}"
+)
+```
+
+**Column map** — add `"RID": "{RID}"`.
+
+**Spec dict** — add `"use_pre_allocated_rid": True`.
+
+### 4.5 deriva-ml — staging path changes
+
+**In `_invoke_deriva_py_uploader._path_for`** (`upload_engine.py`):
+
+```python
+def _path_for(f: dict) -> Path:
+    src = Path(f["path"]).resolve()
+    metadata = f.get("metadata") or {}
+    target_dir = asset_root / schema_name / target_table
+    for col in metadata_cols:
+        target_dir = target_dir / str(metadata.get(col, NULL_SENTINEL))
+    target_dir = target_dir / f["rid"]
+    return target_dir / src.name
+```
+
+**In `Execution._build_upload_staging`** (`execution.py`):
+
+```python
+metadata_parts = [
+    str(entry.metadata.get(k, NULL_SENTINEL)) for k in all_metadata_cols
+] if all_metadata_cols else []
+target_dir = staging_root / entry.schema / asset_table_name
+for part in metadata_parts:
+    target_dir = target_dir / part
+target_dir = target_dir / entry.rid
+target_dir.mkdir(parents=True, exist_ok=True)
+```
+
+**In `dataset/upload.py:asset_file_path`** (bag-export helper, line 657):
+
+```python
+for m in asset_metadata:
+    path = path / str(metadata.get(m, NULL_SENTINEL))
+path = path / rid  # requires new rid argument; see §8
+path.mkdir(parents=True, exist_ok=True)
+return path / file_name
+```
+
+This helper is primarily used by `core/mixins/execution.py:229` for `Execution_Metadata` (zero metadata columns). It will need a new `rid: str` parameter. Callers that don't have a pre-leased RID (bag-export for already-catalog-resident rows) must pass the catalog row's existing RID. See §8.
+
+### 4.6 deriva-ml — dependency pin
+
+In `pyproject.toml`, bump `deriva-py` requirement to the version that includes the `use_pre_allocated_rid` flag. Target version TBD when the upstream release tag is chosen.
+
+## 5. Data flow
+
+### 5.1 Happy path
+
+```
+exe.upload_outputs()
+  → _validate_pending_asset_metadata (Bug C validator, unchanged)
+  → _validate_pending_asset_leases (NEW)
+    [batch query /entity/public:ERMrest_RID_Lease/RID=r1;RID=r2;...]
+    [all found → no error]
+  → staging: .../Table/<col1>/<col2>/<RID>/<file>
+  → GenericUploader.scanDirectory
+  → _initFileMetadata captures RID from regex match_groupdict
+  → [flag set + RID present → pass validation]
+  → hatrac upload (Step 6, unchanged)
+  → _createFileRecordWithRid
+    → GET /entity/{table}/RID={rid}
+    → [no existing row → _catalogRecordCreate with RID in payload]
+  → Catalog row has pre-leased RID ✓
+```
+
+### 5.2 Missing-lease validator failure
+
+```
+exe.upload_outputs()
+  → _validate_pending_asset_metadata — ok
+  → _validate_pending_asset_leases
+    [one or more RIDs not in ERMrest_RID_Lease]
+    → raise DerivaMLValidationError (aggregated)
+```
+
+No hatrac upload, no catalog mutation.
+
+### 5.3 Retry after partial failure
+
+```
+[Attempt 1: hatrac upload succeeds, catalog insert interrupted]
+  → pending_rows.status = failed
+[User retries: exe.upload_outputs(retry_failed=True)]
+  → _validate_pending_asset_leases passes (lease still live)
+  → staging rebuilt with same RID
+  → GenericUploader.scanDirectory → _initFileMetadata ok
+  → _createFileRecordWithRid
+    → GET /entity/{table}/RID={rid}
+    → [row EXISTS from attempt 1 → return existing row, skip create]
+  → Upload reported successful; pending row marked uploaded
+```
+
+### 5.4 Flag-off path (backward compat)
+
+```
+[Asset tables without use_pre_allocated_rid=true — any caller not opted in]
+  → Existing _getFileRecord flow runs (MD5+Filename lookup, server RID on create)
+  → No behavior change vs. pre-Bug-E.2
+```
+
+### 5.5 Interaction with Bug C
+
+Orthogonal. Bug C's validator runs first, then Bug E.2's. Staging path has metadata-column segments (from Bug C) followed by RID segment (from Bug E.2). `NULL_SENTINEL` + `NullSentinelProcessor` continue to work unchanged.
+
+## 6. Error handling summary
+
+| Scenario | Exception / behavior |
+|---|---|
+| Pre-leased RID not in `ERMrest_RID_Lease` (stale SQLite) | `DerivaMLValidationError` (aggregated) |
+| `use_pre_allocated_rid=true` but regex didn't capture RID | `DerivaUploadConfigurationError` (deriva-py, fast-fail in `_initFileMetadata`) |
+| Catalog row at pre-leased RID already exists (retry after partial success) | Treated as idempotent success; existing row returned |
+| Catalog insert fails with RID-collision for some OTHER reason | Row marked `failed` in SQLite; retry behavior same as today |
+| Hatrac upload fails | Same as today — retry re-attempts the upload |
+| Flag not set on asset mapping | Legacy MD5+Filename flow, no validator runs |
+
+## 7. Testing plan
+
+### 7.1 deriva-py unit tests (no catalog)
+
+1. `test_init_file_metadata_raises_when_flag_set_and_no_rid_captured`
+2. `test_init_file_metadata_passes_when_flag_set_and_rid_captured`
+3. `test_create_file_record_with_rid_happy_path` — no existing row → `_catalogRecordCreate` called with RID
+4. `test_create_file_record_with_rid_idempotent_on_existing` — GET returns row → skip create
+5. `test_flag_off_uses_existing_md5_filename_path`
+
+### 7.2 deriva-ml unit tests (no catalog)
+
+6. `test_empty_entries_returns_none`
+7. `test_all_leases_valid_passes`
+8. `test_single_missing_lease_raises`
+9. `test_multiple_missing_leases_aggregated`
+10. `test_batched_queries_use_chunk_size`
+
+### 7.3 deriva-ml upload-spec tests (live catalog)
+
+11. `test_asset_table_upload_spec_has_use_pre_allocated_rid_flag`
+12. `test_asset_table_upload_spec_file_pattern_captures_rid`
+13. `test_asset_table_upload_spec_column_map_includes_rid`
+
+### 7.4 deriva-ml integration tests (DERIVA_HOST-gated)
+
+14. `test_upload_asset_uses_pre_leased_rid` — happy path end-to-end, assert catalog row's RID equals the pre-leased RID.
+15. `test_upload_asset_raises_validation_when_lease_missing` — RID not in lease table → `DerivaMLValidationError`.
+16. `test_upload_asset_retry_after_hatrac_success_is_idempotent` — partial failure + retry → same catalog row.
+
+### 7.5 Regression
+
+- Bug C tests pass unchanged.
+- Plain-row drain path tests pass unchanged.
+- `Execution_Asset` (zero-metadata) smoke test passes — now exercises the new RID-segment path.
+
+## 8. Open questions
+
+- **`asset_file_path` signature.** The bag-export helper at `dataset/upload.py:657` currently takes `(prefix, exec_rid, file_name, asset_table, metadata)`. The new staging layout requires a RID segment. Callers split into two cases:
+  - **Upload-time** (manifest-driven): caller has a pre-leased RID, passes it.
+  - **Bag-export-time** (reading existing catalog rows): caller has the catalog's existing RID.
+  Both cases can supply a RID. The signature gains a new `rid: str` parameter. Any existing callers without a RID at hand need to be updated; grep confirms only `core/mixins/execution.py:229` uses this helper, and that call is for an `Execution_Metadata` row being re-uploaded with known RID.
+- **Retry MD5 mismatch edge case.** If a retry supplies a DIFFERENT file at the same pre-leased RID (e.g., the user re-staged), the idempotency pre-check returns the old row and skips insert. Not a ship blocker — pre-leased RIDs are tied to specific file identities in practice — but worth a follow-up hardening to compare MD5 and raise a clear error on mismatch.
+
+## 9. Rollout
+
+**Phase 1: deriva-py PR** against `2.0-dev`. Minimal: flag + fast-fail + `_createFileRecordWithRid`. Unit tests. Review + merge.
+**Phase 2: deriva-py prerelease** tagged (e.g., `2.0.0.dev<N>`).
+**Phase 3: deriva-ml PR** against `main`. Pin bump + validator + spec changes + staging changes + tests + CHANGELOG. Review + merge.
+
+CHANGELOG entry under `## Unreleased — Bug E.2: asset uploads honor pre-leased RIDs` documenting:
+- The new deriva-py `use_pre_allocated_rid` flag.
+- deriva-ml's opt-in via `asset_table_upload_spec` (automatic — no caller changes needed).
+- The new lease validator and its failure mode.
+- That callers who already supplied correct metadata continue to succeed.

--- a/src/deriva_ml/asset/manifest.py
+++ b/src/deriva_ml/asset/manifest.py
@@ -126,6 +126,23 @@ class AssetManifest:
     def mark_uploaded(self, key: str, rid: str) -> None:
         self._store.mark_asset_uploaded(self._execution_rid, key, rid)
 
+    def set_asset_rid(self, key: str, rid: str) -> None:
+        """Assign a pre-leased RID to an asset entry without changing status.
+
+        Used when the RID is known in advance (from ``ERMrest_RID_Lease``)
+        so the catalog insert at upload time can use the caller-supplied
+        RID. Unlike :meth:`mark_uploaded`, this leaves ``status`` and
+        ``uploaded_at`` unchanged.
+
+        Args:
+            key: Manifest key (``"{AssetTable}/{filename}"``).
+            rid: Pre-allocated RID to assign to the entry.
+
+        Raises:
+            KeyError: If ``key`` is not present in the manifest.
+        """
+        self._store.set_asset_rid(self._execution_rid, key, rid)
+
     def mark_failed(self, key: str, error: str) -> None:
         self._store.mark_asset_failed(self._execution_rid, key, error)
 

--- a/src/deriva_ml/core/mixins/annotation.py
+++ b/src/deriva_ml/core/mixins/annotation.py
@@ -24,7 +24,7 @@ Table = _ermrest_model.Table
 
 from pydantic import ConfigDict, validate_call
 
-from deriva_ml.core.exceptions import DerivaMLException
+from deriva_ml.core.exceptions import DerivaMLException, DerivaMLTableTypeError
 
 if TYPE_CHECKING:
     from deriva_ml.model.catalog import DerivaModel
@@ -36,6 +36,12 @@ VISIBLE_COLUMNS_TAG = "tag:isrd.isi.edu,2016:visible-columns"
 VISIBLE_FOREIGN_KEYS_TAG = "tag:isrd.isi.edu,2016:visible-foreign-keys"
 TABLE_DISPLAY_TAG = "tag:isrd.isi.edu,2016:table-display"
 COLUMN_DISPLAY_TAG = "tag:isrd.isi.edu,2016:column-display"
+# Bug E.2: opt-in strict mode for pre-allocated RID inserts. When set
+# to {"strict": true} on an asset table, deriva-py's uploader raises
+# DerivaUploadCatalogCreateError on RID mismatch instead of silently
+# adopting the existing row's RID. Use for tables whose rows are
+# referenced by FK columns in the same upload batch.
+STRICT_PREALLOCATED_RID_TAG = "tag:isrd.isi.edu,2026:strict-preallocated-rid"
 
 
 class AnnotationMixin:
@@ -312,12 +318,77 @@ class AnnotationMixin:
 
         return f"{table_obj.name}.{column_name}"
 
+    @validate_call(config=ConfigDict(arbitrary_types_allowed=True))
+    def set_strict_preallocated_rid(
+        self,
+        table: str | Table,
+        strict: bool = True,
+    ) -> str:
+        """Mark or unmark an asset table as strict-preallocated-RID.
+
+        When ``strict=True``, deriva-py's uploader raises
+        ``DerivaUploadCatalogCreateError`` if an upload's caller-supplied
+        pre-allocated RID differs from an existing catalog row's RID for
+        the same MD5+Filename. When ``False`` (or the annotation is
+        absent), the uploader silently adopts the existing row's RID
+        (legacy behavior preserved for shared artifacts like
+        ``Execution_Metadata`` configs).
+
+        Use strict mode for tables whose rows are referenced by FK
+        columns in the same upload batch — any unexpected RID
+        reassignment would corrupt those references.
+
+        Args:
+            table: Asset table name or Table object.
+            strict: If True, set the annotation to ``{"strict": true}``.
+                If False, remove the annotation (equivalent to soft mode).
+
+        Returns:
+            The table's name.
+
+        Raises:
+            DerivaMLTableTypeError: If ``table`` is not an asset table.
+
+        Example:
+            >>> ml.set_strict_preallocated_rid("ScanResult", strict=True)
+            >>> ml.apply_annotations()  # Commit to the catalog.
+        """
+        if not self.model.is_asset(table):
+            raise DerivaMLTableTypeError("asset table", str(table))
+        table_obj = self.model.name_to_table(table)
+        if strict:
+            table_obj.annotations[STRICT_PREALLOCATED_RID_TAG] = {"strict": True}
+        else:
+            table_obj.annotations.pop(STRICT_PREALLOCATED_RID_TAG, None)
+        return table_obj.name
+
+    @validate_call(config=ConfigDict(arbitrary_types_allowed=True))
+    def is_strict_preallocated_rid(self, table: str | Table) -> bool:
+        """Return True if the asset table has the strict-preallocated-RID annotation set.
+
+        Checks for the ``tag:isrd.isi.edu,2026:strict-preallocated-rid``
+        annotation. Returns True iff the annotation is present with
+        ``{"strict": true}``.
+
+        Args:
+            table: Asset table name or Table object.
+
+        Returns:
+            True if strict mode is set on this table, False otherwise.
+        """
+        table_obj = self.model.name_to_table(table)
+        anno = table_obj.annotations.get(STRICT_PREALLOCATED_RID_TAG, {})
+        if not isinstance(anno, dict):
+            return False
+        return bool(anno.get("strict", False))
+
     def apply_annotations(self) -> None:
         """Apply all staged annotation changes to the catalog.
 
         Commits any annotation changes made via set_display_annotation,
         set_visible_columns, set_visible_foreign_keys, set_table_display,
-        or set_column_display to the remote catalog.
+        set_column_display, or set_strict_preallocated_rid to the remote
+        catalog.
 
         Example:
             >>> ml.set_display_annotation("Image", {"name": "Images"})

--- a/src/deriva_ml/dataset/upload.py
+++ b/src/deriva_ml/dataset/upload.py
@@ -300,7 +300,14 @@ def asset_table_upload_spec(model: DerivaModel, asset_table: str | Table, chunk_
     # Be careful here as a metadata value might be a string with can contain special characters.
     # metadata_columns is sorted to ensure deterministic directory order matching the regex.
     metadata_path = "/".join([rf"(?P<{c}>[-:._ \w]+)" for c in metadata_columns])
-    asset_path = f"{exec_dir_regex}/asset/{schema}/{asset_table.name}/{metadata_path}/{asset_file_regex}"
+    # Bug E.2: capture pre-allocated RID as an additional path segment
+    # after metadata columns and before the filename.
+    rid_path = r"(?P<RID>[-A-Z0-9]+)"
+    parts = [metadata_path, rid_path] if metadata_path else [rid_path]
+    asset_path = (
+        f"{exec_dir_regex}/asset/{schema}/{asset_table.name}/"
+        f"{'/'.join(parts)}/{asset_file_regex}"
+    )
     asset_table = model.name_to_table(asset_table)
     schema = model.name_to_table(asset_table).schema.name
 
@@ -317,6 +324,7 @@ def asset_table_upload_spec(model: DerivaModel, asset_table: str | Table, chunk_
             "URL": "{URI}",
             "Length": "{file_size}",
             "Filename": "{file_name}",
+            "RID": "{RID}",  # Bug E.2: pre-allocated RID
         }
         | {c: f"{{{c}}}" for c in metadata_columns},
         "file_pattern": asset_path,  # Sets schema, asset_table, file
@@ -329,6 +337,7 @@ def asset_table_upload_spec(model: DerivaModel, asset_table: str | Table, chunk_
             "content-disposition": "filename*=UTF-8''{file_name}",
         },
         "record_query_template": "/entity/{target_table}/MD5={md5}&Filename={file_name}",
+        "use_pre_allocated_rid": True,  # Bug E.2: use caller-supplied RID
     }
     # Wire the NullSentinelProcessor only when the table has metadata
     # columns — otherwise no sentinel values can appear and the

--- a/src/deriva_ml/dataset/upload.py
+++ b/src/deriva_ml/dataset/upload.py
@@ -363,47 +363,21 @@ def bulk_upload_configuration(model: DerivaModel, chunk_size: int | None = None)
         chunk_size: Optional chunk size in bytes for hatrac uploads. If provided,
             large files will be uploaded in chunks of this size.
     """
-    asset_tables_with_metadata = [
+    # Bug E.2: Use asset_table_upload_spec for ALL asset tables, not
+    # just those with metadata columns. The spec handles zero-metadata
+    # tables correctly (RID is the only capturing segment). This
+    # unifies the regex + use_pre_allocated_rid semantics across all
+    # asset tables, fixing the mismatch where Execution_Metadata (and
+    # other zero-metadata tables) went through a fallback mapping that
+    # did not include the RID segment.
+    all_asset_mappings = [
         asset_table_upload_spec(model=model, asset_table=t, chunk_size=chunk_size)
         for t in model.find_assets()
-        if model.asset_metadata(t)
     ]
 
-    # Build hatrac_options with optional chunk_size for non-metadata assets
-    hatrac_options = {"versioned_urls": True}
-    if chunk_size is not None:
-        hatrac_options["chunk_size"] = chunk_size
-
     return {
-        "asset_mappings": asset_tables_with_metadata
+        "asset_mappings": all_asset_mappings
         + [
-            {
-                # Upload assets into an asset table of an asset table without any metadata
-                "column_map": {
-                    "MD5": "{md5}",
-                    "URL": "{URI}",
-                    "Length": "{file_size}",
-                    "Filename": "{file_name}",
-                },
-                "asset_type": "file",
-                "target_table": ["{schema}", "{asset_table}"],
-                "file_pattern": asset_path_regex + "/" + asset_file_regex,  # Sets schema, asset_table, name, ext
-                "checksum_types": ["sha256", "md5"],
-                "hatrac_options": hatrac_options,
-                "hatrac_templates": {
-                    "hatrac_uri": "/hatrac/{asset_table}/{md5}.{file_name}",
-                    "content-disposition": "filename*=UTF-8''{file_name}",
-                },
-                "record_query_template": "/entity/{target_table}/MD5={md5}&Filename={file_name}",
-            },
-            # {
-            #  Upload the records into a  table
-            #   "asset_type": "skip",
-            ##   "default_columns": ["RID", "RCB", "RMB", "RCT", "RMT"],
-            #  "file_pattern": feature_value_regex,  # Sets schema, table,
-            #  "ext_pattern": "^.*[.](?P<file_ext>json|csv)$",
-            #  "target_table": ["{schema}", "{table}"],
-            # },
             {
                 #  Upload the records into a  table
                 "asset_type": "table",

--- a/src/deriva_ml/execution/execution.py
+++ b/src/deriva_ml/execution/execution.py
@@ -1131,11 +1131,21 @@ class Execution:
         Raises:
             DerivaMLException: If upload fails.
         """
+        # Bug E.2: lease pre-allocated RIDs for any pending manifest
+        # entries that don't have one yet. Required because
+        # asset_table_upload_spec emits use_pre_allocated_rid=True and
+        # _build_upload_staging appends entry.rid as a path segment.
+        # The engine-driven path leases RIDs in SQLite separately;
+        # this covers the manifest-driven init-time path.
+        from deriva_ml.execution.manifest_lease import lease_manifest_pending_assets
+        manifest = self._get_manifest()
+        lease_manifest_pending_assets(self._ml_object.catalog, manifest)
+
         # Bug C: refuse to upload if any pending asset is missing a
         # required (NOT-NULL) metadata column. This raises a single
         # DerivaMLValidationError that lists all failures at once.
         from deriva_ml.asset.manifest import _validate_pending_asset_metadata
-        _validate_pending_asset_metadata(self._model, self._get_manifest())
+        _validate_pending_asset_metadata(self._model, manifest)
 
         # Build staging symlinks from manifest into the regex-expected tree
         upload_root = self._build_upload_staging()

--- a/src/deriva_ml/execution/execution.py
+++ b/src/deriva_ml/execution/execution.py
@@ -1080,6 +1080,10 @@ class Execution:
             target_dir = staging_root / entry.schema / asset_table_name
             for part in metadata_parts:
                 target_dir = target_dir / part
+            # Bug E.2: append pre-leased RID as the final path segment.
+            # asset_table_upload_spec's file_pattern expects to capture
+            # this as (?P<RID>[-A-Z0-9]+).
+            target_dir = target_dir / entry.rid
             target_dir.mkdir(parents=True, exist_ok=True)
 
             target = target_dir / filename

--- a/src/deriva_ml/execution/manifest_lease.py
+++ b/src/deriva_ml/execution/manifest_lease.py
@@ -1,0 +1,58 @@
+"""Lease RIDs for manifest-pending asset entries.
+
+Parallel to :func:`~deriva_ml.execution.lease_orchestrator.acquire_leases_for_execution`
+(which operates on SQLite pending rows), this helper operates on
+:class:`~deriva_ml.asset.manifest.AssetManifest` entries. It's used by
+the manifest-driven upload path (``Execution._upload_execution_dirs``)
+to ensure every pending asset has a pre-allocated RID before staging.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from deriva_ml.execution.rid_lease import generate_lease_token, post_lease_batch
+
+if TYPE_CHECKING:
+    from deriva.core import ErmrestCatalog
+
+    from deriva_ml.asset.manifest import AssetManifest
+
+
+def lease_manifest_pending_assets(
+    catalog: "ErmrestCatalog",
+    manifest: "AssetManifest",
+) -> None:
+    """Assign pre-allocated RIDs to manifest entries that lack one.
+
+    Iterates ``manifest.pending_assets()`` and collects entries whose
+    ``rid`` is None. POSTs a batch of lease tokens to
+    ``public:ERMrest_RID_Lease`` and writes each server-assigned RID
+    back to the manifest via ``manifest.set_asset_rid()``.
+
+    No-op when every pending entry already has a RID (e.g., the
+    engine-driven upload path lands here after having leased RIDs
+    into SQLite; the manifest entries mirror the SQLite state).
+
+    Args:
+        catalog: Live ErmrestCatalog for POSTing to ERMrest_RID_Lease.
+        manifest: AssetManifest whose pending entries may need RIDs.
+    """
+    pending = manifest.pending_assets()
+    needs_lease = [
+        (key, entry) for key, entry in pending.items() if entry.rid is None
+    ]
+    if not needs_lease:
+        return
+
+    # Map lease-token → manifest key so we can write RIDs back to the
+    # right entry after the POST response.
+    token_to_key: dict[str, str] = {}
+    for key, _entry in needs_lease:
+        token = generate_lease_token()
+        token_to_key[token] = key
+
+    token_to_rid = post_lease_batch(catalog=catalog, tokens=list(token_to_key.keys()))
+
+    for token, rid in token_to_rid.items():
+        key = token_to_key[token]
+        manifest.set_asset_rid(key, rid)

--- a/src/deriva_ml/execution/rid_lease.py
+++ b/src/deriva_ml/execution/rid_lease.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import logging
 import uuid
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Iterable
 
 if TYPE_CHECKING:
     from deriva.core import ErmrestCatalog
@@ -82,3 +82,69 @@ def post_lease_batch(
             # ERMrest echoes both ID (our token) and RID (assigned).
             result[row["ID"]] = row["RID"]
     return result
+
+
+def _validate_pending_asset_leases(
+    catalog: "ErmrestCatalog",
+    entries: "Iterable[tuple[str, str]]",
+) -> None:
+    """Confirm each (key, rid) pair's RID is still live in ERMrest_RID_Lease.
+
+    Queries the lease table in batches of ``PENDING_ROWS_LEASE_CHUNK``.
+    Aggregates missing RIDs and raises a single
+    :class:`DerivaMLValidationError` listing every failure in sorted
+    order. Returns ``None`` silently when every RID is present.
+
+    Args:
+        catalog: Live ErmrestCatalog for querying the lease table.
+        entries: Iterable of (key, rid) tuples. Key is a
+            human-readable identifier used in the error message.
+
+    Raises:
+        DerivaMLValidationError: If one or more RIDs are not found
+            in ``ERMrest_RID_Lease``.
+    """
+    from deriva_ml.core.exceptions import DerivaMLValidationError
+
+    entries_list = list(entries)
+    if not entries_list:
+        return
+
+    # Build a reverse map so we can attribute a missing RID back to
+    # its caller-supplied key. If the same RID appears under two keys
+    # (shouldn't happen in practice), the forward list below produces
+    # one missing-entry per occurrence.
+    rid_to_keys: dict[str, list[str]] = {}
+    for key, rid in entries_list:
+        rid_to_keys.setdefault(rid, []).append(key)
+
+    all_rids = list(rid_to_keys.keys())
+    found_rids: set[str] = set()
+
+    for i in range(0, len(all_rids), PENDING_ROWS_LEASE_CHUNK):
+        chunk = all_rids[i : i + PENDING_ROWS_LEASE_CHUNK]
+        filter_clause = ";".join(f"RID={rid}" for rid in chunk)
+        path = f"/entity/public:ERMrest_RID_Lease/{filter_clause}"
+        response = catalog.get(path)
+        for row in response.json():
+            found_rids.add(row["RID"])
+
+    missing: list[tuple[str, str]] = []
+    for key, rid in entries_list:
+        if rid not in found_rids:
+            missing.append((key, rid))
+    if not missing:
+        return
+
+    lines = [
+        f"Missing or invalid pre-allocated RIDs for "
+        f"{len(missing)} pending asset(s):"
+    ]
+    for key, rid in sorted(missing):
+        lines.append(f"  - {key}: RID {rid} not found in ERMrest_RID_Lease")
+    lines.append(
+        "A pre-leased RID has become invalid (e.g., cleared from the "
+        "lease table or never successfully POSTed). Restart the "
+        "execution to re-lease, or investigate lease-table state."
+    )
+    raise DerivaMLValidationError("\n".join(lines))

--- a/src/deriva_ml/execution/upload_engine.py
+++ b/src/deriva_ml/execution/upload_engine.py
@@ -679,6 +679,8 @@ def _invoke_deriva_py_uploader(
             target_dir = asset_root / schema_name / target_table
             for col in metadata_cols:
                 target_dir = target_dir / str(metadata.get(col, NULL_SENTINEL))
+            # Bug E.2: pre-leased RID as the final segment before filename.
+            target_dir = target_dir / f["rid"]
             return target_dir / src.name
 
         # Build the symlink farm.

--- a/src/deriva_ml/local_db/manifest_store.py
+++ b/src/deriva_ml/local_db/manifest_store.py
@@ -295,6 +295,30 @@ class ManifestStore:
                 )
             )
 
+    def set_asset_rid(self, execution_rid: str, key: str, rid: str) -> None:
+        """Assign a pre-leased RID to an asset entry without changing status.
+
+        Used when the RID is known in advance (from ``ERMrest_RID_Lease``)
+        so the catalog insert at upload time can use the caller-supplied
+        RID. Unlike :meth:`mark_asset_uploaded`, this leaves ``status``
+        and ``uploaded_at`` unchanged.
+
+        Args:
+            execution_rid: Owning execution RID.
+            key: Asset key.
+            rid: Pre-allocated RID to assign to the entry.
+
+        Raises:
+            KeyError: If the entry does not exist.
+        """
+        self._require_asset(execution_rid, key)
+        with self._engine.begin() as conn:
+            conn.execute(
+                update(self._assets_t)
+                .where((self._assets_t.c.execution_rid == execution_rid) & (self._assets_t.c.key == key))
+                .values(rid=rid, updated_at=_now_iso())
+            )
+
     def mark_asset_failed(self, execution_rid: str, key: str, error: str) -> None:
         """Transition an asset entry to ``status="failed"`` and record the error message.
 

--- a/tests/asset/test_asset.py
+++ b/tests/asset/test_asset.py
@@ -381,6 +381,13 @@ class TestUploadStaging:
             )
             path.write_text("staging test content")
 
+        # Bug E.2: lease pre-allocated RIDs for the manifest entries
+        # so _build_upload_staging can append them as path segments.
+        # (Normally this happens inside _upload_execution_dirs.)
+        from deriva_ml.execution.manifest_lease import lease_manifest_pending_assets
+        manifest = basic_execution._get_manifest()
+        lease_manifest_pending_assets(ml.catalog, manifest)
+
         # Build staging and get the regex from upload spec
         staging_root = basic_execution._build_upload_staging()
         spec = asset_table_upload_spec(basic_execution._model, "Image")

--- a/tests/asset/test_null_sentinel_processor.py
+++ b/tests/asset/test_null_sentinel_processor.py
@@ -73,3 +73,41 @@ def test_asset_table_upload_spec_omits_pre_processors_when_no_metadata(test_ml):
     # columns — a clean canonical example.
     spec = asset_table_upload_spec(test_ml.model, "Execution_Asset")
     assert "pre_processors" not in spec or not spec["pre_processors"]
+
+
+def test_asset_table_upload_spec_has_use_pre_allocated_rid_flag(test_ml):
+    from deriva_ml import BuiltinTypes, ColumnDefinition
+    from deriva_ml.dataset.upload import asset_table_upload_spec
+
+    test_ml.create_asset(
+        "UsePreAllocatedFlagTest",
+        column_defs=[ColumnDefinition(name="foo", type=BuiltinTypes.int4)],
+    )
+    spec = asset_table_upload_spec(test_ml.model, "UsePreAllocatedFlagTest")
+    assert spec.get("use_pre_allocated_rid") is True
+
+
+def test_asset_table_upload_spec_file_pattern_captures_rid(test_ml):
+    from deriva_ml import BuiltinTypes, ColumnDefinition
+    from deriva_ml.dataset.upload import asset_table_upload_spec
+
+    test_ml.create_asset(
+        "UsePreAllocatedRegexTest",
+        column_defs=[ColumnDefinition(name="foo", type=BuiltinTypes.int4)],
+    )
+    spec = asset_table_upload_spec(test_ml.model, "UsePreAllocatedRegexTest")
+    pattern = spec["file_pattern"]
+    # Regex must contain a (?P<RID>...) named group.
+    assert "(?P<RID>" in pattern, f"file_pattern missing RID capture: {pattern}"
+
+
+def test_asset_table_upload_spec_column_map_includes_rid(test_ml):
+    from deriva_ml import BuiltinTypes, ColumnDefinition
+    from deriva_ml.dataset.upload import asset_table_upload_spec
+
+    test_ml.create_asset(
+        "UsePreAllocatedColumnMapTest",
+        column_defs=[ColumnDefinition(name="foo", type=BuiltinTypes.int4)],
+    )
+    spec = asset_table_upload_spec(test_ml.model, "UsePreAllocatedColumnMapTest")
+    assert spec["column_map"].get("RID") == "{RID}"

--- a/tests/core/test_strict_preallocated_rid.py
+++ b/tests/core/test_strict_preallocated_rid.py
@@ -1,0 +1,76 @@
+"""Tests for the set_strict_preallocated_rid / is_strict_preallocated_rid helpers.
+
+See Bug E.2 — the helpers manage the annotation
+``tag:isrd.isi.edu,2026:strict-preallocated-rid`` on asset tables,
+which opts the table into strict-mode RID checks during upload.
+"""
+from __future__ import annotations
+
+import pytest
+
+from deriva_ml.core.mixins.annotation import STRICT_PREALLOCATED_RID_TAG
+
+
+class TestStrictPreallocatedRid:
+    """Tests for strict-preallocated-RID annotation helpers."""
+
+    def test_is_strict_default_false(self, test_ml):
+        """An asset table without the annotation returns False."""
+        # Execution_Asset is a built-in asset table with no strict annotation.
+        assert test_ml.is_strict_preallocated_rid("Execution_Asset") is False
+
+    def test_set_strict_true_updates_annotation(self, test_ml):
+        """set_strict_preallocated_rid(True) applies the annotation."""
+        # Use Execution_Asset (built-in asset table).
+        test_ml.set_strict_preallocated_rid("Execution_Asset", strict=True)
+        table = test_ml.model.name_to_table("Execution_Asset")
+        assert table.annotations.get(STRICT_PREALLOCATED_RID_TAG) == {"strict": True}
+        # is_strict_preallocated_rid now returns True.
+        assert test_ml.is_strict_preallocated_rid("Execution_Asset") is True
+        # Cleanup so other tests see a clean slate.
+        test_ml.set_strict_preallocated_rid("Execution_Asset", strict=False)
+
+    def test_set_strict_false_removes_annotation(self, test_ml):
+        """set_strict_preallocated_rid(False) removes the annotation."""
+        # Apply first, then remove.
+        test_ml.set_strict_preallocated_rid("Execution_Asset", strict=True)
+        assert test_ml.is_strict_preallocated_rid("Execution_Asset") is True
+        test_ml.set_strict_preallocated_rid("Execution_Asset", strict=False)
+        table = test_ml.model.name_to_table("Execution_Asset")
+        assert STRICT_PREALLOCATED_RID_TAG not in table.annotations
+        assert test_ml.is_strict_preallocated_rid("Execution_Asset") is False
+
+    def test_set_strict_raises_for_non_asset_table(self, test_ml):
+        """Non-asset tables (e.g., Workflow) cannot have strict annotation."""
+        from deriva_ml.core.exceptions import DerivaMLTableTypeError
+        with pytest.raises(DerivaMLTableTypeError):
+            test_ml.set_strict_preallocated_rid("Workflow", strict=True)
+
+    def test_is_strict_handles_malformed_annotation(self, test_ml):
+        """If the annotation is set to a non-dict value, returns False."""
+        table = test_ml.model.name_to_table("Execution_Asset")
+        # Planting a malformed annotation directly (not via the helper).
+        table.annotations[STRICT_PREALLOCATED_RID_TAG] = "bogus"
+        try:
+            assert test_ml.is_strict_preallocated_rid("Execution_Asset") is False
+        finally:
+            # Cleanup.
+            table.annotations.pop(STRICT_PREALLOCATED_RID_TAG, None)
+
+    def test_is_strict_false_when_strict_key_missing(self, test_ml):
+        """{"other": true} without "strict" key returns False."""
+        table = test_ml.model.name_to_table("Execution_Asset")
+        table.annotations[STRICT_PREALLOCATED_RID_TAG] = {"other": True}
+        try:
+            assert test_ml.is_strict_preallocated_rid("Execution_Asset") is False
+        finally:
+            table.annotations.pop(STRICT_PREALLOCATED_RID_TAG, None)
+
+    def test_is_strict_false_when_strict_is_false(self, test_ml):
+        """{"strict": false} explicitly returns False."""
+        table = test_ml.model.name_to_table("Execution_Asset")
+        table.annotations[STRICT_PREALLOCATED_RID_TAG] = {"strict": False}
+        try:
+            assert test_ml.is_strict_preallocated_rid("Execution_Asset") is False
+        finally:
+            table.annotations.pop(STRICT_PREALLOCATED_RID_TAG, None)

--- a/tests/execution/test_bug_c_live_smoke.py
+++ b/tests/execution/test_bug_c_live_smoke.py
@@ -52,6 +52,15 @@ def test_upload_asset_with_full_metadata_end_to_end(test_ml, tmp_path):
     with exe.execute():
         pass
 
+    # Bug E.2: ERMrest validates pre-allocated RIDs against
+    # ERMrest_RID_Lease and decodes them as URL-base32; use a real
+    # leased RID instead of a hand-crafted fake one.
+    from deriva_ml.execution.rid_lease import (
+        generate_lease_token, post_lease_batch,
+    )
+    _token = generate_lease_token()
+    _leased = post_lease_batch(catalog=test_ml.catalog, tokens=[_token])[_token]
+
     store.insert_pending_row(
         execution_rid=exe.execution_rid,
         key="k1",
@@ -59,9 +68,9 @@ def test_upload_asset_with_full_metadata_end_to_end(test_ml, tmp_path):
         target_table="Execution_Asset",
         metadata_json=json.dumps({}),
         created_at=now,
-        rid="EA-BUGC-HAPPY-1",
+        rid=_leased,
         status=PendingRowStatus.leased,
-        lease_token="happy-lease",
+        lease_token=_token,
         asset_file_path=str(f),
     )
 
@@ -206,6 +215,13 @@ def test_upload_with_missing_required_metadata_raises_validation(test_ml, tmp_pa
     with exe.execute():
         pass
 
+    # Bug E.2: use a real leased RID (ERMrest validates it at insert time).
+    from deriva_ml.execution.rid_lease import (
+        generate_lease_token, post_lease_batch,
+    )
+    _token = generate_lease_token()
+    _leased = post_lease_batch(catalog=test_ml.catalog, tokens=[_token])[_token]
+
     # Pending row with EMPTY metadata — missing required columns.
     store.insert_pending_row(
         execution_rid=exe.execution_rid,
@@ -214,9 +230,9 @@ def test_upload_with_missing_required_metadata_raises_validation(test_ml, tmp_pa
         target_table=table_name,
         metadata_json=json.dumps({}),
         created_at=now,
-        rid="IMG-BUGC-REQ-1",
+        rid=_leased,
         status=PendingRowStatus.leased,
-        lease_token="req-lease",
+        lease_token=_token,
         asset_file_path=str(f),
     )
 
@@ -254,6 +270,13 @@ def test_upload_with_missing_nullable_metadata_succeeds_with_null(test_ml, tmp_p
     with exe.execute():
         pass
 
+    # Bug E.2: use a real leased RID (ERMrest validates it at insert time).
+    from deriva_ml.execution.rid_lease import (
+        generate_lease_token, post_lease_batch,
+    )
+    _token = generate_lease_token()
+    _leased = post_lease_batch(catalog=test_ml.catalog, tokens=[_token])[_token]
+
     # Supply ONLY the required metadata — nullable cols remain absent.
     store.insert_pending_row(
         execution_rid=exe.execution_rid,
@@ -262,9 +285,9 @@ def test_upload_with_missing_nullable_metadata_succeeds_with_null(test_ml, tmp_p
         target_table=table_name,
         metadata_json=json.dumps(required_md),
         created_at=now,
-        rid="NULL-BUGC-1",
+        rid=_leased,
         status=PendingRowStatus.leased,
-        lease_token="null-lease",
+        lease_token=_token,
         asset_file_path=str(f),
     )
 

--- a/tests/execution/test_bug_e2_live_smoke.py
+++ b/tests/execution/test_bug_e2_live_smoke.py
@@ -1,0 +1,187 @@
+"""Live-catalog integration tests for Bug E.2 (pre-allocated RID upload).
+
+Two tests, both gated on DERIVA_HOST:
+
+1. Happy path: upload uses the pre-leased RID.
+2. Soft mode: identical file uploaded by two executions resolves to the
+   same catalog row (legacy MD5+Filename dedup preserved when the
+   strict annotation is absent).
+
+The strict-mode integration test — where an annotated table raises on
+mismatch — requires manipulating a test asset table's annotation and
+forcing a second upload of a same-MD5 file with a different pre-leased
+RID. This is exercised by the unit-level test in
+``tests/core/test_strict_preallocated_rid.py`` (helper behavior) plus
+the deriva-py unit tests (mismatch-with-annotation → raise); an
+end-to-end integration check is deferred as future hardening.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from datetime import datetime, timezone
+
+import pytest
+
+
+requires_catalog = pytest.mark.skipif(
+    not os.environ.get("DERIVA_HOST"),
+    reason="Bug E.2 live tests require DERIVA_HOST",
+)
+
+
+def _make_workflow(test_ml, name: str):
+    from deriva_ml import MLVocab as vc
+    test_ml.add_term(
+        vc.workflow_type,
+        "Test Workflow",
+        description="for Bug E.2 live tests",
+    )
+    return test_ml.create_workflow(
+        name=name,
+        workflow_type="Test Workflow",
+        description="for Bug E.2 live tests",
+    )
+
+
+def _lease_one_rid(test_ml) -> tuple[str, str]:
+    """POST a single lease to ERMrest_RID_Lease; return (token, rid)."""
+    from deriva_ml.execution.rid_lease import (
+        generate_lease_token, post_lease_batch,
+    )
+    token = generate_lease_token()
+    result = post_lease_batch(catalog=test_ml.catalog, tokens=[token])
+    return token, result[token]
+
+
+@requires_catalog
+def test_upload_asset_uses_pre_leased_rid(test_ml, tmp_path):
+    """End-to-end: the catalog row's RID matches the caller's pre-leased RID."""
+    from deriva_ml.execution.state_store import PendingRowStatus
+
+    f = tmp_path / "bug-e2-happy.bin"
+    f.write_bytes(b"bug-e2 happy path " * 32)
+
+    token, leased_rid = _lease_one_rid(test_ml)
+
+    wf = _make_workflow(test_ml, "Bug E2 happy")
+    exe = test_ml.create_execution(description="bug-e2-happy", workflow=wf)
+    store = test_ml.workspace.execution_state_store()
+    now = datetime.now(timezone.utc)
+
+    with exe.execute():
+        pass
+
+    store.insert_pending_row(
+        execution_rid=exe.execution_rid,
+        key="k-happy",
+        target_schema="deriva-ml",
+        target_table="Execution_Asset",
+        metadata_json=json.dumps({}),
+        created_at=now,
+        rid=leased_rid,
+        status=PendingRowStatus.leased,
+        lease_token=token,
+        asset_file_path=str(f),
+    )
+
+    report = exe.upload_outputs()
+    assert report.total_failed == 0, f"failures: {report.errors}"
+    assert report.total_uploaded == 1
+
+    # Catalog row must have our pre-leased RID.
+    pb = test_ml.pathBuilder()
+    asset_path = pb.schemas["deriva-ml"].tables["Execution_Asset"]
+    rows = list(
+        asset_path.filter(asset_path.RID == leased_rid)
+        .entities().fetch()
+    )
+    assert len(rows) == 1, (
+        f"Execution_Asset row with RID={leased_rid} not found — "
+        f"Bug E.2 regression: server substituted its own RID instead "
+        f"of honoring our lease."
+    )
+    # Sanity: MD5 matches.
+    expected_md5 = hashlib.md5(f.read_bytes()).hexdigest()
+    assert rows[0]["MD5"] == expected_md5
+
+
+@requires_catalog
+def test_soft_mode_second_upload_adopts_existing_rid(test_ml, tmp_path):
+    """Two executions upload the same file; second adopts the first's catalog RID.
+
+    Soft mode (the default, because Execution_Asset has no strict
+    annotation) preserves legacy MD5+Filename dedup: the second
+    execution's upload detects the existing row and adopts its RID
+    instead of raising. The second execution's pre-leased RID is
+    silently discarded.
+    """
+    from deriva_ml.execution.state_store import PendingRowStatus
+
+    f = tmp_path / "bug-e2-shared.bin"
+    f.write_bytes(b"bug-e2 shared artifact " * 32)
+    expected_md5 = hashlib.md5(f.read_bytes()).hexdigest()
+
+    wf = _make_workflow(test_ml, "Bug E2 soft-1")
+
+    # Execution 1 — first to upload.
+    token1, leased_rid_1 = _lease_one_rid(test_ml)
+    exe1 = test_ml.create_execution(description="bug-e2-soft-1", workflow=wf)
+    store = test_ml.workspace.execution_state_store()
+    now = datetime.now(timezone.utc)
+    with exe1.execute():
+        pass
+    store.insert_pending_row(
+        execution_rid=exe1.execution_rid,
+        key="k-soft-1",
+        target_schema="deriva-ml",
+        target_table="Execution_Asset",
+        metadata_json=json.dumps({}),
+        created_at=now,
+        rid=leased_rid_1,
+        status=PendingRowStatus.leased,
+        lease_token=token1,
+        asset_file_path=str(f),
+    )
+    report1 = exe1.upload_outputs()
+    assert report1.total_failed == 0, report1.errors
+
+    # Execution 2 — uploads the SAME file with a DIFFERENT pre-leased RID.
+    token2, leased_rid_2 = _lease_one_rid(test_ml)
+    assert leased_rid_1 != leased_rid_2
+
+    exe2 = test_ml.create_execution(description="bug-e2-soft-2", workflow=wf)
+    with exe2.execute():
+        pass
+    store.insert_pending_row(
+        execution_rid=exe2.execution_rid,
+        key="k-soft-2",
+        target_schema="deriva-ml",
+        target_table="Execution_Asset",
+        metadata_json=json.dumps({}),
+        created_at=now,
+        rid=leased_rid_2,
+        status=PendingRowStatus.leased,
+        lease_token=token2,
+        asset_file_path=str(f),
+    )
+    # Soft mode → upload succeeds by adopting existing row's RID.
+    report2 = exe2.upload_outputs()
+    assert report2.total_failed == 0, (
+        f"Soft-mode upload should succeed but failed: {report2.errors}"
+    )
+
+    # Only ONE catalog row with this MD5 (not two).
+    pb = test_ml.pathBuilder()
+    asset_path = pb.schemas["deriva-ml"].tables["Execution_Asset"]
+    rows = list(
+        asset_path.filter(asset_path.MD5 == expected_md5)
+        .entities().fetch()
+    )
+    assert len(rows) == 1, (
+        f"expected single row for shared artifact, got {len(rows)}"
+    )
+    # The row's RID equals the FIRST lease (soft mode preserved legacy
+    # MD5+Filename dedup).
+    assert rows[0]["RID"] == leased_rid_1

--- a/tests/execution/test_manifest_lease.py
+++ b/tests/execution/test_manifest_lease.py
@@ -1,0 +1,111 @@
+"""Unit tests for lease_manifest_pending_assets."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _fake_catalog(token_to_rid_map: dict[str, str]):
+    """Return a catalog whose POST to ERMrest_RID_Lease returns the
+    server-assigned RIDs for the tokens in ``token_to_rid_map``."""
+    catalog = MagicMock()
+
+    def fake_post(path: str, json):
+        assert path == "/entity/public:ERMrest_RID_Lease"
+        response = MagicMock()
+        response.json.return_value = [
+            {"ID": tok_entry["ID"], "RID": token_to_rid_map[tok_entry["ID"]]}
+            for tok_entry in json
+        ]
+        return response
+
+    catalog.post.side_effect = fake_post
+    return catalog
+
+
+def _fake_manifest(entries: dict):
+    """Build a fake AssetManifest whose pending_assets() returns the given
+    dict and whose set_asset_rid(key, rid) updates the entry in place."""
+    manifest = MagicMock()
+    manifest.pending_assets.return_value = entries
+
+    def fake_set_asset_rid(key, rid):
+        entries[key].rid = rid
+
+    manifest.set_asset_rid.side_effect = fake_set_asset_rid
+    return manifest
+
+
+def _entry(asset_table: str, rid=None):
+    from deriva_ml.asset.manifest import AssetEntry
+    return AssetEntry(asset_table=asset_table, schema="test-schema", rid=rid)
+
+
+def test_empty_manifest_is_noop():
+    from deriva_ml.execution.manifest_lease import lease_manifest_pending_assets
+    catalog = MagicMock()
+    manifest = _fake_manifest({})
+    lease_manifest_pending_assets(catalog, manifest)
+    catalog.post.assert_not_called()
+
+
+def test_all_entries_already_have_rid_is_noop():
+    from deriva_ml.execution.manifest_lease import lease_manifest_pending_assets
+    catalog = MagicMock()
+    manifest = _fake_manifest({
+        "Image/a.png": _entry("Image", rid="1-ABC"),
+        "Image/b.png": _entry("Image", rid="1-DEF"),
+    })
+    lease_manifest_pending_assets(catalog, manifest)
+    catalog.post.assert_not_called()
+
+
+def test_rids_assigned_to_entries_missing_rid(monkeypatch):
+    from deriva_ml.execution import manifest_lease
+    from deriva_ml.execution.manifest_lease import lease_manifest_pending_assets
+
+    # Deterministic tokens — patch generate_lease_token to return fixed tokens.
+    tokens_generated = ["tok-a", "tok-b"]
+    monkeypatch.setattr(
+        manifest_lease, "generate_lease_token",
+        lambda: tokens_generated.pop(0),
+    )
+
+    catalog = _fake_catalog({"tok-a": "1-NEW-A", "tok-b": "1-NEW-B"})
+    entries = {
+        "Image/a.png": _entry("Image"),
+        "Image/b.png": _entry("Image"),
+    }
+    manifest = _fake_manifest(entries)
+
+    lease_manifest_pending_assets(catalog, manifest)
+
+    assert entries["Image/a.png"].rid == "1-NEW-A"
+    assert entries["Image/b.png"].rid == "1-NEW-B"
+    # set_asset_rid was called for each entry.
+    assert manifest.set_asset_rid.call_count == 2
+
+
+def test_mixed_entries_only_missing_rids_leased(monkeypatch):
+    from deriva_ml.execution import manifest_lease
+    from deriva_ml.execution.manifest_lease import lease_manifest_pending_assets
+
+    monkeypatch.setattr(
+        manifest_lease, "generate_lease_token",
+        lambda: "tok-fresh",
+    )
+    catalog = _fake_catalog({"tok-fresh": "1-LEASED"})
+
+    entries = {
+        "Image/a.png": _entry("Image", rid="1-ALREADY"),
+        "Image/b.png": _entry("Image"),
+    }
+    manifest = _fake_manifest(entries)
+
+    lease_manifest_pending_assets(catalog, manifest)
+
+    assert entries["Image/a.png"].rid == "1-ALREADY"  # unchanged
+    assert entries["Image/b.png"].rid == "1-LEASED"
+    # set_asset_rid called only for the one that was missing.
+    assert manifest.set_asset_rid.call_count == 1

--- a/tests/execution/test_pending_asset_lease_validator.py
+++ b/tests/execution/test_pending_asset_lease_validator.py
@@ -1,0 +1,90 @@
+"""Unit tests for _validate_pending_asset_leases."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _fake_catalog(found_rids: set[str]):
+    """Build a fake ErmrestCatalog whose .get() returns rows with
+    RIDs from ``found_rids`` that match the query's filter."""
+    catalog = MagicMock()
+
+    def fake_get(path: str):
+        # Parse "/entity/public:ERMrest_RID_Lease/RID=r1;RID=r2;..."
+        response = MagicMock()
+        assert path.startswith("/entity/public:ERMrest_RID_Lease/")
+        filter_part = path.split("/entity/public:ERMrest_RID_Lease/", 1)[1]
+        queried = []
+        for clause in filter_part.split(";"):
+            key, _, value = clause.partition("=")
+            if key == "RID":
+                queried.append(value)
+        response.json.return_value = [
+            {"RID": rid, "ID": f"token-{rid}"}
+            for rid in queried
+            if rid in found_rids
+        ]
+        return response
+
+    catalog.get.side_effect = fake_get
+    return catalog
+
+
+def test_empty_entries_returns_none():
+    from deriva_ml.execution.rid_lease import _validate_pending_asset_leases
+    catalog = MagicMock()
+    assert _validate_pending_asset_leases(catalog, []) is None
+    catalog.get.assert_not_called()
+
+
+def test_all_leases_valid_passes():
+    from deriva_ml.execution.rid_lease import _validate_pending_asset_leases
+    catalog = _fake_catalog({"1-ABC", "1-DEF"})
+    entries = [("Image/a.png", "1-ABC"), ("Image/b.png", "1-DEF")]
+    assert _validate_pending_asset_leases(catalog, entries) is None
+
+
+def test_single_missing_lease_raises():
+    from deriva_ml.execution.rid_lease import _validate_pending_asset_leases
+    from deriva_ml.core.exceptions import DerivaMLValidationError
+    catalog = _fake_catalog({"1-ABC"})  # 1-DEF NOT there
+    entries = [("Image/a.png", "1-ABC"), ("Image/b.png", "1-DEF")]
+    with pytest.raises(DerivaMLValidationError) as ei:
+        _validate_pending_asset_leases(catalog, entries)
+    msg = str(ei.value)
+    assert "Image/b.png" in msg
+    assert "1-DEF" in msg
+    assert "Image/a.png" not in msg  # the valid one isn't listed
+
+
+def test_multiple_missing_leases_aggregated():
+    from deriva_ml.execution.rid_lease import _validate_pending_asset_leases
+    from deriva_ml.core.exceptions import DerivaMLValidationError
+    catalog = _fake_catalog(set())  # nothing found
+    entries = [
+        ("Image/z.png", "1-ZZZ"),
+        ("Image/a.png", "1-AAA"),
+    ]
+    with pytest.raises(DerivaMLValidationError) as ei:
+        _validate_pending_asset_leases(catalog, entries)
+    msg = str(ei.value)
+    assert "1-ZZZ" in msg
+    assert "1-AAA" in msg
+    # Sorted by (key, rid) — 'a.png' before 'z.png'.
+    assert msg.index("Image/a.png") < msg.index("Image/z.png")
+
+
+def test_batched_queries_use_chunk_size(monkeypatch):
+    """More entries than chunk size → multiple catalog.get calls."""
+    from deriva_ml.execution import rid_lease
+    from deriva_ml.execution.rid_lease import _validate_pending_asset_leases
+
+    # Set chunk size to 2 so 3 entries require 2 batched calls.
+    monkeypatch.setattr(rid_lease, "PENDING_ROWS_LEASE_CHUNK", 2)
+    catalog = _fake_catalog({"1-A", "1-B", "1-C"})
+    entries = [("k1", "1-A"), ("k2", "1-B"), ("k3", "1-C")]
+    _validate_pending_asset_leases(catalog, entries)
+    # Expect 2 calls: first batch of 2, second batch of 1.
+    assert catalog.get.call_count == 2

--- a/uv.lock
+++ b/uv.lock
@@ -695,7 +695,7 @@ wheels = [
 [[package]]
 name = "deriva"
 version = "1.7.12"
-source = { git = "https://github.com/informatics-isi-edu/deriva-py?branch=2.0-dev#213c93adaf2d1eebe2d3c2c531d2604efcd97649" }
+source = { git = "https://github.com/informatics-isi-edu/deriva-py?branch=2.0-dev#35cab15972e60deb1d8b0f4a586a033abb9ff35e" }
 dependencies = [
     { name = "bdbag" },
     { name = "fair-identifiers-client" },

--- a/uv.lock
+++ b/uv.lock
@@ -695,7 +695,7 @@ wheels = [
 [[package]]
 name = "deriva"
 version = "1.7.12"
-source = { git = "https://github.com/informatics-isi-edu/deriva-py?branch=2.0-dev#d5387e52044ed62c9cb21a654e58d52a090716d1" }
+source = { git = "https://github.com/informatics-isi-edu/deriva-py?branch=2.0-dev#213c93adaf2d1eebe2d3c2c531d2604efcd97649" }
 dependencies = [
     { name = "bdbag" },
     { name = "fair-identifiers-client" },


### PR DESCRIPTION
## Summary

Fix pre-S3 architectural gap where the asset-upload path silently ignored pre-allocated RIDs from the lease system (\`ERMrest_RID_Lease\`). The plain-row drain path honored \`pending_rows.rid\`, but asset rows (via deriva-py's GenericUploader) used MD5+Filename lookup and accepted server-generated RIDs, breaking FK references that client code captured between lease-time and upload-completion.

This PR's companion deriva-py changes (PRs #206, #207, #208, #209) added the upstream infrastructure. This PR wires deriva-ml into that infrastructure.

## Design: soft by default, strict opt-in

**Default (soft):** Identical files (same MD5+Filename) across executions continue to resolve to the same catalog row — legacy \`_getFileRecord\` semantics. The caller's pre-leased RID is silently discarded in favor of the existing row's RID. Preserves backward compatibility for common patterns like shared \`Execution_Metadata\` config files.

**Opt-in (strict):** Annotate an asset table with \`tag:isrd.isi.edu,2026:strict-preallocated-rid = {\"strict\": true}\` and any RID mismatch raises \`DerivaUploadCatalogCreateError\`. Use for tables whose rows are referenced by FK columns in the same upload batch.

## New API

- \`DerivaML.set_strict_preallocated_rid(table, strict=True)\` — opt an asset table into strict mode.
- \`DerivaML.is_strict_preallocated_rid(table) -> bool\` — query the annotation.
- \`STRICT_PREALLOCATED_RID_TAG\` — constant in \`deriva_ml.core.mixins.annotation\`.
- \`_validate_pending_asset_leases(catalog, entries)\` — pre-flight validator in \`deriva_ml.execution.rid_lease\`.
- \`lease_manifest_pending_assets(catalog, manifest)\` — helper in \`deriva_ml.execution.manifest_lease\`.
- \`AssetManifest.set_asset_rid(key, rid)\` — new method for RID-only updates.

## Changed behavior

- \`asset_table_upload_spec\` emits \`use_pre_allocated_rid=True\` on ALL asset tables (the fallback mapping for zero-metadata tables was consolidated into \`asset_table_upload_spec\` too).
- Staging path-builders append the pre-leased RID as the final directory segment: \`.../Table/<col1>/<col2>/<RID>/<file>\`.
- \`_upload_execution_dirs\` leases RIDs for any manifest entry with \`rid is None\` before staging begins.
- Both upload entry points (\`_upload_execution_dirs\`, \`run_upload_engine\`) call \`_validate_pending_asset_leases\` at pre-flight.

## Test Plan

- [x] 5 \`_validate_pending_asset_leases\` unit tests
- [x] 4 \`lease_manifest_pending_assets\` unit tests + 1 new \`AssetManifest.set_asset_rid\`
- [x] 7 \`set_strict_preallocated_rid\` / \`is_strict_preallocated_rid\` unit tests
- [x] 3 \`asset_table_upload_spec\` flag/regex/column_map tests
- [x] 2 new live-catalog integration tests (happy path, soft-mode dedup)
- [x] Existing Bug C tests updated to use real leased RIDs (ERMrest validates them now)
- [x] 97 tests pass with \`DERIVA_HOST=localhost\` across asset/, execution/, model/, core/

## External-caller impact

**No action required for existing callers.** Soft mode is the default; identical files continue to resolve to the same catalog row via legacy MD5+Filename dedup.

**New capability:** FK-critical batches can opt into strict mode via the annotation. Without it, the soft fallback preserves backward compatibility.

**Edge case:** Stale SQLite lease state is caught at pre-flight by \`_validate_pending_asset_leases\` with a clear aggregated error. Restart the execution to re-lease.

## Design & Plan

- Spec: \`docs/superpowers/specs/2026-04-22-bug-e2-preallocated-rid-design.md\`
- Plan: \`docs/superpowers/plans/2026-04-22-bug-e2-preallocated-rid.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)