### PR TITLE
refactor: DRY hygiene sprint (5 extractions + format pass)

### DIFF
--- a/src/deriva_ml/catalog/clone.py
+++ b/src/deriva_ml/catalog/clone.py
@@ -31,7 +31,6 @@ from deriva.core.asyncio import AsyncCatalogWrapper, AsyncErmrestCatalog
 from deriva.core.asyncio.async_datapath import copy_tables_concurrent_async
 from deriva.core.hatrac_store import HatracStore
 
-from deriva_ml.model.catalog import VOCAB_COLUMNS
 from deriva_ml.schema import create_ml_schema, initialize_ml_schema
 
 logger = logging.getLogger("deriva_ml")
@@ -904,9 +903,6 @@ def _expand_tables_with_vocabularies(
     Returns:
         Tuple of (all_tables, vocabulary_tables_added).
     """
-    def is_vocabulary(table) -> bool:
-        return VOCAB_COLUMNS.issubset({c.name.upper() for c in table.columns})
-
     included_set: set[tuple[str, str]] = set()
     for table_spec in include_tables:
         if ":" in table_spec:
@@ -928,7 +924,7 @@ def _expand_tables_with_vocabularies(
             if pk_key in included_set:
                 continue
 
-            if is_vocabulary(pk_table):
+            if pk_table.is_vocabulary():
                 included_set.add(pk_key)
                 vocab_spec = f"{pk_key[0]}:{pk_key[1]}"
                 if vocab_spec not in vocabularies_added:

--- a/src/deriva_ml/core/mixins/path_builder.py
+++ b/src/deriva_ml/core/mixins/path_builder.py
@@ -22,6 +22,7 @@ Table = _ermrest_model.Table
 
 import pandas as pd
 
+from deriva_ml.core.pd_utils import rows_to_dataframe
 from deriva_ml.dataset.upload import table_path as _table_path
 
 if TYPE_CHECKING:
@@ -137,7 +138,7 @@ class PathBuilderMixin:
         Example:
             >>> df = ml.get_table_as_dataframe("Subject")  # doctest: +SKIP
         """
-        return pd.DataFrame(list(self.get_table_as_dict(table)))
+        return rows_to_dataframe(self.get_table_as_dict(table))
 
     def get_table_as_dict(self, table: str) -> Iterable[dict[str, Any]]:
         """Get table contents as dictionaries.

--- a/src/deriva_ml/core/mixins/vocabulary.py
+++ b/src/deriva_ml/core/mixins/vocabulary.py
@@ -160,16 +160,20 @@ class VocabularyMixin:
 
         try:
             # Attempt to insert a new term
-            term_data = pb.schemas[schema_name].tables[table_name].insert(
-                [
-                    {
-                        cols["Name"]: term_name,
-                        cols["Description"]: description,
-                        cols["Synonyms"]: synonyms,
-                    }
-                ],
-                defaults={cols["ID"], cols["URI"]},
-            )[0]
+            term_data = (
+                pb.schemas[schema_name]
+                .tables[table_name]
+                .insert(
+                    [
+                        {
+                            cols["Name"]: term_name,
+                            cols["Description"]: description,
+                            cols["Synonyms"]: synonyms,
+                        }
+                    ],
+                    defaults={cols["ID"], cols["URI"]},
+                )[0]
+            )
             term_handle = VocabularyTermHandle(ml=self, table=table_name, **term_data)
             # Invalidate cache for this vocabulary since we added a new term
             self.clear_vocabulary_cache(vocab_table)
@@ -181,9 +185,7 @@ class VocabularyMixin:
                 existing_term = self.lookup_term(vocab_table, term_name)
             except DerivaMLInvalidTerm:
                 # Term doesn't exist — the insert failed for another reason
-                raise DerivaMLException(
-                    f"Failed to insert term '{term_name}' into {vocab_table.name}: {e}"
-                ) from e
+                raise DerivaMLException(f"Failed to insert term '{term_name}' into {vocab_table.name}: {e}") from e
             # Term does exist — either return it or raise depending on exists_ok
             if not exists_ok:
                 raise DerivaMLInvalidTerm(vocab_table.name, term_name, msg="term already exists")
@@ -264,9 +266,7 @@ class VocabularyMixin:
         # Term not found
         raise DerivaMLInvalidTerm(table_name, term_name)
 
-    def _server_lookup_term(
-        self, schema_name: str, table_name: str, term_name: str
-    ) -> VocabularyTermHandle | None:
+    def _server_lookup_term(self, schema_name: str, table_name: str, term_name: str) -> VocabularyTermHandle | None:
         """Look up a term by name using server-side filtering.
 
         This performs a targeted server query for a specific term name.

--- a/src/deriva_ml/core/mixins/vocabulary.py
+++ b/src/deriva_ml/core/mixins/vocabulary.py
@@ -323,6 +323,43 @@ class VocabularyMixin:
         # Fetch and convert all terms to VocabularyTerm objects
         return [VocabularyTerm(**v) for v in pb.schemas[table.schema.name].tables[table.name].entities().fetch()]
 
+    def _update_term_field(
+        self,
+        table: str | Table,
+        term_name: str,
+        field_key: str,
+        value: Any,
+    ) -> None:
+        """Internal: Update a single field on a vocabulary term by name.
+
+        Shared implementation for the per-field update helpers (synonyms,
+        description, etc.). Resolves ``term_name`` to a RID via
+        ``lookup_term``, writes ``{field_key: value}`` to the vocabulary
+        table using the resolved column name, and invalidates the
+        vocabulary cache for the table.
+
+        Args:
+            table: Vocabulary table containing the term.
+            term_name: Primary name of the term to update.
+            field_key: Logical vocab-column key (e.g. ``"Synonyms"``,
+                ``"Description"``). Resolved to the actual column name
+                via :meth:`DerivaModel.vocab_columns`.
+            value: New value for the field. Type depends on the column
+                (list[str] for synonyms, str for description, etc.).
+        """
+        # Look up the term to get its RID
+        term = self.lookup_term(table, term_name)
+
+        # Update the term in the catalog
+        vocab_table = self.model.name_to_table(table)
+        cols = self.model.vocab_columns(vocab_table)
+        pb = self.pathBuilder()
+        table_path = pb.schemas[vocab_table.schema.name].tables[vocab_table.name]
+        table_path.update([{"RID": term.rid, cols[field_key]: value}])
+
+        # Invalidate cache
+        self.clear_vocabulary_cache(table)
+
     def _update_term_synonyms(self, table: str | Table, term_name: str, synonyms: list[str]) -> None:
         """Internal: Update synonyms for a vocabulary term.
 
@@ -333,18 +370,7 @@ class VocabularyMixin:
             term_name: Primary name of the term to update.
             synonyms: New list of synonyms (replaces all existing).
         """
-        # Look up the term to get its RID
-        term = self.lookup_term(table, term_name)
-
-        # Update the term in the catalog
-        vocab_table = self.model.name_to_table(table)
-        cols = self.model.vocab_columns(vocab_table)
-        pb = self.pathBuilder()
-        table_path = pb.schemas[vocab_table.schema.name].tables[vocab_table.name]
-        table_path.update([{"RID": term.rid, cols["Synonyms"]: synonyms}])
-
-        # Invalidate cache
-        self.clear_vocabulary_cache(table)
+        self._update_term_field(table, term_name, "Synonyms", synonyms)
 
     def _update_term_description(self, table: str | Table, term_name: str, description: str) -> None:
         """Internal: Update description for a vocabulary term.
@@ -356,18 +382,7 @@ class VocabularyMixin:
             term_name: Primary name of the term to update.
             description: New description for the term.
         """
-        # Look up the term to get its RID
-        term = self.lookup_term(table, term_name)
-
-        # Update the term in the catalog
-        vocab_table = self.model.name_to_table(table)
-        cols = self.model.vocab_columns(vocab_table)
-        pb = self.pathBuilder()
-        table_path = pb.schemas[vocab_table.schema.name].tables[vocab_table.name]
-        table_path.update([{"RID": term.rid, cols["Description"]: description}])
-
-        # Invalidate cache
-        self.clear_vocabulary_cache(table)
+        self._update_term_field(table, term_name, "Description", description)
 
     @validate_call(config=ConfigDict(arbitrary_types_allowed=True))
     def delete_term(self, table: str | Table, term_name: str) -> None:

--- a/src/deriva_ml/core/mixins/workflow.py
+++ b/src/deriva_ml/core/mixins/workflow.py
@@ -52,11 +52,7 @@ class WorkflowMixin:
         """
         pb = self.pathBuilder()
         assoc_path = pb.schemas[self.ml_schema].Workflow_Workflow_Type
-        types = (
-            assoc_path.filter(assoc_path.Workflow == workflow_rid)
-            .attributes(assoc_path.Workflow_Type)
-            .fetch()
-        )
+        types = assoc_path.filter(assoc_path.Workflow == workflow_rid).attributes(assoc_path.Workflow_Type).fetch()
         return [t["Workflow_Type"] for t in types]
 
     def find_workflows(self) -> list[Workflow]:
@@ -241,8 +237,8 @@ class WorkflowMixin:
         workflow_path = self.pathBuilder().schemas[self.ml_schema].Workflow
         workflow_rid = None
         for w in workflow_path.path.entities().fetch():
-            if w['URL'] == url_or_checksum or w['Checksum'] == url_or_checksum:
-                workflow_rid = w['RID']
+            if w["URL"] == url_or_checksum or w["Checksum"] == url_or_checksum:
+                workflow_rid = w["RID"]
                 break
 
         return workflow_rid
@@ -306,9 +302,7 @@ class WorkflowMixin:
         # Find the RID first
         rid = self._find_workflow_rid_by_url(url_or_checksum)
         if rid is None:
-            raise DerivaMLException(
-                f"Workflow with URL or checksum '{url_or_checksum}' not found in the catalog"
-            )
+            raise DerivaMLException(f"Workflow with URL or checksum '{url_or_checksum}' not found in the catalog")
 
         # Use lookup_workflow to get the full object with catalog binding
         return self.lookup_workflow(rid)

--- a/src/deriva_ml/core/mixins/workflow.py
+++ b/src/deriva_ml/core/mixins/workflow.py
@@ -7,12 +7,9 @@ and creating workflows.
 
 from __future__ import annotations
 
-# Deriva imports - use importlib to avoid shadowing by local 'deriva.py' files
-import importlib
 from typing import TYPE_CHECKING, Any, Callable
 
-_deriva_core = importlib.import_module("deriva.core")
-format_exception = _deriva_core.format_exception
+from deriva.core import format_exception
 
 from deriva_ml.core.definitions import RID, MLVocab, VocabularyTerm
 from deriva_ml.core.exceptions import DerivaMLException

--- a/src/deriva_ml/core/pd_utils.py
+++ b/src/deriva_ml/core/pd_utils.py
@@ -1,0 +1,36 @@
+"""Small pandas-shaped helpers shared across catalog / bag / database code.
+
+Keeps the pandas-coupling narrow — callers that only need the DataFrame
+shape go through these helpers instead of re-inlining the
+``pd.DataFrame(list(rows))`` idiom.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Iterable
+
+import pandas as pd
+
+
+def rows_to_dataframe(rows: Iterable[dict[str, Any]]) -> pd.DataFrame:
+    """Build a DataFrame from an iterable of row dicts.
+
+    A thin wrapper over ``pd.DataFrame(list(rows))`` that centralises the
+    idiom shared by ``PathBuilderMixin.get_table_as_dataframe``,
+    ``DatasetBag.get_table_as_dataframe``, and
+    ``DatasetDatabase.get_table_as_dataframe``. If any of them grows
+    special-case handling (e.g. dtype hints, NaN normalization), this is
+    the single site to evolve.
+
+    Args:
+        rows: Iterable yielding row dicts. Generators, lists, or any
+            other iterable work — the helper materializes to a list
+            before handing off to pandas so a partially-consumed
+            generator can't produce a mismatched frame.
+
+    Returns:
+        A :class:`pandas.DataFrame` with one row per input dict and
+        columns inferred from the union of dict keys (pandas' default
+        behaviour for a list-of-dicts).
+    """
+    return pd.DataFrame(list(rows))

--- a/src/deriva_ml/dataset/dataset.py
+++ b/src/deriva_ml/dataset/dataset.py
@@ -28,6 +28,7 @@ Typical usage example:
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import os
@@ -100,6 +101,25 @@ from deriva_ml.dataset.dataset_bag import DatasetBag
 from deriva_ml.feature import Feature
 from deriva_ml.interfaces import DerivaMLCatalog
 from deriva_ml.model.database import DatabaseModel
+
+
+def _hash_spec(spec: Any) -> str:
+    """SHA-256 hex digest of a download spec, keyed by sorted-JSON form.
+
+    Used to key the bag cache and to compare a freshly computed spec
+    against the ``Minid_Spec_Hash`` recorded on a historical version.
+    ``sort_keys=True`` makes the hash order-insensitive across dict
+    renderings so semantically-equal specs always hash identically.
+
+    Args:
+        spec: The download spec (any JSON-serializable Python object,
+            typically the dict returned by
+            ``CatalogGraph.generate_dataset_download_spec``).
+
+    Returns:
+        Lowercase hex-digest string (64 chars).
+    """
+    return hashlib.sha256(json.dumps(spec, sort_keys=True).encode()).hexdigest()
 
 
 class Dataset:
@@ -2292,8 +2312,6 @@ class Dataset:
             str: URL to the MINID landing page (if use_minid=True) or
                 the direct bag download URL.
         """
-        import hashlib
-
         with TemporaryDirectory() as tmp_dir:
             # Generate spec if not supplied (allows callers to reuse a spec they already computed).
             if spec is None:
@@ -2307,7 +2325,7 @@ class Dataset:
                 spec = downloader.generate_dataset_download_spec(self)
 
             if spec_hash is None:
-                spec_hash = hashlib.sha256(json.dumps(spec, sort_keys=True).encode()).hexdigest()
+                spec_hash = _hash_spec(spec)
 
             spec_file = Path(tmp_dir) / "download_spec.json"
             with spec_file.open("w", encoding="utf-8") as ds:
@@ -2651,8 +2669,6 @@ class Dataset:
             DerivaMLException: If the version doesn't exist, or if
                 ``create=False`` and no cached/registered bag is available.
         """
-        import hashlib
-
         # ----- Resolve version record -----------------------------------------
         version_str = str(version)
         history = self.dataset_history()
@@ -2684,7 +2700,7 @@ class Dataset:
             exclude_tables=exclude_tables,
         )
         spec = downloader.generate_dataset_download_spec(self)
-        spec_hash = hashlib.sha256(json.dumps(spec, sort_keys=True).encode()).hexdigest()
+        spec_hash = _hash_spec(spec)
 
         # The deterministic cache key: {spec_hash[:16]}_{snapshot}
         # - spec_hash[:16] captures the FK traversal plan (schema-dependent)

--- a/src/deriva_ml/dataset/dataset_bag.py
+++ b/src/deriva_ml/dataset/dataset_bag.py
@@ -52,6 +52,7 @@ from sqlalchemy.orm.util import AliasedClass
 
 from deriva_ml.core.definitions import RID
 from deriva_ml.core.exceptions import DerivaMLException
+from deriva_ml.core.pd_utils import rows_to_dataframe
 from deriva_ml.dataset.aux_classes import DatasetHistory, DatasetVersion
 from deriva_ml.feature import Feature, FeatureRecord
 
@@ -261,7 +262,7 @@ class DatasetBag:
             >>> df = bag.get_table_as_dataframe("Image")  # doctest: +SKIP
             >>> print(df.shape)  # doctest: +SKIP
         """
-        return pd.DataFrame(self.get_table_as_dict(table))
+        return rows_to_dataframe(self.get_table_as_dict(table))
 
     @staticmethod
     def _find_relationship_attr(source, target):

--- a/src/deriva_ml/dataset/dataset_bag.py
+++ b/src/deriva_ml/dataset/dataset_bag.py
@@ -655,35 +655,27 @@ class DatasetBag:
 
         with Session(self.engine) as session:
             # Phase 1: try as a Workflow RID.
-            wf_rows = session.execute(
-                sa_select(workflow_table).where(workflow_table.c.RID == workflow)
-            ).mappings().all()
+            wf_rows = (
+                session.execute(sa_select(workflow_table).where(workflow_table.c.RID == workflow)).mappings().all()
+            )
 
             if wf_rows:
                 rows = session.execute(
-                    sa_select(execution_table.c.RID).where(
-                        execution_table.c.Workflow == workflow
-                    )
+                    sa_select(execution_table.c.RID).where(execution_table.c.Workflow == workflow)
                 ).all()
                 return [r[0] for r in rows]
 
             # Phase 2: fall back to Workflow_Type name via association table.
             wwt = self.model.find_table("Workflow_Workflow_Type")
             wf_of_type = [
-                r[0]
-                for r in session.execute(
-                    sa_select(wwt.c.Workflow).where(wwt.c.Workflow_Type == workflow)
-                ).all()
+                r[0] for r in session.execute(sa_select(wwt.c.Workflow).where(wwt.c.Workflow_Type == workflow)).all()
             ]
             if not wf_of_type:
                 raise DerivaMLException(
-                    f"No workflow resolved for '{workflow}' in bag — tried as "
-                    "Workflow RID and Workflow_Type name."
+                    f"No workflow resolved for '{workflow}' in bag — tried as Workflow RID and Workflow_Type name."
                 )
             rows = session.execute(
-                sa_select(execution_table.c.RID).where(
-                    execution_table.c.Workflow.in_(wf_of_type)
-                )
+                sa_select(execution_table.c.RID).where(execution_table.c.Workflow.in_(wf_of_type))
             ).all()
             return [r[0] for r in rows]
 

--- a/src/deriva_ml/model/catalog.py
+++ b/src/deriva_ml/model/catalog.py
@@ -15,7 +15,7 @@ import logging
 from collections import Counter, defaultdict
 from dataclasses import dataclass, field
 from graphlib import CycleError, TopologicalSorter
-from typing import Any, Callable, Final, Iterable, NewType, TypeAlias
+from typing import Any, Callable, Iterable, NewType, TypeAlias
 
 _ermrest_catalog = importlib.import_module("deriva.core.ermrest_catalog")
 _ermrest_model = importlib.import_module("deriva.core.ermrest_model")
@@ -128,9 +128,6 @@ ColumnSet: TypeAlias = set[Column]
 AssociationResult: TypeAlias = FindAssociationResult
 TableSet: TypeAlias = set[Table]
 PathList: TypeAlias = list[list[Table]]
-
-# Define constants:
-VOCAB_COLUMNS: Final[set[str]] = {"NAME", "URI", "SYNONYMS", "DESCRIPTION", "ID"}
 
 FilterPredicate = Callable[[Table], bool]
 

--- a/src/deriva_ml/model/deriva_ml_database.py
+++ b/src/deriva_ml/model/deriva_ml_database.py
@@ -97,9 +97,7 @@ class DerivaMLDatabase:
 
     # ==================== Read Operations (Supported) ====================
 
-    def lookup_dataset(
-        self, dataset: RID | DatasetSpec, deleted: bool = False
-    ) -> DatasetBag:
+    def lookup_dataset(self, dataset: RID | DatasetSpec, deleted: bool = False) -> DatasetBag:
         """Look up a dataset by RID or spec.
 
         Args:
@@ -121,10 +119,7 @@ class DerivaMLDatabase:
         self._database_model.rid_lookup(rid)
 
         # Get dataset metadata
-        dataset_record = next(
-            (d for d in self._database_model._get_table_contents("Dataset") if d["RID"] == rid),
-            None
-        )
+        dataset_record = next((d for d in self._database_model._get_table_contents("Dataset") if d["RID"] == rid), None)
         if not dataset_record:
             raise DerivaMLException(f"Dataset {rid} not found in bag")
 
@@ -196,9 +191,7 @@ class DerivaMLDatabase:
 
         # Search for term in SQLite
         for term in self.get_table_as_dict(table_obj.name):
-            if term_name == term.get("Name") or (
-                term.get("Synonyms") and term_name in term.get("Synonyms", [])
-            ):
+            if term_name == term.get("Name") or (term.get("Synonyms") and term_name in term.get("Synonyms", [])):
                 # Convert synonyms to list if needed
                 synonyms = term.get("Synonyms")
                 if synonyms and not isinstance(synonyms, list):
@@ -264,8 +257,7 @@ class DerivaMLDatabase:
             DerivaMLException: Always, since bags are read-only.
         """
         raise DerivaMLException(
-            "Cannot create datasets in a downloaded bag. "
-            "Bags are immutable snapshots of catalog data."
+            "Cannot create datasets in a downloaded bag. Bags are immutable snapshots of catalog data."
         )
 
     def pathBuilder(self):
@@ -286,8 +278,7 @@ class DerivaMLDatabase:
             DerivaMLException: Always, since bags are already snapshots.
         """
         raise DerivaMLException(
-            "catalog_snapshot is not available for database-backed catalogs. "
-            "Bags are already immutable snapshots."
+            "catalog_snapshot is not available for database-backed catalogs. Bags are already immutable snapshots."
         )
 
     def resolve_rid(self, rid: RID) -> dict[str, Any]:

--- a/src/deriva_ml/model/deriva_ml_database.py
+++ b/src/deriva_ml/model/deriva_ml_database.py
@@ -16,6 +16,7 @@ from deriva.core.ermrest_model import Table
 
 from deriva_ml.core.definitions import RID, MLVocab, VocabularyTerm
 from deriva_ml.core.exceptions import DerivaMLException, DerivaMLInvalidTerm
+from deriva_ml.core.pd_utils import rows_to_dataframe
 from deriva_ml.dataset.aux_classes import DatasetSpec, DatasetVersion
 from deriva_ml.dataset.dataset_bag import DatasetBag
 from deriva_ml.feature import Feature
@@ -216,7 +217,7 @@ class DerivaMLDatabase:
         Returns:
             DataFrame containing all table contents.
         """
-        return pd.DataFrame(list(self.get_table_as_dict(table)))
+        return rows_to_dataframe(self.get_table_as_dict(table))
 
     def get_table_as_dict(self, table: str) -> Generator[dict[str, Any], None, None]:
         """Get table contents as dictionaries.


### PR DESCRIPTION
## Summary

Post-S2 item C from `docs/superpowers/specs/2026-04-23-post-s2-findings.md` §2. Five targeted extract-helper refactors to eliminate the repeated patterns Reviewer #3 called out, plus a ruff format pass on the touched files. No behavior change; the codebase stays mostly well-factored and these nits converge on single sources of truth.

| Commit | What | Severity |
|---|---|---|
| `fff1328` | `catalog/clone.py`: drop nested `is_vocabulary`; use `Table.is_vocabulary()` from deriva-py. Cascades: drop now-unused `VOCAB_COLUMNS` constant + `Final` import in `model/catalog.py` | Important |
| `36a82f9` | `VocabularyMixin`: extract `_update_term_field(table, term_name, field_key, value)`; the two typed helpers become 1-line delegators | Nit |
| `ade6d51` | `dataset.py`: extract module-level `_hash_spec(spec)`; single-source the spec SHA-256 computation (two call sites + two inline `import hashlib`s collapsed) | Nit |
| `f8e1c72` | New `core/pd_utils.rows_to_dataframe(rows)`; unify the 3 copies of `get_table_as_dataframe` across `PathBuilderMixin`, `DatasetBag`, `DatasetDatabase` | Nit |
| `d758399` | `core/mixins/workflow.py`: drop `importlib` round-trip (no `deriva.py` shadow in the tree); match the direct-import style the other modules already use | Nit |
| `eb2dcb7` | ruff format the 4 touched files (pre-existing pending diffs; pure formatter output) | — |

## What changed numerically

- **~70 lines of duplication removed** across 5 refactors
- **1 new utility module** — `src/deriva_ml/core/pd_utils.py` (~37 lines including docstrings)
- **4 files now ruff-format clean** (previously had pending format diffs on main)

## Verification

- Fast suite (`tests/local_db tests/asset tests/model tests/execution/test_state_machine.py`): **458 passed, 3 skipped** after every refactor and after the format pass.
- `ruff check src/deriva_ml/`: 56 errors (same as main baseline; zero net new).
- `ruff format --check src/deriva_ml/`: the 4 DRY-sprint-touched files are now clean; overall count went 65 → 62 (since 4 fixed, 1 new `pd_utils.py` which is clean from the start, and 1 other unrelated file still has pending diffs from something else in main — net 62, lower than the pre-existing baseline).
- `uv run mkdocs build --strict`: 27 warnings (unchanged from main baseline).

## Test Plan

- [ ] Pull branch and run `DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/local_db/ tests/asset/ tests/model/ tests/execution/test_state_machine.py -q` — expect 458 passed / 3 skipped
- [ ] Smoke test: `python -c "from deriva_ml.core.pd_utils import rows_to_dataframe; print(rows_to_dataframe([{'a': 1, 'b': 2}]))"` — confirm the helper works standalone
- [ ] Spot-check: `ml.get_table_as_dataframe("Subject")` continues to return a DataFrame on a live catalog
- [ ] Spot-check: adding/editing a vocabulary term's description still works via the mixin (covered by existing `VocabularyTermHandle` tests)

## Related

- Post-S2 item C from `docs/superpowers/specs/2026-04-23-post-s2-findings.md` §2 (Reviewer #3 — DRY violations)
- Sibling items already shipped:
  - Post-S2 A (state-machine recovery edge, PR merged `27b72bf`)
  - Post-S2 E (nested-dataset version propagation fix, merged `8bd75c3`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)