### PR TITLE
fix(DatasetBag): add public .path property

### DIFF
--- a/src/deriva_ml/dataset/dataset_bag.py
+++ b/src/deriva_ml/dataset/dataset_bag.py
@@ -187,6 +187,33 @@ class DatasetBag:
         """
         return self._current_version
 
+    @property
+    def path(self) -> Path:
+        """Filesystem path to this bag's root directory.
+
+        The bag is a self-contained, immutable snapshot on disk. ``path``
+        is the directory containing ``data/``, ``manifest-md5.txt``, and
+        the bag's SQLite database. Use it to:
+
+        - Read materialized asset files relative to the bag.
+        - Diagnose "which bag is this?" errors in logs.
+        - Archive or copy the bag to a new location.
+
+        The directory exists for the lifetime of the bag object. Do not
+        mutate anything inside it — bags are immutable by contract.
+
+        Returns:
+            Path: Root directory of the materialized bag on disk.
+
+        Example:
+            >>> spec = DatasetSpec(rid="1-abc123", version="1.2.0")
+            >>> bag = ml.download_dataset_bag(spec)
+            >>> print(f"Bag materialized at {bag.path}")
+            >>> # Read an asset file relative to the bag root
+            >>> manifest = (bag.path / "manifest-md5.txt").read_text()
+        """
+        return self.model.bag_path
+
     def list_tables(self) -> list[str]:
         """List all tables available in the bag's SQLite database.
 

--- a/tests/dataset/test_bag_api_coverage.py
+++ b/tests/dataset/test_bag_api_coverage.py
@@ -265,6 +265,44 @@ class TestBagCurrentVersion:
         assert bag.current_version is not None
 
 
+class TestBagPath:
+    """Tests for DatasetBag.path property — filesystem path to the bag root."""
+
+    def test_path_returns_pathlib_path(self, catalog_manager: CatalogManager, tmp_path: Path):
+        """bag.path returns a pathlib.Path (not a string)."""
+        catalog_manager.reset()
+        ml, dataset_desc = catalog_manager.ensure_datasets(tmp_path / "source")
+        dataset = dataset_desc.dataset
+
+        bag = dataset.download_dataset_bag(version=dataset.current_version, use_minid=False)
+
+        assert isinstance(bag.path, Path), f"bag.path should be Path, got {type(bag.path)}"
+
+    def test_path_points_to_existing_directory(self, catalog_manager: CatalogManager, tmp_path: Path):
+        """bag.path points at a directory that exists on disk."""
+        catalog_manager.reset()
+        ml, dataset_desc = catalog_manager.ensure_datasets(tmp_path / "source")
+        dataset = dataset_desc.dataset
+
+        bag = dataset.download_dataset_bag(version=dataset.current_version, use_minid=False)
+
+        assert bag.path.exists(), f"bag.path does not exist on disk: {bag.path}"
+        assert bag.path.is_dir(), f"bag.path is not a directory: {bag.path}"
+
+    def test_path_contains_bag_structure(self, catalog_manager: CatalogManager, tmp_path: Path):
+        """bag.path directory contains the expected BDBag structure (data/, manifest)."""
+        catalog_manager.reset()
+        ml, dataset_desc = catalog_manager.ensure_datasets(tmp_path / "source")
+        dataset = dataset_desc.dataset
+
+        bag = dataset.download_dataset_bag(version=dataset.current_version, use_minid=False)
+
+        # BDBag spec guarantees data/ and at least one manifest-* file.
+        assert (bag.path / "data").is_dir(), "bag should have a data/ subdirectory"
+        manifests = list(bag.path.glob("manifest-*.txt"))
+        assert manifests, f"bag should have at least one manifest-*.txt file in {bag.path}"
+
+
 class TestBagDatasetProperties:
     """Tests for basic DatasetBag properties."""
 


### PR DESCRIPTION
## Summary

`DatasetBag.path` did not exist, even though four library docstrings in `dataset.py`, `execution.py`, and `core/mixins/dataset.py` promise users a `bag.path` accessor. Users either hit `AttributeError` or had to reach into private internals (`_catalog._database_model.bag_path`) to get the bag's root directory.

This PR adds the public accessor: `@property def path(self) -> Path` delegating to the existing internal `self.model.bag_path`. No behavior change — just makes the library honest about what its own docstrings already claim.

Discovered during the user-guide rewrite (Chapter 2, "Working with datasets"): code examples from existing docstrings would have raised `AttributeError` in every `bag.path`-using example.

## Test Plan

- [x] 3 new tests in `TestBagPath`: `bag.path` returns `Path`, points at existing directory, directory has BDBag structure (`data/` + `manifest-*.txt`)
- [x] Full fast unit suite (435 passed, 3 skipped, 0 failed)
- [x] Docstring examples in `dataset.py:1659`, `execution.py:158`, `execution.py:944`, `core/mixins/dataset.py:266` now actually work

🤖 Generated with [Claude Code](https://claude.com/claude-code)