### PR TITLE
feat(dataset): D2 — PyTorch + TensorFlow adapters + restructure_assets vocab alignment

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,7 +97,9 @@ Each mixin lives in `src/deriva_ml/core/mixins/` and handles one concern.
 - Provides same interface as Dataset via `DatasetLike` protocol
 - Works with local BDBag directories (no catalog connection needed)
 - Supports nested dataset traversal and member listing
-- Use `restructure_assets()` to reorganize files by dataset type/features
+- Use `as_torch_dataset()` / `as_tf_dataset()` to feed the bag to PyTorch / TensorFlow / Keras training loops
+- Use `restructure_assets()` to reorganize files by dataset type/features for `ImageFolder`-style third-party trainers
+- All three share the same `targets` / `target_transform` / `missing` vocabulary; lazy import of torch/tensorflow inside each adapter so the base library stays importable without either framework
 
 **ExecutionConfiguration** (`src/deriva_ml/execution/execution_configuration.py`): Pydantic model for execution setup:
 - Dataset specifications with version and materialization options

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,6 +5,11 @@ backed by a Deriva catalog. It captures code provenance, input data
 versions, configuration, and outputs so experiments can be reproduced,
 cited, and shared.
 
+!!! info "Upgrading from a previous release?"
+    If you are upgrading an existing project, see
+    [Migrating from previous versions](user-guide/migration.md) for the list
+    of breaking changes and how to update your code.
+
 ## What deriva-ml does
 
 Four core concepts organize the library:

--- a/docs/superpowers/plans/2026-04-24-torch-dataset-adapter-plan.md
+++ b/docs/superpowers/plans/2026-04-24-torch-dataset-adapter-plan.md
@@ -1,0 +1,1294 @@
+# PyTorch + TensorFlow Dataset Adapter Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `DatasetBag.as_torch_dataset()` and `DatasetBag.as_tf_dataset()` thin adapters that turn a bag into framework-native training datasets, and align `DatasetBag.restructure_assets()` to share the same target-specification vocabulary.
+
+**Architecture:** Both adapters delegate to a shared private helper (`_resolve_targets`) that walks `bag.feature_values()` with matching semantics. Framework-specific code lives in `torch_adapter.py` / `tf_adapter.py`; torch and tensorflow imports are lazy (inside the builder bodies) so the base library stays importable without either framework. `restructure_assets` gets a clean-break signature rename to adopt the shared vocabulary.
+
+**Tech Stack:** Python 3.12+, optional PyTorch ≥2.0 (`deriva-ml[torch]`), optional TensorFlow ≥2.15 (`deriva-ml[tf]`), pytest with `pytest.importorskip` gates, MkDocs for UG docs.
+
+**Design reference:** `docs/superpowers/specs/2026-04-24-torch-dataset-adapter-design.md` (commit `7df8dc9` on branch `feature/torch-adapter`).
+
+---
+
+## Task ordering rationale
+
+The tasks are sequenced to land the shared foundation first, then one adapter, then the second adapter (parallel to the first), then the restructure alignment (which depends on the shared helper), then docs.
+
+1. Shared helper + tests — unblocks all three method implementations.
+2. Package extras — minimal pyproject edit; lets later tasks install torch / tf in their test fixtures.
+3. PyTorch adapter — proves the adapter pattern end-to-end.
+4. TensorFlow adapter — mirrors the torch work; parallel structure.
+5. Restructure alignment — rewires the existing method to use the new vocabulary.
+6. UG section — writes user-facing docs covering all three paths.
+7. Cross-reference sweep — small edits to related docstrings.
+8. Final verification.
+
+Tasks 3 and 4 are independent and can run back-to-back without coordination. Task 5 depends on tasks 1 and 3 (for the shared helper and the method-on-DatasetBag wiring pattern).
+
+---
+
+## Task 1: Shared target-resolution helper
+
+**Files:**
+- Create: `src/deriva_ml/dataset/target_resolution.py`
+- Test: `tests/dataset/test_target_resolution.py`
+
+Create the shared `_resolve_targets()` helper that both adapters and the rewritten `restructure_assets()` will call. It walks `bag.feature_values()` for each target, handles the three `missing=` policies, and returns a dict keyed by element RID mapping to the appropriate target-arity shape.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/dataset/test_target_resolution.py`:
+
+```python
+"""Unit tests for the shared target-resolution helper.
+
+Framework-agnostic: tests the selector/missing/arity logic in isolation
+from torch, tensorflow, and the restructure_assets call-site. If these
+tests fail, the adapter and restructure alignment both break in the
+same way, which is a feature — one helper, one set of semantics.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from deriva_ml.core.exceptions import DerivaMLException
+from deriva_ml.dataset.target_resolution import _resolve_targets
+from deriva_ml.feature import FeatureRecord
+
+
+class _FakeRecord(FeatureRecord):
+    """Minimal FeatureRecord stand-in for target-resolution tests."""
+    Image: str  # target column: asset RID this record describes
+    Grade: str  # scalar label
+
+
+def _make_bag(feature_returns: dict[str, dict[str, list[_FakeRecord]]]):
+    """Build a MagicMock bag whose feature_values returns canned data.
+
+    Args:
+        feature_returns: {feature_name: {element_rid: [records...]}}.
+
+    Returns:
+        A MagicMock standing in for a DatasetBag.
+    """
+    bag = MagicMock()
+
+    def fake_feature_values(element_type, feature_name, selector=None):
+        per_rid = feature_returns.get(feature_name, {})
+        for rid, records in per_rid.items():
+            if selector is None:
+                yield from records
+            else:
+                selected = selector(records)
+                if selected is not None:
+                    yield selected
+
+    bag.feature_values = fake_feature_values
+    bag.list_dataset_members = MagicMock(
+        return_value={"Image": [{"RID": rid} for rid in feature_returns.get(
+            next(iter(feature_returns), "Grade"), {}).keys()]}
+    )
+    return bag
+
+
+def test_resolve_targets_none_returns_unlabeled_per_rid():
+    """targets=None → empty dict (no label resolution needed)."""
+    bag = _make_bag({})
+    result = _resolve_targets(bag, "Image", targets=None, missing="error")
+    assert result == {}
+
+
+def test_resolve_targets_single_target_returns_featurerecord_per_rid():
+    """Single-target list yields one FeatureRecord per element RID."""
+    recs_a = [_FakeRecord(Image="1-IMG1", Grade="Mild")]
+    recs_b = [_FakeRecord(Image="1-IMG2", Grade="Severe")]
+    bag = _make_bag({"Grade": {"1-IMG1": recs_a, "1-IMG2": recs_b}})
+    result = _resolve_targets(bag, "Image", targets=["Grade"], missing="error")
+    assert result["1-IMG1"].Grade == "Mild"
+    assert result["1-IMG2"].Grade == "Severe"
+
+
+def test_resolve_targets_missing_error_raises_with_rid_list():
+    """missing='error' with sparse labels raises and names unlabeled RIDs."""
+    recs = [_FakeRecord(Image="1-IMG1", Grade="Mild")]
+    bag = _make_bag({"Grade": {"1-IMG1": recs, "1-IMG2": []}})
+    with pytest.raises(DerivaMLException, match=r"1-IMG2"):
+        _resolve_targets(bag, "Image", targets=["Grade"], missing="error")
+
+
+def test_resolve_targets_missing_skip_drops_unlabeled():
+    """missing='skip' omits the unlabeled RID from the result entirely."""
+    recs = [_FakeRecord(Image="1-IMG1", Grade="Mild")]
+    bag = _make_bag({"Grade": {"1-IMG1": recs, "1-IMG2": []}})
+    result = _resolve_targets(bag, "Image", targets=["Grade"], missing="skip")
+    assert "1-IMG1" in result
+    assert "1-IMG2" not in result
+
+
+def test_resolve_targets_missing_unknown_yields_none():
+    """missing='unknown' keeps the RID with None as its target value."""
+    recs = [_FakeRecord(Image="1-IMG1", Grade="Mild")]
+    bag = _make_bag({"Grade": {"1-IMG1": recs, "1-IMG2": []}})
+    result = _resolve_targets(bag, "Image", targets=["Grade"], missing="unknown")
+    assert result["1-IMG1"].Grade == "Mild"
+    assert result["1-IMG2"] is None
+
+
+def test_resolve_targets_multi_target_returns_dict_keyed_by_feature():
+    """Multi-target yields dict[feature_name, FeatureRecord] per RID."""
+    grade_recs = [_FakeRecord(Image="1-IMG1", Grade="Mild")]
+    severity_recs = [_FakeRecord(Image="1-IMG1", Grade="Low")]
+    bag = _make_bag({
+        "Grade": {"1-IMG1": grade_recs},
+        "Severity": {"1-IMG1": severity_recs},
+    })
+    result = _resolve_targets(
+        bag, "Image", targets=["Grade", "Severity"], missing="error"
+    )
+    assert set(result["1-IMG1"].keys()) == {"Grade", "Severity"}
+    assert result["1-IMG1"]["Grade"].Grade == "Mild"
+
+
+def test_resolve_targets_selector_dict_applies_per_feature():
+    """dict form passes selectors per-feature to bag.feature_values."""
+    selector = FeatureRecord.select_newest
+    r1 = _FakeRecord(Image="1-IMG1", Grade="Mild")
+    r2 = _FakeRecord(Image="1-IMG1", Grade="Severe")
+    bag = _make_bag({"Grade": {"1-IMG1": [r1, r2]}})
+    result = _resolve_targets(
+        bag, "Image", targets={"Grade": selector}, missing="error"
+    )
+    # The selector picks one; exact choice depends on select_newest's
+    # impl, but the result should be one of the two records.
+    assert result["1-IMG1"].Grade in ("Mild", "Severe")
+
+
+def test_resolve_targets_unknown_feature_raises_at_construction():
+    """Passing a feature name that doesn't exist raises the same error
+    bag.feature_values would raise."""
+    bag = MagicMock()
+    bag.feature_values = MagicMock(side_effect=DerivaMLException("No such feature"))
+    bag.list_dataset_members = MagicMock(return_value={"Image": []})
+    with pytest.raises(DerivaMLException):
+        _resolve_targets(bag, "Image", targets=["Bogus"], missing="error")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/dataset/test_target_resolution.py -v`
+Expected: ALL tests fail with `ImportError: cannot import name '_resolve_targets'` (module doesn't exist yet).
+
+- [ ] **Step 3: Write the helper module**
+
+Create `src/deriva_ml/dataset/target_resolution.py`:
+
+```python
+"""Shared target-resolution logic for DatasetBag adapters and restructure.
+
+Both ``DatasetBag.as_torch_dataset``, ``DatasetBag.as_tf_dataset``, and
+``DatasetBag.restructure_assets`` need the same logic: given a bag, an
+element-table name, and a target specification, walk ``bag.feature_values``
+for each target, apply the requested missing-value policy, and return a
+dict keyed by element RID mapping to the target-arity shape.
+
+Keeping this logic in one module makes the "same semantics" claim across
+the three public methods enforceable by shared code rather than parallel
+implementation. See design spec §8.5.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import TYPE_CHECKING, Any, Callable, Literal
+
+from deriva_ml.core.exceptions import DerivaMLException
+
+if TYPE_CHECKING:
+    from deriva_ml.dataset.dataset_bag import DatasetBag
+    from deriva_ml.feature import FeatureRecord
+
+    FeatureSelector = Callable[[list["FeatureRecord"]], "FeatureRecord | None"]
+
+
+# Maximum unlabeled-RID count to show in missing="error" message before
+# truncating. Keeps error messages readable on very sparse datasets.
+_MISSING_ERROR_RID_LIST_LIMIT = 20
+
+
+def _resolve_targets(
+    bag: "DatasetBag",
+    element_type: str,
+    *,
+    targets: "list[str] | dict[str, FeatureSelector] | None",
+    missing: Literal["error", "skip", "unknown"],
+) -> "dict[str, Any]":
+    """Resolve feature values into per-element target records.
+
+    Walks ``bag.feature_values(element_type, feature_name, selector=...)``
+    for each feature in ``targets``, groups records by their target-
+    element RID, and applies the ``missing`` policy to elements whose
+    feature value is absent.
+
+    Args:
+        bag: Source ``DatasetBag``.
+        element_type: Domain table name whose rows are the elements
+            (e.g., ``"Image"``).
+        targets: Target specification per the aligned vocabulary (spec
+            §3.7). ``None`` yields no labels (empty result). ``list[str]``
+            yields one ``FeatureRecord`` per element for single-target,
+            ``dict[feature_name, FeatureRecord]`` for multi-target.
+            ``dict[str, FeatureSelector]`` passes per-feature selectors
+            through to ``bag.feature_values``.
+        missing: Policy for elements with no feature value.
+
+    Returns:
+        Dict keyed by element RID. Value shape:
+
+        - `targets=None`: empty dict.
+        - `targets=["A"]`: `FeatureRecord`.
+        - `targets=["A", "B"]` or dict with 2+ keys: `dict[str, FeatureRecord]`.
+        - Element absent under `missing="skip"`: key not in returned dict.
+        - Element absent under `missing="unknown"`: value is `None`.
+
+    Raises:
+        DerivaMLException: If ``missing="error"`` and any element lacks a
+            feature value (message lists up to 20 unlabeled RIDs).
+    """
+    if not targets:
+        return {}
+
+    # Normalize targets to (feature_name, selector) pairs. A list form has
+    # selector=None for each feature; a dict form uses the mapped selector.
+    if isinstance(targets, list):
+        feature_specs: list[tuple[str, Any]] = [(name, None) for name in targets]
+    else:
+        feature_specs = list(targets.items())
+
+    # Walk features and collect records keyed by target-element RID.
+    # The target column is the element_type's name (e.g., "Image" on an
+    # Image-target FeatureRecord). FeatureRecord instances carry that
+    # attribute; we pull it dynamically.
+    per_feature_per_rid: dict[str, dict[str, "FeatureRecord"]] = {
+        name: {} for name, _ in feature_specs
+    }
+    for feature_name, selector in feature_specs:
+        for record in bag.feature_values(
+            element_type, feature_name, selector=selector
+        ):
+            rid = getattr(record, element_type)
+            per_feature_per_rid[feature_name][rid] = record
+
+    # Determine the universe of element RIDs. Union across features so an
+    # element labeled for some targets but not others is still considered.
+    all_rids: set[str] = set()
+    for rid_map in per_feature_per_rid.values():
+        all_rids.update(rid_map.keys())
+
+    # Apply missing policy and build the result dict.
+    unlabeled: list[str] = []
+    result: dict[str, Any] = {}
+    is_single_target = len(feature_specs) == 1
+    single_feature_name = feature_specs[0][0] if is_single_target else None
+
+    for rid in sorted(all_rids):
+        feature_records = {
+            name: per_feature_per_rid[name].get(rid)
+            for name, _ in feature_specs
+        }
+        any_missing = any(v is None for v in feature_records.values())
+
+        if any_missing:
+            if missing == "error":
+                unlabeled.append(rid)
+                continue
+            if missing == "skip":
+                continue
+            # missing == "unknown"
+            result[rid] = None
+            continue
+
+        if is_single_target:
+            result[rid] = feature_records[single_feature_name]
+        else:
+            result[rid] = feature_records
+
+    if missing == "error" and unlabeled:
+        preview = unlabeled[:_MISSING_ERROR_RID_LIST_LIMIT]
+        suffix = (
+            f" (and {len(unlabeled) - len(preview)} more)"
+            if len(unlabeled) > len(preview)
+            else ""
+        )
+        raise DerivaMLException(
+            f"{len(unlabeled)} element(s) of type {element_type!r} have no "
+            f"value for one or more targets in {targets!r}. "
+            f"Unlabeled RIDs: {preview}{suffix}. "
+            f"Pass missing='skip' to drop unlabeled elements, or "
+            f"missing='unknown' to keep them with target=None."
+        )
+
+    return result
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/dataset/test_target_resolution.py -v`
+Expected: All tests PASS.
+
+- [ ] **Step 5: Run the full fast suite to confirm no regressions**
+
+Run: `DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/local_db/ tests/asset/ tests/model/ tests/dataset/test_target_resolution.py -q`
+Expected: 498+ passed (same baseline as main + the new target_resolution tests), 3 skipped, 0 failed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/carl/GitHub/deriva-ml/.worktrees/torch-adapter
+git add src/deriva_ml/dataset/target_resolution.py tests/dataset/test_target_resolution.py
+git commit -m "feat(dataset): add _resolve_targets shared helper for D2
+
+Post-S2 D2 Task 1. Shared target-resolution logic consumed by
+as_torch_dataset, as_tf_dataset, and the rewritten restructure_assets.
+Handles feature-value resolution via bag.feature_values, three
+missing= policies (error/skip/unknown), and single/multi-target arity.
+Framework-agnostic — zero torch/tf imports.
+
+See spec §8.5 for the helper's contract.
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Package extras in pyproject.toml
+
+**Files:**
+- Modify: `pyproject.toml`
+
+Add the `[project.optional-dependencies]` table with `torch` and `tf` entries so users can `pip install 'deriva-ml[torch]'` or `pip install 'deriva-ml[tf]'`.
+
+- [ ] **Step 1: Locate the right spot**
+
+Run: `grep -n "^\[project\.optional\|^\[tool\." pyproject.toml | head -5`
+Expected: confirms no existing `[project.optional-dependencies]` table (there's already a stub at line 49 per the initial read, but it's empty).
+
+- [ ] **Step 2: Edit pyproject.toml**
+
+Find the existing empty `[project.optional-dependencies]` stub around line 49-50 and replace with:
+
+```toml
+[project.optional-dependencies]
+torch = ["torch>=2.0"]
+tf = ["tensorflow>=2.15"]
+```
+
+- [ ] **Step 3: Verify build configuration still parses**
+
+Run: `DERIVA_ML_ALLOW_DIRTY=true uv sync --extra torch --extra tf`
+Expected: succeeds, torch and tensorflow get installed to the venv. Note: this may take 1-3 minutes due to tensorflow's size.
+
+Alternative if tf install fails on your platform: `uv sync --extra torch` alone works and is sufficient for Task 3 verification; Task 4 will need TF separately.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add pyproject.toml uv.lock
+git commit -m "build(deps): add torch + tf optional-dependency extras
+
+Post-S2 D2 Task 2. Adds [project.optional-dependencies] with:
+- torch = [\"torch>=2.0\"]
+- tf = [\"tensorflow>=2.15\"]
+
+Users install with 'pip install deriva-ml[torch]' or
+'pip install deriva-ml[tf]' depending on which framework they
+use. The base install remains lean — neither framework is a
+hard dependency, and both are imported lazily inside the
+adapter code per design anchor 3.
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: PyTorch adapter
+
+**Files:**
+- Create: `src/deriva_ml/dataset/torch_adapter.py`
+- Modify: `src/deriva_ml/dataset/dataset_bag.py` (add `as_torch_dataset` method)
+- Test: `tests/dataset/test_torch_adapter_no_torch.py`
+- Test: `tests/dataset/test_torch_adapter_logic.py`
+- Test: `tests/dataset/test_torch_adapter_e2e.py`
+
+Ships `DatasetBag.as_torch_dataset(element_type, *, sample_loader=None, transform=None, targets=None, target_transform=None, missing="error")` returning a `torch.utils.data.Dataset`. Torch is imported lazily inside the builder.
+
+- [ ] **Step 1: Write the no-torch import-guard test**
+
+Create `tests/dataset/test_torch_adapter_no_torch.py`:
+
+```python
+"""Verify the library imports cleanly when torch is absent.
+
+If torch is truly installed in the test venv, we stub it out of
+sys.modules temporarily. The goal is to prove that importing DatasetBag
+does NOT import torch eagerly.
+"""
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+
+def test_dataset_bag_imports_without_torch(monkeypatch):
+    """Removing torch from sys.modules lets DatasetBag still import."""
+    for name in list(sys.modules):
+        if name == "torch" or name.startswith("torch."):
+            monkeypatch.delitem(sys.modules, name, raising=False)
+    monkeypatch.setitem(sys.modules, "torch", None)
+
+    # Re-import dataset_bag under the torch-less sys.modules state.
+    if "deriva_ml.dataset.dataset_bag" in sys.modules:
+        monkeypatch.delitem(sys.modules, "deriva_ml.dataset.dataset_bag", raising=False)
+    from deriva_ml.dataset.dataset_bag import DatasetBag  # noqa: F401
+
+
+def test_as_torch_dataset_raises_importerror_without_torch(monkeypatch):
+    """Calling as_torch_dataset when torch is absent raises ImportError
+    with an install-hint message."""
+    for name in list(sys.modules):
+        if name == "torch" or name.startswith("torch."):
+            monkeypatch.delitem(sys.modules, name, raising=False)
+    monkeypatch.setitem(sys.modules, "torch", None)
+
+    from unittest.mock import MagicMock
+    bag = MagicMock()
+
+    if "deriva_ml.dataset.torch_adapter" in sys.modules:
+        monkeypatch.delitem(sys.modules, "deriva_ml.dataset.torch_adapter", raising=False)
+
+    from deriva_ml.dataset.torch_adapter import build_torch_dataset
+    with pytest.raises(ImportError, match=r"torch"):
+        build_torch_dataset(bag, "Image")
+```
+
+- [ ] **Step 2: Write the logic test (torch stubbed)**
+
+Create `tests/dataset/test_torch_adapter_logic.py`:
+
+```python
+"""Pure-Python logic tests for torch_adapter.
+
+Uses pytest.importorskip — runs only when torch is installed. Tests
+the join logic, selector pass-through, missing= branches, target arity,
+and error paths using the real torch.utils.data.Dataset base class.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+from pathlib import Path
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from deriva_ml.core.exceptions import DerivaMLException  # noqa: E402
+from deriva_ml.dataset.torch_adapter import build_torch_dataset  # noqa: E402
+from deriva_ml.feature import FeatureRecord  # noqa: E402
+
+
+class _FakeRecord(FeatureRecord):
+    Image: str
+    Grade: str
+
+
+def _mock_bag_with_labeled_images(rids_and_labels: dict[str, str]):
+    """Build a MagicMock DatasetBag with the given labeled images."""
+    bag = MagicMock()
+    bag.path = Path("/tmp/fake_bag")
+    bag.list_dataset_members = MagicMock(
+        return_value={"Image": [{"RID": rid} for rid in rids_and_labels]}
+    )
+
+    def fake_feature_values(element_type, feature_name, selector=None):
+        for rid, label in rids_and_labels.items():
+            rec = _FakeRecord(Image=rid, Grade=label)
+            if selector is None:
+                yield rec
+            else:
+                sel = selector([rec])
+                if sel is not None:
+                    yield sel
+
+    bag.feature_values = fake_feature_values
+    # Mock table metadata so the asset-path resolver can find columns.
+    bag.model = MagicMock()
+    asset_row = {"RID": "1-IMG1", "Filename": "img1.jpg"}
+    bag.get_table_as_dict = MagicMock(return_value=iter([asset_row]))
+    bag.is_asset = MagicMock(return_value=True)
+    return bag
+
+
+def test_as_torch_dataset_returns_torch_dataset_subclass():
+    bag = _mock_bag_with_labeled_images({"1-IMG1": "Mild"})
+    ds = build_torch_dataset(
+        bag, "Image",
+        sample_loader=lambda p, row: b"fake",
+        targets=["Grade"],
+    )
+    assert isinstance(ds, torch.utils.data.Dataset)
+
+
+def test_len_reflects_labeled_count_when_missing_skip():
+    bag = _mock_bag_with_labeled_images({"1-IMG1": "Mild", "1-IMG2": ""})
+    # Simulate missing: IMG2 has empty label treated as absent in this
+    # simplified test; for real data the fake feature_values would
+    # simply not yield IMG2.
+    # In logic tests we only check len() semantics.
+    # ...rest of tests follow the same pattern per spec §6.2 matrix.
+
+
+def test_missing_error_raises_at_construction():
+    bag = MagicMock()
+    bag.path = Path("/tmp/fake_bag")
+    bag.list_dataset_members = MagicMock(
+        return_value={"Image": [{"RID": "1-IMG1"}, {"RID": "1-IMG2"}]}
+    )
+    bag.feature_values = MagicMock(return_value=iter([_FakeRecord(Image="1-IMG1", Grade="Mild")]))
+    bag.model = MagicMock()
+    with pytest.raises(DerivaMLException, match=r"1-IMG2"):
+        build_torch_dataset(
+            bag, "Image",
+            sample_loader=lambda p, row: b"",
+            targets=["Grade"],
+            missing="error",
+        )
+
+
+def test_asset_table_without_sample_loader_raises():
+    """Asset-table element_type with no sample_loader raises at construction."""
+    bag = _mock_bag_with_labeled_images({"1-IMG1": "Mild"})
+    with pytest.raises(DerivaMLException, match=r"sample_loader"):
+        build_torch_dataset(bag, "Image", targets=["Grade"])
+```
+
+- [ ] **Step 3: Write the e2e test placeholder**
+
+Create `tests/dataset/test_torch_adapter_e2e.py`:
+
+```python
+"""End-to-end torch adapter test using a real bag fixture.
+
+Gated on torch being importable. Uses catalog_with_datasets fixture
+to build a real bag, then iterates under a real DataLoader.
+"""
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+from torch.utils.data import DataLoader  # noqa: E402
+
+
+def test_bag_to_dataloader_yields_tensors(catalog_with_datasets, tmp_path):
+    ml, dataset_desc = catalog_with_datasets
+    bag = dataset_desc.dataset.download_dataset_bag(version="1.0.0")
+
+    ds = bag.as_torch_dataset(
+        element_type="Image",
+        sample_loader=lambda p, row: torch.tensor([1.0, 2.0, 3.0]),
+        targets=None,  # unlabeled — just exercise the plumbing
+    )
+    loader = DataLoader(ds, batch_size=2, shuffle=False)
+    batches = list(loader)
+    assert len(batches) > 0
+    assert batches[0].shape[0] <= 2
+```
+
+- [ ] **Step 4: Run tests to verify they fail**
+
+Run: `DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/dataset/test_torch_adapter_*.py -v`
+Expected: all fail with ImportError/ModuleNotFoundError for `deriva_ml.dataset.torch_adapter`.
+
+- [ ] **Step 5: Write the torch adapter module**
+
+Create `src/deriva_ml/dataset/torch_adapter.py`:
+
+```python
+"""PyTorch adapter for DatasetBag.
+
+Builds a ``torch.utils.data.Dataset`` that lazy-loads samples and labels
+from an already-downloaded ``DatasetBag``. Torch is imported at builder
+entry (lazy import) so the base library stays importable without torch.
+
+See design spec §§3.1-3.7 for the full contract.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Callable, Literal
+
+from deriva_ml.core.exceptions import DerivaMLException
+from deriva_ml.dataset.target_resolution import _resolve_targets
+
+if TYPE_CHECKING:
+    import torch.utils.data
+    from deriva_ml.dataset.dataset_bag import DatasetBag
+    from deriva_ml.feature import FeatureRecord
+
+    FeatureSelector = Callable[[list["FeatureRecord"]], "FeatureRecord | None"]
+
+
+_TORCH_INSTALL_HINT = (
+    "PyTorch is not installed. Install with:\n"
+    "    pip install 'deriva-ml[torch]'\n"
+    "or install torch directly:\n"
+    "    pip install 'torch>=2.0'"
+)
+
+
+def build_torch_dataset(
+    bag: "DatasetBag",
+    element_type: str,
+    *,
+    sample_loader: "Callable[[Path, dict[str, Any]], Any] | None" = None,
+    transform: "Callable[[Any], Any] | None" = None,
+    targets: "list[str] | dict[str, FeatureSelector] | None" = None,
+    target_transform: "Callable[..., Any] | None" = None,
+    missing: Literal["error", "skip", "unknown"] = "error",
+) -> "torch.utils.data.Dataset":
+    """Build a torch.utils.data.Dataset from a DatasetBag.
+
+    See DatasetBag.as_torch_dataset docstring for full argument docs
+    and spec §3 for the design contract.
+    """
+    try:
+        import torch.utils.data as _torch_data
+    except ImportError as e:
+        raise ImportError(_TORCH_INSTALL_HINT) from e
+
+    # Validate element_type exists in the bag.
+    members_by_type = bag.list_dataset_members(recurse=True)
+    if element_type not in members_by_type:
+        raise DerivaMLException(
+            f"Element type {element_type!r} not found in bag; available "
+            f"types: {sorted(members_by_type.keys())}"
+        )
+
+    # Validate sample_loader is provided for asset-table element types.
+    is_asset = _bag_element_is_asset(bag, element_type)
+    if is_asset and sample_loader is None:
+        raise DerivaMLException(
+            f"Element type {element_type!r} is an asset table and requires "
+            f"a sample_loader. Common loaders:\n"
+            f"    sample_loader=PIL.Image.open       # images\n"
+            f"    sample_loader=nibabel.load         # NIfTI medical volumes\n"
+            f"    sample_loader=h5py.File            # HDF5 arrays\n"
+            f"Or pass sample_loader=lambda path, row: path.read_bytes() "
+            f"if you want raw bytes."
+        )
+
+    # Resolve targets once at construction time.
+    target_map = _resolve_targets(
+        bag, element_type, targets=targets, missing=missing
+    )
+
+    # Build the RID list — all elements if targets=None, only labeled
+    # elements if targets is set.
+    all_rids = [m["RID"] for m in members_by_type[element_type]]
+    if targets is None:
+        rids = all_rids
+    elif missing == "skip":
+        rids = [rid for rid in all_rids if rid in target_map]
+    else:
+        rids = all_rids  # "error" already raised if incomplete; "unknown"
+                         # keeps all RIDs with None target for absent ones
+
+    # Build the row lookup so sample_loader gets the full row dict.
+    row_lookup = _build_row_lookup(bag, element_type)
+
+    class _TorchDataset(_torch_data.Dataset):
+        def __init__(self):
+            self._rids = rids
+            self._target_map = target_map
+            self._is_asset = is_asset
+
+        def __len__(self):
+            return len(self._rids)
+
+        def __getitem__(self, index):
+            rid = self._rids[index]
+            row = row_lookup.get(rid, {"RID": rid})
+
+            if self._is_asset:
+                path = _resolve_asset_path(bag, element_type, rid, row)
+                sample = sample_loader(path, row)
+            else:
+                sample = (
+                    sample_loader(None, row)
+                    if sample_loader is not None
+                    else row
+                )
+
+            if transform is not None:
+                sample = transform(sample)
+
+            if targets is None:
+                return sample
+
+            target = self._target_map.get(rid)
+            if target_transform is not None:
+                target = target_transform(target)
+            return sample, target
+
+    return _TorchDataset()
+
+
+def _bag_element_is_asset(bag: "DatasetBag", element_type: str) -> bool:
+    """Return True if element_type is an asset table in the bag."""
+    try:
+        return bag.is_asset(element_type)
+    except AttributeError:
+        # Fall back to model-level check for bags that don't expose
+        # is_asset directly.
+        return bool(getattr(bag.model, "is_asset", lambda _: False)(element_type))
+
+
+def _build_row_lookup(bag: "DatasetBag", element_type: str) -> dict:
+    """Build {RID: row_dict} lookup for the element table."""
+    return {row["RID"]: row for row in bag.get_table_as_dict(element_type)}
+
+
+def _resolve_asset_path(bag, element_type: str, rid: str, row: dict) -> Path:
+    """Compute the on-disk path for an asset's file."""
+    filename = row.get("Filename") or f"{rid}.bin"
+    return bag.path / "data" / "assets" / element_type / rid / filename
+```
+
+- [ ] **Step 6: Add the DatasetBag method**
+
+Find the class body of `DatasetBag` in `src/deriva_ml/dataset/dataset_bag.py` (around line 1445 where `restructure_assets` lives) and add before `restructure_assets`:
+
+```python
+    def as_torch_dataset(
+        self,
+        element_type: str,
+        *,
+        sample_loader: Callable[[Path, dict[str, Any]], Any] | None = None,
+        transform: Callable[[Any], Any] | None = None,
+        targets: list[str] | dict[str, Any] | None = None,
+        target_transform: Callable[..., Any] | None = None,
+        missing: Literal["error", "skip", "unknown"] = "error",
+    ) -> "torch.utils.data.Dataset":
+        """Build a torch.utils.data.Dataset from this bag.
+
+        [... full docstring per spec §3 ...]
+        """
+        from deriva_ml.dataset.torch_adapter import build_torch_dataset
+        return build_torch_dataset(
+            self,
+            element_type,
+            sample_loader=sample_loader,
+            transform=transform,
+            targets=targets,
+            target_transform=target_transform,
+            missing=missing,
+        )
+```
+
+The docstring should be the full version per spec §3.1-3.6: one-line summary, extended description, Args (one paragraph per argument, matching §3.2), Returns, Raises, Example with `# doctest: +SKIP` on catalog-dependent lines.
+
+- [ ] **Step 7: Run all torch adapter tests**
+
+Run: `DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/dataset/test_torch_adapter_no_torch.py tests/dataset/test_torch_adapter_logic.py -v`
+Expected: all tests PASS. The e2e test needs a live catalog so runs separately.
+
+- [ ] **Step 8: Run fast suite**
+
+Run: `DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/local_db/ tests/asset/ tests/model/ tests/dataset/test_torch_adapter_no_torch.py tests/dataset/test_torch_adapter_logic.py tests/dataset/test_target_resolution.py -q`
+Expected: 500+ passed, 3 skipped, 0 failed.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/deriva_ml/dataset/torch_adapter.py src/deriva_ml/dataset/dataset_bag.py tests/dataset/test_torch_adapter_*.py
+git commit -m "feat(dataset): add DatasetBag.as_torch_dataset adapter
+
+Post-S2 D2 Task 3. Ships the PyTorch adapter per design spec §3.
+
+New module torch_adapter.py builds a torch.utils.data.Dataset from
+a DatasetBag, delegating to the shared _resolve_targets helper for
+label resolution. Torch is imported lazily inside the builder so
+the base library stays importable without torch (anchor 3).
+
+DatasetBag.as_torch_dataset is the public entry point; it delegates
+to build_torch_dataset. Signature mirrors spec §3.1 exactly.
+
+Three test tiers per spec §6:
+- test_torch_adapter_no_torch.py — library still imports when torch
+  is absent; calling adapter raises clean ImportError with hint.
+- test_torch_adapter_logic.py — join logic, missing= branches,
+  target arity, error paths (gated on torch installable).
+- test_torch_adapter_e2e.py — real bag fixture + real DataLoader
+  (gated on live catalog).
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: TensorFlow adapter
+
+**Files:**
+- Create: `src/deriva_ml/dataset/tf_adapter.py`
+- Modify: `src/deriva_ml/dataset/dataset_bag.py` (add `as_tf_dataset` method)
+- Test: `tests/dataset/test_tf_adapter_no_tf.py`
+- Test: `tests/dataset/test_tf_adapter_logic.py`
+- Test: `tests/dataset/test_tf_adapter_e2e.py`
+
+Mirrors Task 3's structure for TensorFlow. Ships `DatasetBag.as_tf_dataset(...)` returning a `tf.data.Dataset`, with `output_signature` inferred from the first sample when `None`.
+
+- [ ] **Step 1: Write the no-tf import-guard test**
+
+Create `tests/dataset/test_tf_adapter_no_tf.py` mirroring `test_torch_adapter_no_torch.py` exactly, substituting `tensorflow` / `tf` for torch. Verify:
+- Importing `DatasetBag` without tensorflow still works.
+- Calling `build_tf_dataset(bag, ...)` raises `ImportError` with install hint `'deriva-ml[tf]'`.
+
+Code shape: same monkeypatch pattern as Task 3 Step 1, substitute `"tensorflow"` wherever `"torch"` appears.
+
+- [ ] **Step 2: Write the logic test (tf stubbed)**
+
+Create `tests/dataset/test_tf_adapter_logic.py` mirroring the torch logic test but verifying `tf.data.Dataset` shape:
+
+```python
+import pytest
+tf = pytest.importorskip("tensorflow")
+
+from deriva_ml.dataset.tf_adapter import build_tf_dataset  # noqa: E402
+
+
+def test_as_tf_dataset_returns_tf_data_dataset():
+    bag = _mock_bag(...)
+    ds = build_tf_dataset(
+        bag, "Image",
+        sample_loader=lambda p, row: tf.constant([1.0, 2.0]),
+        targets=["Grade"],
+    )
+    assert isinstance(ds, tf.data.Dataset)
+
+
+def test_output_signature_inferred_from_first_sample():
+    """output_signature=None triggers first-sample inference."""
+    bag = _mock_bag(...)
+    ds = build_tf_dataset(
+        bag, "Image",
+        sample_loader=lambda p, row: tf.constant([1.0, 2.0, 3.0]),
+        targets=["Grade"],
+        target_transform=lambda rec: 0,
+        output_signature=None,  # explicit default
+    )
+    # element_spec should reflect the inferred shape
+    spec = ds.element_spec
+    assert isinstance(spec, tuple)
+    assert spec[0].shape[-1] == 3
+```
+
+Full test matrix from spec §6.2 applies: all three `missing=` branches, target arity, asset-table-without-loader error, selector dict pass-through.
+
+- [ ] **Step 3: Write the e2e test placeholder**
+
+Create `tests/dataset/test_tf_adapter_e2e.py` — real bag fixture + real `tf.data.Dataset.batch(...).prefetch(...)` iteration. Gated on `pytest.importorskip("tensorflow")` and the `catalog_with_datasets` fixture.
+
+- [ ] **Step 4: Run tests to verify they fail**
+
+Run: `DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/dataset/test_tf_adapter_*.py -v`
+Expected: fails with ModuleNotFoundError for `deriva_ml.dataset.tf_adapter`.
+
+- [ ] **Step 5: Write the tf adapter module**
+
+Create `src/deriva_ml/dataset/tf_adapter.py`:
+
+```python
+"""TensorFlow adapter for DatasetBag.
+
+Builds a ``tf.data.Dataset`` via ``tf.data.Dataset.from_generator`` that
+lazy-loads samples and labels from an already-downloaded ``DatasetBag``.
+Tensorflow is imported at builder entry (lazy import) so the base
+library stays importable without tensorflow.
+
+See design spec §§3.1-3.7 for the full contract. ``output_signature``
+is inferred from the first sample when None (spec §3.2).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Callable, Literal
+
+from deriva_ml.core.exceptions import DerivaMLException
+from deriva_ml.dataset.target_resolution import _resolve_targets
+
+if TYPE_CHECKING:
+    import tensorflow as tf
+    from deriva_ml.dataset.dataset_bag import DatasetBag
+    from deriva_ml.feature import FeatureRecord
+
+    FeatureSelector = Callable[[list["FeatureRecord"]], "FeatureRecord | None"]
+
+
+_TF_INSTALL_HINT = (
+    "TensorFlow is not installed. Install with:\n"
+    "    pip install 'deriva-ml[tf]'\n"
+    "or install tensorflow directly:\n"
+    "    pip install 'tensorflow>=2.15'\n"
+    "macOS: use 'tensorflow-macos' instead of 'tensorflow'.\n"
+    "CUDA:  use 'tensorflow[and-cuda]' for GPU support."
+)
+
+
+def build_tf_dataset(
+    bag: "DatasetBag",
+    element_type: str,
+    *,
+    sample_loader: "Callable[[Path, dict[str, Any]], Any] | None" = None,
+    transform: "Callable[[Any], Any] | None" = None,
+    targets: "list[str] | dict[str, FeatureSelector] | None" = None,
+    target_transform: "Callable[..., Any] | None" = None,
+    missing: Literal["error", "skip", "unknown"] = "error",
+    output_signature: "tf.TensorSpec | tuple[tf.TensorSpec, ...] | None" = None,
+) -> "tf.data.Dataset":
+    """Build a tf.data.Dataset from a DatasetBag.
+
+    See DatasetBag.as_tf_dataset docstring for full argument docs.
+    """
+    try:
+        import tensorflow as tf  # noqa: F401
+    except ImportError as e:
+        raise ImportError(_TF_INSTALL_HINT) from e
+
+    # [Same validation + resolution logic as torch adapter, factored
+    #  out where possible. Wraps the iteration in tf.data.Dataset.from_generator
+    #  with either user-supplied or first-sample-inferred output_signature.]
+    # [Full implementation writes a Python generator, wraps it, handles
+    #  the one-extra-eager-sample path for inference.]
+```
+
+Implementation mirrors `torch_adapter.py` in structure: same validation (element_type exists, asset-table-requires-loader), same delegation to `_resolve_targets`, same RID-list construction per `missing=` policy. Differences:
+
+1. Build a Python generator `def _gen(): for rid in rids: yield (sample, target)` instead of a `Dataset` subclass.
+2. If `output_signature is None`, call `_gen()` once to get the first sample, use `tf.type_spec_from_value` to infer, then re-wrap the generator so the first sample isn't lost.
+3. Return `tf.data.Dataset.from_generator(_gen, output_signature=...)`.
+
+- [ ] **Step 6: Add the DatasetBag method**
+
+Add `as_tf_dataset` method to `DatasetBag` class body, next to `as_torch_dataset`. Same shape as Task 3 Step 6 but delegates to `build_tf_dataset` and includes the `output_signature` parameter.
+
+- [ ] **Step 7: Run all tf adapter tests**
+
+Run: `DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/dataset/test_tf_adapter_no_tf.py tests/dataset/test_tf_adapter_logic.py -v`
+Expected: all pass.
+
+- [ ] **Step 8: Run fast suite**
+
+Run: `DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/local_db/ tests/asset/ tests/model/ tests/dataset/test_torch_adapter_*.py tests/dataset/test_tf_adapter_*.py tests/dataset/test_target_resolution.py -q`
+Expected: 503+ passed, 3 skipped, 0 failed.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/deriva_ml/dataset/tf_adapter.py src/deriva_ml/dataset/dataset_bag.py tests/dataset/test_tf_adapter_*.py
+git commit -m "feat(dataset): add DatasetBag.as_tf_dataset adapter
+
+Post-S2 D2 Task 4. Ships the TensorFlow adapter per design spec §3,
+mirroring the PyTorch adapter's shape for the six shared parameters
+and adding output_signature for TF-specific TensorSpec configuration.
+
+output_signature=None (default) triggers first-sample inference at
+construction time; the generator is re-wrapped so the eagerly-consumed
+first sample is not lost. Users who want deterministic startup pass
+output_signature explicitly.
+
+Test structure parallels the torch adapter: no-tf / logic-stubbed /
+e2e. All three gated appropriately.
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Restructure alignment (clean break)
+
+**Files:**
+- Modify: `src/deriva_ml/dataset/dataset_bag.py` (rewrite `restructure_assets` signature + body)
+- Test: update or add tests in `tests/dataset/` covering the new signature
+
+Rewrite `restructure_assets` to accept the aligned vocabulary (`targets`, `target_transform`, `missing`) instead of `group_by`/`value_selector`/`"Feature.column"` dotted syntax. Uses the shared `_resolve_targets` helper from Task 1.
+
+- [ ] **Step 1: Grep sibling repos for callers of deprecated kwargs**
+
+Run:
+```bash
+for d in ~/GitHub/deriva-ml-model-template ~/GitHub/deriva-ml-apps ~/GitHub/deriva-ml-demo ~/GitHub/deriva-ml-template-test; do
+  echo "=== $d ==="
+  [ -d "$d" ] && grep -rn "group_by=\|value_selector=\|restructure_assets" "$d" --include="*.py" 2>/dev/null | head -10
+done
+```
+
+Record the results — these go into the PR description's "Breaking changes" section so template maintainers can update in lockstep.
+
+- [ ] **Step 2: Update existing tests first (they need to pass with the new signature)**
+
+`grep -rn "group_by\|value_selector" tests/` — enumerate callers. For each test that uses old kwargs, rewrite to the new form:
+- `group_by=["Feature"]` → `targets=["Feature"]`
+- `group_by=["Feature.Col"]` → `targets=["Feature"], target_transform=lambda rec: rec.Col`
+- `value_selector=FeatureRecord.select_newest` → `targets={"Feature": FeatureRecord.select_newest}`
+
+Commit these test updates at the end of the task (with the impl), not separately — keeps the repo in a buildable state only after both sides land.
+
+- [ ] **Step 3: Rewrite `restructure_assets` in `dataset_bag.py`**
+
+Replace the current signature and body. The new signature per spec §3.1 + §8:
+
+```python
+def restructure_assets(
+    self,
+    output_dir: Path | str,
+    *,
+    asset_table: str | None = None,
+    targets: list[str] | dict[str, FeatureSelector] | None = None,
+    target_transform: Callable[..., str] | None = None,
+    missing: Literal["error", "skip", "unknown"] = "unknown",
+    use_symlinks: bool = True,
+    type_selector: Callable[[list[str]], str] | None = None,
+    type_to_dir_map: dict[str, str] | None = None,
+    enforce_vocabulary: bool = True,
+    file_transformer: Callable[[Path, Path], Path] | None = None,
+) -> dict[Path, Path]:
+    """[... full docstring per spec §8 ...]"""
+```
+
+Body:
+1. Validate `asset_table` (auto-detect from members if None; unchanged from today).
+2. Call `_resolve_targets(self, asset_table, targets=targets, missing=missing)` to get the `{rid: FeatureRecord}` map.
+3. For each RID, derive the directory name: if `target_transform` is provided, call it (and validate string return); else use the FeatureRecord's primary value (tricky — spec §3.7.2 says target_transform is required when targets is a multi-column feature because the direct FeatureRecord isn't a string; document this and enforce).
+4. Place file in `{output_dir}/{type_dir}/{target_dir}/{filename}` per existing FK-reachability logic.
+5. Apply missing policy: for `missing="unknown"` put into `unknown/`; for `missing="skip"` omit entirely.
+6. Keep all existing behavior for `type_selector`, `type_to_dir_map`, `enforce_vocabulary`, `file_transformer` — they don't change.
+7. Raise `TypeError` if user passes `group_by=` or `value_selector=` (use the `@validate_call` decorator or explicit check; the stdlib behavior of rejecting unknown kwargs is also acceptable).
+
+- [ ] **Step 4: Verify old-kwarg rejection**
+
+Manually test:
+```python
+bag.restructure_assets(output_dir="/tmp", group_by=["Diagnosis"])
+# Expected: TypeError: restructure_assets() got an unexpected keyword argument 'group_by'
+```
+
+- [ ] **Step 5: Add migration-note paragraph to the docstring**
+
+Per spec §8.7, the docstring gets a short Migration note at the bottom:
+
+```python
+    """[... main docstring ...]
+
+    Migration note (from pre-D2 signature):
+        - group_by=["Diagnosis"] → targets=["Diagnosis"]
+        - group_by=["Classification.Label"] → targets=["Classification"],
+          target_transform=lambda rec: rec.Label
+        - value_selector=FeatureRecord.select_newest →
+          targets={"Feature": FeatureRecord.select_newest}
+    """
+```
+
+- [ ] **Step 6: Run fast suite**
+
+Run: `DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/local_db/ tests/asset/ tests/model/ tests/dataset/ -q`
+Expected: all pass. Any test using old kwargs should have been updated in Step 2.
+
+- [ ] **Step 7: Run full dataset suite (live catalog) — time permitting**
+
+Run: `DERIVA_ML_ALLOW_DIRTY=true DERIVA_HOST=localhost uv run pytest tests/dataset/ --timeout=600`
+Expected: 64+ passed. Focuses on the restructure integration tests.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/deriva_ml/dataset/dataset_bag.py tests/dataset/
+git commit -m "refactor(dataset): align restructure_assets vocab with adapters
+
+Post-S2 D2 Task 5. restructure_assets now uses the same
+target-specification vocabulary (targets, target_transform, missing)
+as as_torch_dataset and as_tf_dataset, delegating feature resolution
+to the shared _resolve_targets helper.
+
+Signature changes (clean break — see spec §8):
+  - group_by → targets
+  - value_selector → merged into targets dict form
+  - \"Feature.column\" dotted syntax → use target_transform
+  - Added missing: Literal[\"error\", \"skip\", \"unknown\"] = \"unknown\"
+
+All other parameters (output_dir, asset_table, use_symlinks,
+type_selector, type_to_dir_map, enforce_vocabulary, file_transformer)
+unchanged. FK-reachability and type-derived directory naming
+unchanged. The default missing=\"unknown\" preserves today's behavior
+for unparameterized calls.
+
+Existing tests using old kwargs are updated to the new signature in
+the same commit. Passing old kwargs after this PR raises TypeError
+(standard Python behavior for removed kwargs).
+
+Migration note in the docstring guides users who hit a TypeError.
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: User guide section
+
+**Files:**
+- Modify: `docs/user-guide/offline.md` (add "How to feed a bag to a training framework" section per spec §7.2)
+
+Write the UG section with the decision tree + three per-framework sub-subsections + Keras routing + ImageFolder pointer.
+
+- [ ] **Step 1: Locate insertion point in offline.md**
+
+The new section goes after the existing `restructure_assets` content and before the section on working with bags in notebooks (exact location TBD from current offline.md structure).
+
+- [ ] **Step 2: Write the new UG section**
+
+Follows spec §7.2 exactly. Structure:
+
+1. **Motivation** (2 sentences).
+2. **Choosing your path** (decision paragraph).
+3. **7.2.1 Using with PyTorch** — simple image-classification example, worked variations (tabular regression, multi-target, multi-annotator selector), notes pointer to `deriva-ml[torch]`.
+4. **7.2.2 Using with TensorFlow** — simple example + output_signature guidance + same three worked variations, notes pointer to `deriva-ml[tf]` and platform wheels.
+5. **7.2.3 Using with Keras** — three-backend routing example.
+6. **7.2.4 Using with `ImageFolder` / third-party tools** — pointer to `restructure_assets`.
+7. **7.2.5 See also** — cross-references.
+
+Each code example should be ~10-20 lines. Use `# doctest: +SKIP` consistently for catalog-dependent examples; mkdocs-jupyter doesn't execute them but the markup should be valid.
+
+- [ ] **Step 3: Run mkdocs --strict**
+
+Run: `uv run mkdocs build --strict 2>&1 | tail -20`
+Expected: either 27 warnings (same as baseline) or fewer. No new griffe warnings from the new section.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/user-guide/offline.md
+git commit -m "docs(user-guide): add 'How to feed a bag to a training framework' section
+
+Post-S2 D2 Task 6. New UG section in Chapter 5 (offline.md) covering
+PyTorch, TensorFlow, Keras (all three backends), and third-party
+ImageFolder-style layout.
+
+Structure follows the UG contract per spec §7.2:
+- Motivation + decision-tree paragraph at the top
+- Per-framework sub-sections with worked examples
+- Keras routing via either adapter based on backend choice
+- Pointer to restructure_assets for class-folder workflows
+
+mkdocs --strict: 27 warnings (unchanged from baseline).
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Cross-reference sweep
+
+**Files:**
+- Modify: various docstrings and related files
+
+Small edits per spec §7.3: docstring cross-references between the adapters, `restructure_assets`, `split_dataset`, and the `DatasetBag` class-level docstring.
+
+- [ ] **Step 1: Update `DatasetBag` class docstring**
+
+Add one bullet mentioning the adapters alongside the existing `restructure_assets()` mention. Keep to one sentence per bullet; link by method name only (mkdocstrings generates the cross-link).
+
+- [ ] **Step 2: Update `split_dataset` docstring**
+
+Add one sentence in the "Examples" or "See Also" section pointing at the adapter composition pattern (spec §7.4.1).
+
+- [ ] **Step 3: Update `restructure_assets` docstring**
+
+Add one sentence (separate from the Migration note) pointing at `as_torch_dataset`/`as_tf_dataset` as the general-case adapter when a directory tree isn't needed.
+
+- [ ] **Step 4: Update CLAUDE.md**
+
+The section on `DatasetBag` in the project-level `CLAUDE.md` gets a one-sentence mention of the adapters for future agentic work.
+
+- [ ] **Step 5: Run mkdocs --strict**
+
+Expected: warnings unchanged.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/deriva_ml/dataset/ CLAUDE.md
+git commit -m "docs: cross-reference sweep for D2 adapters
+
+Post-S2 D2 Task 7. Small edits to related docstrings:
+- DatasetBag class-level docstring mentions the two adapters
+- split_dataset docstring points at the composition pattern
+- restructure_assets docstring points at the adapters for
+  non-class-folder workflows
+- CLAUDE.md DatasetBag section gets the adapter mention
+
+No code changes.
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: Final verification
+
+**Files:** none modified — verification only.
+
+- [ ] **Step 1: Run fast unit tests**
+
+Run: `DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/local_db/ tests/asset/ tests/model/ tests/dataset/test_target_resolution.py tests/dataset/test_torch_adapter_no_torch.py tests/dataset/test_torch_adapter_logic.py tests/dataset/test_tf_adapter_no_tf.py tests/dataset/test_tf_adapter_logic.py -q`
+Expected: 505+ passed, 3 skipped, 0 failed.
+
+- [ ] **Step 2: Run e2e tests (if live catalog available)**
+
+Run: `DERIVA_ML_ALLOW_DIRTY=true DERIVA_HOST=localhost uv run pytest tests/dataset/test_torch_adapter_e2e.py tests/dataset/test_tf_adapter_e2e.py -v`
+Expected: 2+ passed. Verifies end-to-end against a real bag.
+
+- [ ] **Step 3: mkdocs --strict**
+
+Run: `uv run mkdocs build --strict 2>&1 | grep -cE "WARNING|Aborted"`
+Expected: `27` (unchanged from main baseline).
+
+- [ ] **Step 4: ruff check + format**
+
+Run: `uv run ruff check src/deriva_ml/dataset/ && uv run ruff format --check src/deriva_ml/dataset/`
+Expected: clean on the new files (any format issues should have been caught during commits, but belt-and-suspenders).
+
+- [ ] **Step 5: Sibling-repo grep for removed kwargs**
+
+Re-run the grep from Task 5 Step 1 and record results in the PR description under "Breaking changes" so template maintainers see the migration guide.
+
+- [ ] **Step 6: Finish the branch**
+
+Invoke `superpowers:finishing-a-development-branch` and present the four options (merge / PR / keep / discard). The branch has ~9 commits (including the 7 spec commits + task commits). Recommended: Option 2 (push + create PR) given the PR size and the need for review on the clean-break restructure rename.
+
+---
+
+## Summary checklist
+
+| Task | Files touched | Status |
+|---|---|---|
+| 1 | `target_resolution.py`, `test_target_resolution.py` | pending |
+| 2 | `pyproject.toml` | pending |
+| 3 | `torch_adapter.py`, `dataset_bag.py`, 3 test files | pending |
+| 4 | `tf_adapter.py`, `dataset_bag.py`, 3 test files | pending |
+| 5 | `dataset_bag.py` (restructure rewrite), existing test updates | pending |
+| 6 | `offline.md` UG section | pending |
+| 7 | Various docstrings + `CLAUDE.md` | pending |
+| 8 | Verification only | pending |

--- a/docs/superpowers/plans/2026-04-24-torch-dataset-adapter-plan.md
+++ b/docs/superpowers/plans/2026-04-24-torch-dataset-adapter-plan.md
@@ -1280,6 +1280,203 @@ Invoke `superpowers:finishing-a-development-branch` and present the four options
 
 ---
 
+## Task 9: Migration guide
+
+**Files:**
+- Create: `docs/user-guide/migration-from-previous-version.md` (or similar name — see Step 1)
+- Modify: `mkdocs.yml` to include the new page in the nav
+- Modify: `docs/index.md` — add a pointer to the migration guide
+
+Write a user-facing migration guide covering all breaking changes and notable additions shipped to deriva-ml across the post-S2 documentation pass (PR #65 UG rewrite, PR #66 docstring sweep with 12 renames, PR #67 DRY cleanup, PR #68 metrics_file, and this D2 PR). Users upgrading from the previously-published version need a single place that says "here's what changes, here's how to update your code."
+
+### Why this belongs in D2 specifically
+
+The biggest breaking change in the set is **D2's `restructure_assets` signature rename** (`group_by=` → `targets=`, `value_selector=` merged, `"Feature.column"` removed). That's a `TypeError`-on-call for any downstream caller. PRs #66 and #67 had smaller renames (the 12 `_`-prefixed private renames were API cleanup that affected code calling the old public names). The migration guide lands in D2's PR so users pulling the new version find the guide in the same release that breaks them.
+
+- [ ] **Step 1: Decide the file path and naming**
+
+The migration guide should live somewhere discoverable. Three options:
+
+- `docs/user-guide/migration.md` — alongside the other UG chapters. Most discoverable.
+- `docs/migration.md` — top-level, separate from the UG structure. Good if users think of "migration" as a one-time reference not part of the regular UG.
+- `docs/reference/migration.md` — under the reference section. Good if it's more reference material than tutorial.
+
+Lean: `docs/user-guide/migration.md` — users will find it while browsing the UG, and the tone is more "walk me through changing my code" than reference-material lookup.
+
+- [ ] **Step 2: Enumerate every breaking change**
+
+The guide covers:
+
+**A. Breaking changes — `TypeError` or `AttributeError` on call:**
+
+1. **`DatasetBag.restructure_assets` signature rename** (D2):
+   - `group_by=["Diagnosis"]` → `targets=["Diagnosis"]`
+   - `group_by=["Classification.Label"]` → `targets=["Classification"], target_transform=lambda rec: rec.Label`
+   - `value_selector=FeatureRecord.select_newest` → `targets={"Feature": FeatureRecord.select_newest}`
+   - Dotted `"Feature.column"` syntax removed entirely.
+2. **Public methods renamed to `_`-prefixed private** (PR #66 — 12 renames):
+   - `ml.domain_path()` → `ml._domain_path()` (and similar for `table_path`, `is_system_schema`, `get_domain_schemas`, `apply_logger_overrides`, `compute_diff`, `retrieve_rid`, `cache_features`, `add_workflow`, `start_upload`, `asset_record_class` module-level factory)
+   - These were all internal helpers that shouldn't have been public; users calling them were depending on accidental API surface. The underscored versions still work.
+   - User-facing alternatives:
+     - `retrieve_rid` → use `resolve_rid()` instead (user-facing wrapper)
+     - `asset_record_class` — the mixin method `ml.asset_record_class(table)` is still public; only the module-level factory is private.
+     - `add_workflow` → use `create_workflow()` (user-facing factory)
+3. **Methods deleted** (PR #66):
+   - `prefetch_dataset` — was a deprecated one-line shim; use `cache_dataset` directly.
+   - `list_foreign_keys` — no callers, no replacement needed.
+   - `add_page`, `user_list`, `globus_login` — removed from `DerivaML`; these were stale web-app helpers that never had users.
+4. **Documentation-only fix that may affect copy-pasted user code**:
+   - `AssetRIDConfig` (doc name) → `AssetSpec` / `AssetSpecConfig` (real class names). Users who copied example code from the old configuration docs hit an `ImportError`.
+
+**B. New features — additive, no break, but worth flagging:**
+
+1. **`Execution.metrics_file(filename="metrics.jsonl")`** (PR #68) — recommended over manually calling `asset_file_path(MLAsset.execution_metadata, ...)` for training metrics.
+2. **`DatasetBag.as_torch_dataset(...)` and `DatasetBag.as_tf_dataset(...)`** (D2) — recommended over hand-rolling `torch.utils.data.Dataset` subclasses.
+3. **State-machine recovery edge** (PR A) — `Running → Pending_Upload` is now a legal transition. Users doing manual crash-recovery should use `update_status(Pending_Upload)` instead of `update_status(Failed)` (the old workaround).
+
+**C. Environment / tooling changes:**
+
+1. **Python 3.12+ required** (no change — already the floor, but worth stating).
+2. **Optional `deriva-ml[torch]` / `deriva-ml[tf]` extras** (D2) — new install-time choices.
+3. **Dropped `SETUPTOOLS_USE_DISTUTILS` env var** (PR #68 side-effect) — internal fix, no user action needed; documented because users with custom setups may notice the env var no longer gets set process-wide.
+
+- [ ] **Step 3: Draft the migration guide**
+
+Structure the guide as:
+
+```markdown
+# Migrating from previous deriva-ml versions
+
+[one-paragraph intro: "if you're upgrading from X.Y.Z or earlier, here's
+what changes"]
+
+## At a glance
+
+[single summary table: category | old | new | fix]
+
+## Breaking changes
+
+### DatasetBag.restructure_assets signature changes
+[before/after code blocks, one per rename. Include the migration mapping
+from this plan's Task 5.]
+
+### Renamed private methods
+[table of 12 renames + one paragraph per user-facing alternative where
+the rename hides a better public API (resolve_rid, create_workflow)]
+
+### Deleted methods
+[list + replacements]
+
+### Asset specification classes (documentation-only break)
+[AssetRIDConfig was never a real class; copy-paste victims land here]
+
+## New recommended patterns
+
+### Training metrics
+[metrics_file() vs manual asset_file_path]
+
+### PyTorch / TensorFlow / Keras training
+[pointer to the three-framework UG section]
+
+### Crash recovery
+[update_status(Pending_Upload) pattern]
+
+## Finding affected code in your project
+
+[grep recipes for each break:]
+```bash
+# Find restructure_assets old-kwarg callers:
+grep -rn "group_by=\|value_selector=\|restructure_assets.*\"[A-Za-z_]*\.[A-Za-z_]*\"" your_project/
+
+# Find renamed-private callers:
+grep -rn -E "\b(domain_path|table_path|is_system_schema|get_domain_schemas|apply_logger_overrides|compute_diff|retrieve_rid|cache_features|add_workflow|start_upload)\(" your_project/ \
+  | grep -v "_\(domain_path\|table_path\|..." # exclude already-underscored
+
+# Find deleted-method callers:
+grep -rn -E "\.(prefetch_dataset|list_foreign_keys|add_page|user_list|globus_login)\(" your_project/
+```
+
+## Version compatibility matrix
+
+| deriva-ml version | Python | Torch | TF | Notes |
+|---|---|---|---|---|
+| prior published | ≥3.12 | n/a | n/a | [current baseline] |
+| this release | ≥3.12 | ≥2.0 optional | ≥2.15 optional | [what this doc covers] |
+
+## Support
+
+[if users hit a break not documented here, pointer to raising an issue]
+```
+
+Keep it around 400-600 lines; detailed enough to answer "what do I change in my code" but not a rehash of the UG.
+
+- [ ] **Step 4: Update `mkdocs.yml` nav**
+
+Add the migration guide to the User Guide section of the nav, probably at the end (not between chapters):
+
+```yaml
+nav:
+  - Introduction: index.md
+  - User Guide:
+      - Exploring a catalog: user-guide/exploring.md
+      - Working with datasets: user-guide/datasets.md
+      - ... [other chapters] ...
+      - Integrating with hydra-zen: user-guide/hydra-zen.md
+      - Migrating from previous versions: user-guide/migration.md    # new
+  # ... rest unchanged ...
+```
+
+- [ ] **Step 5: Add pointer from Introduction**
+
+`docs/index.md` gets one sentence near the top (or in a "What's new" section if one exists) pointing users coming from older versions at the migration guide. Don't make it prominent — users upgrading need it; new users don't.
+
+- [ ] **Step 6: Grep sibling repos once more**
+
+Run the sibling-repo greps from Task 5 Step 1 and Task 8 Step 5 one more time. This time record the raw output in the migration-guide's "Finding affected code in your project" section as worked examples — real call sites from real deriva-ml-ecosystem projects.
+
+If the sibling repos aren't present on this machine, skip this step and flag in the commit message that the example-output section is representative, not actual.
+
+- [ ] **Step 7: mkdocs --strict**
+
+Run: `uv run mkdocs build --strict 2>&1 | tail -20`
+Expected: no new warnings. Confirm the new page renders (it'll show up in `site/user-guide/migration/index.html` after build).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add docs/user-guide/migration.md mkdocs.yml docs/index.md
+git commit -m "docs(migration): add migration guide from previous deriva-ml version
+
+Post-S2 D2 Task 9. User-facing migration guide covering every
+breaking change and notable addition across the post-S2 documentation
+pass (PRs #65, #66, #67, #68, and this PR).
+
+Sections:
+- At-a-glance table summarizing each change
+- Breaking changes with before/after code:
+  - restructure_assets signature (group_by → targets, value_selector
+    merged, Feature.column dotted syntax removed)
+  - 12 renamed private methods + user-facing alternatives where applicable
+  - 5 deleted methods + replacements
+  - AssetRIDConfig doc-only break (class is actually AssetSpec/
+    AssetSpecConfig)
+- New recommended patterns:
+  - metrics_file() for training-metric logs (D1)
+  - as_torch_dataset / as_tf_dataset for framework integration (D2)
+  - update_status(Pending_Upload) for crash recovery (A)
+- Grep recipes for finding affected call sites
+- Version compatibility matrix
+
+The guide lands in D2's PR because D2 ships the single biggest
+break (restructure_assets kwarg rename — TypeError on call); users
+pulling the new release find the guide in the same release that
+breaks them.
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+```
+
+---
+
 ## Summary checklist
 
 | Task | Files touched | Status |
@@ -1292,3 +1489,4 @@ Invoke `superpowers:finishing-a-development-branch` and present the four options
 | 6 | `offline.md` UG section | pending |
 | 7 | Various docstrings + `CLAUDE.md` | pending |
 | 8 | Verification only | pending |
+| 9 | `migration.md`, `mkdocs.yml`, `index.md` | pending |

--- a/docs/superpowers/specs/2026-04-24-torch-dataset-adapter-design.md
+++ b/docs/superpowers/specs/2026-04-24-torch-dataset-adapter-design.md
@@ -89,8 +89,8 @@ re-solve:
 - **Filesystem-layout rewrites for third-party tools** (`ImageFolder`
   et al.) live in `restructure_assets`. This is an **alternative** to
   the adapter, not a pipeline step: the two tools solve the same
-  problem with different shapes (lazy in-place read vs. eager
-  on-disk rewrite). See §7.4.3 for why they don't chain.
+  problem with different output shapes (lazy in-place read vs.
+  eager on-disk rewrite). See §7.4.2 for why they don't chain.
 - **Catalog-level annotation joins** live in
   `bag.get_denormalized_as_dataframe` and `bag.feature_values`. The
   adapter reads feature values through the existing API (anchor 1),
@@ -100,6 +100,20 @@ The adapter's v1 job is exactly one thing: lazy iteration over an
 already-defined bag. It does not duplicate these neighboring tools,
 does not wrap them in competing convenience methods, and does not
 offer knobs that replicate theirs.
+
+**Anchor 7: Shared target-specification vocabulary across
+`as_torch_dataset` and `restructure_assets`.** Both methods answer
+the same question — "given a bag element, which feature value becomes
+the label?" — so their inputs describing that question use the same
+parameter names, types, and semantics. The divergence is output-only:
+one returns a torch `Dataset`; the other writes a directory tree.
+This is NOT composition (§7.4.2 explains why they don't chain), it is
+*vocabulary alignment*: users who learn one method's label-selection
+arguments can transfer that knowledge directly. Concretely, both
+methods share the same `targets`, `target_transform`, and `missing`
+parameters with matching semantics. Achieving this requires small
+non-breaking changes to `restructure_assets`'s signature, which ship
+in the same PR as the adapter — see §8 for the alignment scope.
 
 ## 3. Public API
 
@@ -254,6 +268,79 @@ is unavoidable: the filesystem can change between construction and
 access (asset file removed, bag directory renamed, etc.), and torch's
 own convention is to propagate `OSError` subclasses from dataset
 access. No library-level retry or fallback.
+
+### 3.7 Shared target-specification vocabulary
+
+Per anchor 7, `as_torch_dataset` and `restructure_assets` share the
+vocabulary for describing how to resolve feature values into labels.
+The same three parameters appear on both methods with identical names,
+types, and semantics:
+
+**`targets: list[str] | dict[str, FeatureSelector] | None`**
+
+Describes which features supply labels for a bag element.
+
+- `None` (adapter only; meaningless for restructure) — yields
+  unlabeled samples.
+- `list[str]` — list of feature names on `element_type` (or on
+  tables FK-reachable from it; see `restructure_assets`'s
+  "Finding assets through foreign key relationships" docstring).
+  Each feature resolves via `bag.feature_values(element_type, name)`
+  with no per-feature selector.
+- `dict[str, FeatureSelector]` — mapping from feature name to a
+  `Callable[[list[FeatureRecord]], FeatureRecord | None]` that
+  resolves multi-annotator cases. Passed through verbatim to
+  `bag.feature_values(element_type, name, selector=...)`. Built-in
+  selectors: `FeatureRecord.select_newest`, `select_first`,
+  `select_latest`, `select_majority_vote(column)`.
+
+Single-key vs multi-key behavior matches each method's output shape
+(see §3.3 for the adapter; §8 for restructure).
+
+**`target_transform: Callable[[FeatureRecord | dict[str, FeatureRecord] | list[FeatureRecord]], Any]`**
+
+User-supplied callable that maps the resolved feature record(s) into
+the final label value.
+
+- For the adapter: return value goes to the training loop unchanged.
+  Any type (int, tensor, list, etc.).
+- For restructure: return value MUST be a string (used as a
+  filesystem directory name). A non-string return raises
+  `DerivaMLValidationError` at construction with a message explaining
+  the string constraint.
+
+The input-shape contract is identical across methods:
+- Single-target (`targets=["A"]`): receives `FeatureRecord`.
+- Multi-target (`targets=["A", "B"]`): receives `dict[str, FeatureRecord]`.
+- Multi-valued single-target: receives `list[FeatureRecord]`.
+
+This means a user's `target_transform` written for one method works
+for the other with a return-type adjustment (e.g., `return CLASS_IDX[rec.Grade]`
+for adapter becomes `return rec.Grade` for restructure).
+
+**`missing: Literal["error", "skip", "unknown"]`**
+
+Policy for elements whose feature value is absent:
+
+- `"error"` — raise `DerivaMLException` at construction listing
+  unlabeled RIDs. Default for **adapter**.
+- `"skip"` — drop unlabeled elements entirely. For restructure, the
+  asset file is not placed in the output tree. For the adapter, the
+  element is absent from `__len__`.
+- `"unknown"` — keep unlabeled elements. For restructure, the asset
+  goes into an `unknown/` directory (matches today's behavior).
+  For the adapter, the target is `None` (user's `target_transform`
+  must handle it). Default for **restructure**.
+
+The default differs by method because the failure modes differ:
+silent mislabeling during training is a correctness hazard (adapter
+default is `"error"`); silently placing an asset in `unknown/` during
+a filesystem lay-out is recoverable by inspection (restructure default
+is `"unknown"`, which preserves today's behavior and avoids breakage).
+
+Users who want the adapter's strictness in restructure just pass
+`missing="error"`; users who want restructure's leniency in the adapter
+pass `missing="unknown"`.
 
 ## 4. Package structure
 
@@ -506,7 +593,161 @@ primitives separate means `restructure_assets` has a clear contract
 (it rewrites disk), the adapter has a clear contract (it reads disk
 lazily), and users see in their own code which tool they chose.
 
-## 8. Non-goals (explicit)
+**But they do share the target-specification vocabulary.** Per
+anchor 7 and §3.7, both methods accept the same `targets`,
+`target_transform`, and `missing` parameters with matching semantics.
+A user who writes `targets={"Diagnosis": FeatureRecord.select_newest}`
+for the adapter can use the same dict for `restructure_assets`. The
+alignment is *input-shape* only; output shapes remain distinct. §8
+documents the specific changes to `restructure_assets` that achieve
+this alignment, and the deprecation path for users on the old
+parameter names.
+
+## 8. `restructure_assets` alignment scope (same PR)
+
+Per anchor 7 and §3.7, the adapter work lands together with a
+coordinated signature update to `restructure_assets`. This section
+enumerates what changes on the restructure side and why.
+
+### 8.1 Parameter renames
+
+| Today | After | Notes |
+|---|---|---|
+| `group_by: list[str] | None` | `targets: list[str] | dict[str, FeatureSelector] | None` | "group_by" was SQL-flavored and misleading in the ML context. "targets" reads consistently across both methods: what determines the output, directory-name or label. |
+| `value_selector: Callable | None` | merged into `targets` dict form | Single-selector was strictly less expressive than per-feature selectors. The dict form subsumes it: `targets={"A": FeatureRecord.select_newest}` covers `value_selector=FeatureRecord.select_newest` for the single-feature case. |
+
+**Deprecation path for `group_by` and `value_selector`**: both continue
+to work for one release cycle. Passing `group_by` emits a
+`DeprecationWarning` pointing at `targets`; same for `value_selector`.
+Removed in the next major release. Concrete mechanism: check for the
+old kwargs in the method body, issue the warning, and forward the
+value to the new parameter name internally.
+
+### 8.2 New parameter: `target_transform`
+
+Restructure today derives directory names directly from feature values
+(or via the `"Feature.column"` dotted-string syntax). After alignment,
+`target_transform` is the canonical way to customize what goes into
+the directory name:
+
+```python
+# Today (still works, deprecated):
+bag.restructure_assets(output_dir="./out", group_by=["Classification.Label"])
+# → directories named after the Label column value
+
+# Aligned form:
+bag.restructure_assets(
+    output_dir="./out",
+    targets=["Classification"],
+    target_transform=lambda rec: rec.Label,   # returns str → directory name
+)
+```
+
+The `"Feature.column"` dotted-string syntax is **deprecated** with a
+`DeprecationWarning` pointing at `target_transform`, but continues to
+work for one release cycle to avoid breakage in existing scripts.
+
+Runtime constraint: `target_transform`'s return type is validated at
+the first `__getitem__`-equivalent call (inside the directory-naming
+loop). A non-string return raises `DerivaMLValidationError` with a
+message explaining that restructure's target_transform must return a
+filesystem-name-compatible string. (The adapter version has no such
+constraint.)
+
+### 8.3 New parameter: `missing`
+
+Currently, `restructure_assets` silently places unlabeled assets in an
+`Unknown/` directory. This is effectively `missing="unknown"` in the
+unified vocabulary.
+
+After alignment:
+
+- `missing: Literal["error", "skip", "unknown"] = "unknown"`
+- Default `"unknown"` preserves today's behavior (non-breaking change).
+- `"error"` gives users the strict-mode option (raise at construction
+  listing unlabeled RIDs) for when they want to ensure their training
+  data is complete before committing to disk.
+- `"skip"` drops the asset from the output tree entirely (new behavior;
+  no directory for it).
+
+### 8.4 Unchanged restructure parameters
+
+Everything else on `restructure_assets` stays as-is:
+
+- `output_dir`, `asset_table`, `use_symlinks`, `type_selector`,
+  `type_to_dir_map`, `enforce_vocabulary`, `file_transformer`.
+- The FK-reachability behavior (find assets through foreign-key
+  relationships from the dataset).
+- The `type_to_dir_map` default (`{"Training": "training",
+  "Testing": "testing", "Unknown": "unknown"}`).
+
+These are restructure-specific and don't map to adapter concepts.
+
+### 8.5 Internal refactor: shared resolution helper
+
+The feature-resolution logic (lookup-features-by-name, apply-selector,
+handle-missing) gets extracted into a private helper in
+`src/deriva_ml/dataset/target_resolution.py` (or similar). Both
+`as_torch_dataset` and `restructure_assets` call into it. This makes
+the "same semantics" claim in anchor 7 enforceable by shared code
+rather than by parallel re-implementation.
+
+Shape of the helper (sketch; implementation-plan will firm up):
+
+```python
+def resolve_targets(
+    bag: "DatasetBag",
+    element_type: str,
+    targets: list[str] | dict[str, FeatureSelector] | None,
+    missing: Literal["error", "skip", "unknown"],
+) -> dict[str, FeatureRecord | dict[str, FeatureRecord] | list[FeatureRecord] | None]:
+    """Resolve feature values per element_rid for the requested targets.
+
+    Returns a dict keyed by element RID. The value shape matches §3.3:
+    single FeatureRecord, dict of FeatureRecords, or list per target arity.
+    Values are None for elements where missing="unknown" / "skip" left
+    the label absent.
+
+    Raises DerivaMLException at construction when missing="error" and
+    any target is absent, or when a target feature doesn't exist.
+    """
+```
+
+This helper is private (`_resolve_targets`) — callers reach it through
+the public methods, not directly. Naming inside the module is an
+implementation-plan detail.
+
+### 8.6 Testing impact
+
+New tests verify the aligned semantics on restructure:
+- `targets=[...]` produces the same dir layout as the old
+  `group_by=[...]` form.
+- `value_selector=...` + `targets=[...]` with no selector dict
+  emits a DeprecationWarning and maps to the dict form correctly.
+- `missing="error"` raises on sparse-labeled bags.
+- `missing="skip"` omits assets from the output tree.
+- `missing="unknown"` preserves today's behavior (assets land in
+  `unknown/`).
+- `target_transform` returning a non-string raises
+  `DerivaMLValidationError`.
+- `"Feature.column"` dotted syntax continues to work with a
+  DeprecationWarning.
+
+Existing restructure tests stay green without modification (they
+exercise the `group_by` + `value_selector` shape, which still works
+with deprecation warnings).
+
+### 8.7 Documentation impact
+
+Docstring for `restructure_assets` is rewritten to use the new
+parameter names (and note the deprecated aliases). The UG Chapter 5
+section on `restructure_assets` gets updated examples in the same
+style as the adapter section — same vocabulary, same selector
+examples, same `missing` callouts. A one-paragraph "Vocabulary
+alignment with `as_torch_dataset`" sidebar explains the shared
+parameter names.
+
+## 9. Non-goals (explicit)
 
 The following are intentionally **out of scope** to keep the v1
 surface focused:
@@ -533,12 +774,14 @@ surface focused:
 - **Label encoding helpers.** Explicit non-goal per anchor 2.
   Users own their encoder; the library surfaces typed records.
 
-## 9. Deliverables checklist
+## 10. Deliverables checklist
 
 Implementation plan (separate document at
 `docs/superpowers/plans/2026-04-24-torch-dataset-adapter-plan.md`)
 will enumerate specific tasks; this spec's checklist names the
-deliverables the plan must cover:
+deliverables the plan must cover.
+
+**Adapter deliverables:**
 
 - [ ] `src/deriva_ml/dataset/torch_adapter.py` — new module
 - [ ] `src/deriva_ml/dataset/dataset_bag.py` — `as_torch_dataset`
@@ -550,12 +793,45 @@ deliverables the plan must cover:
 - [ ] `tests/dataset/test_torch_adapter_e2e.py` (pytest.importorskip)
 - [ ] `docs/user-guide/offline.md` — new "How to train a PyTorch model
   from a bag" section per §7.2
+
+**Shared infrastructure (per §8.5):**
+
+- [ ] `src/deriva_ml/dataset/target_resolution.py` (or equivalent) —
+  private helper `_resolve_targets(bag, element_type, targets, missing)`
+  shared between `as_torch_dataset` and `restructure_assets`
+- [ ] Tests for the shared helper covering the three `missing=`
+  branches and selector-dict vs list forms
+
+**Restructure alignment deliverables (per §8):**
+
+- [ ] `src/deriva_ml/dataset/dataset_bag.py` — `restructure_assets`
+  signature updated:
+  - Rename `group_by` → `targets` (with deprecated alias)
+  - Deprecate `value_selector` (merged into `targets` dict form)
+  - Add `target_transform` parameter
+  - Add `missing: Literal["error", "skip", "unknown"] = "unknown"`
+  - Keep `"Feature.column"` dotted syntax with DeprecationWarning
+- [ ] `restructure_assets` docstring rewritten to use new parameter
+  names and document the deprecated aliases
+- [ ] `docs/user-guide/offline.md` — update existing restructure
+  section to use new parameter names; add short "Vocabulary
+  alignment with `as_torch_dataset`" sidebar
+- [ ] `tests/dataset/test_restructure_*` — new tests per §8.6 covering
+  aligned semantics + deprecation warnings
+- [ ] Any existing test that uses `group_by=` keeps passing (with
+  deprecation warning filtered or matched)
+
+**Cross-cutting:**
+
 - [ ] Cross-references per §7.3
 - [ ] mkdocs --strict clean (no new warnings)
 - [ ] Fast suite green (`tests/local_db/ tests/asset/ tests/model/
-  tests/dataset/test_torch_adapter_*`)
+  tests/dataset/test_torch_adapter_* tests/dataset/test_restructure_*`)
+- [ ] Ruff check + format clean (parity with main baseline)
+- [ ] CHANGELOG or similar (if the project maintains one) noting the
+  `restructure_assets` parameter-rename deprecation
 
-## 10. Risks and mitigations
+## 11. Risks and mitigations
 
 **Risk: PyTorch API changes between versions.** Using only stable APIs
 (`torch.utils.data.Dataset`, no tensor ops in the adapter) keeps the
@@ -585,7 +861,25 @@ anything; it reads.
 without `[torch]` leaves torch out entirely. The default install
 remains lean.
 
-## 11. Future work (named for future-spec continuity)
+**Risk: `restructure_assets` parameter deprecation breaks downstream
+scripts.** Three downstream repos (deriva-ml-model-template, apps,
+demo) may use `group_by=` or `value_selector=` in their example code.
+Mitigation: the old parameter names continue to work for one release
+cycle with a `DeprecationWarning`; removal is a named separate PR
+scheduled for the next major release. The plan's verification step
+includes grepping sibling repos for the deprecated kwargs and noting
+them in the PR description so template-repo owners can schedule their
+update.
+
+**Risk: Shared `_resolve_targets` helper introduces coupling that
+makes future per-method changes harder.** Mitigation: the helper has a
+narrow contract (resolve feature values → dict keyed by element RID;
+apply missing policy). Method-specific concerns (directory-naming for
+restructure, label-in-tuple for adapter) stay in their respective
+methods. If a future change genuinely needs divergence, the helper
+can be inlined back per-method with a single commit.
+
+## 12. Future work (named for future-spec continuity)
 
 - **TF adapter** (separate future spec): `bag.as_tf_dataset(...)` with
   the same target/selector/missing semantics but a `tf.data.Dataset`
@@ -602,3 +896,8 @@ remains lean.
   class-balance computation from feature values could be a helper,
   but users can do this themselves from the dataset length + target
   list today.
+- **Remove deprecated `restructure_assets` parameters** (scheduled):
+  At the next major release, remove the `group_by` and
+  `value_selector` kwargs and the `"Feature.column"` dotted-string
+  syntax in `targets`. Tracked as a separate PR keyed off the major
+  version bump.

--- a/docs/superpowers/specs/2026-04-24-torch-dataset-adapter-design.md
+++ b/docs/superpowers/specs/2026-04-24-torch-dataset-adapter-design.md
@@ -11,29 +11,39 @@ boilerplate every user rewrites."
 ## 1. Problem statement
 
 A deriva-ml user who downloads a `DatasetBag` and wants to train a
-PyTorch model today writes ~35 lines of glue code per project:
-enumerate dataset members, pull feature values for labels, join with
-the asset table to resolve file paths, build `(path, label)` pairs,
-build a label-to-int encoder, subclass `torch.utils.data.Dataset`,
-implement `__len__` and `__getitem__`, and finally instantiate a
-`DataLoader`. The same boilerplate appears in every downstream project
-that targets this library, with minor variations in the label column
-name and the sample loader. It's error-prone (asset-path resolution is
-fragile, feature joins need `recurse=True` knowledge, label encoding
-is easy to get wrong across train/test splits) and every rewrite
-re-encodes decisions that deriva-ml already has typed answers for.
+model with it — whether in **PyTorch**, **TensorFlow**, or **Keras**
+— today writes ~35 lines of glue code per project: enumerate dataset
+members, pull feature values for labels, join with the asset table
+to resolve file paths, build `(path, label)` pairs, build a
+label-to-int encoder, subclass the framework's `Dataset` base or
+build a `tf.data.Dataset.from_generator` wrapper, implement length
+and iteration, and finally instantiate the training loop's data
+loader. The same boilerplate appears in every downstream project
+that targets this library, with minor variations in the label
+column name and the sample loader. It's error-prone (asset-path
+resolution is fragile, feature joins need `recurse=True` knowledge,
+label encoding is easy to get wrong across train/test splits) and
+every rewrite re-encodes decisions that deriva-ml already has typed
+answers for.
 
-`DatasetBag.restructure_assets()` covers the narrow case of image
-classification with a single scalar feature as the label, by emitting
-the `ImageFolder` directory layout. That shape breaks down for
-tabular datasets, multi-modal inputs, regression targets, multi-label
-classification, non-image data, and lazy streaming. It also leaves
-TensorFlow users unserved.
+`DatasetBag.restructure_assets()` covers one shape — classification
+with a single scalar feature as the label, emitted as the
+`ImageFolder`-style directory layout. That's right for third-party
+trainers that expect class-folder trees (RetFound fine-tuning,
+`torchvision.datasets.ImageFolder`,
+`tf.keras.utils.image_dataset_from_directory`), but it breaks down
+for tabular datasets, multi-modal inputs, regression targets,
+multi-label classification, non-image data, and lazy streaming.
 
-Users want a one-line path from bag to `torch.utils.data.Dataset` that
-respects the library's existing feature-access API, stays consistent
-with the `DatasetBag`-vs-catalog parity the rest of the library promises,
-and doesn't force the user to materialize or copy their data.
+Users want a one-line path from bag to the appropriate framework's
+native dataset type — `torch.utils.data.Dataset` for PyTorch (and
+Keras on the PyTorch backend), `tf.data.Dataset` for TensorFlow
+(and Keras on the TF backend) — that respects the library's existing
+feature-access API, stays consistent with the `DatasetBag`-vs-catalog
+parity the rest of the library promises, and doesn't force the user
+to materialize or copy their data. `restructure_assets()` stays as
+the right tool when you specifically need the class-folder layout
+for a third-party consumer; the new adapters handle everything else.
 
 ## 2. Design anchors
 
@@ -419,6 +429,24 @@ without hiding what each method's input actually is. Additionally:
 hook is `file_transformer`, which operates on paths).
 `output_signature` applies only to `as_tf_dataset`
 (TF-specific, no counterpart on torch or restructure).
+
+**Restructure-only parameters preserved unchanged.**
+`restructure_assets` continues to accept every parameter it accepts
+today, unchanged in name, type, default, and behavior, with one
+exception: `group_by` was renamed to `targets` and `value_selector`
+was folded into the `targets` dict form as part of the vocabulary
+alignment (see §8). The parameters that stay exactly as they are
+today:
+
+- `output_dir`, `asset_table`, `use_symlinks`
+- `type_selector`, `type_to_dir_map`, `enforce_vocabulary`
+- `file_transformer`
+
+Plus the algorithmic behavior: FK-reachability for finding assets,
+dataset-type-derived top-level directory naming, silent vs. strict
+missing-label handling (parameterized via `missing=` but default
+`"unknown"` preserves today's behavior). §8.4 enumerates these
+preserved parameters explicitly.
 
 ## 4. Package structure
 
@@ -819,6 +847,18 @@ the migration guidance for any callers on the old parameter names.
 Per anchor 7 and §3.7, the adapter work lands together with a
 coordinated signature update to `restructure_assets`. This section
 enumerates what changes on the restructure side and why.
+
+**The alignment preserves every capability `restructure_assets` has
+today.** §8.4 enumerates the parameters that stay exactly as-is
+(unchanged in name, type, default, and behavior). The algorithmic
+behavior — FK-reachability for finding assets, dataset-type-derived
+top-level directory naming, silent vs. strict missing-label handling
+— is also preserved. What changes is the **vocabulary for
+label-selection**: `group_by` becomes `targets`, `value_selector` is
+subsumed by the `targets` dict form, and the `"Feature.column"`
+dotted-string syntax is replaced by `target_transform`. Every user
+workflow that works today works after this PR with a one-line
+kwarg-rename; no capability is removed.
 
 This is a **clean break** — the old parameter names are removed, not
 deprecated. Rationale: deriva-ml is not yet at the scale where

--- a/docs/superpowers/specs/2026-04-24-torch-dataset-adapter-design.md
+++ b/docs/superpowers/specs/2026-04-24-torch-dataset-adapter-design.md
@@ -131,11 +131,9 @@ make future additions (e.g., `sampler=`, `num_workers_hint=`) awkward.
 
 **`element_type`** — Name of the domain table whose rows become the
 dataset's samples. Must be a table present in the bag (covered by the
-same error path `list_dataset_members` uses). If the element_type is
-an asset table (has `URL`, `Filename`, `MD5` columns), the default
-`sample_loader` returns the file's bytes; if it's a non-asset table,
-no default loader exists and the user must supply one that reads from
-`row_dict` alone.
+same error path `list_dataset_members` uses). Whether `sample_loader`
+is required depends on whether the element_type is an asset table or
+not — see the `sample_loader` entry below.
 
 **`sample_loader`** — `Callable[[Path | None, dict], Any]`. Invoked
 once per `__getitem__` call. Receives:
@@ -150,10 +148,23 @@ Return value is the sample (`PIL.Image`, tensor, array, dict of
 modalities, whatever the user's model expects). The library does not
 inspect it.
 
-Default: when `element_type` is an asset table, the default loader
-returns `path.read_bytes()`. When `element_type` is a non-asset table,
-the default loader returns the `row_dict` unchanged. Either can be
-overridden.
+Default: asymmetric by element-type kind.
+
+- **Asset-table element_type**: no default — the adapter raises
+  `DerivaMLException` at construction if `sample_loader` is `None`.
+  Returning raw bytes isn't useful (users can't train on bytes; they
+  need a decoded PIL Image / tensor / array), so demanding the loader
+  explicitly surfaces the decision the user needs to make. The error
+  message names common loaders the user might reach for
+  (`PIL.Image.open`, `nibabel.load`, `h5py.File`) as hints. Being
+  domain-specific about decoding is the user's job; the library stays
+  domain-agnostic.
+- **Non-asset-table element_type**: default returns `row_dict`
+  unchanged. Useful for tabular training where the element IS the row
+  data and no file-level decoding exists. Can be overridden.
+
+Either default can be overridden by passing any callable with the
+required signature.
 
 **`transform`** — `Callable[[Any], Any]`. Applied to the sample after
 `sample_loader` returns. Standard torchvision-style transform pipeline
@@ -232,10 +243,11 @@ count otherwise.
 | feature named in `targets` does not exist | `DerivaMLException` at construction (same message as `bag.feature_values` itself) |
 | `missing="error"` + sparse labels | `DerivaMLException` at construction listing up to 20 unlabeled RIDs |
 | `import torch` fails | `ImportError` at first call to `as_torch_dataset` with install hint |
-| element_type not asset, no `sample_loader` supplied | Default returns row_dict; no error. Downstream shape is the user's choice. |
+| asset-table element_type, no `sample_loader` supplied | `DerivaMLException` at construction — message suggests common loaders (PIL.Image.open, nibabel.load, h5py.File) |
+| non-asset element_type, no `sample_loader` supplied | No error — default returns row_dict unchanged |
 | asset file missing on disk (bag corrupted) | `FileNotFoundError` on `__getitem__` (torch convention) |
 
-All statically-detectable errors surface at construction time (rows 1-4
+All statically-detectable errors surface at construction time (rows 1-5
 above), so the dataset is valid as soon as it's returned for the
 overwhelmingly common cases. The `__getitem__`-time `FileNotFoundError`
 is unavoidable: the filesystem can change between construction and
@@ -430,17 +442,17 @@ test_bag  = ml.lookup_dataset(split.testing.rid).download_dataset_bag(
     version="1.0.0"
 )
 
-# Build torch datasets from each bag independently
-kwargs = dict(
+# Build torch datasets from each bag independently.
+# Shared adapter config — everything except the per-partition transform:
+shared = dict(
     element_type="Image",
     sample_loader=lambda p, row: PIL.Image.open(p).convert("RGB"),
     targets=["Image_Classification"],
     target_transform=lambda rec: CLASS_TO_IDX[rec.Image_Class],
-    transform=train_transform,
 )
-train_ds = train_bag.as_torch_dataset(**{**kwargs, "transform": train_transform})
-val_ds   = val_bag.as_torch_dataset(**{**kwargs, "transform": eval_transform})
-test_ds  = test_bag.as_torch_dataset(**{**kwargs, "transform": eval_transform})
+train_ds = train_bag.as_torch_dataset(**shared, transform=train_transform)
+val_ds   = val_bag.as_torch_dataset(**shared, transform=eval_transform)
+test_ds  = test_bag.as_torch_dataset(**shared, transform=eval_transform)
 
 train_loader = DataLoader(train_ds, batch_size=32, shuffle=True,  num_workers=4)
 val_loader   = DataLoader(val_ds,   batch_size=32, shuffle=False, num_workers=4)

--- a/docs/superpowers/specs/2026-04-24-torch-dataset-adapter-design.md
+++ b/docs/superpowers/specs/2026-04-24-torch-dataset-adapter-design.md
@@ -1,0 +1,458 @@
+# PyTorch Dataset Adapter Design
+
+**Date:** 2026-04-24
+**Status:** Approved design; implementation plan to follow.
+**Scope label:** Post-S2 item D2.
+**Source context:** Reviewer #5 fit-for-purpose item #2 in
+`docs/superpowers/specs/2026-04-23-post-s2-findings.md` §5 — "the path
+from `DatasetBag` to `torch.utils.data.DataLoader` is 30 lines of
+boilerplate every user rewrites."
+
+## 1. Problem statement
+
+A deriva-ml user who downloads a `DatasetBag` and wants to train a
+PyTorch model today writes ~35 lines of glue code per project:
+enumerate dataset members, pull feature values for labels, join with
+the asset table to resolve file paths, build `(path, label)` pairs,
+build a label-to-int encoder, subclass `torch.utils.data.Dataset`,
+implement `__len__` and `__getitem__`, and finally instantiate a
+`DataLoader`. The same boilerplate appears in every downstream project
+that targets this library, with minor variations in the label column
+name and the sample loader. It's error-prone (asset-path resolution is
+fragile, feature joins need `recurse=True` knowledge, label encoding
+is easy to get wrong across train/test splits) and every rewrite
+re-encodes decisions that deriva-ml already has typed answers for.
+
+`DatasetBag.restructure_assets()` covers the narrow case of image
+classification with a single scalar feature as the label, by emitting
+the `ImageFolder` directory layout. That shape breaks down for
+tabular datasets, multi-modal inputs, regression targets, multi-label
+classification, non-image data, and lazy streaming. It also leaves
+TensorFlow users unserved.
+
+Users want a one-line path from bag to `torch.utils.data.Dataset` that
+respects the library's existing feature-access API, stays consistent
+with the `DatasetBag`-vs-catalog parity the rest of the library promises,
+and doesn't force the user to materialize or copy their data.
+
+## 2. Design anchors
+
+Non-negotiables that constrain all subsequent decisions.
+
+**Anchor 1: Labels come from features.** The existing feature-access
+API is the source of truth for labels. The adapter calls
+`bag.feature_values(table, feature_name, selector=...)` internally; it
+does not invent a separate label-reading path. This keeps one mental
+model: a feature value is "a typed record describing an annotation on
+a domain-table row," whether the consumer is a user inspecting the
+dataset or a PyTorch training loop.
+
+**Anchor 2: User owns the label-to-integer mapping.** The library
+surfaces `FeatureRecord` instances (typed with the feature's declared
+column types); the user's `target_transform` callable does the
+numeric encoding. The library does not hold a class-to-index table,
+does not auto-fit one on first pass, does not persist one. This avoids
+the worst failure mode of other ML data libraries — train/test label
+encoders silently diverging — and respects deriva-ml's broader
+convention of not opining on user numeric shapes.
+
+**Anchor 3: PyTorch is an optional dependency.** The adapter lives
+behind a runtime `import torch` guard. The base library never imports
+torch at module-load time. A user who installs deriva-ml without torch
+can call every non-adapter API normally; calls to `as_torch_dataset`
+raise a clean `ImportError` with install hints. A `deriva-ml[torch]`
+package extra exists as a convenience.
+
+**Anchor 4: Bag-only in v1.** `Dataset.as_torch_dataset` (live-catalog
+variant) is intentionally out of scope. Live-catalog datasets require
+download-during-`__getitem__`, which introduces network IO on hot
+paths, credential lifetime concerns, retry policy, cache eviction —
+all of which deserve their own spec. The bag case covers the primary
+training workflow (download the bag, then train locally) without any
+of that complexity. Live-catalog support is a named follow-up.
+
+**Anchor 5: Feature-parallel consistency.** The adapter's signature,
+error behavior, and selector handling mirror
+`bag.feature_values(...)`'s existing shape. A user who knows the
+feature API should be able to read the adapter's signature without
+surprise.
+
+## 3. Public API
+
+### 3.1 Signature
+
+```python
+class DatasetBag:
+    def as_torch_dataset(
+        self,
+        element_type: str,
+        *,
+        sample_loader: Callable[[Path, dict[str, Any]], Any] | None = None,
+        transform: Callable[[Any], Any] | None = None,
+        targets: list[str] | dict[str, FeatureSelector] | None = None,
+        target_transform: Callable[
+            [FeatureRecord | dict[str, FeatureRecord] | list[FeatureRecord]],
+            Any,
+        ] | None = None,
+        missing: Literal["error", "skip", "none"] = "error",
+    ) -> "torch.utils.data.Dataset":
+        """..."""
+```
+
+All arguments after `element_type` are keyword-only by intent: they
+are semantically independent and the positional-order constraint would
+make future additions (e.g., `sampler=`, `num_workers_hint=`) awkward.
+
+### 3.2 Argument semantics
+
+**`element_type`** — Name of the domain table whose rows become the
+dataset's samples. Must be a table present in the bag (covered by the
+same error path `list_dataset_members` uses). If the element_type is
+an asset table (has `URL`, `Filename`, `MD5` columns), the default
+`sample_loader` returns the file's bytes; if it's a non-asset table,
+no default loader exists and the user must supply one that reads from
+`row_dict` alone.
+
+**`sample_loader`** — `Callable[[Path | None, dict], Any]`. Invoked
+once per `__getitem__` call. Receives:
+- `Path | None`: absolute filesystem path under
+  `bag.path / "data/assets/<element_type>/<rid>/<filename>"` when
+  `element_type` is an asset table; `None` otherwise.
+- `dict[str, Any]`: the raw row dict from the element table (all
+  columns, not just those the framework needs). Lets the loader pull
+  non-asset columns, FK values, timestamps, etc.
+
+Return value is the sample (`PIL.Image`, tensor, array, dict of
+modalities, whatever the user's model expects). The library does not
+inspect it.
+
+Default: when `element_type` is an asset table, the default loader
+returns `path.read_bytes()`. When `element_type` is a non-asset table,
+the default loader returns the `row_dict` unchanged. Either can be
+overridden.
+
+**`transform`** — `Callable[[Any], Any]`. Applied to the sample after
+`sample_loader` returns. Standard torchvision-style transform pipeline
+goes here. No-op default.
+
+**`targets`** — Source of label data. Three shapes accepted:
+- `None` (default) — unlabeled dataset. `__getitem__` returns just the
+  sample (not a tuple). Useful for inference loops and for
+  self-supervised pretext tasks.
+- `list[str]` — feature names to read via
+  `bag.feature_values(element_type, name)` with no selector. The
+  library aggregates one feature record per element.
+- `dict[str, FeatureSelector]` — feature names → selector callables,
+  passed verbatim to `bag.feature_values(element_type, name,
+  selector=...)`. The selector resolves multi-annotator cases. When a
+  selector returns `None` for a group, that element is treated as
+  "unlabeled for this feature" and handled per `missing=`.
+
+**`target_transform`** — `Callable` consuming the raw feature-record
+shape (see §3.3 for arity) and returning whatever the user's loss
+function expects (typically an `int` or a `torch.Tensor`). No-op
+default returns the feature record(s) as-is.
+
+**`missing`** — Behavior when a feature value is absent for an element:
+- `"error"` (default) — raise `DerivaMLException` at adapter
+  construction time, before any `__getitem__` call. Message includes
+  the list of unlabeled RIDs. Explicit-over-silent: users should know
+  if their dataset is partially labeled.
+- `"skip"` — drop unlabeled elements from the dataset entirely. The
+  resulting dataset's `__len__` reflects only labeled elements. Index
+  mapping is stable across the dataset's lifetime.
+- `"none"` — keep all elements; yield `target=None` for unlabeled
+  ones. The user's `target_transform` must handle `None`. Useful for
+  semi-supervised / self-training work.
+
+### 3.3 Target arity
+
+Single-target (`targets=["Feature_A"]`): `target_transform` receives a
+`FeatureRecord` directly.
+
+Multi-target (`targets=["Feature_A", "Feature_B"]`): `target_transform`
+receives `dict[str, FeatureRecord]` keyed by feature name.
+
+Multi-valued feature (single-target where the feature is multi-valued
+— e.g., an `Image → list[Diagnosis]` feature): `target_transform`
+receives `list[FeatureRecord]`. Users who want "just pick the first"
+flatten in their `target_transform`.
+
+The arity is determined by the `targets` argument shape at
+construction time; `target_transform` always sees a stable, predictable
+type. No "do what I mean" inference at `__getitem__`.
+
+### 3.4 `__getitem__` contract
+
+Returns:
+- `sample` when `targets=None` (unlabeled)
+- `(sample, target)` when `targets` is set
+
+Where:
+- `sample = transform(sample_loader(path, row_dict))`
+- `target = target_transform(feature_record_shape)` per §3.3
+
+This matches the torchvision convention exactly, keeping the adapter
+drop-in compatible with standard PyTorch training loops.
+
+### 3.5 `__len__` contract
+
+Equals the count of labeled elements when `missing="skip"`, the total
+count otherwise.
+
+### 3.6 Error behavior summary
+
+| Situation | Behavior |
+|---|---|
+| `element_type` not in bag | `DerivaMLException` at construction |
+| feature named in `targets` does not exist | `DerivaMLException` at construction (same message as `bag.feature_values` itself) |
+| `missing="error"` + sparse labels | `DerivaMLException` at construction listing up to 20 unlabeled RIDs |
+| `import torch` fails | `ImportError` at first call to `as_torch_dataset` with install hint |
+| element_type not asset, no `sample_loader` supplied | Default returns row_dict; no error. Downstream shape is the user's choice. |
+| asset file missing on disk (bag corrupted) | `FileNotFoundError` on `__getitem__` (torch convention) |
+
+All statically-detectable errors surface at construction time (rows 1-4
+above), so the dataset is valid as soon as it's returned for the
+overwhelmingly common cases. The `__getitem__`-time `FileNotFoundError`
+is unavoidable: the filesystem can change between construction and
+access (asset file removed, bag directory renamed, etc.), and torch's
+own convention is to propagate `OSError` subclasses from dataset
+access. No library-level retry or fallback.
+
+## 4. Package structure
+
+New module: `src/deriva_ml/dataset/torch_adapter.py`.
+
+Public entry point: `DatasetBag.as_torch_dataset(...)` as a method,
+delegating to a module-level builder function. The method is defined
+in `dataset_bag.py` (same class body as existing `as_` helpers);
+the builder imports torch lazily inside its body.
+
+```python
+# dataset_bag.py (class body):
+def as_torch_dataset(self, element_type, **kwargs):
+    """..."""
+    from deriva_ml.dataset.torch_adapter import build_torch_dataset
+    return build_torch_dataset(self, element_type, **kwargs)
+```
+
+This keeps the public signature discoverable from the class docstring
+and IDE autocomplete, while isolating the torch coupling to one
+module.
+
+## 5. Package extras
+
+`pyproject.toml` gains:
+
+```toml
+[project.optional-dependencies]
+torch = ["torch>=2.0"]
+```
+
+Installation: `pip install 'deriva-ml[torch]'`. The existing
+`dependency-groups` table for dev / lint stays where it is — the new
+`optional-dependencies` section documents runtime extras users can
+opt into, which is distinct from dev tooling.
+
+Version floor `>=2.0` chosen to match modern PyTorch while leaving
+room for PyTorch 2.x + torchvision users. Specific-version pinning is
+the user's concern.
+
+## 6. Testing strategy
+
+Three test tiers:
+
+### 6.1 Module-import test (no torch installed)
+
+Verify the library still imports when torch is absent. Mocks or
+manipulates `sys.modules` to remove torch; confirms `DatasetBag` is
+importable and every method except `as_torch_dataset` works normally.
+Confirms `as_torch_dataset` raises `ImportError` with the expected
+install-hint message.
+
+Lives in: `tests/dataset/test_torch_adapter_no_torch.py`.
+
+### 6.2 Pure-Python logic (torch stubbed)
+
+Exercises the join logic, selector pass-through, `missing=` branches,
+target arity, and error paths without a real torch install. Uses a
+minimal `torch.utils.data.Dataset` stub. No GPU/CPU tensor ops
+involved; just the library's data-plumbing logic.
+
+Lives in: `tests/dataset/test_torch_adapter_logic.py`.
+
+### 6.3 End-to-end with real torch
+
+Runs only when torch is importable. Builds a dataset from a test-catalog
+bag fixture, iterates it under a real `DataLoader`, verifies the output
+tuple shape, label encoding round-trip, and `missing="skip"` filters
+correctly.
+
+Lives in: `tests/dataset/test_torch_adapter_e2e.py`. Skipped with
+`pytest.importorskip("torch")` when torch is not installed.
+
+### 6.4 Test catalog fixture
+
+Leverages the existing `catalog_with_datasets` fixture. The test
+doesn't need new catalog setup — the demo catalog already has
+subjects, images, and a Glaucoma_Grade-style feature via
+`create_demo_features`. The spec assumes that fixture is stable;
+implementation will verify.
+
+## 7. Documentation deliverables
+
+**User-facing documentation is a first-class deliverable**, not
+optional work to punt to a follow-up.
+
+### 7.1 Docstrings
+
+Every public surface gets the full library docstring contract (one-line
+summary + extended description + Args + Returns + Raises + Example).
+
+Covered public surfaces:
+- `DatasetBag.as_torch_dataset(...)` — the method docstring
+- `build_torch_dataset(...)` — the module-level builder (if exposed
+  publicly; likely `_build_torch_dataset` private)
+
+For each argument with non-obvious semantics (`targets` shapes,
+`missing` behavior, `sample_loader` signature), include a dedicated
+paragraph in the Args section that shows what the user hands in and
+what they get back. The catalog-dependent end-to-end `Example:` block
+uses `# doctest: +SKIP`; a smaller pure-Python assertion (e.g.,
+enum-value check or import-guard behavior) runs at doctest collection.
+
+### 7.2 User guide section
+
+New section in `docs/user-guide/offline.md` (Chapter 5, which already
+covers `DatasetBag` and `restructure_assets`) titled **"How to train a
+PyTorch model from a bag"**. Structure follows the UG contract:
+
+1. **Motivation.** Two sentences explaining why the adapter exists and
+   when a user would reach for it instead of `restructure_assets`.
+2. **Simple example.** Image classification with one feature as label,
+   `PIL.Image.open` as loader, a torchvision transform pipeline. ~15
+   lines of code end-to-end.
+3. **Explanation.** How labels come from features, how the selector
+   pattern handles multi-annotator cases, how `missing=` resolves
+   sparse-label choices.
+4. **Worked variations:**
+   - Tabular regression (non-asset element_type, no `sample_loader`
+     default override, continuous-valued feature)
+   - Multi-target (two features → dict target)
+   - Multi-annotator resolution (selector-dict form)
+5. **Notes:** pointer to the `deriva-ml[torch]` extra; pointer to
+   `restructure_assets` for the narrow image-classification case
+   that predates the adapter; explicit note that
+   `Dataset.as_torch_dataset` (live-catalog variant) is not yet
+   shipped.
+6. **See also:** Chapter 3 (features API for selector pattern); the
+   `DatasetBag.feature_values` docstring for the selector shape.
+
+### 7.3 Cross-references
+
+- The new UG section gets linked from Chapter 1 (exploring) where
+  users first learn about bags.
+- `DatasetBag.restructure_assets`'s docstring gets one sentence
+  pointing at `as_torch_dataset` as the general-case companion.
+- The `DatasetBag` class-level docstring gets one bullet mentioning
+  the adapter alongside the existing `restructure_assets()` mention.
+  (The corresponding paragraph in `CLAUDE.md` — the project-level
+  codebase notes — gets the same one-sentence addition for future
+  agentic work, tracked as part of the plan's UG-integration task.)
+
+## 8. Non-goals (explicit)
+
+The following are intentionally **out of scope** to keep the v1
+surface focused:
+
+- **TensorFlow adapter.** Parallel `as_tf_dataset` has the same shape
+  but is a separate deliverable. If this PR lands cleanly, a follow-up
+  adds TF with minimal new design (the join logic, path resolution,
+  and feature-value plumbing are directly reusable).
+- **`Dataset.as_torch_dataset` (live-catalog variant).** Covered in
+  anchor 4 above. Named follow-up; not v1.
+- **DataLoader construction.** The library returns a `Dataset`; the
+  user wraps it in `torch.utils.data.DataLoader` with their own
+  `batch_size`, `shuffle`, `num_workers`, etc. The library does not
+  opine on batching.
+- **Train/val/test splits.** Already covered by
+  `split_dataset` / `stratify_by_column`. The adapter takes whatever
+  bag you hand it; splitting happens upstream.
+- **In-memory caching across epochs.** Torch's own DataLoader +
+  dataset-level caching is the standard pattern. The library doesn't
+  layer on top.
+- **Inference-result writeback.** That's feature-record territory (D1
+  + existing `add_features` path), orthogonal to the data-loading
+  adapter.
+- **Label encoding helpers.** Explicit non-goal per anchor 2.
+  Users own their encoder; the library surfaces typed records.
+
+## 9. Deliverables checklist
+
+Implementation plan (separate document at
+`docs/superpowers/plans/2026-04-24-torch-dataset-adapter-plan.md`)
+will enumerate specific tasks; this spec's checklist names the
+deliverables the plan must cover:
+
+- [ ] `src/deriva_ml/dataset/torch_adapter.py` — new module
+- [ ] `src/deriva_ml/dataset/dataset_bag.py` — `as_torch_dataset`
+  method added with full docstring
+- [ ] `pyproject.toml` — `[project.optional-dependencies]` table with
+  `torch = [...]`
+- [ ] `tests/dataset/test_torch_adapter_no_torch.py`
+- [ ] `tests/dataset/test_torch_adapter_logic.py`
+- [ ] `tests/dataset/test_torch_adapter_e2e.py` (pytest.importorskip)
+- [ ] `docs/user-guide/offline.md` — new "How to train a PyTorch model
+  from a bag" section per §7.2
+- [ ] Cross-references per §7.3
+- [ ] mkdocs --strict clean (no new warnings)
+- [ ] Fast suite green (`tests/local_db/ tests/asset/ tests/model/
+  tests/dataset/test_torch_adapter_*`)
+
+## 10. Risks and mitigations
+
+**Risk: PyTorch API changes between versions.** Using only stable APIs
+(`torch.utils.data.Dataset`, no tensor ops in the adapter) keeps the
+surface insulated from PyTorch point-release churn. Pinning `torch>=2.0`
+draws the line at a clear stability boundary.
+
+**Risk: Bag path resolution breaks if a future bag format changes the
+`data/assets/<type>/<rid>/...` layout.** Mitigation: the adapter reads
+path structure via `bag.path` + the asset table's URL column rather
+than hard-coding the layout; if the layout ever changes, the same
+code path that breaks `restructure_assets` breaks the adapter, so
+they're in sync.
+
+**Risk: Selector-pattern inconsistency between bag and Dataset
+variants.** Mitigation: bag-only v1 eliminates this by construction.
+When the `Dataset.as_torch_dataset` follow-up lands, the selector
+signature is lifted verbatim from the bag variant, preserving the
+parity promise.
+
+**Risk: Users expect MLflow-compat `log_metric`-style automatic
+metric writeback.** Mitigation: docstring Notes section points at D1's
+`exe.metrics_file()` for that use case. The adapter does not write
+anything; it reads.
+
+**Risk: Torch dependency bloat for users who install
+`deriva-ml[torch]` accidentally.** Mitigation: named extra; pip install
+without `[torch]` leaves torch out entirely. The default install
+remains lean.
+
+## 11. Future work (named for future-spec continuity)
+
+- **TF adapter** (separate future spec): `bag.as_tf_dataset(...)` with
+  the same target/selector/missing semantics but a `tf.data.Dataset`
+  return type. Reuses the join logic, path resolution, and
+  feature-value plumbing; only the framework wrapper is new.
+- **`Dataset.as_torch_dataset` (live-catalog variant)** (separate
+  future spec): live-download semantics, credential lifetime, retry
+  policy, cache eviction.
+- **Numpy/Arrow adapters** (lower priority): for users who want
+  framework-agnostic iteration over (sample, target) tuples.
+- **Streaming / iterable datasets** (lower priority): `IterableDataset`
+  variant for bags that exceed local disk.
+- **Sampler hooks** (lower priority): `WeightedRandomSampler` +
+  class-balance computation from feature values could be a helper,
+  but users can do this themselves from the dataset length + target
+  list today.

--- a/docs/superpowers/specs/2026-04-24-torch-dataset-adapter-design.md
+++ b/docs/superpowers/specs/2026-04-24-torch-dataset-adapter-design.md
@@ -56,20 +56,24 @@ the worst failure mode of other ML data libraries — train/test label
 encoders silently diverging — and respects deriva-ml's broader
 convention of not opining on user numeric shapes.
 
-**Anchor 3: PyTorch is an optional dependency.** The adapter lives
-behind a runtime `import torch` guard. The base library never imports
-torch at module-load time. A user who installs deriva-ml without torch
-can call every non-adapter API normally; calls to `as_torch_dataset`
-raise a clean `ImportError` with install hints. A `deriva-ml[torch]`
-package extra exists as a convenience.
+**Anchor 3: PyTorch and TensorFlow are optional dependencies.** Each
+adapter lives behind a runtime framework-import guard (`import torch`
+for `as_torch_dataset`, `import tensorflow` for `as_tf_dataset`). The
+base library never imports either at module-load time. A user who
+installs deriva-ml without one or both frameworks can call every
+non-adapter API normally; calls to the corresponding adapter method
+raise a clean `ImportError` with install hints. Package extras
+`deriva-ml[torch]` and `deriva-ml[tf]` exist as conveniences.
 
-**Anchor 4: Bag-only in v1.** `Dataset.as_torch_dataset` (live-catalog
-variant) is intentionally out of scope. Live-catalog datasets require
+**Anchor 4: Bag-only in v1.** Live-catalog adapter variants
+(`Dataset.as_torch_dataset`, `Dataset.as_tf_dataset`) are
+intentionally out of scope. Live-catalog datasets require
 download-during-`__getitem__`, which introduces network IO on hot
 paths, credential lifetime concerns, retry policy, cache eviction —
 all of which deserve their own spec. The bag case covers the primary
 training workflow (download the bag, then train locally) without any
-of that complexity. Live-catalog support is a named follow-up.
+of that complexity. Live-catalog support is a named follow-up for
+both framework adapters.
 
 **Anchor 5: Feature-parallel consistency.** The adapter's signature,
 error behavior, and selector handling mirror
@@ -117,7 +121,10 @@ in the same PR as the adapter — see §8 for the alignment scope.
 
 ## 3. Public API
 
-### 3.1 Signature
+### 3.1 Signatures
+
+Two adapter methods, with identical shapes for their six shared
+keyword arguments:
 
 ```python
 class DatasetBag:
@@ -129,17 +136,38 @@ class DatasetBag:
         transform: Callable[[Any], Any] | None = None,
         targets: list[str] | dict[str, FeatureSelector] | None = None,
         target_transform: Callable[
-            [FeatureRecord | dict[str, FeatureRecord] | list[FeatureRecord]],
+            [FeatureRecord | dict[str, FeatureRecord] | list[FeatureRecord] | None],
             Any,
         ] | None = None,
-        missing: Literal["error", "skip", "none"] = "error",
+        missing: Literal["error", "skip", "unknown"] = "error",
     ) -> "torch.utils.data.Dataset":
+        """..."""
+
+    def as_tf_dataset(
+        self,
+        element_type: str,
+        *,
+        sample_loader: Callable[[Path, dict[str, Any]], Any] | None = None,
+        transform: Callable[[Any], Any] | None = None,
+        targets: list[str] | dict[str, FeatureSelector] | None = None,
+        target_transform: Callable[
+            [FeatureRecord | dict[str, FeatureRecord] | list[FeatureRecord] | None],
+            Any,
+        ] | None = None,
+        missing: Literal["error", "skip", "unknown"] = "error",
+        output_signature: "tf.TensorSpec | tuple[tf.TensorSpec, ...] | None" = None,
+    ) -> "tf.data.Dataset":
         """..."""
 ```
 
-All arguments after `element_type` are keyword-only by intent: they
-are semantically independent and the positional-order constraint would
-make future additions (e.g., `sampler=`, `num_workers_hint=`) awkward.
+Both adapters share six keyword-only parameters with matching names,
+types, and semantics (`element_type`, `sample_loader`, `transform`,
+`targets`, `target_transform`, `missing`). `as_tf_dataset` adds one
+TF-specific parameter (`output_signature`) that has no counterpart in
+the torch shape; see §3.2 for its semantics. All arguments after
+`element_type` are keyword-only by intent: they are semantically
+independent and positional order would make future additions
+(e.g., `sampler=` on torch, `prefetch=` on tf) awkward.
 
 ### 3.2 Argument semantics
 
@@ -210,9 +238,45 @@ default returns the feature record(s) as-is.
 - `"skip"` — drop unlabeled elements from the dataset entirely. The
   resulting dataset's `__len__` reflects only labeled elements. Index
   mapping is stable across the dataset's lifetime.
-- `"none"` — keep all elements; yield `target=None` for unlabeled
-  ones. The user's `target_transform` must handle `None`. Useful for
+- `"unknown"` — keep all elements; pass `None` to the user's
+  `target_transform` for unlabeled ones. The user's
+  `target_transform` must handle `None` (typically returning a
+  sentinel class index or an ignore-mask value). Useful for
   semi-supervised / self-training work.
+
+  Note the naming: `"unknown"` is the **policy name** (shared across
+  `as_torch_dataset`, `as_tf_dataset`, and `restructure_assets` —
+  see §3.7), while the runtime value the adapter hands to
+  `target_transform` is Python `None`. The same literal policy value
+  drives restructure's `unknown/` directory and the adapter's
+  `None` target — one name, two honest realizations of the same
+  "keep it, flag it" intent.
+
+**`output_signature`** (`as_tf_dataset` only) — the `tf.TensorSpec`
+structure describing the `(sample, target)` tuple shape and dtype.
+TensorFlow's `tf.data.Dataset.from_generator` path requires this
+signature to do graph-mode tracing over the dataset.
+
+- `None` (default) — the adapter **infers** the signature from the
+  first `(sample, target)` tuple produced at construction time. The
+  adapter pulls one sample eagerly, builds the appropriate
+  `tf.TensorSpec` via `tf.type_spec_from_value`, and re-wraps the
+  generator so that eagerly-consumed first sample is not lost on
+  iteration. Cost: one extra iteration at adapter-construction. This
+  mirrors the behavior of `keras.utils.timeseries_dataset_from_array`
+  and other Keras data-loading helpers that auto-infer when they
+  can.
+- `tf.TensorSpec(...)` or nested tuple of same — the user provides
+  the signature explicitly. Recommended for production pipelines that
+  want deterministic startup (no eager first-sample read) or where
+  the first sample's shape isn't representative (e.g., ragged
+  tensors, variable-length sequences).
+
+Inference limitations: the inferred signature uses `tf.TensorSpec`
+with the first sample's exact shape. If later samples have different
+shapes (variable-height images, variable-length sequences), the user
+must pass `output_signature` explicitly with `shape=[None, ...]`
+markers where ragged. The docstring example covers this case.
 
 ### 3.3 Target arity
 
@@ -271,10 +335,11 @@ access. No library-level retry or fallback.
 
 ### 3.7 Shared target-specification vocabulary
 
-Per anchor 7, `as_torch_dataset` and `restructure_assets` share the
-vocabulary for describing how to resolve feature values into labels.
-The same three parameters appear on both methods with identical names,
-types, and semantics:
+Per anchor 7, the two adapter methods (`as_torch_dataset`,
+`as_tf_dataset`) and `restructure_assets` share the vocabulary for
+describing how to resolve feature values into labels. The same three
+parameters appear on all three methods with identical names, types,
+and semantics:
 
 **`targets: list[str] | dict[str, FeatureSelector] | None`**
 
@@ -302,8 +367,9 @@ Single-key vs multi-key behavior matches each method's output shape
 User-supplied callable that maps the resolved feature record(s) into
 the final label value.
 
-- For the adapter: return value goes to the training loop unchanged.
-  Any type (int, tensor, list, etc.).
+- For the adapters (both torch and tf): return value goes to the
+  training loop unchanged. Any type (int, `torch.Tensor`, `tf.Tensor`,
+  dict of tensors, etc.). The library does not inspect it.
 - For restructure: return value MUST be a string (used as a
   filesystem directory name). A non-string return raises
   `DerivaMLValidationError` at construction with a message explaining
@@ -323,33 +389,53 @@ for adapter becomes `return rec.Grade` for restructure).
 Policy for elements whose feature value is absent:
 
 - `"error"` — raise `DerivaMLException` at construction listing
-  unlabeled RIDs. Default for **adapter**.
+  unlabeled RIDs. Default for **both adapters** (torch and tf).
 - `"skip"` — drop unlabeled elements entirely. For restructure, the
-  asset file is not placed in the output tree. For the adapter, the
-  element is absent from `__len__`.
+  asset file is not placed in the output tree. For the adapters, the
+  element is absent from `__len__` / iteration.
 - `"unknown"` — keep unlabeled elements. For restructure, the asset
   goes into an `unknown/` directory (matches today's behavior).
-  For the adapter, the target is `None` (user's `target_transform`
+  For the adapters, the target is `None` (user's `target_transform`
   must handle it). Default for **restructure**.
 
 The default differs by method because the failure modes differ:
 silent mislabeling during training is a correctness hazard (adapter
-default is `"error"`); silently placing an asset in `unknown/` during
-a filesystem lay-out is recoverable by inspection (restructure default
-is `"unknown"`, which preserves today's behavior and avoids breakage).
+defaults are `"error"`); silently placing an asset in `unknown/`
+during a filesystem lay-out is recoverable by inspection (restructure
+default is `"unknown"`, which preserves pre-alignment behavior and
+avoids breakage for unparameterized calls).
 
-Users who want the adapter's strictness in restructure just pass
-`missing="error"`; users who want restructure's leniency in the adapter
-pass `missing="unknown"`.
+Users who want the adapter strictness in restructure pass
+`missing="error"`; users who want restructure's leniency in an
+adapter pass `missing="unknown"` and handle `None` in their
+`target_transform`.
+
+**Per-method unique arguments.** The required positional argument
+differs: both adapter methods take `element_type` (a table name);
+`restructure_assets` takes `output_dir` (a path). These can't unify
+without hiding what each method's input actually is. Additionally:
+`sample_loader` and `transform` apply only to the adapters
+(restructure doesn't load in-memory samples; its on-disk rewrite
+hook is `file_transformer`, which operates on paths).
+`output_signature` applies only to `as_tf_dataset`
+(TF-specific, no counterpart on torch or restructure).
 
 ## 4. Package structure
 
-New module: `src/deriva_ml/dataset/torch_adapter.py`.
+Three new modules: two framework adapters and a shared helper:
 
-Public entry point: `DatasetBag.as_torch_dataset(...)` as a method,
-delegating to a module-level builder function. The method is defined
-in `dataset_bag.py` (same class body as existing `as_` helpers);
-the builder imports torch lazily inside its body.
+- `src/deriva_ml/dataset/torch_adapter.py` — builds
+  `torch.utils.data.Dataset`. Imports torch lazily inside the builder
+  function body.
+- `src/deriva_ml/dataset/tf_adapter.py` — builds `tf.data.Dataset`.
+  Imports tensorflow lazily inside the builder function body. Handles
+  the `from_generator` + `output_signature` inference plumbing.
+- `src/deriva_ml/dataset/target_resolution.py` — private helper
+  `_resolve_targets(...)` consumed by both adapter modules AND by
+  `restructure_assets`. See §8.5.
+
+Public entry points are methods on `DatasetBag` that delegate to the
+module-level builders:
 
 ```python
 # dataset_bag.py (class body):
@@ -357,11 +443,19 @@ def as_torch_dataset(self, element_type, **kwargs):
     """..."""
     from deriva_ml.dataset.torch_adapter import build_torch_dataset
     return build_torch_dataset(self, element_type, **kwargs)
+
+def as_tf_dataset(self, element_type, **kwargs):
+    """..."""
+    from deriva_ml.dataset.tf_adapter import build_tf_dataset
+    return build_tf_dataset(self, element_type, **kwargs)
 ```
 
-This keeps the public signature discoverable from the class docstring
-and IDE autocomplete, while isolating the torch coupling to one
-module.
+This keeps the public signatures discoverable from the class
+docstring and IDE autocomplete, while isolating each framework's
+coupling to one module. Users who install deriva-ml without torch
+or without tensorflow can still import `DatasetBag` and call every
+other method; only the adapter method corresponding to the missing
+framework raises on first call, with an install-hint message.
 
 ## 5. Package extras
 
@@ -370,51 +464,104 @@ module.
 ```toml
 [project.optional-dependencies]
 torch = ["torch>=2.0"]
+tf    = ["tensorflow>=2.15"]
 ```
 
-Installation: `pip install 'deriva-ml[torch]'`. The existing
-`dependency-groups` table for dev / lint stays where it is — the new
-`optional-dependencies` section documents runtime extras users can
-opt into, which is distinct from dev tooling.
+Installation:
+- `pip install 'deriva-ml[torch]'` — for PyTorch users.
+- `pip install 'deriva-ml[tf]'` — for TensorFlow / Keras-on-TF users.
+- `pip install 'deriva-ml[torch,tf]'` — both (uncommon but valid).
 
-Version floor `>=2.0` chosen to match modern PyTorch while leaving
-room for PyTorch 2.x + torchvision users. Specific-version pinning is
-the user's concern.
+The existing `dependency-groups` table for dev / lint stays where
+it is — the new `optional-dependencies` section documents runtime
+extras users can opt into, which is distinct from dev tooling.
+
+**Version-floor rationale:**
+
+- **PyTorch `>=2.0`** — modern torch; torchvision users typically
+  already have this. Specific-version pinning is the user's concern.
+- **TensorFlow `>=2.15`** — recent-enough to cover Keras 3 migration
+  (Keras 3 requires TF 2.15+), and cleanly supports the modern
+  `tf.data.Dataset.from_generator(output_signature=...)` path this
+  adapter uses. Older TF versions had bugs in the generator
+  output-signature inference that we'd have to work around.
+
+**Platform note (tensorflow wheel selection):**
+
+On macOS (Apple Silicon) the conventional install is
+`tensorflow-macos` rather than vanilla `tensorflow`. On CUDA-enabled
+Linux it's `tensorflow[and-cuda]`. Our extra pins `tensorflow>=2.15`
+as the package name; users on special platforms should install their
+preferred tf wheel separately and install `deriva-ml` without the
+`[tf]` extra (the import guard inside `as_tf_dataset` just checks
+that `tensorflow` is importable — it doesn't care which wheel). The
+UG section documents this.
 
 ## 6. Testing strategy
 
-Three test tiers:
+Three test tiers per adapter (torch and TF), plus shared-helper tests
+and the existing catalog fixture.
 
-### 6.1 Module-import test (no torch installed)
+### 6.1 Module-import tests (framework not installed)
 
-Verify the library still imports when torch is absent. Mocks or
-manipulates `sys.modules` to remove torch; confirms `DatasetBag` is
-importable and every method except `as_torch_dataset` works normally.
-Confirms `as_torch_dataset` raises `ImportError` with the expected
-install-hint message.
+Verify the library still imports when a given framework is absent.
+Two parallel tests:
 
-Lives in: `tests/dataset/test_torch_adapter_no_torch.py`.
+- `tests/dataset/test_torch_adapter_no_torch.py` — removes torch via
+  `sys.modules` manipulation, confirms `DatasetBag` is importable and
+  every method except `as_torch_dataset` works, confirms
+  `as_torch_dataset` raises `ImportError` with install-hint message.
+- `tests/dataset/test_tf_adapter_no_tf.py` — same shape for
+  tensorflow. The two tests are independent (removing torch does not
+  touch the TF import path and vice versa).
 
-### 6.2 Pure-Python logic (torch stubbed)
+### 6.2 Pure-Python logic (framework stubbed)
 
 Exercises the join logic, selector pass-through, `missing=` branches,
-target arity, and error paths without a real torch install. Uses a
-minimal `torch.utils.data.Dataset` stub. No GPU/CPU tensor ops
-involved; just the library's data-plumbing logic.
+target arity, and error paths without a real framework install. Two
+parallel tests:
 
-Lives in: `tests/dataset/test_torch_adapter_logic.py`.
+- `tests/dataset/test_torch_adapter_logic.py` — stubs
+  `torch.utils.data.Dataset`.
+- `tests/dataset/test_tf_adapter_logic.py` — stubs `tf.data.Dataset`
+  plus `tf.TensorSpec` (the `output_signature` inference is tested
+  against the stub).
 
-### 6.3 End-to-end with real torch
+Both tiers share the same test matrix:
+- `missing="error"` raises at construction with RID list.
+- `missing="skip"` drops unlabeled elements.
+- `missing="unknown"` passes `None` to `target_transform`.
+- Selector dict form vs list form yield equivalent results when no
+  selector is provided.
+- `target_transform` is called on the right shape (FeatureRecord /
+  dict / list per target arity).
+- Asset-table element with no `sample_loader` raises at construction.
 
-Runs only when torch is importable. Builds a dataset from a test-catalog
-bag fixture, iterates it under a real `DataLoader`, verifies the output
-tuple shape, label encoding round-trip, and `missing="skip"` filters
-correctly.
+### 6.3 End-to-end with real frameworks
 
-Lives in: `tests/dataset/test_torch_adapter_e2e.py`. Skipped with
-`pytest.importorskip("torch")` when torch is not installed.
+Runs only when the framework is importable. Two parallel tests:
 
-### 6.4 Test catalog fixture
+- `tests/dataset/test_torch_adapter_e2e.py` — gated by
+  `pytest.importorskip("torch")`. Builds a dataset from the
+  `catalog_with_datasets` fixture, iterates under a real
+  `DataLoader`, verifies tuple shape, label-encoding round-trip,
+  `missing="skip"` filtering, and (where applicable) multi-worker
+  behavior.
+- `tests/dataset/test_tf_adapter_e2e.py` — gated by
+  `pytest.importorskip("tensorflow")`. Same flow using
+  `tf.data.Dataset.batch(...)` / `.prefetch(...)`. Additionally
+  verifies `output_signature=None` inference works (caller passes
+  no signature; first `.take(1)` produces the expected shape).
+
+### 6.4 Shared-helper tests
+
+`tests/dataset/test_target_resolution.py` tests the
+`_resolve_targets` helper in isolation from any framework. Covers
+the contract enumerated in §8.5 (returns-dict-keyed-by-RID semantics,
+three `missing=` branches, selector dict behavior). Independent of
+torch and tf — pure-Python.
+
+### 6.5 Test catalog fixture
 
 Leverages the existing `catalog_with_datasets` fixture. The test
 doesn't need new catalog setup — the demo catalog already has
@@ -447,29 +594,93 @@ enum-value check or import-guard behavior) runs at doctest collection.
 ### 7.2 User guide section
 
 New section in `docs/user-guide/offline.md` (Chapter 5, which already
-covers `DatasetBag` and `restructure_assets`) titled **"How to train a
-PyTorch model from a bag"**. Structure follows the UG contract:
+covers `DatasetBag` and `restructure_assets`) titled **"How to feed a
+bag to a training framework"**. Structure follows the UG contract,
+with sub-subsections for each supported framework plus Keras routing:
 
-1. **Motivation.** Two sentences explaining why the adapter exists and
-   when a user would reach for it instead of `restructure_assets`.
-2. **Simple example.** Image classification with one feature as label,
-   `PIL.Image.open` as loader, a torchvision transform pipeline. ~15
-   lines of code end-to-end.
-3. **Explanation.** How labels come from features, how the selector
-   pattern handles multi-annotator cases, how `missing=` resolves
-   sparse-label choices.
-4. **Worked variations:**
-   - Tabular regression (non-asset element_type, no `sample_loader`
-     default override, continuous-valued feature)
-   - Multi-target (two features → dict target)
-   - Multi-annotator resolution (selector-dict form)
-5. **Notes:** pointer to the `deriva-ml[torch]` extra; pointer to
-   `restructure_assets` for the narrow image-classification case
-   that predates the adapter; explicit note that
-   `Dataset.as_torch_dataset` (live-catalog variant) is not yet
-   shipped.
-6. **See also:** Chapter 3 (features API for selector pattern); the
-   `DatasetBag.feature_values` docstring for the selector shape.
+1. **Motivation.** Two sentences explaining why these adapters exist
+   and when a user would reach for them instead of
+   `restructure_assets`.
+2. **Choosing your path.** Short decision paragraph:
+   - `as_torch_dataset` — if you're using PyTorch (native) or Keras
+     on the PyTorch backend.
+   - `as_tf_dataset` — if you're using TensorFlow (native) or Keras
+     on the TensorFlow backend.
+   - `restructure_assets` — if you're using a third-party trainer
+     that expects `ImageFolder` class-folder layout (e.g., RetFound
+     fine-tuning scripts, `torchvision.datasets.ImageFolder`,
+     `tf.keras.utils.image_dataset_from_directory`).
+
+#### 7.2.1 Using with PyTorch
+
+Structure:
+- **Simple example.** Image classification with one feature as
+  label, `PIL.Image.open` as loader, torchvision transform
+  pipeline. ~15 lines end-to-end.
+- **Explanation.** How labels come from features, how the selector
+  pattern handles multi-annotator cases, how `missing=` resolves
+  sparse-label choices.
+- **Worked variations:**
+  - Tabular regression (non-asset element_type, no `sample_loader`
+    override needed, continuous-valued feature).
+  - Multi-target (two features → dict target).
+  - Multi-annotator resolution (selector-dict form).
+- **Notes:** pointer to `deriva-ml[torch]` extra; explicit note that
+  `Dataset.as_torch_dataset` (live-catalog variant) is not yet
+  shipped.
+
+#### 7.2.2 Using with TensorFlow
+
+Structure:
+- **Simple example.** Same image-classification task but returning
+  `tf.data.Dataset`, showing `.batch().prefetch()` pipeline. ~15
+  lines end-to-end.
+- **`output_signature` guidance.** When to let inference happen
+  (default; one-shot research code), when to pass it explicitly
+  (production pipelines with deterministic startup; ragged tensors).
+- **Worked variations:** the same three from the PyTorch section,
+  translated to TF shape.
+- **Notes:** pointer to `deriva-ml[tf]` extra and to the platform
+  note (§5) about `tensorflow-macos` / `tensorflow[and-cuda]` for
+  users who want a specific wheel.
+
+#### 7.2.3 Using with Keras
+
+Keras 3 accepts data from either backend's native format. Users
+don't need a separate adapter; they pick the method matching their
+Keras backend:
+
+- **Keras on PyTorch backend:** wrap `as_torch_dataset(...)` in a
+  `DataLoader` and pass to `model.fit(...)`. Keras consumes
+  `torch.utils.data.DataLoader` natively.
+- **Keras on TensorFlow backend:** pass `as_tf_dataset(...)` directly
+  to `model.fit(...)`. Keras consumes `tf.data.Dataset` natively.
+- **Keras on JAX backend:** use either adapter; Keras 3 accepts
+  Python iterables of `(x, y)` tuples regardless of origin.
+
+A ~20-line worked example shows the backend choice via
+`os.environ["KERAS_BACKEND"] = "torch"` or `"tensorflow"` and then
+the appropriate adapter call. Explicit note: no `as_keras_dataset`
+method exists because Keras is a consumer of both adapters, not a
+third parallel one.
+
+#### 7.2.4 Using with `ImageFolder` / third-party tools
+
+Pointer to §7.4.2: `restructure_assets` is the tool when your
+downstream consumer wants the class-folder directory layout
+(including RetFound fine-tuning scripts,
+`torchvision.datasets.ImageFolder`,
+`tf.keras.utils.image_dataset_from_directory`, and similar).
+Aligned vocabulary (§3.7) means the `targets` / `target_transform`
+/ `missing` kwargs you'd use with `as_torch_dataset` work
+identically with `restructure_assets`.
+
+#### 7.2.5 See also
+
+Chapter 3 (features API for selector pattern); the
+`DatasetBag.feature_values` docstring for the selector shape;
+the `split_dataset` docstring for the stratified-split flow that
+composes upstream of all three framework paths (see §7.4.1).
 
 ### 7.3 Cross-references
 
@@ -766,25 +977,23 @@ shared parameter names.
 The following are intentionally **out of scope** to keep the v1
 surface focused:
 
-- **TensorFlow adapter.** Parallel `as_tf_dataset` has the same shape
-  but is a separate deliverable. If this PR lands cleanly, a follow-up
-  adds TF with minimal new design (the join logic, path resolution,
-  and feature-value plumbing are directly reusable).
-- **`Dataset.as_torch_dataset` (live-catalog variant).** Covered in
-  anchor 4 above. Named follow-up; not v1.
-- **DataLoader construction.** The library returns a `Dataset`; the
-  user wraps it in `torch.utils.data.DataLoader` with their own
-  `batch_size`, `shuffle`, `num_workers`, etc. The library does not
-  opine on batching.
+- **Live-catalog adapter variants** (`Dataset.as_torch_dataset`,
+  `Dataset.as_tf_dataset`). Covered in anchor 4 above. Named
+  follow-up; not v1.
+- **DataLoader / `.batch()` construction.** Both adapters return a
+  raw `Dataset` (torch) or `tf.data.Dataset` (tf). The user wraps in
+  `torch.utils.data.DataLoader` with their own `batch_size`,
+  `shuffle`, `num_workers`, or chains `.batch().prefetch()` on the
+  TF side. The library does not opine on batching.
 - **Train/val/test splits.** Already covered by
-  `split_dataset` / `stratify_by_column`. The adapter takes whatever
-  bag you hand it; splitting happens upstream.
-- **In-memory caching across epochs.** Torch's own DataLoader +
-  dataset-level caching is the standard pattern. The library doesn't
-  layer on top.
-- **Inference-result writeback.** That's feature-record territory (D1
-  + existing `add_features` path), orthogonal to the data-loading
-  adapter.
+  `split_dataset` / `stratify_by_column`. The adapters take whatever
+  bag you hand them; splitting happens upstream.
+- **In-memory caching across epochs.** Both frameworks have standard
+  idioms (`torch.utils.data.DataLoader` persistent workers,
+  `tf.data.Dataset.cache()`). The library doesn't layer on top.
+- **Inference-result writeback.** That's feature-record territory
+  (D1 + existing `add_features` path), orthogonal to the data-loading
+  adapters.
 - **Label encoding helpers.** Explicit non-goal per anchor 2.
   Users own their encoder; the library surfaces typed records.
 
@@ -795,26 +1004,42 @@ Implementation plan (separate document at
 will enumerate specific tasks; this spec's checklist names the
 deliverables the plan must cover.
 
-**Adapter deliverables:**
+**Adapter deliverables (PyTorch):**
 
 - [ ] `src/deriva_ml/dataset/torch_adapter.py` — new module
 - [ ] `src/deriva_ml/dataset/dataset_bag.py` — `as_torch_dataset`
   method added with full docstring
-- [ ] `pyproject.toml` — `[project.optional-dependencies]` table with
-  `torch = [...]`
 - [ ] `tests/dataset/test_torch_adapter_no_torch.py`
 - [ ] `tests/dataset/test_torch_adapter_logic.py`
 - [ ] `tests/dataset/test_torch_adapter_e2e.py` (pytest.importorskip)
-- [ ] `docs/user-guide/offline.md` — new "How to train a PyTorch model
-  from a bag" section per §7.2
+
+**Adapter deliverables (TensorFlow):**
+
+- [ ] `src/deriva_ml/dataset/tf_adapter.py` — new module
+- [ ] `src/deriva_ml/dataset/dataset_bag.py` — `as_tf_dataset`
+  method added with full docstring (incl. `output_signature`
+  inference behavior)
+- [ ] `tests/dataset/test_tf_adapter_no_tf.py`
+- [ ] `tests/dataset/test_tf_adapter_logic.py`
+- [ ] `tests/dataset/test_tf_adapter_e2e.py` (pytest.importorskip;
+  verifies `output_signature=None` inference)
 
 **Shared infrastructure (per §8.5):**
 
-- [ ] `src/deriva_ml/dataset/target_resolution.py` (or equivalent) —
-  private helper `_resolve_targets(bag, element_type, targets, missing)`
-  shared between `as_torch_dataset` and `restructure_assets`
-- [ ] Tests for the shared helper covering the three `missing=`
-  branches and selector-dict vs list forms
+- [ ] `src/deriva_ml/dataset/target_resolution.py` — private helper
+  `_resolve_targets(bag, element_type, targets, missing)` shared
+  among `as_torch_dataset`, `as_tf_dataset`, and `restructure_assets`
+- [ ] `tests/dataset/test_target_resolution.py` — tests for the
+  shared helper covering the three `missing=` branches and
+  selector-dict vs list forms
+- [ ] `pyproject.toml` — `[project.optional-dependencies]` table
+  with `torch = [...]` and `tf = [...]` extras
+
+**User guide:**
+
+- [ ] `docs/user-guide/offline.md` — new "How to feed a bag to a
+  training framework" section per §7.2 covering PyTorch, TensorFlow,
+  Keras (both backends), and `ImageFolder`-style layout
 
 **Restructure alignment deliverables (per §8):**
 
@@ -879,7 +1104,35 @@ anything; it reads.
 **Risk: Torch dependency bloat for users who install
 `deriva-ml[torch]` accidentally.** Mitigation: named extra; pip install
 without `[torch]` leaves torch out entirely. The default install
-remains lean.
+remains lean. Same reasoning applies to `deriva-ml[tf]`.
+
+**Risk: TensorFlow wheel selection is platform-dependent and confuses
+users.** On macOS (Apple Silicon) the canonical install is
+`tensorflow-macos`, not vanilla `tensorflow`. On CUDA-enabled Linux
+it's `tensorflow[and-cuda]`. Mitigation: document the wheel choice in
+both the package-extras section of pyproject.toml's PyPI description
+and in the UG TensorFlow sub-section. The import guard inside
+`as_tf_dataset` just checks that `tensorflow` is importable, so any
+properly-installed tf wheel satisfies it regardless of which variant
+the user chose.
+
+**Risk: `tf.data.Dataset.from_generator` is slower than
+`from_tensor_slices`.** `from_generator` can't be traced into a
+tf.graph, so tf.data optimizations (autograph, XLA) don't apply
+inside our iteration. Mitigation: anchor 4 (no eager materialization)
+is a deliberate choice — the cost is acceptable for research-scale
+datasets, and the alternative (eager materialization) would violate
+our lazy-loading contract for any bag larger than RAM. Users with
+performance-critical pipelines and smaller datasets can use
+`.cache()` on the returned `tf.data.Dataset` as a standard TF
+escape hatch.
+
+**Risk: `output_signature=None` inference consumes one sample eagerly
+at adapter construction.** For pipelines where even the first sample
+is expensive (e.g., huge 4D medical volumes), this adds measurable
+startup cost. Mitigation: documented in §3.2 and in the docstring;
+users with this concern pass `output_signature` explicitly to skip
+the eager-infer path.
 
 **Risk: `restructure_assets` parameter rename is a hard break for any
 downstream caller using `group_by=`, `value_selector=`, or the
@@ -910,13 +1163,13 @@ can be inlined back per-method with a single commit.
 
 ## 12. Future work (named for future-spec continuity)
 
-- **TF adapter** (separate future spec): `bag.as_tf_dataset(...)` with
-  the same target/selector/missing semantics but a `tf.data.Dataset`
-  return type. Reuses the join logic, path resolution, and
-  feature-value plumbing; only the framework wrapper is new.
-- **`Dataset.as_torch_dataset` (live-catalog variant)** (separate
-  future spec): live-download semantics, credential lifetime, retry
-  policy, cache eviction.
+- **Live-catalog adapter variants** (separate future spec):
+  `Dataset.as_torch_dataset` and `Dataset.as_tf_dataset` with
+  live-download-during-iteration semantics. Requires design work on
+  credential lifetime, retry policy, cache eviction, and
+  download-during-`__getitem__` performance. The bag-only v1 covers
+  the primary training workflow (download once, train many times)
+  without any of that complexity.
 - **Numpy/Arrow adapters** (lower priority): for users who want
   framework-agnostic iteration over (sample, target) tuples.
 - **Streaming / iterable datasets** (lower priority): `IterableDataset`

--- a/docs/superpowers/specs/2026-04-24-torch-dataset-adapter-design.md
+++ b/docs/superpowers/specs/2026-04-24-torch-dataset-adapter-design.md
@@ -77,6 +77,30 @@ error behavior, and selector handling mirror
 feature API should be able to read the adapter's signature without
 surprise.
 
+**Anchor 6: Composition over replacement; no feature overlap.**
+deriva-ml already answers several questions the adapter could try to
+re-solve:
+
+- **Train/val/test splitting** lives in `split_dataset` (with
+  stratification via `stratify_by_column`). Each partition becomes its
+  own catalog dataset and its own bag; the adapter handles each bag
+  independently. This is the one real **composition** pattern — see
+  §7.4.1.
+- **Filesystem-layout rewrites for third-party tools** (`ImageFolder`
+  et al.) live in `restructure_assets`. This is an **alternative** to
+  the adapter, not a pipeline step: the two tools solve the same
+  problem with different shapes (lazy in-place read vs. eager
+  on-disk rewrite). See §7.4.3 for why they don't chain.
+- **Catalog-level annotation joins** live in
+  `bag.get_denormalized_as_dataframe` and `bag.feature_values`. The
+  adapter reads feature values through the existing API (anchor 1),
+  it doesn't invent a second path.
+
+The adapter's v1 job is exactly one thing: lazy iteration over an
+already-defined bag. It does not duplicate these neighboring tools,
+does not wrap them in competing convenience methods, and does not
+offer knobs that replicate theirs.
+
 ## 3. Public API
 
 ### 3.1 Signature
@@ -354,11 +378,121 @@ PyTorch model from a bag"**. Structure follows the UG contract:
   users first learn about bags.
 - `DatasetBag.restructure_assets`'s docstring gets one sentence
   pointing at `as_torch_dataset` as the general-case companion.
+- `split_dataset` (in `src/deriva_ml/dataset/split.py`) gets one
+  sentence in its docstring's Examples / See Also section pointing
+  at the composition pattern in §7.4 below. No signature change;
+  existing behavior preserved.
 - The `DatasetBag` class-level docstring gets one bullet mentioning
   the adapter alongside the existing `restructure_assets()` mention.
   (The corresponding paragraph in `CLAUDE.md` — the project-level
   codebase notes — gets the same one-sentence addition for future
   agentic work, tracked as part of the plan's UG-integration task.)
+
+### 7.4 Composition with existing dataset APIs
+
+The adapter **composes** with the other data-shaping primitives; it
+does not replace them. Three composition patterns need dedicated
+coverage in the UG section and in docstrings because they are the
+most common production flows.
+
+#### 7.4.1 Stratified train/val/test split → per-partition torch datasets
+
+`split_dataset` creates a parent `Split` catalog dataset with child
+`Training`, `Testing`, and optionally `Validation` datasets. Each
+partition is a standalone dataset — download each as its own bag,
+then turn each bag into its own `torch.utils.data.Dataset` via the
+adapter. The adapter does not need split-awareness; each bag is
+independent.
+
+```python
+from deriva_ml.dataset.split import split_dataset
+
+# Upstream (online): create stratified split hierarchy in catalog
+split = split_dataset(
+    ml,
+    source_dataset_rid="28D0",
+    test_size=0.2,
+    val_size=0.1,
+    stratify_by_column="Image_Classification.Image_Class",
+    seed=42,
+)
+# split.training.rid, split.testing.rid, split.validation.rid are
+# three new catalog dataset RIDs.
+
+# Later (offline training): one bag per partition
+train_bag = ml.lookup_dataset(split.training.rid).download_dataset_bag(
+    version="1.0.0"
+)
+val_bag   = ml.lookup_dataset(split.validation.rid).download_dataset_bag(
+    version="1.0.0"
+)
+test_bag  = ml.lookup_dataset(split.testing.rid).download_dataset_bag(
+    version="1.0.0"
+)
+
+# Build torch datasets from each bag independently
+kwargs = dict(
+    element_type="Image",
+    sample_loader=lambda p, row: PIL.Image.open(p).convert("RGB"),
+    targets=["Image_Classification"],
+    target_transform=lambda rec: CLASS_TO_IDX[rec.Image_Class],
+    transform=train_transform,
+)
+train_ds = train_bag.as_torch_dataset(**{**kwargs, "transform": train_transform})
+val_ds   = val_bag.as_torch_dataset(**{**kwargs, "transform": eval_transform})
+test_ds  = test_bag.as_torch_dataset(**{**kwargs, "transform": eval_transform})
+
+train_loader = DataLoader(train_ds, batch_size=32, shuffle=True,  num_workers=4)
+val_loader   = DataLoader(val_ds,   batch_size=32, shuffle=False, num_workers=4)
+test_loader  = DataLoader(test_ds,  batch_size=32, shuffle=False, num_workers=4)
+```
+
+**Why this works cleanly:** each partition inherits the full feature
+coverage of the source dataset (the split only selects RIDs; feature
+values for those RIDs remain attached). Stratification happens at
+split time against the denormalized catalog DataFrame, so the label
+distribution is correct by construction; the adapter just reads it
+back through `feature_values(...)` the same way it would for any bag.
+
+#### 7.4.2 `restructure_assets` vs `as_torch_dataset` — these are alternatives, not a pipeline
+
+A natural question: "can I call `restructure_assets` first and then feed
+the result into `as_torch_dataset`?" The short answer is **no, and you
+wouldn't want to**. These two tools solve the same problem with
+different shapes, not two halves of one workflow.
+
+| Need | Tool |
+|---|---|
+| Lazy streaming, no disk rewrite, full `FeatureRecord` access, any element type | `as_torch_dataset` |
+| Compatibility with `torchvision.datasets.ImageFolder` or a third-party trainer that expects the `ImageFolder` directory convention | `restructure_assets` + `ImageFolder` |
+
+**Why they don't chain:** `restructure_assets` creates a *new directory*
+with the `ImageFolder` layout by copying or symlinking from the bag's
+flat `data/assets/<type>/<rid>/<file>` tree. It doesn't modify the
+bag. `as_torch_dataset`'s path resolution is hard-coded to
+`bag.path / "data/assets/<type>/<rid>/<file>"` — it reads from the
+bag, not from the restructured sibling tree. Restructuring first and
+then calling the adapter buys nothing: the adapter still reads the
+unchanged bag, and the restructured tree sits unused.
+
+**Picking between them:**
+
+- If your downstream consumer is a `torchvision.datasets.ImageFolder`
+  instance (or any code that expects a class-folder directory layout),
+  use `restructure_assets`. The adapter is the wrong tool.
+- If your downstream consumer is your own `torch.utils.data.DataLoader`
+  and you want the full `FeatureRecord` for each sample, use the
+  adapter. `restructure_assets` is the wrong tool.
+- If you need **both** — e.g., you want an `ImageFolder` for a baseline
+  comparison and a custom adapter for your main model — run
+  `restructure_assets` once and call `as_torch_dataset` independently
+  on the same bag. They don't conflict; they just don't collaborate.
+
+The adapter deliberately does **not** offer a `layout="image_folder"`
+shortcut to drive `restructure_assets` under the hood. Keeping the two
+primitives separate means `restructure_assets` has a clear contract
+(it rewrites disk), the adapter has a clear contract (it reads disk
+lazily), and users see in their own code which tool they chose.
 
 ## 8. Non-goals (explicit)
 

--- a/docs/superpowers/specs/2026-04-24-torch-dataset-adapter-design.md
+++ b/docs/superpowers/specs/2026-04-24-torch-dataset-adapter-design.md
@@ -600,14 +600,21 @@ A user who writes `targets={"Diagnosis": FeatureRecord.select_newest}`
 for the adapter can use the same dict for `restructure_assets`. The
 alignment is *input-shape* only; output shapes remain distinct. §8
 documents the specific changes to `restructure_assets` that achieve
-this alignment, and the deprecation path for users on the old
-parameter names.
+this alignment — a clean-break rename, not a deprecation cycle — and
+the migration guidance for any callers on the old parameter names.
 
 ## 8. `restructure_assets` alignment scope (same PR)
 
 Per anchor 7 and §3.7, the adapter work lands together with a
 coordinated signature update to `restructure_assets`. This section
 enumerates what changes on the restructure side and why.
+
+This is a **clean break** — the old parameter names are removed, not
+deprecated. Rationale: deriva-ml is not yet at the scale where
+maintaining a deprecation-warning surface pays for itself, and
+carrying legacy kwargs through the rename would bake in the exact
+naming inconsistency this alignment is meant to remove. Downstream
+impact is explicitly accepted and called out in §11 (risks).
 
 ### 8.1 Parameter renames
 
@@ -616,12 +623,9 @@ enumerates what changes on the restructure side and why.
 | `group_by: list[str] | None` | `targets: list[str] | dict[str, FeatureSelector] | None` | "group_by" was SQL-flavored and misleading in the ML context. "targets" reads consistently across both methods: what determines the output, directory-name or label. |
 | `value_selector: Callable | None` | merged into `targets` dict form | Single-selector was strictly less expressive than per-feature selectors. The dict form subsumes it: `targets={"A": FeatureRecord.select_newest}` covers `value_selector=FeatureRecord.select_newest` for the single-feature case. |
 
-**Deprecation path for `group_by` and `value_selector`**: both continue
-to work for one release cycle. Passing `group_by` emits a
-`DeprecationWarning` pointing at `targets`; same for `value_selector`.
-Removed in the next major release. Concrete mechanism: check for the
-old kwargs in the method body, issue the warning, and forward the
-value to the new parameter name internally.
+Passing the old kwargs after this PR lands raises `TypeError`
+("unexpected keyword argument") — the standard Python signal for a
+removed keyword. No `DeprecationWarning` shim, no alias.
 
 ### 8.2 New parameter: `target_transform`
 
@@ -631,11 +635,11 @@ Restructure today derives directory names directly from feature values
 the directory name:
 
 ```python
-# Today (still works, deprecated):
+# Before this PR:
 bag.restructure_assets(output_dir="./out", group_by=["Classification.Label"])
 # → directories named after the Label column value
 
-# Aligned form:
+# After this PR:
 bag.restructure_assets(
     output_dir="./out",
     targets=["Classification"],
@@ -643,16 +647,16 @@ bag.restructure_assets(
 )
 ```
 
-The `"Feature.column"` dotted-string syntax is **deprecated** with a
-`DeprecationWarning` pointing at `target_transform`, but continues to
-work for one release cycle to avoid breakage in existing scripts.
+The `"Feature.column"` dotted-string syntax is **removed**. Calls that
+pass it raise `DerivaMLValidationError` at construction explaining the
+new form. Users rewrite their one-line `group_by=["Feature.column"]`
+as a two-line `targets=["Feature"]` + `target_transform=lambda rec: rec.column`.
 
-Runtime constraint: `target_transform`'s return type is validated at
-the first `__getitem__`-equivalent call (inside the directory-naming
-loop). A non-string return raises `DerivaMLValidationError` with a
-message explaining that restructure's target_transform must return a
-filesystem-name-compatible string. (The adapter version has no such
-constraint.)
+Runtime constraint: `target_transform`'s return type is checked at
+the first directory-naming call. A non-string return raises
+`DerivaMLValidationError` with a message explaining that restructure's
+target_transform must return a filesystem-name-compatible string.
+(The adapter version has no such constraint.)
 
 ### 8.3 New parameter: `missing`
 
@@ -663,7 +667,11 @@ unified vocabulary.
 After alignment:
 
 - `missing: Literal["error", "skip", "unknown"] = "unknown"`
-- Default `"unknown"` preserves today's behavior (non-breaking change).
+- Default `"unknown"` preserves today's behavior for callers that
+  don't explicitly pass the kwarg. This is the one concession to
+  continuity: the typical `bag.restructure_assets(output_dir="./out",
+  targets=["Diagnosis"])` call produces the same directory tree as
+  before.
 - `"error"` gives users the strict-mode option (raise at construction
   listing unlabeled RIDs) for when they want to ensure their training
   data is complete before committing to disk.
@@ -720,32 +728,38 @@ implementation-plan detail.
 ### 8.6 Testing impact
 
 New tests verify the aligned semantics on restructure:
-- `targets=[...]` produces the same dir layout as the old
-  `group_by=[...]` form.
-- `value_selector=...` + `targets=[...]` with no selector dict
-  emits a DeprecationWarning and maps to the dict form correctly.
+- `targets=[...]` produces the expected directory layout.
+- `targets={"A": selector}` applies the selector per-feature.
 - `missing="error"` raises on sparse-labeled bags.
 - `missing="skip"` omits assets from the output tree.
-- `missing="unknown"` preserves today's behavior (assets land in
-  `unknown/`).
+- `missing="unknown"` places unlabeled assets in `unknown/` (the
+  preserved default behavior).
 - `target_transform` returning a non-string raises
   `DerivaMLValidationError`.
-- `"Feature.column"` dotted syntax continues to work with a
-  DeprecationWarning.
+- Passing `group_by=` raises `TypeError` (unexpected keyword).
+- Passing `value_selector=` raises `TypeError` (unexpected keyword).
+- Passing a `"Feature.column"` dotted string as a target raises
+  `DerivaMLValidationError` with the new-form hint.
 
-Existing restructure tests stay green without modification (they
-exercise the `group_by` + `value_selector` shape, which still works
-with deprecation warnings).
+**Existing restructure tests that use `group_by` / `value_selector`
+must be updated as part of this PR** — the break is intentional.
+The implementation plan's verification step includes converting the
+existing test suite to the new signature and confirming it still
+covers the same behavior.
 
 ### 8.7 Documentation impact
 
-Docstring for `restructure_assets` is rewritten to use the new
-parameter names (and note the deprecated aliases). The UG Chapter 5
-section on `restructure_assets` gets updated examples in the same
-style as the adapter section — same vocabulary, same selector
-examples, same `missing` callouts. A one-paragraph "Vocabulary
-alignment with `as_torch_dataset`" sidebar explains the shared
-parameter names.
+Docstring for `restructure_assets` is rewritten to the new signature
+— no references to the old parameter names in the docstring body.
+A short "Migration note" section near the bottom of the docstring
+maps the old call shapes (`group_by=`, `value_selector=`,
+`"Feature.column"`) onto the new equivalents so users who find the
+docstring while debugging a `TypeError` can translate their code.
+The UG Chapter 5 section on `restructure_assets` gets updated
+examples in the same style as the adapter section — same vocabulary,
+same selector examples, same `missing` callouts. A one-paragraph
+"Vocabulary alignment with `as_torch_dataset`" sidebar explains the
+shared parameter names.
 
 ## 9. Non-goals (explicit)
 
@@ -806,20 +820,24 @@ deliverables the plan must cover.
 
 - [ ] `src/deriva_ml/dataset/dataset_bag.py` — `restructure_assets`
   signature updated:
-  - Rename `group_by` → `targets` (with deprecated alias)
-  - Deprecate `value_selector` (merged into `targets` dict form)
-  - Add `target_transform` parameter
+  - Rename `group_by` → `targets` (clean break; old kwarg removed)
+  - Remove `value_selector` (replaced by `targets` dict form)
+  - Add `target_transform` parameter with string-return check
   - Add `missing: Literal["error", "skip", "unknown"] = "unknown"`
-  - Keep `"Feature.column"` dotted syntax with DeprecationWarning
-- [ ] `restructure_assets` docstring rewritten to use new parameter
-  names and document the deprecated aliases
+  - Remove `"Feature.column"` dotted syntax in targets
+- [ ] `restructure_assets` docstring rewritten to the new signature.
+  No references to the old parameter names beyond a single migration
+  note (see cross-cutting checklist below).
 - [ ] `docs/user-guide/offline.md` — update existing restructure
   section to use new parameter names; add short "Vocabulary
   alignment with `as_torch_dataset`" sidebar
-- [ ] `tests/dataset/test_restructure_*` — new tests per §8.6 covering
-  aligned semantics + deprecation warnings
-- [ ] Any existing test that uses `group_by=` keeps passing (with
-  deprecation warning filtered or matched)
+- [ ] `tests/dataset/test_restructure_*` — update existing tests to
+  use the new signature (intentional break, not a migration path);
+  add new tests per §8.6 covering the aligned semantics
+- [ ] Grep sibling repos (`deriva-ml-model-template`, `deriva-ml-apps`,
+  `deriva-ml-demo`, `deriva-ml-template-test`) for callers of the
+  removed kwargs and flag them in the PR description so template
+  maintainers can update in lockstep
 
 **Cross-cutting:**
 
@@ -828,8 +846,10 @@ deliverables the plan must cover.
 - [ ] Fast suite green (`tests/local_db/ tests/asset/ tests/model/
   tests/dataset/test_torch_adapter_* tests/dataset/test_restructure_*`)
 - [ ] Ruff check + format clean (parity with main baseline)
-- [ ] CHANGELOG or similar (if the project maintains one) noting the
-  `restructure_assets` parameter-rename deprecation
+- [ ] PR description includes a "Breaking changes" section naming
+  the removed `restructure_assets` kwargs and the required migration
+  (`group_by=` → `targets=`, `value_selector=` → `targets={feature:
+  selector}`, `"Feature.column"` → explicit `target_transform`)
 
 ## 11. Risks and mitigations
 
@@ -861,15 +881,24 @@ anything; it reads.
 without `[torch]` leaves torch out entirely. The default install
 remains lean.
 
-**Risk: `restructure_assets` parameter deprecation breaks downstream
-scripts.** Three downstream repos (deriva-ml-model-template, apps,
-demo) may use `group_by=` or `value_selector=` in their example code.
-Mitigation: the old parameter names continue to work for one release
-cycle with a `DeprecationWarning`; removal is a named separate PR
-scheduled for the next major release. The plan's verification step
-includes grepping sibling repos for the deprecated kwargs and noting
-them in the PR description so template-repo owners can schedule their
-update.
+**Risk: `restructure_assets` parameter rename is a hard break for any
+downstream caller using `group_by=`, `value_selector=`, or the
+`"Feature.column"` dotted-string syntax in targets.** This is an
+explicit choice (§8) — deriva-ml is not yet at the scale where a
+deprecation surface pays for itself, and keeping the old names as
+aliases would bake in the inconsistency that motivated the rename.
+Mitigation is twofold: (1) the implementation plan includes a grep of
+sibling repos (`deriva-ml-model-template`, `deriva-ml-apps`,
+`deriva-ml-demo`, `deriva-ml-template-test`) to enumerate callers and
+flag them in the PR description, so template maintainers can update
+in lockstep with this PR landing; (2) the PR description carries a
+"Breaking changes" section with a concrete migration mapping so
+downstream users who pull the new version see exactly what to
+substitute. The `missing` default stays at `"unknown"` so the
+most common unparameterized call (`bag.restructure_assets(output_dir=
+"./out", targets=["Diagnosis"])`) produces the same tree as before
+the PR — the break is contained to callers that were exercising the
+renamed surface.
 
 **Risk: Shared `_resolve_targets` helper introduces coupling that
 makes future per-method changes harder.** Mitigation: the helper has a
@@ -896,8 +925,3 @@ can be inlined back per-method with a single commit.
   class-balance computation from feature values could be a helper,
   but users can do this themselves from the dataset length + target
   list today.
-- **Remove deprecated `restructure_assets` parameters** (scheduled):
-  At the next major release, remove the `group_by` and
-  `value_selector` kwargs and the `"Feature.column"` dotted-string
-  syntax in `targets`. Tracked as a separate PR keyed off the major
-  version bump.

--- a/docs/user-guide/migration.md
+++ b/docs/user-guide/migration.md
@@ -1,0 +1,305 @@
+# Migrating from previous deriva-ml versions
+
+If you are upgrading from the previously-published deriva-ml version to the post-S2 release, several public methods changed signature or were renamed, and a small number of new additive methods became available. This chapter enumerates every user-visible change and shows the before/after code for each, so you can update a downstream project in one pass.
+
+## At a glance
+
+| Category | What changed | Action |
+|---|---|---|
+| **`DatasetBag.restructure_assets`** | `group_by` → `targets`; `value_selector` merged into `targets` dict form; `"Feature.column"` dotted syntax removed | Rename kwargs; `target_transform` replaces dotted syntax |
+| **12 private-named methods** | Public methods that were internal helpers are now `_`-prefixed | Switch to the public alternative where one exists; otherwise your calls break with `AttributeError` |
+| **5 deleted methods** | `prefetch_dataset`, `list_foreign_keys`, `add_page`, `user_list`, `globus_login` removed | Use replacements (below) or delete the calls |
+| **`AssetRIDConfig` (doc-only)** | The class was never actually named `AssetRIDConfig`; real name is `AssetSpec` / `AssetSpecConfig` | Update imports |
+| **`Execution.metrics_file()`** | New recommended path for training-metric logs | Additive; replace ad-hoc `asset_file_path()` calls for metrics if you want the cleaner API |
+| **`DatasetBag.as_torch_dataset()` / `as_tf_dataset()`** | New framework adapters | Additive; consider replacing hand-rolled `Dataset` subclasses |
+| **Crash recovery** | `Running → Pending_Upload` is now a legal state transition | Additive; drop the `update_status(Failed)` workaround if you had one |
+
+## Breaking changes
+
+### DatasetBag.restructure_assets signature (`TypeError` on call)
+
+This is the largest break in the release. `restructure_assets` now shares the `targets` / `target_transform` / `missing` vocabulary with the new framework adapters (`as_torch_dataset`, `as_tf_dataset`). The old `group_by` / `value_selector` kwargs and the `"Feature.column"` dotted-string syntax are **removed**. Passing them raises `TypeError` (standard Python "unexpected keyword argument" behavior).
+
+**Simple rename — single feature:**
+
+```python
+# Before
+bag.restructure_assets(
+    output_dir="./ml_data",
+    group_by=["Diagnosis"],
+)
+
+# After
+bag.restructure_assets(
+    output_dir="./ml_data",
+    targets=["Diagnosis"],
+)
+```
+
+**Dotted column syntax → `target_transform`:**
+
+```python
+# Before
+bag.restructure_assets(
+    output_dir="./ml_data",
+    group_by=["Classification.Label"],  # picks the Label column of the Classification feature
+)
+
+# After
+bag.restructure_assets(
+    output_dir="./ml_data",
+    targets=["Classification"],
+    target_transform=lambda rec: rec.Label,  # the transform extracts the column you want
+)
+```
+
+`target_transform` must return a string (used as the directory name). Non-string returns raise `DerivaMLValidationError` at construction.
+
+**`value_selector` → per-feature selector dict:**
+
+```python
+# Before
+from deriva_ml.feature import FeatureRecord
+bag.restructure_assets(
+    output_dir="./ml_data",
+    group_by=["Glaucoma"],
+    value_selector=FeatureRecord.select_newest,
+)
+
+# After
+bag.restructure_assets(
+    output_dir="./ml_data",
+    targets={"Glaucoma": FeatureRecord.select_newest},
+)
+```
+
+The dict form is strictly more expressive — you can attach a different selector per feature, which `value_selector` (single callable for all features) could not do.
+
+**New `missing` parameter:**
+
+```python
+# Default preserves pre-D2 behavior: unlabeled assets go to unknown/
+bag.restructure_assets(
+    output_dir="./ml_data",
+    targets=["Diagnosis"],
+    missing="unknown",  # default; same tree as before
+)
+
+# Strict mode: raise if any asset is unlabeled
+bag.restructure_assets(
+    output_dir="./ml_data",
+    targets=["Diagnosis"],
+    missing="error",
+)
+
+# Drop mode: omit unlabeled assets from the output tree
+bag.restructure_assets(
+    output_dir="./ml_data",
+    targets=["Diagnosis"],
+    missing="skip",
+)
+```
+
+**Unchanged parameters:** `output_dir`, `asset_table`, `use_symlinks`, `type_selector`, `type_to_dir_map`, `enforce_vocabulary`, `file_transformer` work exactly as before. FK-reachability for finding assets through parent datasets is unchanged. Type-derived top-level directory naming (`Training` → `training` etc.) is unchanged.
+
+### Renamed private methods (`AttributeError` on call)
+
+Twelve methods that were public-named but actually internal helpers are now `_`-prefixed. If your code called them by the old name, switch to the underscored version or to the public alternative where one exists.
+
+| Old name | New name | Recommended replacement (if different) |
+|---|---|---|
+| `ml.domain_path()` | `ml._domain_path()` | — |
+| `ml.table_path()` | `ml._table_path()` | — |
+| `ml.is_system_schema()` | `ml._is_system_schema()` | — |
+| `ml.get_domain_schemas()` | `ml._get_domain_schemas()` | — |
+| `ml.apply_logger_overrides()` | `ml._apply_logger_overrides()` | — |
+| `ml.compute_diff()` | `ml._compute_diff()` | — |
+| `ml.retrieve_rid()` | `ml._retrieve_rid()` | **`ml.resolve_rid()`** is the user-facing API |
+| `ml.cache_features()` | `ml._cache_features()` | — (legacy workspace-cache shortcut) |
+| `ml.add_workflow()` | `ml._add_workflow()` | **`ml.create_workflow()`** is the user-facing factory |
+| `ml.start_upload()` | `ml._start_upload()` | — (internal upload plumbing) |
+| `asset_record_class()` (module-level factory) | `_asset_record_class()` | **`ml.asset_record_class(table)`** mixin method stays public |
+
+The underscored versions still work and behave identically — they are simply no longer part of the library's documented public surface. If your code calls one of them, the recommended fix is the public alternative where the table above names one; otherwise, just add the underscore.
+
+### Deleted methods (`AttributeError` on call)
+
+Five methods with no callers in any sibling repo were removed entirely.
+
+| Deleted | Replacement |
+|---|---|
+| `ml.prefetch_dataset(rid)` | `ml.cache_dataset(rid)` — `prefetch_dataset` was a one-line deprecated shim |
+| `ml.list_foreign_keys(...)` | None needed — the method had no users |
+| `ml.add_page(...)` | None — stale web-app helper |
+| `ml.user_list()` | None — stale web-app helper |
+| `ml.globus_login()` | None — handled transparently by deriva-py |
+
+### AssetRIDConfig class name (`ImportError` on copy-paste)
+
+The previously-published configuration documentation referred to a class named `AssetRIDConfig`. That class never existed under that name — the real public classes are `AssetSpec` (runtime Pydantic model) and `AssetSpecConfig` (hydra-zen interface). If you copied example code from the old configuration docs, you hit `ImportError`.
+
+```python
+# Before (from old docs — never actually worked)
+from deriva_ml.execution import AssetRIDConfig
+asset = AssetRIDConfig(rid="YYYY", description="Pretrained weights")
+
+# After (the real classes)
+from deriva_ml.execution import AssetSpec, AssetSpecConfig
+
+# For direct construction in non-hydra code:
+asset = AssetSpec(rid="YYYY", cache=True)
+
+# For hydra-zen store definitions:
+cfg = AssetSpecConfig(rid="YYYY", cache=True)
+```
+
+Note that the real classes do not accept a `description` parameter (that kwarg was fabricated in the old docs).
+
+## New recommended patterns (additive; no migration required)
+
+You are not required to adopt these, but they replace common hand-rolled patterns with cleaner API surface.
+
+### Training metrics
+
+Before, users wrote metrics to an `Execution_Metadata` asset via `asset_file_path` with a generic type:
+
+```python
+# Before — works but the asset type is misleading
+path = exe.asset_file_path(
+    MLAsset.execution_metadata,
+    "metrics.jsonl",
+    asset_types=ExecMetadataType.execution_config.value,  # not really a config
+)
+with path.open("a") as f:
+    f.write(json.dumps({"epoch": 0, "val_loss": 0.23}) + "\n")
+```
+
+Now there is a dedicated method and asset type:
+
+```python
+# After
+with exe.metrics_file().open("a") as f:
+    f.write(json.dumps({"epoch": 0, "val_loss": 0.23}) + "\n")
+```
+
+The file uploads as an `Execution_Metadata` asset with `asset_types=Metrics_File`, honestly describing its purpose. See [Chapter 4 — Running an experiment](executions.md#how-to-record-training-metrics).
+
+### PyTorch / TensorFlow / Keras training
+
+Before, users hand-rolled `torch.utils.data.Dataset` subclasses (~35 lines of join code) or reached for `restructure_assets` + `ImageFolder` for image classification only. Now both frameworks have native adapters:
+
+```python
+# After — PyTorch
+ds = bag.as_torch_dataset(
+    element_type="Image",
+    sample_loader=PIL.Image.open,
+    targets=["Glaucoma"],
+    target_transform=lambda rec: CLASS_TO_IDX[rec.Glaucoma],
+)
+loader = DataLoader(ds, batch_size=32, shuffle=True)
+
+# After — TensorFlow
+ds = bag.as_tf_dataset(
+    element_type="Image",
+    sample_loader=lambda p, row: tf.io.decode_image(tf.io.read_file(str(p))),
+    targets=["Glaucoma"],
+    target_transform=lambda rec: CLASS_TO_IDX[rec.Glaucoma],
+).batch(32).prefetch(tf.data.AUTOTUNE)
+
+# Keras works with either — choose the adapter matching your backend.
+```
+
+See [Chapter 5 — Working offline](offline.md#how-to-feed-a-bag-to-a-training-framework) for the full walkthrough covering PyTorch, TensorFlow, Keras (all three backends), and the `restructure_assets` alternative for third-party trainers.
+
+`restructure_assets` still exists and is still the right tool when your downstream trainer expects the `ImageFolder` class-folder directory layout (e.g., RetFound fine-tuning scripts). The new adapters and `restructure_assets` share the same `targets` / `target_transform` / `missing` vocabulary (that is the whole point of the D2 rename) — but they are alternatives, not a pipeline.
+
+### Crash recovery
+
+Before, after a hard process crash (OOM, SIGKILL) in the middle of an execution, you had to manually mark the execution `Failed` so `upload_execution_outputs` could proceed:
+
+```python
+# Before — workaround that polluted the audit trail
+exe = ml.resume_execution(rid)
+exe.update_status(ExecutionStatus.Failed, "Resumed after crash")  # spurious Failed marker
+exe.upload_execution_outputs()  # Failed → Pending_Upload → Uploaded
+```
+
+Now `Running → Pending_Upload` is a legal state transition; the crash-recovery path is explicit and does not lie about the execution's outcome:
+
+```python
+# After — clean path
+exe = ml.resume_execution(rid)
+exe.update_status(ExecutionStatus.Pending_Upload)  # honest: "advance the state machine, please upload"
+exe.upload_execution_outputs()  # Pending_Upload → Uploaded
+```
+
+See [Chapter 4 — Running an experiment](executions.md#how-to-handle-a-crash-resume) for the full crash-recovery flow.
+
+## Environment and tooling
+
+### Python version
+
+deriva-ml requires Python ≥3.12. This is unchanged from the previous release; stated here for completeness.
+
+### Optional dependencies
+
+Two new optional dependency extras are available for the framework adapters:
+
+```bash
+# For PyTorch users:
+pip install 'deriva-ml[torch]'
+
+# For TensorFlow / Keras-on-TF users:
+pip install 'deriva-ml[tf]'
+
+# Both (uncommon but valid):
+pip install 'deriva-ml[torch,tf]'
+```
+
+The base install remains lean — neither framework is a hard dependency. Library imports continue to work without either installed; only the corresponding `as_*_dataset` method raises `ImportError` with an install hint when called.
+
+**Platform note for TensorFlow:** on macOS (Apple Silicon), the conventional wheel is `tensorflow-macos` rather than vanilla `tensorflow`. On CUDA-enabled Linux, it is `tensorflow[and-cuda]`. Our extra pins `tensorflow>=2.15` as the package name; if you want a different variant, install it separately and skip the `[tf]` extra — the import guard inside `as_tf_dataset` checks only that `tensorflow` is importable.
+
+### SETUPTOOLS_USE_DISTUTILS env var
+
+A small internal fix: `Workflow.get_dynamic_version()` used to set `os.environ["SETUPTOOLS_USE_DISTUTILS"] = "stdlib"` as a defensive measure for an older setuptools bug. That mutation leaked into every subsequent `subprocess.Popen`, which on Python 3.13 crashed third-party packages (e.g., `fair_identifiers_client`) that still import `distutils.version`. The env mutation is gone. No user action required; noted here because observers may have seen the env var appear process-wide before and wondered why.
+
+## Finding affected code in your project
+
+Run these greps against your project directory to enumerate call sites that need updates:
+
+```bash
+# restructure_assets old kwargs
+grep -rn "group_by=\|value_selector=" your_project/ --include="*.py"
+grep -rnE 'restructure_assets.*"[A-Za-z_]+\.[A-Za-z_]+"' your_project/ --include="*.py"
+
+# Renamed private methods — find calls by the old public name
+grep -rnE "\b(domain_path|table_path|is_system_schema|get_domain_schemas|apply_logger_overrides|compute_diff|retrieve_rid|cache_features|add_workflow|start_upload)\(" your_project/ --include="*.py" \
+  | grep -v -E "\._\(?(domain_path|table_path|is_system_schema|get_domain_schemas|apply_logger_overrides|compute_diff|retrieve_rid|cache_features|add_workflow|start_upload)"
+
+# Deleted methods
+grep -rnE "\.(prefetch_dataset|list_foreign_keys|add_page|user_list|globus_login)\(" your_project/ --include="*.py"
+
+# AssetRIDConfig (doc-only break)
+grep -rn "AssetRIDConfig" your_project/ --include="*.py"
+```
+
+For known downstream projects in the deriva-ml ecosystem, the sibling-repo grep at the time this guide was written found the following call sites:
+
+```
+~/GitHub/deriva-ml-template-test/src/models/cifar10_cnn.py:288:        dataset.restructure_assets(
+~/GitHub/deriva-ml-template-test/src/models/cifar10_cnn.py:291:            group_by=["Image_Classification"],  # Group by feature to create class subdirs
+```
+
+Template maintainers should update the `group_by=` to `targets=` in lockstep with upgrading.
+
+## Version compatibility
+
+| deriva-ml version | Python | Torch | TensorFlow | Notes |
+|---|---|---|---|---|
+| Previous published release | ≥3.12 | n/a | n/a | Pre-S2 baseline |
+| This release (post-S2) | ≥3.12 | ≥2.0 optional (`[torch]` extra) | ≥2.15 optional (`[tf]` extra) | This migration guide applies |
+
+## Support
+
+If you hit a break not documented in this chapter, please open an issue. In particular, if you have code that worked on the previous release and fails after upgrading with an error that is not listed here, that is likely a bug on our side — the clean-break renames are all enumerated above, and everything else in the release is intended to be additive.

--- a/docs/user-guide/offline.md
+++ b/docs/user-guide/offline.md
@@ -328,6 +328,307 @@ manifest = bag.restructure_assets(
 
 When `file_transformer` is provided, `use_symlinks` is ignored.
 
+## How to feed a bag to a training framework
+
+Training a model on a `DatasetBag` used to mean writing ~35 lines of join code per project: resolve asset paths, pull feature values, encode labels, subclass your framework's dataset base class. The adapters below collapse that to a single method call. If your downstream consumer is a standard `torch.utils.data.DataLoader` or a `tf.data.Dataset` pipeline, start here.
+
+### Choosing your path
+
+Three tools cover the space of framework consumers:
+
+- **`bag.as_torch_dataset(...)`** — use when your training loop is PyTorch-native, or when you are running Keras 3 on the PyTorch backend. Returns `torch.utils.data.Dataset`.
+- **`bag.as_tf_dataset(...)`** — use when your training loop is TensorFlow-native, or when you are running Keras 3 on the TensorFlow backend. Returns `tf.data.Dataset`.
+- **`bag.restructure_assets(...)`** — use when your downstream consumer expects the `ImageFolder` class-folder directory layout (e.g., RetFound fine-tuning scripts, `torchvision.datasets.ImageFolder`, `tf.keras.utils.image_dataset_from_directory`). This is the right tool for third-party trainers you cannot modify; it rewrites the bag's flat asset tree into a labeled directory structure on disk.
+
+All three share the same `targets`, `target_transform`, and `missing` vocabulary. A `target_transform` you write for one method transfers directly to the others with only a return-type adjustment.
+
+### Using with PyTorch
+
+`as_torch_dataset` returns a `torch.utils.data.Dataset` that reads asset files lazily. Wrap it in a `DataLoader` exactly as you would any other PyTorch dataset.
+
+```python
+# doctest: +SKIP
+from pathlib import Path
+
+import PIL.Image
+import torchvision.transforms as T
+from torch.utils.data import DataLoader
+
+from deriva_ml.feature import FeatureRecord
+
+CLASS_TO_IDX = {"Normal": 0, "Mild": 1, "Moderate": 2, "Severe": 3}
+
+transform = T.Compose([
+    T.Resize(224),
+    T.CenterCrop(224),
+    T.ToTensor(),
+    T.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
+])
+
+ds = bag.as_torch_dataset(
+    "Image",
+    sample_loader=lambda p, row: PIL.Image.open(p).convert("RGB"),
+    transform=transform,
+    targets=["Glaucoma"],
+    target_transform=lambda rec: CLASS_TO_IDX[rec.Glaucoma],
+)
+
+loader = DataLoader(ds, batch_size=32, shuffle=True, num_workers=4)
+
+for images, labels in loader:
+    # images: (B, 3, 224, 224) tensor; labels: (B,) int tensor
+    loss = criterion(model(images), labels)
+    loss.backward()
+```
+
+Labels come from features. `targets=["Glaucoma"]` tells the adapter to look up the `Glaucoma` feature for each `Image` row via `bag.feature_values("Image", "Glaucoma")`. The `target_transform` receives a `FeatureRecord` and must return whatever your loss function expects — typically an integer class index. The adapter never builds its own encoder; that decision stays in your code where train/val/test consistency is your responsibility.
+
+`sample_loader` is required for asset tables. It receives the absolute `Path` to the materialized file and the raw row dict; return whatever your model consumes. The error message at construction time names common loaders (`PIL.Image.open`, `nibabel.load`, `h5py.File`) if you forget to supply one.
+
+`missing="error"` (the default) raises at construction if any `Image` row has no `Glaucoma` label, listing up to twenty unlabeled RIDs. Pass `missing="skip"` to drop unlabeled elements silently, or `missing="unknown"` to keep them and receive `None` in your `target_transform`.
+
+**Worked variations**
+
+*Tabular regression — no asset file, no `sample_loader` needed:*
+
+```python
+# doctest: +SKIP
+# MeasurementRecord is a plain row dict when sample_loader is omitted
+# for non-asset element types.
+ds = bag.as_torch_dataset(
+    "Measurement",
+    targets=["IOP_Reading"],
+    target_transform=lambda rec: float(rec.IOP_Value),
+)
+```
+
+Non-asset element types default to returning the raw row dict as the sample; no `sample_loader` is needed. Each `__getitem__` returns `(row_dict, target)`.
+
+*Multi-target — two features become a dict target:*
+
+```python
+# doctest: +SKIP
+ds = bag.as_torch_dataset(
+    "Image",
+    sample_loader=lambda p, row: PIL.Image.open(p).convert("RGB"),
+    transform=transform,
+    targets=["Glaucoma", "Cup_Disc_Ratio"],
+    target_transform=lambda recs: {
+        "grade": CLASS_TO_IDX[recs["Glaucoma"].Glaucoma],
+        "cdr":   float(recs["Cup_Disc_Ratio"].Cup_Disc_Ratio),
+    },
+)
+# __getitem__ returns (image_tensor, {"grade": int, "cdr": float})
+```
+
+When `targets` lists more than one feature name, `target_transform` receives `dict[str, FeatureRecord]` keyed by feature name.
+
+*Multi-annotator resolution — selector-dict form:*
+
+```python
+# doctest: +SKIP
+ds = bag.as_torch_dataset(
+    "Image",
+    sample_loader=lambda p, row: PIL.Image.open(p).convert("RGB"),
+    transform=transform,
+    targets={"Glaucoma": FeatureRecord.select_newest},
+    target_transform=lambda rec: CLASS_TO_IDX[rec.Glaucoma],
+    missing="skip",
+)
+```
+
+Passing a `dict` for `targets` lets you supply a per-feature selector. `FeatureRecord.select_newest` picks the annotation with the latest creation timestamp when multiple annotators labeled the same image. Other built-in selectors: `FeatureRecord.select_first`, `FeatureRecord.select_majority_vote("column_name")`.
+
+**Notes**
+
+- Install the PyTorch extra: `pip install 'deriva-ml[torch]'`. Without it, calling `as_torch_dataset` raises `ImportError` with an install hint; every other `DatasetBag` method continues to work.
+- `Dataset.as_torch_dataset` (the live-catalog variant) is not yet available. The bag-only adapter covers the primary training workflow: download the bag offline, then train. Live-catalog streaming is a named follow-up.
+
+### Using with TensorFlow
+
+`as_tf_dataset` returns a `tf.data.Dataset` that wraps the bag as a generator. Chain `.batch()`, `.prefetch()`, and `.cache()` on the result exactly as you would any other `tf.data.Dataset`.
+
+```python
+# doctest: +SKIP
+import PIL.Image
+import numpy as np
+import tensorflow as tf
+import torchvision.transforms.functional as TF
+
+CLASS_TO_IDX = {"Normal": 0, "Mild": 1, "Moderate": 2, "Severe": 3}
+
+def load_image(p, row):
+    img = PIL.Image.open(p).convert("RGB").resize((224, 224))
+    return np.array(img, dtype=np.float32) / 255.0
+
+ds = bag.as_tf_dataset(
+    "Image",
+    sample_loader=load_image,
+    targets=["Glaucoma"],
+    target_transform=lambda rec: CLASS_TO_IDX[rec.Glaucoma],
+)
+
+# Standard tf.data pipeline
+ds = ds.batch(32).prefetch(tf.data.AUTOTUNE)
+
+model.compile(optimizer="adam", loss="sparse_categorical_crossentropy")
+model.fit(ds, epochs=10)
+```
+
+**`output_signature` — when to let it infer, when to set it explicitly**
+
+`as_tf_dataset` builds its generator via `tf.data.Dataset.from_generator`, which requires a type/shape signature. By default (`output_signature=None`) the adapter eagerly reads the first `(sample, target)` pair at construction time, derives a `tf.TensorSpec` from it via `tf.type_spec_from_value`, and re-wraps the generator so that first sample is not skipped during iteration. This adds one extra sample load at startup — acceptable for research workflows.
+
+Pass `output_signature` explicitly in two situations:
+
+1. **Production pipelines** where you want deterministic startup with no eager reads:
+   ```python
+   # doctest: +SKIP
+   import tensorflow as tf
+   sig = (
+       tf.TensorSpec(shape=(224, 224, 3), dtype=tf.float32),
+       tf.TensorSpec(shape=(),            dtype=tf.int32),
+   )
+   ds = bag.as_tf_dataset("Image", ..., output_signature=sig)
+   ```
+
+2. **Variable-shape inputs** (ragged tensors, variable-length sequences) where the first sample's shape is not representative:
+   ```python
+   # doctest: +SKIP
+   sig = (
+       tf.TensorSpec(shape=(None, None, 3), dtype=tf.float32),  # variable H x W
+       tf.TensorSpec(shape=(),              dtype=tf.int32),
+   )
+   ds = bag.as_tf_dataset("Image", ..., output_signature=sig)
+   ```
+
+**Worked variations**
+
+*Tabular regression:*
+
+```python
+# doctest: +SKIP
+ds = bag.as_tf_dataset(
+    "Measurement",
+    targets=["IOP_Reading"],
+    target_transform=lambda rec: float(rec.IOP_Value),
+).batch(64).prefetch(tf.data.AUTOTUNE)
+```
+
+*Multi-target:*
+
+```python
+# doctest: +SKIP
+ds = bag.as_tf_dataset(
+    "Image",
+    sample_loader=load_image,
+    targets=["Glaucoma", "Cup_Disc_Ratio"],
+    target_transform=lambda recs: (
+        CLASS_TO_IDX[recs["Glaucoma"].Glaucoma],
+        float(recs["Cup_Disc_Ratio"].Cup_Disc_Ratio),
+    ),
+)
+```
+
+*Multi-annotator resolution:*
+
+```python
+# doctest: +SKIP
+from deriva_ml.feature import FeatureRecord
+
+ds = bag.as_tf_dataset(
+    "Image",
+    sample_loader=load_image,
+    targets={"Glaucoma": FeatureRecord.select_newest},
+    target_transform=lambda rec: CLASS_TO_IDX[rec.Glaucoma],
+    missing="skip",
+)
+```
+
+**Notes**
+
+- Install the TensorFlow extra: `pip install 'deriva-ml[tf]'`. Without it, calling `as_tf_dataset` raises `ImportError`; other methods continue to work.
+- On macOS (Apple Silicon) use `pip install tensorflow-macos` rather than `tensorflow`. On CUDA Linux use `pip install tensorflow[and-cuda]`. Either wheel satisfies the import guard inside `as_tf_dataset`; install deriva-ml itself without the `[tf]` extra when using a platform-specific wheel.
+- `Dataset.as_tf_dataset` (live-catalog variant) is not yet available. Same bag-only scope as the PyTorch adapter.
+
+### Using with Keras
+
+Keras 3 consumes data from either backend's native format. There is no separate `as_keras_dataset` method — Keras is a consumer of the adapters above, not a third parallel adapter. Pick the method that matches the Keras backend you have configured.
+
+**PyTorch backend** — wrap `as_torch_dataset` in a `DataLoader` and pass it to `model.fit`:
+
+```python
+# doctest: +SKIP
+import os
+os.environ["KERAS_BACKEND"] = "torch"
+
+import keras
+from torch.utils.data import DataLoader
+
+ds = bag.as_torch_dataset(
+    "Image",
+    sample_loader=lambda p, row: PIL.Image.open(p).convert("RGB"),
+    transform=transform,
+    targets=["Glaucoma"],
+    target_transform=lambda rec: CLASS_TO_IDX[rec.Glaucoma],
+)
+loader = DataLoader(ds, batch_size=32, shuffle=True, num_workers=4)
+
+model = keras.applications.ResNet50(weights=None, classes=4)
+model.compile(optimizer="adam", loss="sparse_categorical_crossentropy")
+model.fit(loader, epochs=10)
+```
+
+Keras on the PyTorch backend natively accepts `torch.utils.data.DataLoader` objects in `model.fit`.
+
+**TensorFlow backend** — pass `as_tf_dataset` directly to `model.fit`:
+
+```python
+# doctest: +SKIP
+import os
+os.environ["KERAS_BACKEND"] = "tensorflow"
+
+import keras
+import tensorflow as tf
+
+ds = bag.as_tf_dataset(
+    "Image",
+    sample_loader=load_image,
+    targets=["Glaucoma"],
+    target_transform=lambda rec: CLASS_TO_IDX[rec.Glaucoma],
+).batch(32).prefetch(tf.data.AUTOTUNE)
+
+model = keras.applications.ResNet50(weights=None, classes=4)
+model.compile(optimizer="adam", loss="sparse_categorical_crossentropy")
+model.fit(ds, epochs=10)
+```
+
+**JAX backend** — either adapter works. Keras 3 on JAX accepts any Python iterable of `(x, y)` tuples. Pass a `DataLoader` wrapping `as_torch_dataset`, or chain `as_tf_dataset` through a generator, or materialize to NumPy arrays directly. The JAX backend does not add requirements beyond what Keras itself needs.
+
+**Note:** Set `KERAS_BACKEND` before importing Keras — the backend is selected at import time and cannot change in the same process.
+
+### Using with ImageFolder / third-party tools
+
+When your downstream consumer expects a class-folder directory layout — `torchvision.datasets.ImageFolder`, `tf.keras.utils.image_dataset_from_directory`, RetFound fine-tuning scripts, or any other tool that walks a `class/image.jpg` tree — use `bag.restructure_assets()` instead of the adapters above. It writes (or symlinks) the bag's flat asset tree into the labeled directory structure those tools require.
+
+The `targets`, `target_transform`, and `missing` parameters on `restructure_assets` carry identical names and semantics to the ones on `as_torch_dataset` and `as_tf_dataset`. A `target_transform` you write for one method transfers directly to the other with only the return-type constraint: `restructure_assets` requires a string (used as the directory name), while the adapters accept any type.
+
+**These two tools are alternatives, not a pipeline.** A common question is whether to call `restructure_assets` first and then feed the result to `as_torch_dataset`. The answer is no, and there is nothing to gain from doing so. `restructure_assets` writes a new directory tree by symlinking from `bag.path/data/assets/...`; `as_torch_dataset` reads directly from `bag.path/data/assets/...` regardless of what `restructure_assets` produced. Restructuring first and then calling the adapter changes nothing: the adapter still reads the unchanged bag, and the restructured tree sits unused.
+
+Pick one tool based on your downstream consumer:
+
+- Your consumer expects `ImageFolder` layout → use `restructure_assets`.
+- Your consumer is a `DataLoader` or `tf.data` pipeline you control → use `as_torch_dataset` or `as_tf_dataset`.
+- You need both (e.g., a baseline comparison against `ImageFolder` and a custom adapter for your main model) → run each independently on the same bag. They do not conflict.
+
+See the "How to restructure assets for ML frameworks" section above for the full `restructure_assets` signature and directory-layout examples.
+
+## See also (framework adapters)
+
+- [Defining and using features](features.md) — Chapter 3: `feature_values()` selectors, `FeatureRecord` record shapes, built-in selectors (`select_newest`, `select_majority_vote`).
+- `DatasetBag.feature_values` docstring — selector callable shape, multi-annotator patterns, and the `missing=` policy interaction.
+- `split_dataset` docstring — stratified train/val/test split that composes upstream of all three framework paths: split the catalog dataset, download each partition as its own bag, then call the appropriate adapter on each bag independently.
+
 ## Common pitfalls
 
 !!! warning "restructure_assets returns a dict, not a Path"

--- a/docs/user-guide/offline.md
+++ b/docs/user-guide/offline.md
@@ -188,14 +188,14 @@ exe.upload_execution_outputs()
 
 ## How to restructure assets for ML frameworks
 
-PyTorch `ImageFolder` and Keras `image_dataset_from_directory` both expect a `class/image.jpg` directory tree. `bag.restructure_assets()` builds that tree from a downloaded bag, using dataset types and feature labels as directory names.
+PyTorch `ImageFolder` and Keras `image_dataset_from_directory` both expect a `class/image.jpg` directory tree. `bag.restructure_assets()` builds that tree from a downloaded bag, using dataset types and feature labels as directory names. It shares the same `targets` / `target_transform` / `missing` vocabulary as `as_torch_dataset` / `as_tf_dataset` (below) — same label-selection semantics, different output shape.
 
 ```python
 from deriva_ml.feature import FeatureRecord
 
 manifest = bag.restructure_assets(
     output_dir="./ml_data",
-    group_by=["Glaucoma"],
+    targets=["Glaucoma"],
 )
 # Produces:
 # ./ml_data/training/Normal/retina_001.jpg  -> symlink
@@ -207,7 +207,7 @@ The method returns `dict[Path, Path]` — a manifest mapping each source path to
 
 ```python
 # Correct: manifest is a dict
-manifest = bag.restructure_assets(output_dir="./ml_data", group_by=["Glaucoma"])
+manifest = bag.restructure_assets(output_dir="./ml_data", targets=["Glaucoma"])
 for src, dst in manifest.items():
     print(f"{src.name} -> {dst}")
 
@@ -221,22 +221,23 @@ output_path = bag.restructure_assets(...)  # this is a dict, not a Path
 manifest = bag.restructure_assets(
     output_dir="./ml_data",
     asset_table="Image",           # auto-detected if omitted and only one asset table exists
-    group_by=["Glaucoma"],         # column names or feature names; creates subdirectory levels
+    targets=["Glaucoma"],          # feature names or column names; creates subdirectory levels
+    target_transform=None,         # callable returning str for directory naming; see below
+    missing="unknown",             # "error" | "skip" | "unknown" (default); unknown → `unknown/` dir
     use_symlinks=True,             # True (default) = symlinks; False = copies
     type_selector=None,            # callable(list[str]) -> str for multi-type datasets
     type_to_dir_map={              # map dataset type names to directory names
         "Training": "training",
         "Testing": "testing",
     },
-    enforce_vocabulary=True,       # only allow vocabulary-based features in group_by
-    value_selector=None,           # callable(list[FeatureRecord]) -> FeatureRecord for multi-value features
+    enforce_vocabulary=True,       # only allow vocabulary-based features in targets
     file_transformer=None,         # callable(src: Path, dest: Path) -> Path for format conversion
 )  # returns dict[Path, Path]
 ```
 
 ### Directory structure
 
-Top-level subdirectories come from dataset types (`Training` → `training`, `Testing` → `testing`). Below that, each entry in `group_by` adds one level of subdirectories named after the label value.
+Top-level subdirectories come from dataset types (`Training` → `training`, `Testing` → `testing`). Below that, each entry in `targets` adds one level of subdirectories named after the label value.
 
 ```
 ./ml_data/
@@ -245,60 +246,69 @@ Top-level subdirectories come from dataset types (`Training` → `training`, `Te
       retina_001.jpg
     Severe/
       retina_002.jpg
-    Unknown/            # assets with no label for this feature
+    unknown/            # assets with no label for this feature (missing="unknown" default)
       retina_003.jpg
   testing/
     Normal/
       retina_099.jpg
 ```
 
-### Using features as group_by keys
+### Using features as targets
 
-If a `group_by` name matches a feature defined on the asset table (or a table it references via FK), `restructure_assets` reads the feature values from the bag's SQLite cache and uses the vocabulary term as the directory name.
+If a name in `targets` matches a feature defined on the asset table (or a table it references via FK), `restructure_assets` reads the feature values from the bag's SQLite cache and uses the vocabulary term as the directory name.
 
 ```python
 # Group by a feature defined on Image
 manifest = bag.restructure_assets(
     output_dir="./ml_data",
-    group_by=["Glaucoma"],          # feature name
+    targets=["Glaucoma"],          # feature name
 )
 
-# Group by a specific column of a multi-term feature
+# Group by a specific column of a multi-term feature (use target_transform
+# instead of the old "Feature.column" dotted syntax)
 manifest = bag.restructure_assets(
     output_dir="./ml_data",
-    group_by=["Classification.Label"],  # FeatureName.column_name
+    targets=["Classification"],
+    target_transform=lambda rec: rec.Label,  # return str; becomes dir name
 )
 ```
 
-Column names on the asset record are checked first; feature names are checked if no column matches.
+Column names on the asset record are checked first; feature names are checked if no column matches. Direct column targets do not need `target_transform` — the column value is stringified automatically.
 
 ### Handling multiple feature values
 
-When an asset has more than one value for the same feature (e.g., two annotators disagreed), `restructure_assets` raises `DerivaMLException` by default. Provide a `value_selector` to resolve the conflict:
+When an asset has more than one value for the same feature (e.g., two annotators disagreed), pass a per-feature selector via the dict form of `targets`:
 
 ```python
 manifest = bag.restructure_assets(
     output_dir="./ml_data",
-    group_by=["Glaucoma"],
-    value_selector=FeatureRecord.select_newest,
+    targets={"Glaucoma": FeatureRecord.select_newest},
 )
 ```
 
-`FeatureRecord.select_newest` picks the record with the latest creation timestamp. Other built-in selectors: `FeatureRecord.select_first`. For majority voting, use `FeatureRecord.select_majority_vote("column_name")` — it is a `@classmethod` factory that takes a column name and returns a selector; pass the result as `value_selector=FeatureRecord.select_majority_vote("Glaucoma")`.
+`FeatureRecord.select_newest` picks the record with the latest creation timestamp. Other built-in selectors: `FeatureRecord.select_first`. For majority voting, use `FeatureRecord.select_majority_vote("column_name")` — it is a `@classmethod` factory that takes a column name and returns a selector; pass the result as `targets={"Glaucoma": FeatureRecord.select_majority_vote("Glaucoma")}`.
 
 Set `enforce_vocabulary=False` to silently use the first value when multiple exist without raising.
 
+### Missing-label policy
+
+The `missing` parameter controls what happens when an asset has no value for a requested target:
+
+- **`missing="unknown"`** (default): place the asset under `unknown/`. Matches pre-D2 behavior; existing unparameterized calls produce the same tree as before.
+- **`missing="skip"`**: omit the asset from the output tree entirely. Useful for building fully-labeled datasets when your training code cannot tolerate unlabeled samples.
+- **`missing="error"`**: raise `DerivaMLException` at construction listing the unlabeled RIDs. Matches the adapter default; use it when you want to fail loudly on incomplete labeling before committing files to disk.
+
 ### Prediction scenarios
 
-Datasets with no type defined are treated as `Testing`. Assets with no label for a `group_by` key land in `Unknown/`. This allows `restructure_assets` to run on unlabeled inference data:
+Datasets with no type defined are treated as `Testing`. Assets with no label for a `targets` key land in `unknown/` under the default `missing="unknown"` policy. This allows `restructure_assets` to run on unlabeled inference data:
 
 ```python
 # Unlabeled prediction dataset — no types, no Glaucoma labels
 manifest = bag.restructure_assets(
     output_dir="./predictions",
-    group_by=["Glaucoma"],
+    targets=["Glaucoma"],
 )
-# ./predictions/testing/Unknown/retina_new_001.jpg
+# ./predictions/testing/unknown/retina_new_001.jpg
 ```
 
 ### Using symlinks vs copies

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,6 +48,7 @@ nav:
       - Sharing and collaboration: user-guide/sharing.md
       - Reproducibility: user-guide/reproducibility.md
       - Integrating with hydra-zen: user-guide/hydra-zen.md
+      - Migrating from previous versions: user-guide/migration.md
   - Configuration:
       - Overview: configuration/overview.md
       - Configuration Groups: configuration/groups.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,8 @@ deriva-ml-upload = "deriva_ml.cli.upload:main"
 deriva-ml-validate-schema = "deriva_ml.tools.validate_schema_doc:main"
 
 [project.optional-dependencies]
+torch = ["torch>=2.0"]
+tf = ["tensorflow>=2.15"]
 
 [build-system]
 requires = ["setuptools>=80", "setuptools_scm[toml]>=8", "wheel"]

--- a/src/deriva_ml/dataset/dataset_bag.py
+++ b/src/deriva_ml/dataset/dataset_bag.py
@@ -37,7 +37,7 @@ import shutil
 from collections import defaultdict
 from copy import copy
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Generator, Iterable, Self, cast
+from typing import TYPE_CHECKING, Any, Callable, Generator, Iterable, Literal, Self, cast
 
 # Third-party imports
 import pandas as pd
@@ -57,6 +57,8 @@ from deriva_ml.dataset.aux_classes import DatasetHistory, DatasetVersion
 from deriva_ml.feature import Feature, FeatureRecord
 
 if TYPE_CHECKING:
+    import torch.utils.data
+
     from deriva_ml.model.deriva_ml_database import DerivaMLDatabase
 
 try:
@@ -1441,6 +1443,170 @@ class DatasetBag:
 
         check_dataset(self, set())
         return list(found_types) if found_types else None
+
+    def as_torch_dataset(
+        self,
+        element_type: str,
+        *,
+        sample_loader: Callable[[Path | None, dict[str, Any]], Any] | None = None,
+        transform: Callable[[Any], Any] | None = None,
+        targets: list[str] | dict[str, Any] | None = None,
+        target_transform: Callable[..., Any] | None = None,
+        missing: Literal["error", "skip", "unknown"] = "error",
+    ) -> "torch.utils.data.Dataset":
+        """Build a ``torch.utils.data.Dataset`` from this bag.
+
+        Creates a lazy PyTorch dataset that reads samples and labels from
+        this already-downloaded ``DatasetBag``. The dataset's
+        ``__getitem__`` returns individual samples (and optionally labels)
+        without materializing the entire dataset into memory at construction
+        time. Torch is imported lazily inside the builder so the base
+        library stays importable without torch installed.
+
+        This is the recommended path from a ``DatasetBag`` to a
+        ``torch.utils.data.DataLoader`` for custom training loops and
+        models. For workflows that need the ``ImageFolder``-style class-
+        folder directory layout (e.g., ``torchvision.datasets.ImageFolder``
+        or third-party fine-tuning scripts), use ``restructure_assets()``
+        instead — the two tools are alternatives, not a pipeline.
+
+        Labels come from the bag's feature values via
+        ``bag.feature_values(element_type, feature_name, selector=...)``.
+        The user's ``target_transform`` maps the typed ``FeatureRecord``
+        into whatever numeric shape the loss function expects. The library
+        does not hold or auto-fit a class-to-index table (design anchor 2).
+
+        Args:
+            element_type: Name of the domain table whose rows become the
+                dataset's samples (e.g., ``"Image"``). Must be a table
+                present in the bag (same error path as
+                ``list_dataset_members``). Whether ``sample_loader`` is
+                required depends on whether this is an asset table — see
+                the ``sample_loader`` entry below.
+
+            sample_loader: ``Callable[[Path | None, dict], Any]``. Invoked
+                once per ``__getitem__`` call. Receives:
+
+                - ``Path | None`` — absolute filesystem path under
+                  ``bag.path / "data/assets/<element_type>/<rid>/<filename>"``
+                  when ``element_type`` is an asset table; ``None``
+                  otherwise.
+                - ``dict[str, Any]`` — the raw row dict from the element
+                  table (all columns, not just those the framework needs).
+
+                For **asset-table** ``element_type``: no default — raises
+                ``DerivaMLException`` at construction if ``sample_loader``
+                is ``None``. The error message names common loaders
+                (``PIL.Image.open``, ``nibabel.load``, ``h5py.File``) as
+                hints.
+
+                For **non-asset-table** ``element_type``: default returns
+                ``row_dict`` unchanged. Useful for tabular training where
+                the element IS the row data with no file decoding.
+
+            transform: ``Callable[[Any], Any]``. Applied to the sample
+                after ``sample_loader`` returns. Standard torchvision-style
+                transform pipeline goes here (e.g.,
+                ``torchvision.transforms.Compose([...])``). No-op default.
+
+            targets: Source of label data. Three shapes are accepted:
+
+                - ``None`` (default) — unlabeled dataset. ``__getitem__``
+                  returns just the sample (not a tuple). Useful for
+                  inference loops and self-supervised pretext tasks.
+                - ``list[str]`` — feature names read via
+                  ``bag.feature_values(element_type, name)`` with no
+                  selector. One ``FeatureRecord`` is resolved per element.
+                - ``dict[str, FeatureSelector]`` — feature names mapped to
+                  selector callables, passed verbatim to
+                  ``bag.feature_values(..., selector=...)``. Resolves
+                  multi-annotator cases. Built-in selectors:
+                  ``FeatureRecord.select_newest``, ``select_first``, etc.
+
+            target_transform: ``Callable`` consuming the raw feature-record
+                shape (see target arity below) and returning whatever the
+                user's loss function expects (typically an ``int`` or a
+                ``torch.Tensor``). No-op default returns the feature
+                record(s) as-is.
+
+                Target arity:
+
+                - Single-target (``targets=["A"]``): receives a
+                  ``FeatureRecord`` directly.
+                - Multi-target (``targets=["A", "B"]``): receives
+                  ``dict[str, FeatureRecord]`` keyed by feature name.
+
+            missing: Behavior when a feature value is absent for an element:
+
+                - ``"error"`` (default) — raise ``DerivaMLException`` at
+                  adapter construction time, before any ``__getitem__``
+                  call. Message includes the list of unlabeled RIDs.
+                  Explicit-over-silent: users should know if their dataset
+                  is partially labeled.
+                - ``"skip"`` — drop unlabeled elements from the dataset
+                  entirely. The resulting dataset's ``__len__`` reflects
+                  only labeled elements. Index mapping is stable across the
+                  dataset's lifetime.
+                - ``"unknown"`` — keep all elements; pass ``None`` to the
+                  user's ``target_transform`` for unlabeled ones. The
+                  ``target_transform`` must handle ``None`` (typically
+                  returning a sentinel class index or an ignore-mask value).
+                  Useful for semi-supervised and self-training workflows.
+
+        Returns:
+            A ``torch.utils.data.Dataset`` whose ``__getitem__`` returns:
+
+            - ``sample`` when ``targets=None`` (unlabeled).
+            - ``(sample, target)`` when ``targets`` is set, where
+              ``sample = transform(sample_loader(path, row_dict))`` and
+              ``target = target_transform(feature_record_shape)``.
+
+            ``__len__`` equals the count of labeled elements when
+            ``missing="skip"``, the total element count otherwise.
+
+        Raises:
+            ImportError: If PyTorch is not installed. Install with
+                ``pip install 'deriva-ml[torch]'`` or
+                ``pip install 'torch>=2.0'``.
+            DerivaMLException: If ``element_type`` is not in the bag,
+                if ``element_type`` is an asset table and ``sample_loader``
+                is ``None``, or if ``missing="error"`` and any element
+                lacks a feature value (message lists up to 20 unlabeled
+                RIDs).
+            FileNotFoundError: On ``__getitem__`` if the asset file is
+                missing on disk (bag corrupted or removed after
+                construction). This is the standard torch convention —
+                the library does not retry or fall back.
+
+        Example:
+            >>> # Simple image classification with a single feature label:
+            >>> import PIL.Image  # doctest: +SKIP
+            >>> from torch.utils.data import DataLoader  # doctest: +SKIP
+            >>> bag = ml.download_dataset_bag(version="1.0.0")  # doctest: +SKIP
+            >>> ds = bag.as_torch_dataset(  # doctest: +SKIP
+            ...     element_type="Image",
+            ...     sample_loader=lambda p, row: PIL.Image.open(p).convert("RGB"),
+            ...     targets=["Glaucoma_Grade"],
+            ...     target_transform=lambda rec: CLASS_TO_IDX[rec.Grade],
+            ... )
+            >>> loader = DataLoader(ds, batch_size=32, shuffle=True)  # doctest: +SKIP
+
+            >>> # Pure-Python assertion — runs for real:
+            >>> from deriva_ml.dataset.torch_adapter import build_torch_dataset
+            >>> callable(build_torch_dataset)
+            True
+        """
+        from deriva_ml.dataset.torch_adapter import build_torch_dataset
+
+        return build_torch_dataset(
+            self,
+            element_type,
+            sample_loader=sample_loader,
+            transform=transform,
+            targets=targets,
+            target_transform=target_transform,
+            missing=missing,
+        )
 
     def restructure_assets(
         self,

--- a/src/deriva_ml/dataset/dataset_bag.py
+++ b/src/deriva_ml/dataset/dataset_bag.py
@@ -57,6 +57,7 @@ from deriva_ml.dataset.aux_classes import DatasetHistory, DatasetVersion
 from deriva_ml.feature import Feature, FeatureRecord
 
 if TYPE_CHECKING:
+    import tensorflow as tf
     import torch.utils.data
 
     from deriva_ml.model.deriva_ml_database import DerivaMLDatabase
@@ -1606,6 +1607,177 @@ class DatasetBag:
             targets=targets,
             target_transform=target_transform,
             missing=missing,
+        )
+
+    def as_tf_dataset(
+        self,
+        element_type: str,
+        *,
+        sample_loader: Callable[[Path | None, dict[str, Any]], Any] | None = None,
+        transform: Callable[[Any], Any] | None = None,
+        targets: list[str] | dict[str, Any] | None = None,
+        target_transform: Callable[..., Any] | None = None,
+        missing: Literal["error", "skip", "unknown"] = "error",
+        output_signature: "tf.TensorSpec | tuple[tf.TensorSpec, ...] | None" = None,
+    ) -> "tf.data.Dataset":
+        """Build a ``tf.data.Dataset`` from this bag.
+
+        Creates a ``tf.data.Dataset`` backed by a Python generator that
+        reads samples and labels from this already-downloaded
+        ``DatasetBag``. TensorFlow is imported lazily inside the builder
+        so the base library stays importable without TensorFlow installed.
+
+        Each call to the generator yields one element (sample, or
+        ``(sample, target)`` when ``targets`` is supplied). Callers are
+        responsible for chaining ``.batch()`` and ``.prefetch()`` to get
+        production throughput — the method does not apply batching itself.
+
+        Labels come from the bag's feature values via
+        ``bag.feature_values(element_type, feature_name, selector=...)``.
+        The user's ``target_transform`` maps the typed ``FeatureRecord``
+        into whatever numeric shape the loss function expects. The library
+        does not hold or auto-fit a class-to-index table (design anchor 2).
+
+        Args:
+            element_type: Name of the domain table whose rows become the
+                dataset's samples (e.g., ``"Image"``). Must be a table
+                present in the bag (same error path as
+                ``list_dataset_members``). Whether ``sample_loader`` is
+                required depends on whether this is an asset table — see
+                the ``sample_loader`` entry below.
+
+            sample_loader: ``Callable[[Path | None, dict], Any]``. Invoked
+                once per generated element. Receives:
+
+                - ``Path | None`` — absolute filesystem path under
+                  ``bag.path / "data/assets/<element_type>/<rid>/<filename>"``
+                  when ``element_type`` is an asset table; ``None``
+                  otherwise.
+                - ``dict[str, Any]`` — the raw row dict from the element
+                  table (all columns, not just those the framework needs).
+
+                For **asset-table** ``element_type``: no default — raises
+                ``DerivaMLException`` at construction if ``sample_loader``
+                is ``None``. The error message names common loaders
+                (``PIL.Image.open``, ``nibabel.load``, ``h5py.File``) as
+                hints.
+
+                For **non-asset-table** ``element_type``: default returns
+                ``row_dict`` unchanged. Useful for tabular training where
+                the element IS the row data with no file decoding.
+
+            transform: ``Callable[[Any], Any]``. Applied to the sample
+                after ``sample_loader`` returns. Use this for any
+                preprocessing (e.g., resizing, normalization, conversion
+                to ``tf.Tensor``). No-op default.
+
+            targets: Source of label data. Three shapes are accepted:
+
+                - ``None`` (default) — unlabeled dataset. Each element is
+                  just the sample (not a tuple). Useful for inference loops
+                  and self-supervised pretext tasks.
+                - ``list[str]`` — feature names read via
+                  ``bag.feature_values(element_type, name)`` with no
+                  selector. One ``FeatureRecord`` is resolved per element.
+                - ``dict[str, FeatureSelector]`` — feature names mapped to
+                  selector callables, passed verbatim to
+                  ``bag.feature_values(..., selector=...)``. Resolves
+                  multi-annotator cases. Built-in selectors:
+                  ``FeatureRecord.select_newest``, ``select_first``, etc.
+
+            target_transform: ``Callable`` consuming the raw feature-record
+                shape (see target arity below) and returning whatever the
+                user's loss function expects (typically a ``tf.Tensor``).
+                No-op default returns the feature record(s) as-is.
+
+                Target arity:
+
+                - Single-target (``targets=["A"]``): receives a
+                  ``FeatureRecord`` directly.
+                - Multi-target (``targets=["A", "B"]``): receives
+                  ``dict[str, FeatureRecord]`` keyed by feature name.
+
+            missing: Behavior when a feature value is absent for an element:
+
+                - ``"error"`` (default) — raise ``DerivaMLException`` at
+                  adapter construction time, before any element is generated.
+                  Message includes the list of unlabeled RIDs.
+                  Explicit-over-silent: users should know if their dataset
+                  is partially labeled.
+                - ``"skip"`` — drop unlabeled elements from the dataset
+                  entirely. Only labeled elements are yielded.
+                - ``"unknown"`` — keep all elements; pass ``None`` to the
+                  user's ``target_transform`` for unlabeled ones. The
+                  ``target_transform`` must handle ``None`` (typically
+                  returning a sentinel class index or an ignore-mask value).
+                  Useful for semi-supervised and self-training workflows.
+
+            output_signature: ``tf.TypeSpec`` (or nested structure of specs
+                such as ``(tf.TensorSpec(...), tf.TensorSpec(...))``)
+                describing the shape and dtype of each element produced by
+                the generator. When ``None`` (default), the first sample is
+                consumed eagerly to infer the signature via
+                ``tf.type_spec_from_value``, then the generator is
+                re-wrapped so the first sample is not lost. Providing an
+                explicit signature avoids the eager-inference overhead and
+                is preferred for production use.
+
+        Returns:
+            A ``tf.data.Dataset`` whose elements are:
+
+            - ``sample`` when ``targets=None`` (unlabeled).
+            - ``(sample, target)`` when ``targets`` is set, where
+              ``sample = transform(sample_loader(path, row_dict))`` and
+              ``target = target_transform(feature_record_shape)``.
+
+            Callers must chain ``.batch()`` / ``.prefetch()`` themselves —
+            the returned dataset is unbatched.
+
+        Raises:
+            ImportError: If TensorFlow is not installed. Install with
+                ``pip install 'deriva-ml[tf]'`` or
+                ``pip install 'tensorflow>=2.15'``.
+            DerivaMLException: If ``element_type`` is not in the bag,
+                if ``element_type`` is an asset table and ``sample_loader``
+                is ``None``, if ``missing="error"`` and any element lacks
+                a feature value (message lists up to 20 unlabeled RIDs),
+                or if ``output_signature=None`` and the generator produces
+                no elements (cannot infer signature).
+            FileNotFoundError: During iteration if the asset file is
+                missing on disk (bag corrupted or removed after
+                construction).
+
+        Example:
+            >>> # Simple image classification with a single feature label:
+            >>> import PIL.Image  # doctest: +SKIP
+            >>> bag = ml.download_dataset_bag(version="1.0.0")  # doctest: +SKIP
+            >>> ds = bag.as_tf_dataset(  # doctest: +SKIP
+            ...     element_type="Image",
+            ...     sample_loader=lambda p, row: tf.image.decode_jpeg(
+            ...         tf.io.read_file(str(p))
+            ...     ),
+            ...     targets=["Glaucoma_Grade"],
+            ...     target_transform=lambda rec: CLASS_TO_IDX[rec.Grade],
+            ... )
+            >>> for batch in ds.batch(32).prefetch(2):  # doctest: +SKIP
+            ...     images, labels = batch
+
+            >>> # Pure-Python assertion — runs for real:
+            >>> from deriva_ml.dataset.tf_adapter import build_tf_dataset
+            >>> callable(build_tf_dataset)
+            True
+        """
+        from deriva_ml.dataset.tf_adapter import build_tf_dataset
+
+        return build_tf_dataset(
+            self,
+            element_type,
+            sample_loader=sample_loader,
+            transform=transform,
+            targets=targets,
+            target_transform=target_transform,
+            missing=missing,
+            output_signature=output_signature,
         )
 
     def restructure_assets(

--- a/src/deriva_ml/dataset/dataset_bag.py
+++ b/src/deriva_ml/dataset/dataset_bag.py
@@ -129,6 +129,12 @@ class DatasetBag:
     - Navigating dataset relationships (parents, children)
     - Accessing feature values
     - Denormalizing data across related tables
+    - Feeding the bag to training frameworks via ``as_torch_dataset`` /
+      ``as_tf_dataset`` (framework adapters), or rewriting its layout via
+      ``restructure_assets`` for tools that expect a class-folder directory
+      tree. All three share the same ``targets`` / ``target_transform`` /
+      ``missing`` vocabulary; see the User Guide "How to feed a bag to a
+      training framework" section.
 
     A bag may contain multiple datasets when nested datasets are involved. Each
     DatasetBag instance represents a single dataset within the bag - use
@@ -2049,6 +2055,15 @@ class DatasetBag:
               ``targets=["Classification"], target_transform=lambda rec: rec.Label``
             - ``value_selector=FeatureRecord.select_newest`` →
               ``targets={"Feature": FeatureRecord.select_newest}``
+
+        See Also:
+            ``DatasetBag.as_torch_dataset``, ``DatasetBag.as_tf_dataset``:
+                Framework adapters. Use these when you want lazy in-place
+                iteration and do NOT need a class-folder directory tree.
+                They share the same ``targets`` / ``target_transform`` /
+                ``missing`` vocabulary as ``restructure_assets``. The two
+                paths are alternatives, not a pipeline — pick one per the
+                User Guide "How to feed a bag to a training framework".
         """
         from deriva_ml.core.exceptions import DerivaMLValidationError
         from deriva_ml.dataset.target_resolution import _resolve_targets

--- a/src/deriva_ml/dataset/dataset_bag.py
+++ b/src/deriva_ml/dataset/dataset_bag.py
@@ -60,12 +60,63 @@ if TYPE_CHECKING:
     import tensorflow as tf
     import torch.utils.data
 
+    from deriva_ml.dataset.target_resolution import FeatureSelector
     from deriva_ml.model.deriva_ml_database import DerivaMLDatabase
 
 try:
     from icecream import ic
 except ImportError:  # Graceful fallback if IceCream isn't installed.
     ic = lambda *a: None if not a else (a[0] if len(a) == 1 else a)  # noqa
+
+
+def _default_dir_name_from_target(
+    target: "FeatureRecord | dict[str, FeatureRecord] | str | None",
+    targets: "list[str] | dict[str, Any] | None",
+) -> str:
+    """Derive a directory name string from a resolved target without target_transform.
+
+    For single-target with a single-column FeatureRecord: returns the value of the
+    first non-FK, non-metadata column (the term column).
+
+    For multi-target or multi-column features: raises DerivaMLException explaining
+    that target_transform is required.
+
+    For plain string values (column targets already converted to str): returns as-is.
+
+    Args:
+        target: The resolved target from _resolve_targets or column lookup.
+        targets: The original targets spec (for error messages).
+
+    Returns:
+        Directory name string.
+
+    Raises:
+        DerivaMLException: When the target is a dict (multi-target case) and
+            no target_transform was provided.
+    """
+    from deriva_ml.core.exceptions import DerivaMLException
+
+    if target is None:
+        return "Unknown"
+    if isinstance(target, str):
+        return target
+    if isinstance(target, dict):
+        # Multi-target — can't auto-derive a single string
+        raise DerivaMLException(
+            f"restructure_assets with multi-target {list(targets)!r} requires "
+            f"target_transform to derive a single directory name. "
+            f"Provide target_transform=lambda rec: ... that returns a str."
+        )
+    # Single FeatureRecord — find the first term/value column that has a value
+    record_data = target.model_dump()
+    # Skip well-known metadata columns to find the label column
+    _skip_cols = {"RID", "RCT", "RMT", "RCB", "RMB", "Feature_Name", "Execution"}
+    for col, val in record_data.items():
+        if col in _skip_cols:
+            continue
+        if val is not None and not isinstance(val, (dict, list)):
+            return str(val)
+    return "Unknown"
 
 
 class DatasetBag:
@@ -1783,32 +1834,35 @@ class DatasetBag:
     def restructure_assets(
         self,
         output_dir: Path | str,
+        *,
         asset_table: str | None = None,
-        group_by: list[str] | None = None,
+        targets: "list[str] | dict[str, FeatureSelector] | None" = None,
+        target_transform: Callable[..., str] | None = None,
+        missing: Literal["error", "skip", "unknown"] = "unknown",
         use_symlinks: bool = True,
         type_selector: Callable[[list[str]], str] | None = None,
         type_to_dir_map: dict[str, str] | None = None,
         enforce_vocabulary: bool = True,
-        value_selector: Callable | None = None,
         file_transformer: Callable[[Path, Path], Path] | None = None,
     ) -> dict[Path, Path]:
         """Restructure downloaded assets into a directory hierarchy.
 
         Creates a directory structure organizing assets by dataset types and
-        grouping values. This is useful for ML workflows that expect data
-        organized in conventional folder structures (e.g., PyTorch ImageFolder).
+        target label values. This is useful for ML workflows that expect data
+        organized in conventional folder structures (e.g., PyTorch ImageFolder,
+        ``torchvision.datasets.ImageFolder``).
 
         The dataset should be of type Training or Testing, or have nested
         children of those types. The top-level directory name is determined
-        by the dataset type (e.g., "Training" -> "training").
+        by the dataset type (e.g., ``"Training"`` → ``"training"``).
 
         **Finding assets through foreign key relationships:**
 
         Assets are found by traversing all foreign key paths from the dataset,
         not just direct associations. For example, if a dataset contains Subjects,
-        and the schema has Subject -> Encounter -> Image relationships, this method
+        and the schema has Subject → Encounter → Image relationships, this method
         will find all Images reachable through those paths even though they are
-        not directly in a Dataset_Image association table.
+        not directly in a ``Dataset_Image`` association table.
 
         **Handling datasets without types (prediction scenarios):**
 
@@ -1818,28 +1872,63 @@ class DatasetBag:
 
         **Handling missing labels:**
 
-        If an asset doesn't have a value for a group_by key (e.g., no label
-        assigned), it is placed in an "Unknown" directory. This allows
-        restructure_assets to work with unlabeled data for prediction.
+        If an asset doesn't have a value for a requested target, the ``missing``
+        parameter controls the behavior: ``"unknown"`` (default) places the asset
+        in an ``"Unknown"`` directory; ``"skip"`` omits it from the output tree;
+        ``"error"`` raises at construction time listing all unlabeled RIDs.
 
         Args:
             output_dir: Base directory for restructured assets.
-            asset_table: Name of the asset table (e.g., "Image"). If None,
-                auto-detects from dataset members. Raises DerivaMLException
+            asset_table: Name of the asset table (e.g., ``"Image"``). If None,
+                auto-detects from dataset members. Raises ``DerivaMLException``
                 if multiple asset tables are found and none is specified.
-            group_by: Names to group assets by. Each name creates a subdirectory
-                level after the dataset type path. Names can be:
+            targets: Source of directory-naming label data. Three shapes:
 
-                - **Column names**: Direct columns on the asset table. The column
-                  value becomes the subdirectory name.
-                - **Feature names**: Features defined on the asset table (or tables
-                  it references via foreign keys). The feature's vocabulary term
-                  value becomes the subdirectory name.
-                - **Feature.column**: Specify a particular column from a multi-term
-                  feature (e.g., "Classification.Label" to use the Label column).
+                - ``None`` (default) — no label grouping. Assets are placed
+                  directly under the type-derived directory with no further
+                  subdirectory levels.
+                - ``list[str]`` — feature names (or direct column names) to
+                  group by. Each name adds one subdirectory level. For a
+                  single feature the resolved ``FeatureRecord`` is passed to
+                  ``target_transform`` (if provided). For multiple features
+                  a ``dict[str, FeatureRecord]`` is passed.
+                - ``dict[str, FeatureSelector]`` — feature names mapped to
+                  per-feature selector callables; passed verbatim to
+                  ``bag.feature_values(..., selector=...)``. Built-in
+                  selectors: ``FeatureRecord.select_newest``,
+                  ``select_first``, ``select_majority_vote(column)``.
 
-                Column names are checked first, then feature names. If a value
-                is not found, "unknown" is used as the subdirectory name.
+                Column names (direct columns on the asset table, not features)
+                are resolved via column lookup on the asset record. They are
+                converted to strings for the directory name; ``target_transform``
+                receives the raw column value (as a string).
+
+                Dotted ``"Feature.column"`` syntax from earlier releases is
+                **removed** — pass it as a target string with ``target_transform``
+                instead (see Migration note below).
+
+            target_transform: ``Callable`` consuming the resolved label shape
+                (a ``FeatureRecord`` for single-target, ``dict[str, FeatureRecord]``
+                for multi-target, or the raw column value string for column
+                targets) and **returning a ``str``** used as the subdirectory
+                name. No-op default derives the name from the feature's primary
+                value column (single-target) or raises a clear error explaining
+                that ``target_transform`` is required for multi-target and
+                multi-column feature cases.
+
+                Runtime constraint: the return type is checked at the first
+                call; a non-``str`` return raises ``DerivaMLValidationError``
+                with a message explaining the requirement.
+
+            missing: Behavior when a target value is absent for an asset:
+
+                - ``"unknown"`` (default) — place the asset in an ``Unknown/``
+                  subdirectory. Preserves the pre-alignment behavior.
+                - ``"skip"`` — omit the asset from the output tree entirely.
+                  New behavior; no directory is created for it.
+                - ``"error"`` — raise ``DerivaMLException`` at construction
+                  time listing unlabeled RIDs. Useful for ensuring training
+                  data is complete before committing to disk.
 
             use_symlinks: If True (default), create symlinks to original files.
                 If False, copy files. Symlinks save disk space but require
@@ -1847,25 +1936,16 @@ class DatasetBag:
                 ``file_transformer`` is provided.
             type_selector: Function to select type when dataset has multiple types.
                 Receives list of type names, returns selected type name.
-                Defaults to selecting first type or "unknown" if no types.
+                Defaults to selecting first type or ``"testing"`` if no types.
             type_to_dir_map: Optional mapping from dataset type names to directory
-                names. Defaults to {"Training": "training", "Testing": "testing",
-                "Unknown": "unknown"}. Use this to customize directory names or
+                names. Defaults to ``{"Training": "training", "Testing": "testing",
+                "Unknown": "unknown"}``. Use this to customize directory names or
                 add new type mappings.
             enforce_vocabulary: If True (default), only allow features that have
                 controlled vocabulary term columns, and raise an error if an asset
-                has multiple different values for the same feature without a
-                value_selector. This ensures clean, unambiguous directory structures.
-                If False, allow any feature type and use the first value found
-                when multiple values exist.
-            value_selector: Optional function to select which feature value to use
-                when an asset has multiple values for the same feature. Receives a
-                list of FeatureRecord objects (typed Pydantic models with named
-                attributes for each feature column) and returns the selected one.
-                Use the Execution attribute to distinguish between values from
-                different executions. Built-in selectors on FeatureRecord:
-                ``select_newest``, ``select_first``, ``select_latest``,
-                ``select_majority_vote(column)``.
+                has multiple different values for the same feature. Set to False
+                to allow non-vocabulary features and use the first value when
+                multiple exist.
             file_transformer: Optional callable invoked instead of the default
                 symlink/copy step. Receives ``(src_path, dest_path)`` where
                 ``dest_path`` is the suggested destination (preserving the original
@@ -1884,7 +1964,7 @@ class DatasetBag:
 
                     bag.restructure_assets(
                         output_dir="./ml_data",
-                        group_by=["Diagnosis"],
+                        targets=["Diagnosis"],
                         file_transformer=oct_to_png,
                     )
 
@@ -1896,17 +1976,20 @@ class DatasetBag:
             or extension.
 
         Raises:
-            DerivaMLException: If asset_table cannot be determined (multiple
-                asset tables exist without specification), if no valid dataset
-                types (Training/Testing) are found, or if enforce_vocabulary
-                is True and a feature has multiple values without value_selector.
+            DerivaMLException: If ``asset_table`` cannot be determined, if
+                ``missing="error"`` and any asset lacks a target value, or if
+                ``enforce_vocabulary=True`` and a feature has no vocabulary
+                term columns.
+            DerivaMLValidationError: If ``target_transform`` returns a
+                non-``str`` value, or if a dotted ``"Feature.column"`` string
+                is passed in ``targets``.
 
         Examples:
             Basic restructuring with auto-detected asset table::
 
                 manifest = bag.restructure_assets(
                     output_dir="./ml_data",
-                    group_by=["Diagnosis"],
+                    targets=["Diagnosis"],
                 )
                 # Creates:
                 # ./ml_data/training/Normal/image1.jpg
@@ -1916,41 +1999,29 @@ class DatasetBag:
 
                 manifest = bag.restructure_assets(
                     output_dir="./ml_data",
-                    group_by=["Diagnosis"],
+                    targets=["Diagnosis"],
                     type_to_dir_map={"Training": "train", "Testing": "test"},
                 )
                 # Creates:
                 # ./ml_data/train/Normal/image1.jpg
                 # ./ml_data/test/Abnormal/image2.jpg
 
-            Select specific feature column for multi-term features::
-
-                manifest = bag.restructure_assets(
-                    output_dir="./ml_data",
-                    group_by=["Classification.Label"],  # Use Label column
-                )
-
-            Handle multiple feature values with a built-in selector::
+            Per-feature selector for multi-annotator datasets::
 
                 from deriva_ml.feature import FeatureRecord
 
                 manifest = bag.restructure_assets(
                     output_dir="./ml_data",
-                    group_by=["Diagnosis"],
-                    value_selector=FeatureRecord.select_newest,
+                    targets={"Diagnosis": FeatureRecord.select_newest},
                 )
 
-            Prediction scenario with unlabeled data::
+            Extract a specific column from a multi-column feature::
 
-                # Dataset has no type - treated as Testing
-                # Assets have no labels - placed in Unknown directory
                 manifest = bag.restructure_assets(
-                    output_dir="./prediction_data",
-                    group_by=["Diagnosis"],
+                    output_dir="./ml_data",
+                    targets=["Classification"],
+                    target_transform=lambda rec: rec.Label,
                 )
-                # Creates:
-                # ./prediction_data/testing/Unknown/image1.jpg
-                # ./prediction_data/testing/Unknown/image2.jpg
 
             Convert DICOM files to PNG during restructuring::
 
@@ -1965,17 +2036,37 @@ class DatasetBag:
                 manifest = bag.restructure_assets(
                     output_dir="./ml_data",
                     asset_table="OCT_DICOM",
-                    group_by=["Image_Diagnosis.Diagnosis_Image"],
+                    targets=["Diagnosis"],
                     type_to_dir_map={"Training": "train", "Testing": "test"},
                     file_transformer=oct_to_png,
                 )
-                # manifest maps each source .dcm Path to its output .png Path:
-                # Path(".../bag/OCT/image1.dcm") -> Path("./ml_data/train/Normal/image1.png")
+
+        Note:
+            Migration note (from pre-D2 signature):
+
+            - ``group_by=["Diagnosis"]`` → ``targets=["Diagnosis"]``
+            - ``group_by=["Classification.Label"]`` →
+              ``targets=["Classification"], target_transform=lambda rec: rec.Label``
+            - ``value_selector=FeatureRecord.select_newest`` →
+              ``targets={"Feature": FeatureRecord.select_newest}``
         """
+        from deriva_ml.core.exceptions import DerivaMLValidationError
+        from deriva_ml.dataset.target_resolution import _resolve_targets
+
         logger = logging.getLogger("deriva_ml")
-        group_by = group_by or []
         output_dir = Path(output_dir)
         output_dir.mkdir(parents=True, exist_ok=True)
+
+        # Validate targets: dotted "Feature.column" syntax is removed
+        if targets is not None:
+            target_names = list(targets) if isinstance(targets, dict) else targets
+            for t in target_names:
+                if "." in t:
+                    raise DerivaMLValidationError(
+                        f"Dotted target syntax {t!r} is no longer supported. "
+                        f"Replace with: targets=[{t.split('.')[0]!r}], "
+                        f"target_transform=lambda rec: rec.{t.split('.')[1]}"
+                    )
 
         # Default type-to-directory mapping
         if type_to_dir_map is None:
@@ -2018,13 +2109,62 @@ class DatasetBag:
         # Step 2: Get asset-to-dataset mapping
         asset_dataset_map = self._get_asset_dataset_mapping(asset_table)
 
-        # Step 3: Load feature values cache for relevant features
-        feature_cache = self._load_feature_values_cache(asset_table, group_by, enforce_vocabulary, value_selector)
+        # Step 3: Separate feature-based targets from column-based targets.
+        # _resolve_targets only works with features (via bag.feature_values).
+        # Direct column names on the asset table must be handled separately.
+        feature_target_map: dict[str, Any] = {}
+        column_targets: list[str] = []
+        feature_targets_spec: "list[str] | dict[str, Any] | None" = None
 
-        # Step 4: Get all assets reachable through FK paths
-        # This uses _get_reachable_assets which traverses FK relationships,
-        # so assets connected via Subject -> Encounter -> Image are found
-        # even if the dataset only contains Subjects directly.
+        if targets is not None:
+            target_names_list = list(targets) if isinstance(targets, dict) else list(targets)
+
+            # Classify each target as feature or column by probing lookup_feature.
+            feature_names: list[str] = []
+            for t_name in target_names_list:
+                try:
+                    self.lookup_feature(asset_table, t_name)
+                    feature_names.append(t_name)
+                except Exception:
+                    # Not a recognized feature on asset_table — treat as column
+                    column_targets.append(t_name)
+
+            # Build the feature-only targets spec to pass to _resolve_targets
+            if feature_names:
+                if isinstance(targets, dict):
+                    feature_targets_spec = {k: v for k, v in targets.items() if k in feature_names}
+                else:
+                    feature_targets_spec = feature_names
+
+            # Call _resolve_targets only for feature-based targets
+            if feature_targets_spec:
+                feature_target_map = _resolve_targets(
+                    self,
+                    asset_table,
+                    targets=feature_targets_spec,
+                    missing=missing,
+                )
+
+        # Step 4: For column-based targets, load a simple {rid: value_str} map
+        # by scanning all asset records once.
+        column_value_map: dict[str, dict[str, str]] = {col: {} for col in column_targets}
+
+        # Step 5: Load feature values cache for enforce_vocabulary enforcement.
+        # _load_feature_values_cache raises at load time if enforce_vocabulary=True
+        # and a feature has no vocabulary term columns. We discard the cache dict
+        # itself (naming comes from feature_target_map); this call is for its
+        # validation side-effect only.
+        group_keys_for_cache = [
+            t for t in (list(targets) if isinstance(targets, list) else
+                        list(targets.keys()) if isinstance(targets, dict) else [])
+            if t not in column_targets
+        ]
+        if group_keys_for_cache:
+            self._load_feature_values_cache(
+                asset_table, group_keys_for_cache, enforce_vocabulary, None
+            )
+
+        # Step 6: Get all assets reachable through FK paths
         assets = self._get_reachable_assets(asset_table)
 
         manifest: dict[Path, Path] = {}
@@ -2033,12 +2173,21 @@ class DatasetBag:
             logger.warning(f"No assets found in table '{asset_table}'")
             return manifest
 
-        # Step 5: Process each asset
+        # Populate column_value_map from the asset records
         for asset in assets:
+            for col in column_targets:
+                val = asset.get(col)
+                if val is not None:
+                    column_value_map[col][asset["RID"]] = str(val)
+
+        # Step 7: Process each asset
+        for asset in assets:
+            asset_rid = asset.get("RID")
+
             # Get source file path
             filename = asset.get("Filename")
             if not filename:
-                logger.warning(f"Asset {asset.get('RID')} has no Filename")
+                logger.warning(f"Asset {asset_rid} has no Filename")
                 continue
 
             source_path = Path(filename)
@@ -2057,14 +2206,100 @@ class DatasetBag:
                 continue
 
             # Get dataset type path
-            dataset_rid = asset_dataset_map.get(asset["RID"])
+            dataset_rid = asset_dataset_map.get(asset_rid)
             type_path = type_path_map.get(dataset_rid, ["unknown"])
 
-            # Resolve grouping values
-            group_path = []
-            for key in group_by:
-                value = self._resolve_grouping_value(asset, key, feature_cache)
-                group_path.append(value)
+            # Resolve grouping path components from targets.
+            # Each target name contributes one directory level. Target names are
+            # processed in order (column targets get column lookup; feature targets
+            # get resolution from feature_target_map built by _resolve_targets above).
+            group_path: list[str] = []
+            skip_asset = False
+
+            if targets is not None:
+                target_names_list = list(targets) if isinstance(targets, dict) else list(targets)
+                # For single-feature target, feature_target_map[rid] is FeatureRecord|None.
+                # For multi-feature target, feature_target_map[rid] is dict[str, FeatureRecord].
+                # We unpack accordingly when passing to target_transform or _default_dir_name_from_target.
+                feature_raw = feature_target_map.get(asset_rid)
+
+                # If the RID is absent from the feature_target_map entirely AND there are
+                # feature targets, apply the missing policy at the group level.
+                if feature_targets_spec and asset_rid not in feature_target_map:
+                    if missing == "skip":
+                        skip_asset = True
+                    elif missing == "error":
+                        raise DerivaMLException(
+                            f"Asset {asset_rid!r} has no value for target feature(s). "
+                            f"Pass missing='skip' to drop unlabeled assets, or "
+                            f"missing='unknown' to place them in Unknown/."
+                        )
+                    else:
+                        # missing="unknown": place in Unknown dir
+                        # Build partial path from column targets, then add Unknown for features
+                        for t_name in target_names_list:
+                            if t_name in column_targets:
+                                col_val = column_value_map.get(t_name, {}).get(asset_rid)
+                                group_path.append(str(col_val) if col_val is not None else "Unknown")
+                            else:
+                                group_path.append("Unknown")
+                elif not skip_asset:
+                    # Normal path: resolve each target in order
+                    for t_name in target_names_list:
+                        if t_name in column_targets:
+                            # Column-based target
+                            col_val = column_value_map.get(t_name, {}).get(asset_rid)
+                            if col_val is not None:
+                                if target_transform is not None:
+                                    dir_name = target_transform(col_val)
+                                    if not isinstance(dir_name, str):
+                                        raise DerivaMLValidationError(
+                                            f"restructure_assets target_transform must return str "
+                                            f"(for directory naming); got {type(dir_name).__name__}"
+                                        )
+                                else:
+                                    dir_name = col_val
+                            else:
+                                # Missing column value
+                                if missing == "error":
+                                    raise DerivaMLException(
+                                        f"Asset {asset_rid!r} has no value for column target {t_name!r}. "
+                                        f"Pass missing='skip' to drop unlabeled assets, or "
+                                        f"missing='unknown' to place them in Unknown/."
+                                    )
+                                elif missing == "skip":
+                                    skip_asset = True
+                                    break
+                                else:
+                                    dir_name = "Unknown"
+                            group_path.append(dir_name)
+                        else:
+                            # Feature-based target: look up from feature_target_map
+                            # feature_raw is either FeatureRecord (single) or
+                            # dict[str, FeatureRecord] (multi-feature). Extract for this feature.
+                            if feature_raw is None:
+                                per_feature_val = None
+                            elif isinstance(feature_raw, dict):
+                                per_feature_val = feature_raw.get(t_name)
+                            else:
+                                # Single feature target — feature_raw IS the FeatureRecord
+                                per_feature_val = feature_raw
+
+                            if per_feature_val is None:
+                                dir_name = "Unknown"
+                            elif target_transform is not None:
+                                dir_name = target_transform(per_feature_val)
+                                if not isinstance(dir_name, str):
+                                    raise DerivaMLValidationError(
+                                        f"restructure_assets target_transform must return str "
+                                        f"(for directory naming); got {type(dir_name).__name__}"
+                                    )
+                            else:
+                                dir_name = _default_dir_name_from_target(per_feature_val, [t_name])
+                            group_path.append(dir_name)
+
+            if skip_asset:
+                continue
 
             # Build target directory
             target_dir = output_dir.joinpath(*type_path, *group_path)

--- a/src/deriva_ml/dataset/dataset_bag.py
+++ b/src/deriva_ml/dataset/dataset_bag.py
@@ -2170,14 +2170,18 @@ class DatasetBag:
         # itself (naming comes from feature_target_map); this call is for its
         # validation side-effect only.
         group_keys_for_cache = [
-            t for t in (list(targets) if isinstance(targets, list) else
-                        list(targets.keys()) if isinstance(targets, dict) else [])
+            t
+            for t in (
+                list(targets)
+                if isinstance(targets, list)
+                else list(targets.keys())
+                if isinstance(targets, dict)
+                else []
+            )
             if t not in column_targets
         ]
         if group_keys_for_cache:
-            self._load_feature_values_cache(
-                asset_table, group_keys_for_cache, enforce_vocabulary, None
-            )
+            self._load_feature_values_cache(asset_table, group_keys_for_cache, enforce_vocabulary, None)
 
         # Step 6: Get all assets reachable through FK paths
         assets = self._get_reachable_assets(asset_table)

--- a/src/deriva_ml/dataset/split.py
+++ b/src/deriva_ml/dataset/split.py
@@ -667,6 +667,31 @@ def split_dataset(
                 rid=result.split.rid,
                 version=result.split.version,
             )
+
+        Train directly from the split partitions (composition with
+        framework adapters)::
+
+            result = split_dataset(ml, "28D0", test_size=0.2, seed=42)
+            train_bag = ml.lookup_dataset(result.training.rid).download_dataset_bag(
+                version=result.training.version
+            )
+            test_bag = ml.lookup_dataset(result.testing.rid).download_dataset_bag(
+                version=result.testing.version
+            )
+            train_ds = train_bag.as_torch_dataset(
+                element_type="Image",
+                sample_loader=PIL.Image.open,
+                targets=["Glaucoma_Grade"],
+            )
+            # Each partition bag feeds independently into PyTorch / TensorFlow;
+            # the split hierarchy IS the train/val/test partitioning.
+
+    See Also:
+        ``DatasetBag.as_torch_dataset``, ``DatasetBag.as_tf_dataset``:
+            Build framework-native datasets from any partition bag; same
+            ``targets`` / ``target_transform`` / ``missing`` vocabulary.
+        ``DatasetBag.restructure_assets``:
+            Class-folder layout for ``ImageFolder``-style consumers.
     """
     # -------------------------------------------------------------------------
     # Validate inputs

--- a/src/deriva_ml/dataset/target_resolution.py
+++ b/src/deriva_ml/dataset/target_resolution.py
@@ -1,0 +1,151 @@
+"""Shared target-resolution logic for DatasetBag adapters and restructure.
+
+Both ``DatasetBag.as_torch_dataset``, ``DatasetBag.as_tf_dataset``, and
+``DatasetBag.restructure_assets`` need the same logic: given a bag, an
+element-table name, and a target specification, walk ``bag.feature_values``
+for each target, apply the requested missing-value policy, and return a
+dict keyed by element RID mapping to the target-arity shape.
+
+Keeping this logic in one module makes the "same semantics" claim across
+the three public methods enforceable by shared code rather than parallel
+implementation. See design spec §8.5.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import TYPE_CHECKING, Any, Callable, Literal
+
+from deriva_ml.core.exceptions import DerivaMLException
+
+if TYPE_CHECKING:
+    from deriva_ml.dataset.dataset_bag import DatasetBag
+    from deriva_ml.feature import FeatureRecord
+
+    FeatureSelector = Callable[[list["FeatureRecord"]], "FeatureRecord | None"]
+
+
+# Maximum unlabeled-RID count to show in missing="error" message before
+# truncating. Keeps error messages readable on very sparse datasets.
+_MISSING_ERROR_RID_LIST_LIMIT = 20
+
+
+def _resolve_targets(
+    bag: "DatasetBag",
+    element_type: str,
+    *,
+    targets: "list[str] | dict[str, FeatureSelector] | None",
+    missing: Literal["error", "skip", "unknown"],
+) -> "dict[str, Any]":
+    """Resolve feature values into per-element target records.
+
+    Walks ``bag.feature_values(element_type, feature_name, selector=...)``
+    for each feature in ``targets``, groups records by their target-
+    element RID, and applies the ``missing`` policy to elements whose
+    feature value is absent.
+
+    Args:
+        bag: Source ``DatasetBag``.
+        element_type: Domain table name whose rows are the elements
+            (e.g., ``"Image"``).
+        targets: Target specification per the aligned vocabulary (spec
+            §3.7). ``None`` yields no labels (empty result). ``list[str]``
+            yields one ``FeatureRecord`` per element for single-target,
+            ``dict[feature_name, FeatureRecord]`` for multi-target.
+            ``dict[str, FeatureSelector]`` passes per-feature selectors
+            through to ``bag.feature_values``.
+        missing: Policy for elements with no feature value.
+
+    Returns:
+        Dict keyed by element RID. Value shape:
+
+        - `targets=None`: empty dict.
+        - `targets=["A"]`: `FeatureRecord`.
+        - `targets=["A", "B"]` or dict with 2+ keys: `dict[str, FeatureRecord]`.
+        - Element absent under `missing="skip"`: key not in returned dict.
+        - Element absent under `missing="unknown"`: value is `None`.
+
+    Raises:
+        DerivaMLException: If ``missing="error"`` and any element lacks a
+            feature value (message lists up to 20 unlabeled RIDs).
+    """
+    if not targets:
+        return {}
+
+    # Normalize targets to (feature_name, selector) pairs. A list form has
+    # selector=None for each feature; a dict form uses the mapped selector.
+    if isinstance(targets, list):
+        feature_specs: list[tuple[str, Any]] = [(name, None) for name in targets]
+    else:
+        feature_specs = list(targets.items())
+
+    # Walk features and collect records keyed by target-element RID.
+    # The target column is the element_type's name (e.g., "Image" on an
+    # Image-target FeatureRecord). FeatureRecord instances carry that
+    # attribute; we pull it dynamically.
+    per_feature_per_rid: dict[str, dict[str, "FeatureRecord"]] = {
+        name: {} for name, _ in feature_specs
+    }
+    for feature_name, selector in feature_specs:
+        for record in bag.feature_values(
+            element_type, feature_name, selector=selector
+        ):
+            rid = getattr(record, element_type)
+            per_feature_per_rid[feature_name][rid] = record
+
+    # Determine the universe of element RIDs. Start from the bag's full
+    # membership list so we detect elements with no feature values at all
+    # (they would otherwise be silently absent from the feature iterator).
+    # Then union in any RIDs seen from feature_values in case list_dataset_members
+    # is unavailable or returns a subset.
+    members_by_type = bag.list_dataset_members(recurse=True)
+    all_rids: set[str] = {
+        m["RID"] for m in members_by_type.get(element_type, [])
+    }
+    for rid_map in per_feature_per_rid.values():
+        all_rids.update(rid_map.keys())
+
+    # Apply missing policy and build the result dict.
+    unlabeled: list[str] = []
+    result: dict[str, Any] = {}
+    is_single_target = len(feature_specs) == 1
+    single_feature_name = feature_specs[0][0] if is_single_target else None
+
+    for rid in sorted(all_rids):
+        feature_records = {
+            name: per_feature_per_rid[name].get(rid)
+            for name, _ in feature_specs
+        }
+        any_missing = any(v is None for v in feature_records.values())
+
+        if any_missing:
+            if missing == "error":
+                unlabeled.append(rid)
+                continue
+            if missing == "skip":
+                continue
+            # missing == "unknown"
+            result[rid] = None
+            continue
+
+        if is_single_target:
+            result[rid] = feature_records[single_feature_name]
+        else:
+            result[rid] = feature_records
+
+    if missing == "error" and unlabeled:
+        preview = unlabeled[:_MISSING_ERROR_RID_LIST_LIMIT]
+        suffix = (
+            f" (and {len(unlabeled) - len(preview)} more)"
+            if len(unlabeled) > len(preview)
+            else ""
+        )
+        raise DerivaMLException(
+            f"{len(unlabeled)} element(s) of type {element_type!r} have no "
+            f"value for one or more targets in {targets!r}. "
+            f"Unlabeled RIDs: {preview}{suffix}. "
+            f"Pass missing='skip' to drop unlabeled elements, or "
+            f"missing='unknown' to keep them with target=None."
+        )
+
+    return result

--- a/src/deriva_ml/dataset/target_resolution.py
+++ b/src/deriva_ml/dataset/target_resolution.py
@@ -13,7 +13,6 @@ implementation. See design spec §8.5.
 
 from __future__ import annotations
 
-from collections import defaultdict
 from typing import TYPE_CHECKING, Any, Callable, Literal
 
 from deriva_ml.core.exceptions import DerivaMLException
@@ -83,13 +82,9 @@ def _resolve_targets(
     # The target column is the element_type's name (e.g., "Image" on an
     # Image-target FeatureRecord). FeatureRecord instances carry that
     # attribute; we pull it dynamically.
-    per_feature_per_rid: dict[str, dict[str, "FeatureRecord"]] = {
-        name: {} for name, _ in feature_specs
-    }
+    per_feature_per_rid: dict[str, dict[str, "FeatureRecord"]] = {name: {} for name, _ in feature_specs}
     for feature_name, selector in feature_specs:
-        for record in bag.feature_values(
-            element_type, feature_name, selector=selector
-        ):
+        for record in bag.feature_values(element_type, feature_name, selector=selector):
             rid = getattr(record, element_type)
             per_feature_per_rid[feature_name][rid] = record
 
@@ -99,9 +94,7 @@ def _resolve_targets(
     # Then union in any RIDs seen from feature_values in case list_dataset_members
     # is unavailable or returns a subset.
     members_by_type = bag.list_dataset_members(recurse=True)
-    all_rids: set[str] = {
-        m["RID"] for m in members_by_type.get(element_type, [])
-    }
+    all_rids: set[str] = {m["RID"] for m in members_by_type.get(element_type, [])}
     for rid_map in per_feature_per_rid.values():
         all_rids.update(rid_map.keys())
 
@@ -112,10 +105,7 @@ def _resolve_targets(
     single_feature_name = feature_specs[0][0] if is_single_target else None
 
     for rid in sorted(all_rids):
-        feature_records = {
-            name: per_feature_per_rid[name].get(rid)
-            for name, _ in feature_specs
-        }
+        feature_records = {name: per_feature_per_rid[name].get(rid) for name, _ in feature_specs}
         any_missing = any(v is None for v in feature_records.values())
 
         if any_missing:
@@ -135,11 +125,7 @@ def _resolve_targets(
 
     if missing == "error" and unlabeled:
         preview = unlabeled[:_MISSING_ERROR_RID_LIST_LIMIT]
-        suffix = (
-            f" (and {len(unlabeled) - len(preview)} more)"
-            if len(unlabeled) > len(preview)
-            else ""
-        )
+        suffix = f" (and {len(unlabeled) - len(preview)} more)" if len(unlabeled) > len(preview) else ""
         raise DerivaMLException(
             f"{len(unlabeled)} element(s) of type {element_type!r} have no "
             f"value for one or more targets in {targets!r}. "

--- a/src/deriva_ml/dataset/tf_adapter.py
+++ b/src/deriva_ml/dataset/tf_adapter.py
@@ -1,0 +1,208 @@
+"""TensorFlow adapter for DatasetBag.
+
+Builds a ``tf.data.Dataset`` that lazy-loads samples and labels from an
+already-downloaded ``DatasetBag``. TensorFlow is imported at builder
+entry (lazy import) so the base library stays importable without
+TensorFlow installed.
+
+See design spec §§3.1-3.7 for the full contract.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Callable, Literal
+
+from deriva_ml.core.exceptions import DerivaMLException
+from deriva_ml.dataset.target_resolution import _resolve_targets
+
+if TYPE_CHECKING:
+    import tensorflow as tf
+
+    from deriva_ml.dataset.dataset_bag import DatasetBag
+    from deriva_ml.feature import FeatureRecord
+
+    FeatureSelector = Callable[[list["FeatureRecord"]], "FeatureRecord | None"]
+
+
+_TF_INSTALL_HINT = (
+    "TensorFlow is not installed. Install with:\n"
+    "    pip install 'deriva-ml[tf]'\n"
+    "or install tensorflow directly:\n"
+    "    pip install 'tensorflow>=2.15'\n"
+    "macOS: use 'tensorflow-macos' instead of 'tensorflow'.\n"
+    "CUDA:  use 'tensorflow[and-cuda]' for GPU support."
+)
+
+
+def build_tf_dataset(
+    bag: "DatasetBag",
+    element_type: str,
+    *,
+    sample_loader: "Callable[[Path | None, dict[str, Any]], Any] | None" = None,
+    transform: "Callable[[Any], Any] | None" = None,
+    targets: "list[str] | dict[str, FeatureSelector] | None" = None,
+    target_transform: "Callable[..., Any] | None" = None,
+    missing: Literal["error", "skip", "unknown"] = "error",
+    output_signature: "tf.TensorSpec | tuple | None" = None,
+) -> "tf.data.Dataset":
+    """Build a tf.data.Dataset from a DatasetBag.
+
+    See DatasetBag.as_tf_dataset docstring for full argument docs
+    and spec §3 for the design contract.
+
+    Args:
+        bag: The source DatasetBag to build the dataset from.
+        element_type: Name of the domain table whose rows become samples.
+        sample_loader: Callable receiving ``(path, row_dict)``. For asset
+            tables, ``path`` is the on-disk file path; for non-asset tables,
+            ``path=None``. Required for asset-table element types.
+        transform: Applied to the sample after ``sample_loader`` returns.
+        targets: Feature names that supply labels. ``None`` yields unlabeled
+            samples. ``list[str]`` yields one FeatureRecord per element.
+            ``dict[str, selector]`` passes per-feature selectors.
+        target_transform: Callable consuming the raw feature-record shape
+            (FeatureRecord, dict, or None) and returning the final label.
+        missing: Policy for elements with no feature value. ``"error"``
+            raises at construction; ``"skip"`` drops unlabeled elements;
+            ``"unknown"`` keeps them with target=None.
+        output_signature: ``tf.TypeSpec`` (or nested structure of specs)
+            describing the shape and dtype of each element yielded by the
+            generator. When ``None`` (default), the first sample is consumed
+            eagerly to infer the signature via ``tf.type_spec_from_value``,
+            then the generator is re-wrapped so the first sample is not lost.
+
+    Returns:
+        A ``tf.data.Dataset`` whose elements are ``sample`` when
+        ``targets=None``, or ``(sample, target)`` otherwise.
+
+    Raises:
+        ImportError: If TensorFlow is not installed.
+        DerivaMLException: If element_type is not in the bag, if
+            element_type is an asset table and sample_loader is None,
+            if missing="error" and any element lacks a feature value, or
+            if output_signature=None and the dataset is empty (cannot
+            infer signature).
+    """
+    try:
+        import tensorflow as tf
+    except ImportError as e:
+        raise ImportError(_TF_INSTALL_HINT) from e
+
+    # Validate element_type exists in the bag.
+    members_by_type = bag.list_dataset_members(recurse=True)
+    if element_type not in members_by_type:
+        raise DerivaMLException(
+            f"Element type {element_type!r} not found in bag; available types: {sorted(members_by_type.keys())}"
+        )
+
+    # Validate sample_loader is provided for asset-table element types.
+    is_asset = _bag_element_is_asset(bag, element_type)
+    if is_asset and sample_loader is None:
+        raise DerivaMLException(
+            f"Element type {element_type!r} is an asset table and requires "
+            f"a sample_loader. Common loaders:\n"
+            f"    sample_loader=PIL.Image.open       # images\n"
+            f"    sample_loader=nibabel.load         # NIfTI medical volumes\n"
+            f"    sample_loader=h5py.File            # HDF5 arrays\n"
+            f"Or pass sample_loader=lambda path, row: path.read_bytes() "
+            f"if you want raw bytes."
+        )
+
+    # Resolve targets once at construction time.
+    target_map = _resolve_targets(bag, element_type, targets=targets, missing=missing)
+
+    # Build the RID list — all elements if targets=None, only labeled
+    # elements if targets is set.
+    all_rids = [m["RID"] for m in members_by_type[element_type]]
+    if targets is None:
+        rids = all_rids
+    elif missing == "skip":
+        rids = [rid for rid in all_rids if rid in target_map]
+    else:
+        rids = all_rids  # "error" already raised if incomplete; "unknown"
+        # keeps all RIDs with None target for absent ones
+
+    # Build the row lookup so sample_loader gets the full row dict.
+    row_lookup = _build_row_lookup(bag, element_type)
+
+    # The iteration body — a Python generator function.
+    def _generate():
+        for rid in rids:
+            row = row_lookup.get(rid, {"RID": rid})
+
+            if is_asset:
+                path = _resolve_asset_path(bag, element_type, rid, row)
+                sample = sample_loader(path, row)
+            else:
+                sample = sample_loader(None, row) if sample_loader is not None else row
+
+            if transform is not None:
+                sample = transform(sample)
+
+            if targets is None:
+                yield sample
+            else:
+                target = target_map.get(rid)
+                if target_transform is not None:
+                    target = target_transform(target)
+                yield (sample, target)
+
+    # output_signature handling.
+    if output_signature is None:
+        # Infer from first sample. Consume one iteration eagerly.
+        gen = _generate()
+        try:
+            first = next(gen)
+        except StopIteration:
+            raise DerivaMLException(
+                f"Cannot build tf.data.Dataset from empty generator "
+                f"(element_type={element_type!r}, targets={targets!r}). "
+                f"Either the bag has no members of this type, or all were "
+                f"filtered by missing='skip'."
+            )
+        inferred = tf.nest.map_structure(tf.type_spec_from_value, first)
+
+        # Re-wrap so we don't lose the first sample.
+        def _generate_with_first():
+            yield first
+            yield from gen
+
+        return tf.data.Dataset.from_generator(
+            _generate_with_first, output_signature=inferred
+        )
+    else:
+        return tf.data.Dataset.from_generator(
+            _generate, output_signature=output_signature
+        )
+
+
+def _bag_element_is_asset(bag: "DatasetBag", element_type: str) -> bool:
+    """Return True if element_type is an asset table in the bag."""
+    # Try the direct is_asset method first (used in mock bags / tests).
+    is_asset_method = getattr(bag, "is_asset", None)
+    if is_asset_method is not None and callable(is_asset_method):
+        try:
+            return bool(is_asset_method(element_type))
+        except Exception:
+            pass
+    # Fall back to model-level check for real DatasetBag instances.
+    try:
+        table = bag.model.name_to_table(element_type)
+        return bool(bag.model.is_asset(table))
+    except (AttributeError, KeyError, Exception):
+        return False
+
+
+def _build_row_lookup(bag: "DatasetBag", element_type: str) -> dict:
+    """Build {RID: row_dict} lookup for the element table."""
+    try:
+        return {row["RID"]: row for row in bag.get_table_as_dict(element_type)}
+    except Exception:
+        return {}
+
+
+def _resolve_asset_path(bag: "DatasetBag", element_type: str, rid: str, row: dict) -> Path:
+    """Compute the on-disk path for an asset's file."""
+    filename = row.get("Filename") or f"{rid}.bin"
+    return bag.path / "data" / "assets" / element_type / rid / filename

--- a/src/deriva_ml/dataset/tf_adapter.py
+++ b/src/deriva_ml/dataset/tf_adapter.py
@@ -168,13 +168,9 @@ def build_tf_dataset(
             yield first
             yield from gen
 
-        return tf.data.Dataset.from_generator(
-            _generate_with_first, output_signature=inferred
-        )
+        return tf.data.Dataset.from_generator(_generate_with_first, output_signature=inferred)
     else:
-        return tf.data.Dataset.from_generator(
-            _generate, output_signature=output_signature
-        )
+        return tf.data.Dataset.from_generator(_generate, output_signature=output_signature)
 
 
 def _bag_element_is_asset(bag: "DatasetBag", element_type: str) -> bool:

--- a/src/deriva_ml/dataset/torch_adapter.py
+++ b/src/deriva_ml/dataset/torch_adapter.py
@@ -1,0 +1,179 @@
+"""PyTorch adapter for DatasetBag.
+
+Builds a ``torch.utils.data.Dataset`` that lazy-loads samples and labels
+from an already-downloaded ``DatasetBag``. Torch is imported at builder
+entry (lazy import) so the base library stays importable without torch.
+
+See design spec §§3.1-3.7 for the full contract.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Callable, Literal
+
+from deriva_ml.core.exceptions import DerivaMLException
+from deriva_ml.dataset.target_resolution import _resolve_targets
+
+if TYPE_CHECKING:
+    import torch.utils.data
+
+    from deriva_ml.dataset.dataset_bag import DatasetBag
+    from deriva_ml.feature import FeatureRecord
+
+    FeatureSelector = Callable[[list["FeatureRecord"]], "FeatureRecord | None"]
+
+
+_TORCH_INSTALL_HINT = (
+    "PyTorch is not installed. Install with:\n"
+    "    pip install 'deriva-ml[torch]'\n"
+    "or install torch directly:\n"
+    "    pip install 'torch>=2.0'"
+)
+
+
+def build_torch_dataset(
+    bag: "DatasetBag",
+    element_type: str,
+    *,
+    sample_loader: "Callable[[Path | None, dict[str, Any]], Any] | None" = None,
+    transform: "Callable[[Any], Any] | None" = None,
+    targets: "list[str] | dict[str, FeatureSelector] | None" = None,
+    target_transform: "Callable[..., Any] | None" = None,
+    missing: Literal["error", "skip", "unknown"] = "error",
+) -> "torch.utils.data.Dataset":
+    """Build a torch.utils.data.Dataset from a DatasetBag.
+
+    See DatasetBag.as_torch_dataset docstring for full argument docs
+    and spec §3 for the design contract.
+
+    Args:
+        bag: The source DatasetBag to build the dataset from.
+        element_type: Name of the domain table whose rows become samples.
+        sample_loader: Callable receiving ``(path, row_dict)``. For asset
+            tables, ``path`` is the on-disk file path; for non-asset tables,
+            ``path=None``. Required for asset-table element types.
+        transform: Applied to the sample after ``sample_loader`` returns.
+        targets: Feature names that supply labels. ``None`` yields unlabeled
+            samples. ``list[str]`` yields one FeatureRecord per element.
+            ``dict[str, selector]`` passes per-feature selectors.
+        target_transform: Callable consuming the raw feature-record shape
+            (FeatureRecord, dict, or None) and returning the final label.
+        missing: Policy for elements with no feature value. ``"error"``
+            raises at construction; ``"skip"`` drops unlabeled elements;
+            ``"unknown"`` keeps them with target=None.
+
+    Returns:
+        A ``torch.utils.data.Dataset`` whose ``__getitem__`` returns
+        ``sample`` when ``targets=None``, or ``(sample, target)`` otherwise.
+
+    Raises:
+        ImportError: If torch is not installed.
+        DerivaMLException: If element_type is not in the bag, if
+            element_type is an asset table and sample_loader is None,
+            or if missing="error" and any element lacks a feature value.
+    """
+    try:
+        import torch.utils.data as _torch_data
+    except ImportError as e:
+        raise ImportError(_TORCH_INSTALL_HINT) from e
+
+    # Validate element_type exists in the bag.
+    members_by_type = bag.list_dataset_members(recurse=True)
+    if element_type not in members_by_type:
+        raise DerivaMLException(
+            f"Element type {element_type!r} not found in bag; available types: {sorted(members_by_type.keys())}"
+        )
+
+    # Validate sample_loader is provided for asset-table element types.
+    is_asset = _bag_element_is_asset(bag, element_type)
+    if is_asset and sample_loader is None:
+        raise DerivaMLException(
+            f"Element type {element_type!r} is an asset table and requires "
+            f"a sample_loader. Common loaders:\n"
+            f"    sample_loader=PIL.Image.open       # images\n"
+            f"    sample_loader=nibabel.load         # NIfTI medical volumes\n"
+            f"    sample_loader=h5py.File            # HDF5 arrays\n"
+            f"Or pass sample_loader=lambda path, row: path.read_bytes() "
+            f"if you want raw bytes."
+        )
+
+    # Resolve targets once at construction time.
+    target_map = _resolve_targets(bag, element_type, targets=targets, missing=missing)
+
+    # Build the RID list — all elements if targets=None, only labeled
+    # elements if targets is set.
+    all_rids = [m["RID"] for m in members_by_type[element_type]]
+    if targets is None:
+        rids = all_rids
+    elif missing == "skip":
+        rids = [rid for rid in all_rids if rid in target_map]
+    else:
+        rids = all_rids  # "error" already raised if incomplete; "unknown"
+        # keeps all RIDs with None target for absent ones
+
+    # Build the row lookup so sample_loader gets the full row dict.
+    row_lookup = _build_row_lookup(bag, element_type)
+
+    class _TorchDataset(_torch_data.Dataset):
+        def __init__(self):
+            self._rids = rids
+            self._target_map = target_map
+            self._is_asset = is_asset
+
+        def __len__(self):
+            return len(self._rids)
+
+        def __getitem__(self, index):
+            rid = self._rids[index]
+            row = row_lookup.get(rid, {"RID": rid})
+
+            if self._is_asset:
+                path = _resolve_asset_path(bag, element_type, rid, row)
+                sample = sample_loader(path, row)
+            else:
+                sample = sample_loader(None, row) if sample_loader is not None else row
+
+            if transform is not None:
+                sample = transform(sample)
+
+            if targets is None:
+                return sample
+
+            target = self._target_map.get(rid)
+            if target_transform is not None:
+                target = target_transform(target)
+            return sample, target
+
+    return _TorchDataset()
+
+
+def _bag_element_is_asset(bag: "DatasetBag", element_type: str) -> bool:
+    """Return True if element_type is an asset table in the bag."""
+    # Try the direct is_asset method first (used in mock bags / tests).
+    is_asset_method = getattr(bag, "is_asset", None)
+    if is_asset_method is not None and callable(is_asset_method):
+        try:
+            return bool(is_asset_method(element_type))
+        except Exception:
+            pass
+    # Fall back to model-level check for real DatasetBag instances.
+    try:
+        table = bag.model.name_to_table(element_type)
+        return bool(bag.model.is_asset(table))
+    except (AttributeError, KeyError, Exception):
+        return False
+
+
+def _build_row_lookup(bag: "DatasetBag", element_type: str) -> dict:
+    """Build {RID: row_dict} lookup for the element table."""
+    try:
+        return {row["RID"]: row for row in bag.get_table_as_dict(element_type)}
+    except Exception:
+        return {}
+
+
+def _resolve_asset_path(bag: "DatasetBag", element_type: str, rid: str, row: dict) -> Path:
+    """Compute the on-disk path for an asset's file."""
+    filename = row.get("Filename") or f"{rid}.bin"
+    return bag.path / "data" / "assets" / element_type / rid / filename

--- a/tests/dataset/test_restructure.py
+++ b/tests/dataset/test_restructure.py
@@ -25,15 +25,14 @@ class TestRestructureAssets:
     """Tests for the restructure_assets method on DatasetBag."""
 
     def test_restructure_basic_types_only(self, dataset_test, tmp_path):
-        """Test basic restructuring with dataset types only (no group_by)."""
+        """Test basic restructuring with dataset types only (no targets)."""
         dataset = dataset_test.dataset_description.dataset
         bag = dataset.download_dataset_bag(version=dataset.current_version, use_minid=False)
 
         output_dir = tmp_path / "restructured"
         result = bag.restructure_assets(
+            output_dir,
             asset_table="Image",
-            output_dir=output_dir,
-            group_by=[],
         )
 
         assert isinstance(result, dict), f"Expected dict manifest, got {type(result).__name__}"
@@ -61,9 +60,8 @@ class TestRestructureAssets:
 
         output_dir = tmp_path / "restructured_copy"
         bag.restructure_assets(
+            output_dir,
             asset_table="Image",
-            output_dir=output_dir,
-            group_by=[],
             use_symlinks=False,
         )
 
@@ -82,9 +80,8 @@ class TestRestructureAssets:
 
         # Use last type instead of first
         bag.restructure_assets(
+            output_dir,
             asset_table="Image",
-            output_dir=output_dir,
-            group_by=[],
             type_selector=lambda types: types[-1] if types else "custom_unknown",
         )
 
@@ -102,9 +99,9 @@ class TestRestructureAssets:
 
         # Group by Subject column (foreign key)
         bag.restructure_assets(
+            output_dir,
             asset_table="Image",
-            output_dir=output_dir,
-            group_by=["Subject"],
+            targets=["Subject"],
         )
 
         assert output_dir.exists()
@@ -121,9 +118,9 @@ class TestRestructureAssets:
 
         # Use a non-existent column - should result in "Unknown" folders
         bag.restructure_assets(
+            output_dir,
             asset_table="Image",
-            output_dir=output_dir,
-            group_by=["NonExistentColumn"],
+            targets=["NonExistentColumn"],
         )
 
         assert output_dir.exists()
@@ -162,9 +159,8 @@ class TestRestructureAssets:
 
         output_dir = tmp_path / "restructured_prediction"
         bag.restructure_assets(
+            output_dir,
             asset_table="Image",
-            output_dir=output_dir,
-            group_by=[],
         )
 
         assert output_dir.exists()
@@ -191,7 +187,7 @@ class TestRestructureAssets:
 
         This tests the complete prediction workflow where:
         1. Dataset has no type (treated as Testing)
-        2. Assets have no labels for group_by (placed in Unknown)
+        2. Assets have no labels for targets (placed in Unknown)
         Result: files end up in testing/Unknown/
         """
         ml = dataset_test.ml_instance
@@ -216,9 +212,9 @@ class TestRestructureAssets:
 
         output_dir = tmp_path / "restructured_full_prediction"
         bag.restructure_assets(
+            output_dir,
             asset_table="Image",
-            output_dir=output_dir,
-            group_by=["NonExistentLabel"],  # No labels - will use Unknown
+            targets=["NonExistentLabel"],  # No labels - will use Unknown
         )
 
         assert output_dir.exists()
@@ -249,9 +245,8 @@ class TestRestructureAssets:
         # Use a valid table that exists but might not have members in this dataset
         # Use "File" which exists in the schema but likely has no members
         result = bag.restructure_assets(
+            output_dir,
             asset_table="File",
-            output_dir=output_dir,
-            group_by=[],
         )
 
         assert isinstance(result, dict), f"Expected dict manifest, got {type(result).__name__}"
@@ -269,9 +264,8 @@ class TestRestructureAssets:
 
         output_dir = tmp_path / "restructured_nested"
         bag.restructure_assets(
+            output_dir,
             asset_table="Image",
-            output_dir=output_dir,
-            group_by=[],
         )
 
         assert output_dir.exists()
@@ -342,9 +336,8 @@ class TestRestructureAssets:
 
         output_dir = tmp_path / "restructured_split"
         bag.restructure_assets(
+            output_dir,
             asset_table="Image",
-            output_dir=output_dir,
-            group_by=[],
         )
 
         assert output_dir.exists()
@@ -388,9 +381,9 @@ class TestRestructureAssets:
 
         # Group by multiple columns
         bag.restructure_assets(
+            output_dir,
             asset_table="Image",
-            output_dir=output_dir,
-            group_by=["Subject", "Description"],
+            targets=["Subject", "Description"],
         )
 
         assert output_dir.exists()
@@ -502,9 +495,8 @@ class TestRestructureForeignKeyPaths:
 
         output_dir = tmp_path / "restructured_fk"
         result = bag.restructure_assets(
+            output_dir,
             asset_table="Image",
-            output_dir=output_dir,
-            group_by=[],
         )
 
         assert isinstance(result, dict), f"Expected dict manifest, got {type(result).__name__}"
@@ -650,9 +642,9 @@ class TestRestructureWithFeatures:
 
         # Group by the Quality feature which uses ImageQuality vocabulary
         bag.restructure_assets(
+            output_dir,
             asset_table="Image",
-            output_dir=output_dir,
-            group_by=["Quality"],
+            targets=["Quality"],
         )
 
         assert output_dir.exists()
@@ -676,9 +668,9 @@ class TestRestructureWithFeatures:
 
         # Group by Subject column first, then Quality feature
         bag.restructure_assets(
+            output_dir,
             asset_table="Image",
-            output_dir=output_dir,
-            group_by=["Subject", "Quality"],
+            targets=["Subject", "Quality"],
         )
 
         assert output_dir.exists()
@@ -700,9 +692,9 @@ class TestRestructureWithFeatures:
 
         # Group by Quality feature first, then Subject column
         bag.restructure_assets(
+            output_dir,
             asset_table="Image",
-            output_dir=output_dir,
-            group_by=["Quality", "Subject"],
+            targets=["Quality", "Subject"],
         )
 
         assert output_dir.exists()
@@ -725,9 +717,9 @@ class TestEnforceVocabulary:
         # BoundingBox is an asset-based feature with no vocabulary terms
         with pytest.raises(DerivaMLException) as exc_info:
             bag.restructure_assets(
+                output_dir,
                 asset_table="Image",
-                output_dir=output_dir,
-                group_by=["BoundingBox"],
+                targets=["BoundingBox"],
                 enforce_vocabulary=True,
             )
 
@@ -742,9 +734,9 @@ class TestEnforceVocabulary:
 
         # Should not raise with enforce_vocabulary=False
         bag.restructure_assets(
+            output_dir,
             asset_table="Image",
-            output_dir=output_dir,
-            group_by=["BoundingBox"],
+            targets=["BoundingBox"],
             enforce_vocabulary=False,
         )
 
@@ -762,9 +754,9 @@ class TestEnforceVocabulary:
         # BoundingBox feature should fail without explicitly setting enforce_vocabulary
         with pytest.raises(DerivaMLException):
             bag.restructure_assets(
+                output_dir,
                 asset_table="Image",
-                output_dir=output_dir,
-                group_by=["BoundingBox"],
+                targets=["BoundingBox"],
                 # enforce_vocabulary not specified, should default to True
             )
 
@@ -777,9 +769,9 @@ class TestEnforceVocabulary:
 
         # Quality feature uses ImageQuality vocabulary - should work
         bag.restructure_assets(
+            output_dir,
             asset_table="Image",
-            output_dir=output_dir,
-            group_by=["Quality"],
+            targets=["Quality"],
             enforce_vocabulary=True,
         )
 
@@ -888,10 +880,9 @@ class TestValueSelectorWithNestedDatasets:
         # Even if there's only one value per asset, we want to verify the
         # feature cache includes assets from child datasets
         bag.restructure_assets(
+            output_dir,
             asset_table="Image",
-            output_dir=output_dir,
-            group_by=["Quality"],  # Feature that may have values
-            value_selector=tracking_selector,
+            targets={"Quality": tracking_selector},  # Feature with per-feature selector
         )
 
         # If there were feature values for child assets, the selector would see them
@@ -1049,9 +1040,9 @@ class TestFeatureTablesInBagExport:
 
         # This should work because feature tables are exported with the bag
         bag.restructure_assets(
+            output_dir,
             asset_table="Image",
-            output_dir=output_dir,
-            group_by=["Quality"],
+            targets=["Quality"],
         )
 
         assert output_dir.exists()

--- a/tests/dataset/test_target_resolution.py
+++ b/tests/dataset/test_target_resolution.py
@@ -1,0 +1,134 @@
+"""Unit tests for the shared target-resolution helper.
+
+Framework-agnostic: tests the selector/missing/arity logic in isolation
+from torch, tensorflow, and the restructure_assets call-site. If these
+tests fail, the adapter and restructure alignment both break in the
+same way, which is a feature — one helper, one set of semantics.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from deriva_ml.core.exceptions import DerivaMLException
+from deriva_ml.dataset.target_resolution import _resolve_targets
+from deriva_ml.feature import FeatureRecord
+
+
+class _FakeRecord(FeatureRecord):
+    """Minimal FeatureRecord stand-in for target-resolution tests."""
+    Image: str  # target column: asset RID this record describes
+    Grade: str  # scalar label
+    Feature_Name: str = "Grade"  # default so tests don't repeat it
+
+
+def _make_bag(feature_returns: dict[str, dict[str, list[_FakeRecord]]]):
+    """Build a MagicMock bag whose feature_values returns canned data.
+
+    Args:
+        feature_returns: {feature_name: {element_rid: [records...]}}.
+
+    Returns:
+        A MagicMock standing in for a DatasetBag.
+    """
+    bag = MagicMock()
+
+    def fake_feature_values(element_type, feature_name, selector=None):
+        per_rid = feature_returns.get(feature_name, {})
+        for rid, records in per_rid.items():
+            if selector is None:
+                yield from records
+            else:
+                selected = selector(records)
+                if selected is not None:
+                    yield selected
+
+    bag.feature_values = fake_feature_values
+    bag.list_dataset_members = MagicMock(
+        return_value={"Image": [{"RID": rid} for rid in feature_returns.get(
+            next(iter(feature_returns), "Grade"), {}).keys()]}
+    )
+    return bag
+
+
+def test_resolve_targets_none_returns_unlabeled_per_rid():
+    """targets=None → empty dict (no label resolution needed)."""
+    bag = _make_bag({})
+    result = _resolve_targets(bag, "Image", targets=None, missing="error")
+    assert result == {}
+
+
+def test_resolve_targets_single_target_returns_featurerecord_per_rid():
+    """Single-target list yields one FeatureRecord per element RID."""
+    recs_a = [_FakeRecord(Image="1-IMG1", Grade="Mild")]
+    recs_b = [_FakeRecord(Image="1-IMG2", Grade="Severe")]
+    bag = _make_bag({"Grade": {"1-IMG1": recs_a, "1-IMG2": recs_b}})
+    result = _resolve_targets(bag, "Image", targets=["Grade"], missing="error")
+    assert result["1-IMG1"].Grade == "Mild"
+    assert result["1-IMG2"].Grade == "Severe"
+
+
+def test_resolve_targets_missing_error_raises_with_rid_list():
+    """missing='error' with sparse labels raises and names unlabeled RIDs."""
+    recs = [_FakeRecord(Image="1-IMG1", Grade="Mild")]
+    bag = _make_bag({"Grade": {"1-IMG1": recs, "1-IMG2": []}})
+    with pytest.raises(DerivaMLException, match=r"1-IMG2"):
+        _resolve_targets(bag, "Image", targets=["Grade"], missing="error")
+
+
+def test_resolve_targets_missing_skip_drops_unlabeled():
+    """missing='skip' omits the unlabeled RID from the result entirely."""
+    recs = [_FakeRecord(Image="1-IMG1", Grade="Mild")]
+    bag = _make_bag({"Grade": {"1-IMG1": recs, "1-IMG2": []}})
+    result = _resolve_targets(bag, "Image", targets=["Grade"], missing="skip")
+    assert "1-IMG1" in result
+    assert "1-IMG2" not in result
+
+
+def test_resolve_targets_missing_unknown_yields_none():
+    """missing='unknown' keeps the RID with None as its target value."""
+    recs = [_FakeRecord(Image="1-IMG1", Grade="Mild")]
+    bag = _make_bag({"Grade": {"1-IMG1": recs, "1-IMG2": []}})
+    result = _resolve_targets(bag, "Image", targets=["Grade"], missing="unknown")
+    assert result["1-IMG1"].Grade == "Mild"
+    assert result["1-IMG2"] is None
+
+
+def test_resolve_targets_multi_target_returns_dict_keyed_by_feature():
+    """Multi-target yields dict[feature_name, FeatureRecord] per RID."""
+    grade_recs = [_FakeRecord(Image="1-IMG1", Grade="Mild")]
+    severity_recs = [_FakeRecord(Image="1-IMG1", Grade="Low")]
+    bag = _make_bag({
+        "Grade": {"1-IMG1": grade_recs},
+        "Severity": {"1-IMG1": severity_recs},
+    })
+    result = _resolve_targets(
+        bag, "Image", targets=["Grade", "Severity"], missing="error"
+    )
+    assert set(result["1-IMG1"].keys()) == {"Grade", "Severity"}
+    assert result["1-IMG1"]["Grade"].Grade == "Mild"
+
+
+def test_resolve_targets_selector_dict_applies_per_feature():
+    """dict form passes selectors per-feature to bag.feature_values."""
+    selector = FeatureRecord.select_newest
+    r1 = _FakeRecord(Image="1-IMG1", Grade="Mild")
+    r2 = _FakeRecord(Image="1-IMG1", Grade="Severe")
+    bag = _make_bag({"Grade": {"1-IMG1": [r1, r2]}})
+    result = _resolve_targets(
+        bag, "Image", targets={"Grade": selector}, missing="error"
+    )
+    # The selector picks one; exact choice depends on select_newest's
+    # impl, but the result should be one of the two records.
+    assert result["1-IMG1"].Grade in ("Mild", "Severe")
+
+
+def test_resolve_targets_unknown_feature_raises_at_construction():
+    """Passing a feature name that doesn't exist raises the same error
+    bag.feature_values would raise."""
+    bag = MagicMock()
+    bag.feature_values = MagicMock(side_effect=DerivaMLException("No such feature"))
+    bag.list_dataset_members = MagicMock(return_value={"Image": []})
+    with pytest.raises(DerivaMLException):
+        _resolve_targets(bag, "Image", targets=["Bogus"], missing="error")

--- a/tests/dataset/test_tf_adapter_e2e.py
+++ b/tests/dataset/test_tf_adapter_e2e.py
@@ -1,0 +1,25 @@
+"""End-to-end TensorFlow adapter test using a real bag fixture.
+
+Gated on tensorflow being importable. Uses catalog_with_datasets fixture
+to build a real bag, then iterates under tf.data.Dataset.batch().prefetch().
+"""
+from __future__ import annotations
+
+import pytest
+
+tf = pytest.importorskip("tensorflow")
+
+
+def test_bag_to_tf_dataset_yields_batches(catalog_with_datasets, tmp_path):
+    ml, dataset_desc = catalog_with_datasets
+    bag = dataset_desc.dataset.download_dataset_bag(version="1.0.0")
+
+    ds = bag.as_tf_dataset(
+        element_type="Image",
+        sample_loader=lambda p, row: tf.constant([1.0, 2.0, 3.0]),
+        targets=None,  # unlabeled — just exercise the plumbing
+    )
+    ds = ds.batch(2).prefetch(2)
+    batches = list(ds)
+    assert len(batches) > 0
+    assert batches[0].shape[0] <= 2

--- a/tests/dataset/test_tf_adapter_logic.py
+++ b/tests/dataset/test_tf_adapter_logic.py
@@ -1,0 +1,449 @@
+"""Pure-Python logic tests for tf_adapter.
+
+Uses pytest.importorskip — runs only when tensorflow is installed. Tests
+the join logic, selector pass-through, missing= branches, target arity,
+output_signature inference, and error paths using real tf.data.Dataset.
+
+Coverage matrix (spec §6.2):
+- missing="error" raises at construction with RID list
+- missing="skip" drops unlabeled elements
+- missing="unknown" passes None target for unlabeled elements
+- Selector dict form vs list form yield equivalent results
+- Single-target returns FeatureRecord via target_transform
+- Multi-target returns dict[str, FeatureRecord] via target_transform
+- Asset-table element with no sample_loader raises at construction
+- Non-asset-table element works without sample_loader
+- output_signature=None triggers first-sample inference
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+tf = pytest.importorskip("tensorflow")
+
+from deriva_ml.core.exceptions import DerivaMLException  # noqa: E402
+from deriva_ml.dataset.tf_adapter import build_tf_dataset  # noqa: E402
+from deriva_ml.feature import FeatureRecord  # noqa: E402
+
+
+class _FakeRecord(FeatureRecord):
+    """Minimal FeatureRecord stand-in for tf adapter tests."""
+
+    Image: str
+    Grade: str
+    Feature_Name: str = "Grade"  # default so tests don't need to pass it
+
+
+def _mock_bag_with_labeled_images(rids_and_labels: dict[str, str]):
+    """Build a MagicMock DatasetBag with the given labeled images.
+
+    Args:
+        rids_and_labels: Mapping of RID to label string for labeled images.
+            Only RIDs with non-empty labels will be returned by feature_values.
+
+    Returns:
+        A MagicMock DatasetBag.
+    """
+    bag = MagicMock()
+    bag.path = Path("/tmp/fake_bag")
+    bag.list_dataset_members = MagicMock(
+        return_value={"Image": [{"RID": rid} for rid in rids_and_labels]}
+    )
+
+    def fake_feature_values(element_type, feature_name, selector=None):
+        for rid, label in rids_and_labels.items():
+            if not label:
+                # Simulate missing: no record yielded for empty label
+                continue
+            rec = _FakeRecord(Image=rid, Grade=label)
+            if selector is None:
+                yield rec
+            else:
+                sel = selector([rec])
+                if sel is not None:
+                    yield sel
+
+    bag.feature_values = fake_feature_values
+    # Mock table metadata so the asset-path resolver can find columns.
+    bag.model = MagicMock()
+    bag.model.is_asset = MagicMock(return_value=True)
+    asset_row = {"RID": "1-IMG1", "Filename": "img1.jpg"}
+    bag.get_table_as_dict = MagicMock(return_value=iter([asset_row]))
+    bag.is_asset = MagicMock(return_value=True)
+    return bag
+
+
+class _FakeSubjectRecord(FeatureRecord):
+    """FeatureRecord for non-asset (tabular) tests with Subject element column."""
+
+    Subject: str
+    Grade: str
+    Feature_Name: str = "Grade"
+
+
+def _mock_non_asset_bag(rids_and_labels: dict[str, str]):
+    """Build a MagicMock bag for a non-asset element type (tabular)."""
+    bag = MagicMock()
+    bag.path = Path("/tmp/fake_bag")
+    bag.list_dataset_members = MagicMock(
+        return_value={"Subject": [{"RID": rid} for rid in rids_and_labels]}
+    )
+
+    def fake_feature_values(element_type, feature_name, selector=None):
+        for rid, label in rids_and_labels.items():
+            if not label:
+                continue
+            rec = _FakeSubjectRecord(Subject=rid, Grade=label)
+            if selector is None:
+                yield rec
+            else:
+                sel = selector([rec])
+                if sel is not None:
+                    yield sel
+
+    bag.feature_values = fake_feature_values
+    bag.model = MagicMock()
+    bag.model.is_asset = MagicMock(return_value=False)
+    bag.get_table_as_dict = MagicMock(return_value=iter([]))
+    bag.is_asset = MagicMock(return_value=False)
+    return bag
+
+
+# ---------------------------------------------------------------------------
+# Basic construction tests
+# ---------------------------------------------------------------------------
+
+
+def test_as_tf_dataset_returns_tf_dataset():
+    """build_tf_dataset returns an instance of tf.data.Dataset."""
+    bag = _mock_bag_with_labeled_images({"1-IMG1": "Mild"})
+    ds = build_tf_dataset(
+        bag,
+        "Image",
+        sample_loader=lambda p, row: tf.constant([1.0, 2.0, 3.0]),
+        targets=["Grade"],
+        output_signature=(
+            tf.TensorSpec(shape=(3,), dtype=tf.float32),
+            tf.TensorSpec(shape=(), dtype=tf.string),
+        ),
+    )
+    assert isinstance(ds, tf.data.Dataset)
+
+
+def test_element_count_reflects_all_when_no_skip():
+    """Dataset element count equals total member count when missing != 'skip'."""
+    bag = _mock_bag_with_labeled_images({"1-IMG1": "Mild", "1-IMG2": "Severe"})
+    bag.get_table_as_dict.return_value = iter([
+        {"RID": "1-IMG1", "Filename": "img1.jpg"},
+        {"RID": "1-IMG2", "Filename": "img2.jpg"},
+    ])
+    ds = build_tf_dataset(
+        bag,
+        "Image",
+        sample_loader=lambda p, row: tf.constant([1.0]),
+        targets=["Grade"],
+        target_transform=lambda rec: tf.constant(rec.Grade if rec is not None else ""),
+        output_signature=(
+            tf.TensorSpec(shape=(1,), dtype=tf.float32),
+            tf.TensorSpec(shape=(), dtype=tf.string),
+        ),
+    )
+    count = sum(1 for _ in ds)
+    assert count == 2
+
+
+# ---------------------------------------------------------------------------
+# missing= branch tests (spec §6.2)
+# ---------------------------------------------------------------------------
+
+
+def test_missing_error_raises_at_construction():
+    """missing='error' raises DerivaMLException at construction listing RIDs."""
+    bag = MagicMock()
+    bag.path = Path("/tmp/fake_bag")
+    bag.list_dataset_members = MagicMock(
+        return_value={"Image": [{"RID": "1-IMG1"}, {"RID": "1-IMG2"}]}
+    )
+    bag.feature_values = MagicMock(
+        return_value=iter([_FakeRecord(Image="1-IMG1", Grade="Mild")])
+    )
+    bag.model = MagicMock()
+    bag.model.is_asset = MagicMock(return_value=True)
+    bag.get_table_as_dict = MagicMock(return_value=iter([]))
+    bag.is_asset = MagicMock(return_value=True)
+    with pytest.raises(DerivaMLException, match=r"1-IMG2"):
+        build_tf_dataset(
+            bag,
+            "Image",
+            sample_loader=lambda p, row: tf.constant([]),
+            targets=["Grade"],
+            missing="error",
+        )
+
+
+def test_missing_skip_drops_unlabeled_elements():
+    """missing='skip' drops unlabeled elements from the dataset."""
+    # Only IMG1 has a label; IMG2 has empty label (skipped by fake_feature_values)
+    bag = _mock_bag_with_labeled_images({"1-IMG1": "Mild", "1-IMG2": ""})
+    ds = build_tf_dataset(
+        bag,
+        "Image",
+        sample_loader=lambda p, row: tf.constant([1.0]),
+        targets=["Grade"],
+        target_transform=lambda rec: tf.constant(rec.Grade if rec is not None else ""),
+        missing="skip",
+        output_signature=(
+            tf.TensorSpec(shape=(1,), dtype=tf.float32),
+            tf.TensorSpec(shape=(), dtype=tf.string),
+        ),
+    )
+    count = sum(1 for _ in ds)
+    assert count == 1
+
+
+def test_missing_unknown_keeps_all_elements_with_none_target():
+    """missing='unknown' keeps all elements; target is None for unlabeled."""
+    bag = _mock_bag_with_labeled_images({"1-IMG1": "Mild", "1-IMG2": ""})
+    # Override get_table_as_dict to return both rows
+    bag.get_table_as_dict.return_value = iter([
+        {"RID": "1-IMG1", "Filename": "img1.jpg"},
+        {"RID": "1-IMG2", "Filename": "img2.jpg"},
+    ])
+    # target_transform must handle None for the unlabeled element.
+    targets_seen = []
+
+    def capture_and_convert(rec):
+        targets_seen.append(rec)
+        return tf.constant(rec.Grade if rec is not None else "")
+
+    ds = build_tf_dataset(
+        bag,
+        "Image",
+        sample_loader=lambda p, row: tf.constant([1.0]),
+        targets=["Grade"],
+        target_transform=capture_and_convert,
+        missing="unknown",
+        output_signature=(
+            tf.TensorSpec(shape=(1,), dtype=tf.float32),
+            tf.TensorSpec(shape=(), dtype=tf.string),
+        ),
+    )
+    count = sum(1 for _ in ds)
+    assert count == 2
+    assert None in targets_seen
+
+
+# ---------------------------------------------------------------------------
+# Target arity tests (spec §3.3 / §6.2)
+# ---------------------------------------------------------------------------
+
+
+def test_single_target_target_transform_receives_featurerecord():
+    """Single-target: target_transform receives a FeatureRecord directly."""
+    bag = _mock_bag_with_labeled_images({"1-IMG1": "Mild"})
+    bag.get_table_as_dict.return_value = iter([{"RID": "1-IMG1", "Filename": "f.jpg"}])
+    received = []
+
+    def capture_target(target):
+        received.append(target)
+        return tf.constant(0)
+
+    ds = build_tf_dataset(
+        bag,
+        "Image",
+        sample_loader=lambda p, row: tf.constant([1.0]),
+        targets=["Grade"],
+        target_transform=capture_target,
+        output_signature=(
+            tf.TensorSpec(shape=(1,), dtype=tf.float32),
+            tf.TensorSpec(shape=(), dtype=tf.int32),
+        ),
+    )
+    list(ds)  # consume to trigger __call__
+    assert len(received) == 1
+    assert isinstance(received[0], FeatureRecord)
+    assert received[0].Grade == "Mild"
+
+
+def test_multi_target_target_transform_receives_dict():
+    """Multi-target: target_transform receives dict[str, FeatureRecord]."""
+    bag = MagicMock()
+    bag.path = Path("/tmp/fake_bag")
+    bag.list_dataset_members = MagicMock(
+        return_value={"Image": [{"RID": "1-IMG1"}]}
+    )
+
+    class _FakeGradeRecord(FeatureRecord):
+        Image: str
+        Grade: str
+        Feature_Name: str = "Grade"
+
+    class _FakeSeverityRecord(FeatureRecord):
+        Image: str
+        Severity: str
+        Feature_Name: str = "Severity"
+
+    grade_rec = _FakeGradeRecord(Image="1-IMG1", Grade="Mild")
+    severity_rec = _FakeSeverityRecord(Image="1-IMG1", Severity="Low")
+
+    def fake_feature_values(element_type, feature_name, selector=None):
+        if feature_name == "Grade":
+            yield grade_rec
+        elif feature_name == "Severity":
+            yield severity_rec
+
+    bag.feature_values = fake_feature_values
+    bag.model = MagicMock()
+    bag.model.is_asset = MagicMock(return_value=True)
+    bag.get_table_as_dict = MagicMock(return_value=iter([{"RID": "1-IMG1", "Filename": "f.jpg"}]))
+    bag.is_asset = MagicMock(return_value=True)
+
+    received = []
+
+    def capture_target(target):
+        received.append(target)
+        return tf.constant(0)
+
+    ds = build_tf_dataset(
+        bag,
+        "Image",
+        sample_loader=lambda p, row: tf.constant([1.0]),
+        targets=["Grade", "Severity"],
+        target_transform=capture_target,
+        output_signature=(
+            tf.TensorSpec(shape=(1,), dtype=tf.float32),
+            tf.TensorSpec(shape=(), dtype=tf.int32),
+        ),
+    )
+    list(ds)
+    assert len(received) == 1
+    target_dict = received[0]
+    assert isinstance(target_dict, dict)
+    assert set(target_dict.keys()) == {"Grade", "Severity"}
+
+
+# ---------------------------------------------------------------------------
+# Selector dict form (spec §6.2)
+# ---------------------------------------------------------------------------
+
+
+def test_selector_dict_form_passes_selector_to_feature_values():
+    """dict form targets passes per-feature selectors through."""
+    bag = _mock_bag_with_labeled_images({"1-IMG1": "Mild"})
+    bag.get_table_as_dict.return_value = iter([{"RID": "1-IMG1", "Filename": "f.jpg"}])
+    selector_called = []
+
+    def my_selector(records):
+        selector_called.append(True)
+        return records[0] if records else None
+
+    ds = build_tf_dataset(
+        bag,
+        "Image",
+        sample_loader=lambda p, row: tf.constant([1.0]),
+        targets={"Grade": my_selector},
+        target_transform=lambda rec: tf.constant(rec.Grade if rec is not None else ""),
+        output_signature=(
+            tf.TensorSpec(shape=(1,), dtype=tf.float32),
+            tf.TensorSpec(shape=(), dtype=tf.string),
+        ),
+    )
+    list(ds)
+    assert selector_called, "selector was never called"
+
+
+# ---------------------------------------------------------------------------
+# Asset-table-without-sample_loader error (spec §6.2)
+# ---------------------------------------------------------------------------
+
+
+def test_asset_table_without_sample_loader_raises():
+    """Asset-table element_type with no sample_loader raises at construction."""
+    bag = _mock_bag_with_labeled_images({"1-IMG1": "Mild"})
+    with pytest.raises(DerivaMLException, match=r"sample_loader"):
+        build_tf_dataset(bag, "Image", targets=["Grade"])
+
+
+# ---------------------------------------------------------------------------
+# Non-asset table: no sample_loader required (spec §3.2)
+# ---------------------------------------------------------------------------
+
+
+def test_non_asset_table_no_sample_loader_returns_row_dict():
+    """Non-asset element_type with no sample_loader defaults to returning the row.
+
+    The adapter constructs successfully without a sample_loader. Because
+    tf.data.Dataset requires tensors, we supply a sample_loader that
+    converts the row dict to a tensor — this is also how real users would
+    work with tabular data in TF. The key assertion is that construction
+    does NOT raise even without a sample_loader.
+    """
+    bag = _mock_non_asset_bag({"1-SUB1": "active"})
+    bag.get_table_as_dict.return_value = iter([{"RID": "1-SUB1", "Status": "active"}])
+
+    # First verify that construction succeeds (no sample_loader, no error).
+    # We don't iterate — just check isinstance.
+    ds_no_loader = build_tf_dataset(
+        bag,
+        "Subject",
+        targets=["Grade"],
+        target_transform=lambda rec: tf.constant(rec.Grade if rec is not None else ""),
+        output_signature=(
+            tf.TensorSpec(shape=None, dtype=tf.string),
+            tf.TensorSpec(shape=(), dtype=tf.string),
+        ),
+    )
+    assert isinstance(ds_no_loader, tf.data.Dataset)
+
+    # With a sample_loader that converts the dict to a tensor, iteration works.
+    bag2 = _mock_non_asset_bag({"1-SUB1": "active"})
+    bag2.get_table_as_dict.return_value = iter([{"RID": "1-SUB1", "Status": "active"}])
+    ds = build_tf_dataset(
+        bag2,
+        "Subject",
+        sample_loader=lambda path, row: tf.constant(row.get("RID", "")),
+        targets=["Grade"],
+        target_transform=lambda rec: tf.constant(rec.Grade if rec is not None else ""),
+        output_signature=(
+            tf.TensorSpec(shape=(), dtype=tf.string),
+            tf.TensorSpec(shape=(), dtype=tf.string),
+        ),
+    )
+    assert isinstance(ds, tf.data.Dataset)
+    count = sum(1 for _ in ds)
+    assert count >= 1
+
+
+# ---------------------------------------------------------------------------
+# TF-specific: output_signature=None triggers first-sample inference
+# ---------------------------------------------------------------------------
+
+
+def test_output_signature_none_infers_from_first_sample():
+    """output_signature=None: element_spec is inferred from the first yielded sample."""
+    bag = _mock_bag_with_labeled_images({"1-IMG1": "Mild", "1-IMG2": "Severe"})
+    bag.get_table_as_dict.return_value = iter([
+        {"RID": "1-IMG1", "Filename": "img1.jpg"},
+        {"RID": "1-IMG2", "Filename": "img2.jpg"},
+    ])
+
+    ds = build_tf_dataset(
+        bag,
+        "Image",
+        sample_loader=lambda p, row: tf.constant([1.0, 2.0, 3.0]),
+        targets=None,
+        output_signature=None,  # trigger inference
+    )
+
+    assert isinstance(ds, tf.data.Dataset)
+    # element_spec should reflect a float32 tensor of shape (3,)
+    spec = ds.element_spec
+    assert spec.dtype == tf.float32
+    assert spec.shape == (3,)
+
+    # All elements should be present (inference must not drop the first sample)
+    count = sum(1 for _ in ds)
+    assert count == 2

--- a/tests/dataset/test_tf_adapter_no_tf.py
+++ b/tests/dataset/test_tf_adapter_no_tf.py
@@ -1,0 +1,43 @@
+"""Verify the library imports cleanly when tensorflow is absent.
+
+If tensorflow is truly installed in the test venv, we stub it out of
+sys.modules temporarily. The goal is to prove that importing DatasetBag
+does NOT import tensorflow eagerly.
+"""
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+
+def test_dataset_bag_imports_without_tf(monkeypatch):
+    """Removing tensorflow from sys.modules lets DatasetBag still import."""
+    for name in list(sys.modules):
+        if name == "tensorflow" or name.startswith("tensorflow."):
+            monkeypatch.delitem(sys.modules, name, raising=False)
+    monkeypatch.setitem(sys.modules, "tensorflow", None)
+
+    # Re-import dataset_bag under the tensorflow-less sys.modules state.
+    if "deriva_ml.dataset.dataset_bag" in sys.modules:
+        monkeypatch.delitem(sys.modules, "deriva_ml.dataset.dataset_bag", raising=False)
+    from deriva_ml.dataset.dataset_bag import DatasetBag  # noqa: F401
+
+
+def test_as_tf_dataset_raises_importerror_without_tf(monkeypatch):
+    """Calling build_tf_dataset when tensorflow is absent raises ImportError
+    with an install-hint message containing 'tensorflow' and 'deriva-ml[tf]'."""
+    for name in list(sys.modules):
+        if name == "tensorflow" or name.startswith("tensorflow."):
+            monkeypatch.delitem(sys.modules, name, raising=False)
+    monkeypatch.setitem(sys.modules, "tensorflow", None)
+
+    from unittest.mock import MagicMock
+    bag = MagicMock()
+
+    if "deriva_ml.dataset.tf_adapter" in sys.modules:
+        monkeypatch.delitem(sys.modules, "deriva_ml.dataset.tf_adapter", raising=False)
+
+    from deriva_ml.dataset.tf_adapter import build_tf_dataset
+    with pytest.raises(ImportError, match=r"tensorflow"):
+        build_tf_dataset(bag, "Image")

--- a/tests/dataset/test_torch_adapter_e2e.py
+++ b/tests/dataset/test_torch_adapter_e2e.py
@@ -1,0 +1,26 @@
+"""End-to-end torch adapter test using a real bag fixture.
+
+Gated on torch being importable. Uses catalog_with_datasets fixture
+to build a real bag, then iterates under a real DataLoader.
+"""
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+from torch.utils.data import DataLoader  # noqa: E402
+
+
+def test_bag_to_dataloader_yields_tensors(catalog_with_datasets, tmp_path):
+    ml, dataset_desc = catalog_with_datasets
+    bag = dataset_desc.dataset.download_dataset_bag(version="1.0.0")
+
+    ds = bag.as_torch_dataset(
+        element_type="Image",
+        sample_loader=lambda p, row: torch.tensor([1.0, 2.0, 3.0]),
+        targets=None,  # unlabeled — just exercise the plumbing
+    )
+    loader = DataLoader(ds, batch_size=2, shuffle=False)
+    batches = list(loader)
+    assert len(batches) > 0
+    assert batches[0].shape[0] <= 2

--- a/tests/dataset/test_torch_adapter_logic.py
+++ b/tests/dataset/test_torch_adapter_logic.py
@@ -1,0 +1,342 @@
+"""Pure-Python logic tests for torch_adapter.
+
+Uses pytest.importorskip — runs only when torch is installed. Tests
+the join logic, selector pass-through, missing= branches, target arity,
+and error paths using the real torch.utils.data.Dataset base class.
+
+Coverage matrix (spec §6.2):
+- missing="error" raises at construction with RID list
+- missing="skip" drops unlabeled elements
+- missing="unknown" passes None target for unlabeled elements
+- Selector dict form vs list form yield equivalent results
+- Single-target returns FeatureRecord via target_transform
+- Multi-target returns dict[str, FeatureRecord] via target_transform
+- Asset-table element with no sample_loader raises at construction
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from deriva_ml.core.exceptions import DerivaMLException  # noqa: E402
+from deriva_ml.dataset.torch_adapter import build_torch_dataset  # noqa: E402
+from deriva_ml.feature import FeatureRecord  # noqa: E402
+
+
+class _FakeRecord(FeatureRecord):
+    """Minimal FeatureRecord stand-in for torch adapter tests."""
+
+    Image: str
+    Grade: str
+    Feature_Name: str = "Grade"  # default so tests don't need to pass it
+
+
+def _mock_bag_with_labeled_images(rids_and_labels: dict[str, str]):
+    """Build a MagicMock DatasetBag with the given labeled images.
+
+    Args:
+        rids_and_labels: Mapping of RID to label string for labeled images.
+            Only RIDs with non-empty labels will be returned by feature_values.
+
+    Returns:
+        A MagicMock DatasetBag.
+    """
+    bag = MagicMock()
+    bag.path = Path("/tmp/fake_bag")
+    bag.list_dataset_members = MagicMock(
+        return_value={"Image": [{"RID": rid} for rid in rids_and_labels]}
+    )
+
+    def fake_feature_values(element_type, feature_name, selector=None):
+        for rid, label in rids_and_labels.items():
+            if not label:
+                # Simulate missing: no record yielded for empty label
+                continue
+            rec = _FakeRecord(Image=rid, Grade=label)
+            if selector is None:
+                yield rec
+            else:
+                sel = selector([rec])
+                if sel is not None:
+                    yield sel
+
+    bag.feature_values = fake_feature_values
+    # Mock table metadata so the asset-path resolver can find columns.
+    bag.model = MagicMock()
+    bag.model.is_asset = MagicMock(return_value=True)
+    asset_row = {"RID": "1-IMG1", "Filename": "img1.jpg"}
+    bag.get_table_as_dict = MagicMock(return_value=iter([asset_row]))
+    bag.is_asset = MagicMock(return_value=True)
+    return bag
+
+
+class _FakeSubjectRecord(FeatureRecord):
+    """FeatureRecord for non-asset (tabular) tests with Subject element column."""
+
+    Subject: str
+    Grade: str
+    Feature_Name: str = "Grade"
+
+
+def _mock_non_asset_bag(rids_and_labels: dict[str, str]):
+    """Build a MagicMock bag for a non-asset element type (tabular)."""
+    bag = MagicMock()
+    bag.path = Path("/tmp/fake_bag")
+    bag.list_dataset_members = MagicMock(
+        return_value={"Subject": [{"RID": rid} for rid in rids_and_labels]}
+    )
+
+    def fake_feature_values(element_type, feature_name, selector=None):
+        for rid, label in rids_and_labels.items():
+            if not label:
+                continue
+            rec = _FakeSubjectRecord(Subject=rid, Grade=label)
+            if selector is None:
+                yield rec
+            else:
+                sel = selector([rec])
+                if sel is not None:
+                    yield sel
+
+    bag.feature_values = fake_feature_values
+    bag.model = MagicMock()
+    bag.model.is_asset = MagicMock(return_value=False)
+    bag.get_table_as_dict = MagicMock(return_value=iter([]))
+    bag.is_asset = MagicMock(return_value=False)
+    return bag
+
+
+# ---------------------------------------------------------------------------
+# Basic construction tests
+# ---------------------------------------------------------------------------
+
+
+def test_as_torch_dataset_returns_torch_dataset_subclass():
+    """build_torch_dataset returns an instance of torch.utils.data.Dataset."""
+    bag = _mock_bag_with_labeled_images({"1-IMG1": "Mild"})
+    ds = build_torch_dataset(
+        bag,
+        "Image",
+        sample_loader=lambda p, row: b"fake",
+        targets=["Grade"],
+    )
+    assert isinstance(ds, torch.utils.data.Dataset)
+
+
+def test_len_reflects_all_when_no_skip():
+    """Dataset length equals total member count when missing != 'skip'."""
+    bag = _mock_bag_with_labeled_images({"1-IMG1": "Mild", "1-IMG2": "Severe"})
+    ds = build_torch_dataset(
+        bag,
+        "Image",
+        sample_loader=lambda p, row: b"fake",
+        targets=["Grade"],
+    )
+    assert len(ds) == 2
+
+
+# ---------------------------------------------------------------------------
+# missing= branch tests (spec §6.2)
+# ---------------------------------------------------------------------------
+
+
+def test_missing_error_raises_at_construction():
+    """missing='error' raises DerivaMLException at construction listing RIDs."""
+    bag = MagicMock()
+    bag.path = Path("/tmp/fake_bag")
+    bag.list_dataset_members = MagicMock(
+        return_value={"Image": [{"RID": "1-IMG1"}, {"RID": "1-IMG2"}]}
+    )
+    bag.feature_values = MagicMock(
+        return_value=iter([_FakeRecord(Image="1-IMG1", Grade="Mild")])
+    )
+    bag.model = MagicMock()
+    bag.model.is_asset = MagicMock(return_value=True)
+    bag.get_table_as_dict = MagicMock(return_value=iter([]))
+    bag.is_asset = MagicMock(return_value=True)
+    with pytest.raises(DerivaMLException, match=r"1-IMG2"):
+        build_torch_dataset(
+            bag,
+            "Image",
+            sample_loader=lambda p, row: b"",
+            targets=["Grade"],
+            missing="error",
+        )
+
+
+def test_missing_skip_drops_unlabeled_elements():
+    """missing='skip' drops unlabeled elements from the dataset."""
+    # Only IMG1 has a label; IMG2 has empty label (skipped by fake_feature_values)
+    bag = _mock_bag_with_labeled_images({"1-IMG1": "Mild", "1-IMG2": ""})
+    ds = build_torch_dataset(
+        bag,
+        "Image",
+        sample_loader=lambda p, row: b"fake",
+        targets=["Grade"],
+        missing="skip",
+    )
+    assert len(ds) == 1
+
+
+def test_missing_unknown_keeps_all_elements_with_none_target():
+    """missing='unknown' keeps all elements; target is None for unlabeled."""
+    bag = _mock_bag_with_labeled_images({"1-IMG1": "Mild", "1-IMG2": ""})
+    # Override get_table_as_dict to return both rows
+    bag.get_table_as_dict.return_value = iter([
+        {"RID": "1-IMG1", "Filename": "img1.jpg"},
+        {"RID": "1-IMG2", "Filename": "img2.jpg"},
+    ])
+    ds = build_torch_dataset(
+        bag,
+        "Image",
+        sample_loader=lambda p, row: b"fake",
+        targets=["Grade"],
+        missing="unknown",
+    )
+    assert len(ds) == 2
+    # Find the unlabeled item — target should be None
+    targets_seen = []
+    for i in range(len(ds)):
+        sample, target = ds[i]
+        targets_seen.append(target)
+    assert None in targets_seen
+
+
+# ---------------------------------------------------------------------------
+# Target arity tests (spec §3.3 / §6.2)
+# ---------------------------------------------------------------------------
+
+
+def test_single_target_target_transform_receives_featurerecord():
+    """Single-target: target_transform receives a FeatureRecord directly."""
+    bag = _mock_bag_with_labeled_images({"1-IMG1": "Mild"})
+    bag.get_table_as_dict.return_value = iter([{"RID": "1-IMG1", "Filename": "f.jpg"}])
+    received = []
+
+    def capture_target(target):
+        received.append(target)
+        return 0
+
+    ds = build_torch_dataset(
+        bag,
+        "Image",
+        sample_loader=lambda p, row: b"fake",
+        targets=["Grade"],
+        target_transform=capture_target,
+    )
+    _ = ds[0]
+    assert len(received) == 1
+    assert isinstance(received[0], FeatureRecord)
+    assert received[0].Grade == "Mild"
+
+
+def test_multi_target_target_transform_receives_dict():
+    """Multi-target: target_transform receives dict[str, FeatureRecord]."""
+    bag = MagicMock()
+    bag.path = Path("/tmp/fake_bag")
+    bag.list_dataset_members = MagicMock(
+        return_value={"Image": [{"RID": "1-IMG1"}]}
+    )
+
+    class _FakeGradeRecord(FeatureRecord):
+        Image: str
+        Grade: str
+        Feature_Name: str = "Grade"
+
+    class _FakeSeverityRecord(FeatureRecord):
+        Image: str
+        Severity: str
+        Feature_Name: str = "Severity"
+
+    grade_rec = _FakeGradeRecord(Image="1-IMG1", Grade="Mild")
+    severity_rec = _FakeSeverityRecord(Image="1-IMG1", Severity="Low")
+
+    def fake_feature_values(element_type, feature_name, selector=None):
+        if feature_name == "Grade":
+            yield grade_rec
+        elif feature_name == "Severity":
+            yield severity_rec
+
+    bag.feature_values = fake_feature_values
+    bag.model = MagicMock()
+    bag.model.is_asset = MagicMock(return_value=True)
+    bag.get_table_as_dict = MagicMock(return_value=iter([{"RID": "1-IMG1", "Filename": "f.jpg"}]))
+    bag.is_asset = MagicMock(return_value=True)
+
+    received = []
+
+    def capture_target(target):
+        received.append(target)
+        return {}
+
+    ds = build_torch_dataset(
+        bag,
+        "Image",
+        sample_loader=lambda p, row: b"fake",
+        targets=["Grade", "Severity"],
+        target_transform=capture_target,
+    )
+    _ = ds[0]
+    assert len(received) == 1
+    target_dict = received[0]
+    assert isinstance(target_dict, dict)
+    assert set(target_dict.keys()) == {"Grade", "Severity"}
+
+
+# ---------------------------------------------------------------------------
+# Selector dict form (spec §6.2)
+# ---------------------------------------------------------------------------
+
+
+def test_selector_dict_form_passes_selector_to_feature_values():
+    """dict form targets passes per-feature selectors through."""
+    bag = _mock_bag_with_labeled_images({"1-IMG1": "Mild"})
+    bag.get_table_as_dict.return_value = iter([{"RID": "1-IMG1", "Filename": "f.jpg"}])
+    selector_called = []
+
+    def my_selector(records):
+        selector_called.append(True)
+        return records[0] if records else None
+
+    ds = build_torch_dataset(
+        bag,
+        "Image",
+        sample_loader=lambda p, row: b"fake",
+        targets={"Grade": my_selector},
+    )
+    _ = ds[0]
+    assert selector_called, "selector was never called"
+
+
+# ---------------------------------------------------------------------------
+# Asset-table-without-sample_loader error (spec §6.2)
+# ---------------------------------------------------------------------------
+
+
+def test_asset_table_without_sample_loader_raises():
+    """Asset-table element_type with no sample_loader raises at construction."""
+    bag = _mock_bag_with_labeled_images({"1-IMG1": "Mild"})
+    with pytest.raises(DerivaMLException, match=r"sample_loader"):
+        build_torch_dataset(bag, "Image", targets=["Grade"])
+
+
+# ---------------------------------------------------------------------------
+# Non-asset table: no sample_loader required (spec §3.2)
+# ---------------------------------------------------------------------------
+
+
+def test_non_asset_table_no_sample_loader_returns_row_dict():
+    """Non-asset element_type with no sample_loader defaults to returning row."""
+    bag = _mock_non_asset_bag({"1-SUB1": "active"})
+    bag.get_table_as_dict.return_value = iter([{"RID": "1-SUB1", "Status": "active"}])
+    ds = build_torch_dataset(
+        bag,
+        "Subject",
+        targets=["Grade"],
+    )
+    assert isinstance(ds, torch.utils.data.Dataset)
+    assert len(ds) >= 0  # construction succeeded

--- a/tests/dataset/test_torch_adapter_no_torch.py
+++ b/tests/dataset/test_torch_adapter_no_torch.py
@@ -1,0 +1,43 @@
+"""Verify the library imports cleanly when torch is absent.
+
+If torch is truly installed in the test venv, we stub it out of
+sys.modules temporarily. The goal is to prove that importing DatasetBag
+does NOT import torch eagerly.
+"""
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+
+def test_dataset_bag_imports_without_torch(monkeypatch):
+    """Removing torch from sys.modules lets DatasetBag still import."""
+    for name in list(sys.modules):
+        if name == "torch" or name.startswith("torch."):
+            monkeypatch.delitem(sys.modules, name, raising=False)
+    monkeypatch.setitem(sys.modules, "torch", None)
+
+    # Re-import dataset_bag under the torch-less sys.modules state.
+    if "deriva_ml.dataset.dataset_bag" in sys.modules:
+        monkeypatch.delitem(sys.modules, "deriva_ml.dataset.dataset_bag", raising=False)
+    from deriva_ml.dataset.dataset_bag import DatasetBag  # noqa: F401
+
+
+def test_as_torch_dataset_raises_importerror_without_torch(monkeypatch):
+    """Calling as_torch_dataset when torch is absent raises ImportError
+    with an install-hint message."""
+    for name in list(sys.modules):
+        if name == "torch" or name.startswith("torch."):
+            monkeypatch.delitem(sys.modules, name, raising=False)
+    monkeypatch.setitem(sys.modules, "torch", None)
+
+    from unittest.mock import MagicMock
+    bag = MagicMock()
+
+    if "deriva_ml.dataset.torch_adapter" in sys.modules:
+        monkeypatch.delitem(sys.modules, "deriva_ml.dataset.torch_adapter", raising=False)
+
+    from deriva_ml.dataset.torch_adapter import build_torch_dataset
+    with pytest.raises(ImportError, match=r"torch"):
+        build_torch_dataset(bag, "Image")

--- a/uv.lock
+++ b/uv.lock
@@ -5,9 +5,21 @@ resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
     "python_full_version >= '3.14' and sys_platform == 'emscripten'",
     "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version < '3.14' and sys_platform == 'win32'",
-    "python_full_version < '3.14' and sys_platform == 'emscripten'",
-    "python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version < '3.13' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
+    "python_full_version < '3.13' and sys_platform == 'emscripten'",
+    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
+
+[[package]]
+name = "absl-py"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/64/c7/8de93764ad66968d19329a7e0c147a2bb3c7054c554d4a119111b8f9440f/absl_py-2.4.0.tar.gz", hash = "sha256:8c6af82722b35cf71e0f4d1d47dcaebfff286e27110a99fc359349b247dfb5d4", size = 116543, upload-time = "2026-01-28T10:17:05.322Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/a6/907a406bb7d359e6a63f99c313846d9eec4f7e6f7437809e03aa00fa3074/absl_py-2.4.0-py3-none-any.whl", hash = "sha256:88476fd881ca8aab94ffa78b7b6c632a782ab3ba1cd19c9bd423abc4fb4cd28d", size = 135750, upload-time = "2026-01-28T10:17:04.19Z" },
 ]
 
 [[package]]
@@ -226,6 +238,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/be/a5/8e3f9b6771b0b408517c82d97aed8f2036509bc247d46114925e32fe33f0/asttokens-3.0.1.tar.gz", hash = "sha256:71a4ee5de0bde6a31d64f6b13f2293ac190344478f081c3d1bccfcf5eacb0cb7", size = 62308, upload-time = "2025-11-15T16:43:48.578Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/39/e7eaf1799466a4aef85b6a4fe7bd175ad2b1c6345066aa33f1f58d4b18d0/asttokens-3.0.1-py3-none-any.whl", hash = "sha256:15a3ebc0f43c2d0a50eeafea25e19046c68398e487b9f1f5b517f7c0f40f976a", size = 27047, upload-time = "2025-11-15T16:43:16.109Z" },
+]
+
+[[package]]
+name = "astunparse"
+version = "1.6.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+    { name = "wheel" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f3/af/4182184d3c338792894f34a62672919db7ca008c89abee9b564dd34d8029/astunparse-1.6.3.tar.gz", hash = "sha256:5ad93a8456f0d084c3456d059fd9a92cce667963232cbf763eac3bc5b7940872", size = 18290, upload-time = "2019-12-22T18:12:13.129Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2b/03/13dde6512ad7b4557eb792fbcf0c653af6076b81e5941d36ec61f7ce6028/astunparse-1.6.3-py2.py3-none-any.whl", hash = "sha256:c2652417f2c8b5bb325c885ae329bdf3f86424075c4fd1a128674bc6fba4b8e8", size = 12732, upload-time = "2019-12-22T18:12:11.297Z" },
 ]
 
 [[package]]
@@ -642,6 +667,75 @@ wheels = [
 ]
 
 [[package]]
+name = "cuda-bindings"
+version = "13.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cuda-pathfinder", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/c8/b2589d68acf7e3d63e2be330b84bc25712e97ed799affbca7edd7eae25d6/cuda_bindings-13.2.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e865447abfb83d6a98ad5130ed3c70b1fc295ae3eeee39fd07b4ddb0671b6788", size = 5722404, upload-time = "2026-03-11T00:12:44.041Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/92/f899f7bbb5617bb65ec52a6eac1e9a1447a86b916c4194f8a5001b8cde0c/cuda_bindings-13.2.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:46d8776a55d6d5da9dd6e9858fba2efcda2abe6743871dee47dd06eb8cb6d955", size = 6320619, upload-time = "2026-03-11T00:12:45.939Z" },
+    { url = "https://files.pythonhosted.org/packages/df/93/eef988860a3ca985f82c4f3174fc0cdd94e07331ba9a92e8e064c260337f/cuda_bindings-13.2.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6629ca2df6f795b784752409bcaedbd22a7a651b74b56a165ebc0c9dcbd504d0", size = 5614610, upload-time = "2026-03-11T00:12:50.337Z" },
+    { url = "https://files.pythonhosted.org/packages/18/23/6db3aba46864aee357ab2415135b3fe3da7e9f1fa0221fa2a86a5968099c/cuda_bindings-13.2.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7dca0da053d3b4cc4869eff49c61c03f3c5dbaa0bcd712317a358d5b8f3f385d", size = 6149914, upload-time = "2026-03-11T00:12:52.374Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/87/87a014f045b77c6de5c8527b0757fe644417b184e5367db977236a141602/cuda_bindings-13.2.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a6464b30f46692d6c7f65d4a0e0450d81dd29de3afc1bb515653973d01c2cd6e", size = 5685673, upload-time = "2026-03-11T00:12:56.371Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/5e/c0fe77a73aaefd3fff25ffaccaac69c5a63eafdf8b9a4c476626ef0ac703/cuda_bindings-13.2.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f4af9f3e1be603fa12d5ad6cfca7844c9d230befa9792b5abdf7dd79979c3626", size = 6191386, upload-time = "2026-03-11T00:12:58.965Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/58/ed2c3b39c8dd5f96aa7a4abef0d47a73932c7a988e30f5fa428f00ed0da1/cuda_bindings-13.2.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:df850a1ff8ce1b3385257b08e47b70e959932f5f432d0a4e46a355962b4e4771", size = 5507469, upload-time = "2026-03-11T00:13:04.063Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/01/0c941b112ceeb21439b05895eace78ca1aa2eaaf695c8521a068fd9b4c00/cuda_bindings-13.2.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e8a16384c6494e5485f39314b0b4afb04bee48d49edb16d5d8593fd35bbd231b", size = 6059693, upload-time = "2026-03-11T00:13:06.003Z" },
+]
+
+[[package]]
+name = "cuda-pathfinder"
+version = "1.5.3"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d3/d6/ac63065d33dd700fee7ebd7d287332401b54e31b9346e142f871e1f0b116/cuda_pathfinder-1.5.3-py3-none-any.whl", hash = "sha256:dff021123aedbb4117cc7ec81717bbfe198fb4e8b5f1ee57e0e084fec5c8577d", size = 49991, upload-time = "2026-04-14T20:09:27.037Z" },
+]
+
+[[package]]
+name = "cuda-toolkit"
+version = "13.0.2"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/b2/453099f5f3b698d7d0eab38916aac44c7f76229f451709e2eb9db6615dcd/cuda_toolkit-13.0.2-py2.py3-none-any.whl", hash = "sha256:b198824cf2f54003f50d64ada3a0f184b42ca0846c1c94192fa269ecd97a66eb", size = 2364, upload-time = "2025-12-19T23:24:07.328Z" },
+]
+
+[package.optional-dependencies]
+cublas = [
+    { name = "nvidia-cublas", marker = "sys_platform == 'linux'" },
+]
+cudart = [
+    { name = "nvidia-cuda-runtime", marker = "sys_platform == 'linux'" },
+]
+cufft = [
+    { name = "nvidia-cufft", marker = "sys_platform == 'linux'" },
+]
+cufile = [
+    { name = "nvidia-cufile", marker = "sys_platform == 'linux'" },
+]
+cupti = [
+    { name = "nvidia-cuda-cupti", marker = "sys_platform == 'linux'" },
+]
+curand = [
+    { name = "nvidia-curand", marker = "sys_platform == 'linux'" },
+]
+cusolver = [
+    { name = "nvidia-cusolver", marker = "sys_platform == 'linux'" },
+]
+cusparse = [
+    { name = "nvidia-cusparse", marker = "sys_platform == 'linux'" },
+]
+nvjitlink = [
+    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux'" },
+]
+nvrtc = [
+    { name = "nvidia-cuda-nvrtc", marker = "sys_platform == 'linux'" },
+]
+nvtx = [
+    { name = "nvidia-nvtx", marker = "sys_platform == 'linux'" },
+]
+
+[[package]]
 name = "debugpy"
 version = "1.8.20"
 source = { registry = "https://pypi.org/simple" }
@@ -735,6 +829,14 @@ dependencies = [
     { name = "textual" },
 ]
 
+[package.optional-dependencies]
+tf = [
+    { name = "tensorflow" },
+]
+torch = [
+    { name = "torch" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "icecream" },
@@ -775,8 +877,11 @@ requires-dist = [
     { name = "setuptools", specifier = ">=80" },
     { name = "setuptools-scm", specifier = ">=8.0" },
     { name = "sqlalchemy" },
+    { name = "tensorflow", marker = "extra == 'tf'", specifier = ">=2.15" },
     { name = "textual", specifier = ">=3.0" },
+    { name = "torch", marker = "extra == 'torch'", specifier = ">=2.0" },
 ]
+provides-extras = ["torch", "tf"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -845,6 +950,23 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/20/b5/23b216d9d985a956623b6bd12d4086b60f0059b27799f23016af04a74ea1/fastjsonschema-2.21.2.tar.gz", hash = "sha256:b1eb43748041c880796cd077f1a07c3d94e93ae84bba5ed36800a33554ae05de", size = 374130, upload-time = "2025-08-14T18:49:36.666Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/a8/20d0723294217e47de6d9e2e40fd4a9d2f7c4b6ef974babd482a59743694/fastjsonschema-2.21.2-py3-none-any.whl", hash = "sha256:1c797122d0a86c5cace2e54bf4e819c36223b552017172f32c5c024a6b77e463", size = 24024, upload-time = "2025-08-14T18:49:34.776Z" },
+]
+
+[[package]]
+name = "filelock"
+version = "3.29.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/fe/997687a931ab51049acce6fa1f23e8f01216374ea81374ddee763c493db5/filelock-3.29.0.tar.gz", hash = "sha256:69974355e960702e789734cb4871f884ea6fe50bd8404051a3530bc07809cf90", size = 57571, upload-time = "2026-04-19T15:39:10.068Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/47/dd9a212ef6e343a6857485ffe25bba537304f1913bdbed446a23f7f592e1/filelock-3.29.0-py3-none-any.whl", hash = "sha256:96f5f6344709aa1572bbf631c640e4ebeeb519e08da902c39a001882f30ac258", size = 39812, upload-time = "2026-04-19T15:39:08.752Z" },
+]
+
+[[package]]
+name = "flatbuffers"
+version = "25.12.19"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/2d/d2a548598be01649e2d46231d151a6c56d10b964d94043a335ae56ea2d92/flatbuffers-25.12.19-py2.py3-none-any.whl", hash = "sha256:7634f50c427838bb021c2d66a3d1168e9d199b0607e6329399f04846d42e20b4", size = 26661, upload-time = "2025-12-19T23:16:13.622Z" },
 ]
 
 [[package]]
@@ -946,6 +1068,24 @@ wheels = [
 ]
 
 [[package]]
+name = "fsspec"
+version = "2026.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e1/cf/b50ddf667c15276a9ab15a70ef5f257564de271957933ffea49d2cdbcdfb/fsspec-2026.3.0.tar.gz", hash = "sha256:1ee6a0e28677557f8c2f994e3eea77db6392b4de9cd1f5d7a9e87a0ae9d01b41", size = 313547, upload-time = "2026-03-27T19:11:14.892Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d5/1f/5f4a3cd9e4440e9d9bc78ad0a91a1c8d46b4d429d5239ebe6793c9fe5c41/fsspec-2026.3.0-py3-none-any.whl", hash = "sha256:d2ceafaad1b3457968ed14efa28798162f1638dbb5d2a6868a2db002a5ee39a4", size = 202595, upload-time = "2026-03-27T19:11:13.595Z" },
+]
+
+[[package]]
+name = "gast"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/91/f6/e73969782a2ecec280f8a176f2476149dd9dba69d5f8779ec6108a7721e6/gast-0.7.0.tar.gz", hash = "sha256:0bb14cd1b806722e91ddbab6fb86bba148c22b40e7ff11e248974e04c8adfdae", size = 33630, upload-time = "2025-11-29T15:30:05.266Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/33/f1c6a276de27b7d7339a34749cc33fa87f077f921969c47185d34a887ae2/gast-0.7.0-py3-none-any.whl", hash = "sha256:99cbf1365633a74099f69c59bd650476b96baa5ef196fec88032b00b31ba36f7", size = 22966, upload-time = "2025-11-29T15:30:03.983Z" },
+]
+
+[[package]]
 name = "ghp-import"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -969,6 +1109,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/49/93/a6f6686bb2beb038047abe203b48c7f995f6a96884679eedf7e9aa34300b/globus_sdk-3.65.0.tar.gz", hash = "sha256:a4b350b980809e86d768c8e327de9ddee4405b60cfb83429cdf831ac0c63d763", size = 275365, upload-time = "2025-10-03T01:56:45.402Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/cd/f89c1d66a678d456887d305669ad929cb3ea742be1f563899a9949bcb41f/globus_sdk-3.65.0-py3-none-any.whl", hash = "sha256:d14154c3a40bb6c4d6a77e7200234d43358bd1daca9224841d4297f0edea80e6", size = 418025, upload-time = "2025-10-03T01:56:43.495Z" },
+]
+
+[[package]]
+name = "google-pasta"
+version = "0.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/35/4a/0bd53b36ff0323d10d5f24ebd67af2de10a1117f5cf4d7add90df92756f1/google-pasta-0.2.0.tar.gz", hash = "sha256:c9f2c8dfc8f96d0d5808299920721be30c9eec37f2389f28904f454565c8a16e", size = 40430, upload-time = "2020-03-13T18:57:50.34Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/de/c648ef6835192e6e2cc03f40b19eeda4382c49b5bafb43d88b931c4c74ac/google_pasta-0.2.0-py3-none-any.whl", hash = "sha256:b32482794a366b5366a32c92a9a9201b107821889935a02b3e51f6b432ea84ed", size = 57471, upload-time = "2020-03-13T18:57:48.872Z" },
 ]
 
 [[package]]
@@ -1023,12 +1175,74 @@ wheels = [
 ]
 
 [[package]]
+name = "grpcio"
+version = "1.80.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b7/48/af6173dbca4454f4637a4678b67f52ca7e0c1ed7d5894d89d434fecede05/grpcio-1.80.0.tar.gz", hash = "sha256:29aca15edd0688c22ba01d7cc01cb000d72b2033f4a3c72a81a19b56fd143257", size = 12978905, upload-time = "2026-03-30T08:49:10.502Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/e8/a2b749265eb3415abc94f2e619bbd9e9707bebdda787e61c593004ec927a/grpcio-1.80.0-cp312-cp312-linux_armv7l.whl", hash = "sha256:c624cc9f1008361014378c9d776de7182b11fe8b2e5a81bc69f23a295f2a1ad0", size = 6015616, upload-time = "2026-03-30T08:47:13.428Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/97/b1282161a15d699d1e90c360df18d19165a045ce1c343c7f313f5e8a0b77/grpcio-1.80.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:f49eddcac43c3bf350c0385366a58f36bed8cc2c0ec35ef7b74b49e56552c0c2", size = 12014204, upload-time = "2026-03-30T08:47:15.873Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/5e/d319c6e997b50c155ac5a8cb12f5173d5b42677510e886d250d50264949d/grpcio-1.80.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d334591df610ab94714048e0d5b4f3dd5ad1bee74dfec11eee344220077a79de", size = 6563866, upload-time = "2026-03-30T08:47:18.588Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/f6/fdd975a2cb4d78eb67769a7b3b3830970bfa2e919f1decf724ae4445f42c/grpcio-1.80.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:0cb517eb1d0d0aaf1d87af7cc5b801d686557c1d88b2619f5e31fab3c2315921", size = 7273060, upload-time = "2026-03-30T08:47:21.113Z" },
+    { url = "https://files.pythonhosted.org/packages/db/f0/a3deb5feba60d9538a962913e37bd2e69a195f1c3376a3dd44fe0427e996/grpcio-1.80.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4e78c4ac0d97dc2e569b2f4bcbbb447491167cb358d1a389fc4af71ab6f70411", size = 6782121, upload-time = "2026-03-30T08:47:23.827Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/84/36c6dcfddc093e108141f757c407902a05085e0c328007cb090d56646cdf/grpcio-1.80.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2ed770b4c06984f3b47eb0517b1c69ad0b84ef3f40128f51448433be904634cd", size = 7383811, upload-time = "2026-03-30T08:47:26.517Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/ef/f3a77e3dc5b471a0ec86c564c98d6adfa3510d38f8ee99010410858d591e/grpcio-1.80.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:256507e2f524092f1473071a05e65a5b10d84b82e3ff24c5b571513cfaa61e2f", size = 8393860, upload-time = "2026-03-30T08:47:29.439Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/8d/9d4d27ed7f33d109c50d6b5ce578a9914aa68edab75d65869a17e630a8d1/grpcio-1.80.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:9a6284a5d907c37db53350645567c522be314bac859a64a7a5ca63b77bb7958f", size = 7830132, upload-time = "2026-03-30T08:47:33.254Z" },
+    { url = "https://files.pythonhosted.org/packages/14/e4/9990b41c6d7a44e1e9dee8ac11d7a9802ba1378b40d77468a7761d1ad288/grpcio-1.80.0-cp312-cp312-win32.whl", hash = "sha256:c71309cfce2f22be26aa4a847357c502db6c621f1a49825ae98aa0907595b193", size = 4140904, upload-time = "2026-03-30T08:47:35.319Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/2c/296f6138caca1f4b92a31ace4ae1b87dab692fc16a7a3417af3bb3c805bf/grpcio-1.80.0-cp312-cp312-win_amd64.whl", hash = "sha256:9fe648599c0e37594c4809d81a9e77bd138cc82eb8baa71b6a86af65426723ff", size = 4880944, upload-time = "2026-03-30T08:47:37.831Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/3a/7c3c25789e3f069e581dc342e03613c5b1cb012c4e8c7d9d5cf960a75856/grpcio-1.80.0-cp313-cp313-linux_armv7l.whl", hash = "sha256:e9e408fc016dffd20661f0126c53d8a31c2821b5c13c5d67a0f5ed5de93319ad", size = 6017243, upload-time = "2026-03-30T08:47:40.075Z" },
+    { url = "https://files.pythonhosted.org/packages/04/19/21a9806eb8240e174fd1ab0cd5b9aa948bb0e05c2f2f55f9d5d7405e6d08/grpcio-1.80.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:92d787312e613754d4d8b9ca6d3297e69994a7912a32fa38c4c4e01c272974b0", size = 12010840, upload-time = "2026-03-30T08:47:43.11Z" },
+    { url = "https://files.pythonhosted.org/packages/18/3a/23347d35f76f639e807fb7a36fad3068aed100996849a33809591f26eca6/grpcio-1.80.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8ac393b58aa16991a2f1144ec578084d544038c12242da3a215966b512904d0f", size = 6567644, upload-time = "2026-03-30T08:47:46.806Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/40/96e07ecb604a6a67ae6ab151e3e35b132875d98bc68ec65f3e5ab3e781d7/grpcio-1.80.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:68e5851ac4b9afe07e7f84483803ad167852570d65326b34d54ca560bfa53fb6", size = 7277830, upload-time = "2026-03-30T08:47:49.643Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/e2/da1506ecea1f34a5e365964644b35edef53803052b763ca214ba3870c856/grpcio-1.80.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:873ff5d17d68992ef6605330127425d2fc4e77e612fa3c3e0ed4e668685e3140", size = 6783216, upload-time = "2026-03-30T08:47:52.817Z" },
+    { url = "https://files.pythonhosted.org/packages/44/83/3b20ff58d0c3b7f6caaa3af9a4174d4023701df40a3f39f7f1c8e7c48f9d/grpcio-1.80.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2bea16af2750fd0a899bf1abd9022244418b55d1f37da2202249ba4ba673838d", size = 7385866, upload-time = "2026-03-30T08:47:55.687Z" },
+    { url = "https://files.pythonhosted.org/packages/47/45/55c507599c5520416de5eefecc927d6a0d7af55e91cfffb2e410607e5744/grpcio-1.80.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ba0db34f7e1d803a878284cd70e4c63cb6ae2510ba51937bf8f45ba997cefcf7", size = 8391602, upload-time = "2026-03-30T08:47:58.303Z" },
+    { url = "https://files.pythonhosted.org/packages/10/bb/dd06f4c24c01db9cf11341b547d0a016b2c90ed7dbbb086a5710df7dd1d7/grpcio-1.80.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8eb613f02d34721f1acf3626dfdb3545bd3c8505b0e52bf8b5710a28d02e8aa7", size = 7826752, upload-time = "2026-03-30T08:48:01.311Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/1e/9d67992ba23371fd63d4527096eb8c6b76d74d52b500df992a3343fd7251/grpcio-1.80.0-cp313-cp313-win32.whl", hash = "sha256:93b6f823810720912fd131f561f91f5fed0fda372b6b7028a2681b8194d5d294", size = 4142310, upload-time = "2026-03-30T08:48:04.594Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/e6/283326a27da9e2c3038bc93eeea36fb118ce0b2d03922a9cda6688f53c5b/grpcio-1.80.0-cp313-cp313-win_amd64.whl", hash = "sha256:e172cf795a3ba5246d3529e4d34c53db70e888fa582a8ffebd2e6e48bc0cba50", size = 4882833, upload-time = "2026-03-30T08:48:07.363Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/6d/e65307ce20f5a09244ba9e9d8476e99fb039de7154f37fb85f26978b59c3/grpcio-1.80.0-cp314-cp314-linux_armv7l.whl", hash = "sha256:3d4147a97c8344d065d01bbf8b6acec2cf86fb0400d40696c8bdad34a64ffc0e", size = 6017376, upload-time = "2026-03-30T08:48:10.005Z" },
+    { url = "https://files.pythonhosted.org/packages/69/10/9cef5d9650c72625a699c549940f0abb3c4bfdb5ed45a5ce431f92f31806/grpcio-1.80.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d8e11f167935b3eb089ac9038e1a063e6d7dbe995c0bb4a661e614583352e76f", size = 12018133, upload-time = "2026-03-30T08:48:12.927Z" },
+    { url = "https://files.pythonhosted.org/packages/04/82/983aabaad82ba26113caceeb9091706a0696b25da004fe3defb5b346e15b/grpcio-1.80.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f14b618fc30de822681ee986cfdcc2d9327229dc4c98aed16896761cacd468b9", size = 6574748, upload-time = "2026-03-30T08:48:16.386Z" },
+    { url = "https://files.pythonhosted.org/packages/07/d7/031666ef155aa0bf399ed7e19439656c38bbd143779ae0861b038ce82abd/grpcio-1.80.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:4ed39fbdcf9b87370f6e8df4e39ca7b38b3e5e9d1b0013c7b6be9639d6578d14", size = 7277711, upload-time = "2026-03-30T08:48:19.627Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/43/f437a78f7f4f1d311804189e8f11fb311a01049b2e08557c1068d470cb2e/grpcio-1.80.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2dcc70e9f0ba987526e8e8603a610fb4f460e42899e74e7a518bf3c68fe1bf05", size = 6785372, upload-time = "2026-03-30T08:48:22.373Z" },
+    { url = "https://files.pythonhosted.org/packages/93/3d/f6558e9c6296cb4227faa5c43c54a34c68d32654b829f53288313d16a86e/grpcio-1.80.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:448c884b668b868562b1bda833c5fce6272d26e1926ec46747cda05741d302c1", size = 7395268, upload-time = "2026-03-30T08:48:25.638Z" },
+    { url = "https://files.pythonhosted.org/packages/06/21/0fdd77e84720b08843c371a2efa6f2e19dbebf56adc72df73d891f5506f0/grpcio-1.80.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:a1dc80fe55685b4a543555e6eef975303b36c8db1023b1599b094b92aa77965f", size = 8392000, upload-time = "2026-03-30T08:48:28.974Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/68/67f4947ed55d2e69f2cc199ab9fd85e0a0034d813bbeef84df6d2ba4d4b7/grpcio-1.80.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:31b9ac4ad1aa28ffee5503821fafd09e4da0a261ce1c1281c6c8da0423c83b6e", size = 7828477, upload-time = "2026-03-30T08:48:32.054Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b6/8d4096691b2e385e8271911a0de4f35f0a6c7d05aff7098e296c3de86939/grpcio-1.80.0-cp314-cp314-win32.whl", hash = "sha256:367ce30ba67d05e0592470428f0ec1c31714cab9ef19b8f2e37be1f4c7d32fae", size = 4218563, upload-time = "2026-03-30T08:48:34.538Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/8c/bbe6baf2557262834f2070cf668515fa308b2d38a4bbf771f8f7872a7036/grpcio-1.80.0-cp314-cp314-win_amd64.whl", hash = "sha256:3b01e1f5464c583d2f567b2e46ff0d516ef979978f72091fd81f5ab7fa6e2e7f", size = 5019457, upload-time = "2026-03-30T08:48:37.308Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "h5py"
+version = "3.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5d/57/dfb3c5c3f1bf5f5ef2e59a22dec4ff1f3d7408b55bfcefcfb0ea69ef21c6/h5py-3.14.0.tar.gz", hash = "sha256:2372116b2e0d5d3e5e705b7f663f7c8d96fa79a4052d250484ef91d24d6a08f4", size = 424323, upload-time = "2025-06-06T14:06:15.01Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/77/8f651053c1843391e38a189ccf50df7e261ef8cd8bfd8baba0cbe694f7c3/h5py-3.14.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:e0045115d83272090b0717c555a31398c2c089b87d212ceba800d3dc5d952e23", size = 3312740, upload-time = "2025-06-06T14:05:01.193Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/10/20436a6cf419b31124e59fefc78d74cb061ccb22213226a583928a65d715/h5py-3.14.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6da62509b7e1d71a7d110478aa25d245dd32c8d9a1daee9d2a42dba8717b047a", size = 2829207, upload-time = "2025-06-06T14:05:05.061Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/19/c8bfe8543bfdd7ccfafd46d8cfd96fce53d6c33e9c7921f375530ee1d39a/h5py-3.14.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:554ef0ced3571366d4d383427c00c966c360e178b5fb5ee5bb31a435c424db0c", size = 4708455, upload-time = "2025-06-06T14:05:11.528Z" },
+    { url = "https://files.pythonhosted.org/packages/86/f9/f00de11c82c88bfc1ef22633557bfba9e271e0cb3189ad704183fc4a2644/h5py-3.14.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0cbd41f4e3761f150aa5b662df991868ca533872c95467216f2bec5fcad84882", size = 4929422, upload-time = "2025-06-06T14:05:18.399Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/6d/6426d5d456f593c94b96fa942a9b3988ce4d65ebaf57d7273e452a7222e8/h5py-3.14.0-cp312-cp312-win_amd64.whl", hash = "sha256:bf4897d67e613ecf5bdfbdab39a1158a64df105827da70ea1d90243d796d367f", size = 2862845, upload-time = "2025-06-06T14:05:23.699Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/c2/7efe82d09ca10afd77cd7c286e42342d520c049a8c43650194928bcc635c/h5py-3.14.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:aa4b7bbce683379b7bf80aaba68e17e23396100336a8d500206520052be2f812", size = 3289245, upload-time = "2025-06-06T14:05:28.24Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/31/f570fab1239b0d9441024b92b6ad03bb414ffa69101a985e4c83d37608bd/h5py-3.14.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:ef9603a501a04fcd0ba28dd8f0995303d26a77a980a1f9474b3417543d4c6174", size = 2807335, upload-time = "2025-06-06T14:05:31.997Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/ce/3a21d87896bc7e3e9255e0ad5583ae31ae9e6b4b00e0bcb2a67e2b6acdbc/h5py-3.14.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e8cbaf6910fa3983c46172666b0b8da7b7bd90d764399ca983236f2400436eeb", size = 4700675, upload-time = "2025-06-06T14:05:37.38Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/ec/86f59025306dcc6deee5fda54d980d077075b8d9889aac80f158bd585f1b/h5py-3.14.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d90e6445ab7c146d7f7981b11895d70bc1dd91278a4f9f9028bc0c95e4a53f13", size = 4921632, upload-time = "2025-06-06T14:05:43.464Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/6d/0084ed0b78d4fd3e7530c32491f2884140d9b06365dac8a08de726421d4a/h5py-3.14.0-cp313-cp313-win_amd64.whl", hash = "sha256:ae18e3de237a7a830adb76aaa68ad438d85fe6e19e0d99944a3ce46b772c69b3", size = 2852929, upload-time = "2025-06-06T14:05:47.659Z" },
 ]
 
 [[package]]
@@ -1511,12 +1725,48 @@ wheels = [
 ]
 
 [[package]]
+name = "keras"
+version = "3.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "absl-py" },
+    { name = "h5py" },
+    { name = "ml-dtypes" },
+    { name = "namex" },
+    { name = "numpy" },
+    { name = "optree" },
+    { name = "packaging" },
+    { name = "rich" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/88/ce/47874047a49eedc2a5d3b41bc4f1f572bb637f51e4351ef3538e49a63800/keras-3.14.0.tar.gz", hash = "sha256:86fcf8249a25264a566ac393c287c7ad657000e5e62615dcaad4b3472a17aeda", size = 1263098, upload-time = "2026-04-03T01:42:16.386Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/20/78d26f81115d570bdf0e57d19b81de9ad8aa55ddb68eb10c8f0699fccb63/keras-3.14.0-py3-none-any.whl", hash = "sha256:19ce94b798caaba4d404ab6ef4753b44219170e5c2868156de8bb0494a260114", size = 1627362, upload-time = "2026-04-03T01:42:11.606Z" },
+]
+
+[[package]]
 name = "lark"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/da/34/28fff3ab31ccff1fd4f6c7c7b0ceb2b6968d8ea4950663eadcb5720591a0/lark-1.3.1.tar.gz", hash = "sha256:b426a7a6d6d53189d318f2b6236ab5d6429eaf09259f1ca33eb716eed10d2905", size = 382732, upload-time = "2025-10-27T18:25:56.653Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/82/3d/14ce75ef66813643812f3093ab17e46d3a206942ce7376d31ec2d36229e7/lark-1.3.1-py3-none-any.whl", hash = "sha256:c629b661023a014c37da873b4ff58a817398d12635d3bbb2c5a03be7fe5d1e12", size = 113151, upload-time = "2025-10-27T18:25:54.882Z" },
+]
+
+[[package]]
+name = "libclang"
+version = "18.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/5c/ca35e19a4f142adffa27e3d652196b7362fa612243e2b916845d801454fc/libclang-18.1.1.tar.gz", hash = "sha256:a1214966d08d73d971287fc3ead8dfaf82eb07fb197680d8b3859dbbbbf78250", size = 39612, upload-time = "2024-03-17T16:04:37.434Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/49/f5e3e7e1419872b69f6f5e82ba56e33955a74bd537d8a1f5f1eff2f3668a/libclang-18.1.1-1-py2.py3-none-macosx_11_0_arm64.whl", hash = "sha256:0b2e143f0fac830156feb56f9231ff8338c20aecfe72b4ffe96f19e5a1dbb69a", size = 25836045, upload-time = "2024-06-30T17:40:31.646Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/e5/fc61bbded91a8830ccce94c5294ecd6e88e496cc85f6704bf350c0634b70/libclang-18.1.1-py2.py3-none-macosx_10_9_x86_64.whl", hash = "sha256:6f14c3f194704e5d09769108f03185fce7acaf1d1ae4bbb2f30a72c2400cb7c5", size = 26502641, upload-time = "2024-03-18T15:52:26.722Z" },
+    { url = "https://files.pythonhosted.org/packages/db/ed/1df62b44db2583375f6a8a5e2ca5432bbdc3edb477942b9b7c848c720055/libclang-18.1.1-py2.py3-none-macosx_11_0_arm64.whl", hash = "sha256:83ce5045d101b669ac38e6da8e58765f12da2d3aafb3b9b98d88b286a60964d8", size = 26420207, upload-time = "2024-03-17T15:00:26.63Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/fc/716c1e62e512ef1c160e7984a73a5fc7df45166f2ff3f254e71c58076f7c/libclang-18.1.1-py2.py3-none-manylinux2010_x86_64.whl", hash = "sha256:c533091d8a3bbf7460a00cb6c1a71da93bffe148f172c7d03b1c31fbf8aa2a0b", size = 24515943, upload-time = "2024-03-17T16:03:45.942Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/3d/f0ac1150280d8d20d059608cf2d5ff61b7c3b7f7bcf9c0f425ab92df769a/libclang-18.1.1-py2.py3-none-manylinux2014_aarch64.whl", hash = "sha256:54dda940a4a0491a9d1532bf071ea3ef26e6dbaf03b5000ed94dd7174e8f9592", size = 23784972, upload-time = "2024-03-17T16:12:47.677Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/2f/d920822c2b1ce9326a4c78c0c2b4aa3fde610c7ee9f631b600acb5376c26/libclang-18.1.1-py2.py3-none-manylinux2014_armv7l.whl", hash = "sha256:cf4a99b05376513717ab5d82a0db832c56ccea4fd61a69dbb7bccf2dfb207dbe", size = 20259606, upload-time = "2024-03-17T16:17:42.437Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/c2/de1db8c6d413597076a4259cea409b83459b2db997c003578affdd32bf66/libclang-18.1.1-py2.py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:69f8eb8f65c279e765ffd28aaa7e9e364c776c17618af8bff22a8df58677ff4f", size = 24921494, upload-time = "2024-03-17T16:14:20.132Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/2d/3f480b1e1d31eb3d6de5e3ef641954e5c67430d5ac93b7fa7e07589576c7/libclang-18.1.1-py2.py3-none-win_amd64.whl", hash = "sha256:4dd2d3b82fab35e2bf9ca717d7b63ac990a3519c7e312f19fa8e86dcc712f7fb", size = 26415083, upload-time = "2024-03-17T16:42:21.703Z" },
+    { url = "https://files.pythonhosted.org/packages/71/cf/e01dc4cc79779cd82d77888a88ae2fa424d93b445ad4f6c02bfc18335b70/libclang-18.1.1-py2.py3-none-win_arm64.whl", hash = "sha256:3f0e1f49f04d3cd198985fea0511576b0aee16f9ff0e0f0cad7f9c57ec3c20e8", size = 22361112, upload-time = "2024-03-17T16:42:59.565Z" },
 ]
 
 [[package]]
@@ -1808,6 +2058,51 @@ wheels = [
 ]
 
 [[package]]
+name = "ml-dtypes"
+version = "0.5.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/4a/c27b42ed9b1c7d13d9ba8b6905dece787d6259152f2309338aed29b2447b/ml_dtypes-0.5.4.tar.gz", hash = "sha256:8ab06a50fb9bf9666dd0fe5dfb4676fa2b0ac0f31ecff72a6c3af8e22c063453", size = 692314, upload-time = "2025-11-17T22:32:31.031Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/b8/3c70881695e056f8a32f8b941126cf78775d9a4d7feba8abcb52cb7b04f2/ml_dtypes-0.5.4-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a174837a64f5b16cab6f368171a1a03a27936b31699d167684073ff1c4237dac", size = 676927, upload-time = "2025-11-17T22:31:48.182Z" },
+    { url = "https://files.pythonhosted.org/packages/54/0f/428ef6881782e5ebb7eca459689448c0394fa0a80bea3aa9262cba5445ea/ml_dtypes-0.5.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a7f7c643e8b1320fd958bf098aa7ecf70623a42ec5154e3be3be673f4c34d900", size = 5028464, upload-time = "2025-11-17T22:31:50.135Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/cb/28ce52eb94390dda42599c98ea0204d74799e4d8047a0eb559b6fd648056/ml_dtypes-0.5.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9ad459e99793fa6e13bd5b7e6792c8f9190b4e5a1b45c63aba14a4d0a7f1d5ff", size = 5009002, upload-time = "2025-11-17T22:31:52.001Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/f0/0cfadd537c5470378b1b32bd859cf2824972174b51b873c9d95cfd7475a5/ml_dtypes-0.5.4-cp312-cp312-win_amd64.whl", hash = "sha256:c1a953995cccb9e25a4ae19e34316671e4e2edaebe4cf538229b1fc7109087b7", size = 212222, upload-time = "2025-11-17T22:31:53.742Z" },
+    { url = "https://files.pythonhosted.org/packages/16/2e/9acc86985bfad8f2c2d30291b27cd2bb4c74cea08695bd540906ed744249/ml_dtypes-0.5.4-cp312-cp312-win_arm64.whl", hash = "sha256:9bad06436568442575beb2d03389aa7456c690a5b05892c471215bfd8cf39460", size = 160793, upload-time = "2025-11-17T22:31:55.358Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/a1/4008f14bbc616cfb1ac5b39ea485f9c63031c4634ab3f4cf72e7541f816a/ml_dtypes-0.5.4-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:8c760d85a2f82e2bed75867079188c9d18dae2ee77c25a54d60e9cc79be1bc48", size = 676888, upload-time = "2025-11-17T22:31:56.907Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/b7/dff378afc2b0d5a7d6cd9d3209b60474d9819d1189d347521e1688a60a53/ml_dtypes-0.5.4-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ce756d3a10d0c4067172804c9cc276ba9cc0ff47af9078ad439b075d1abdc29b", size = 5036993, upload-time = "2025-11-17T22:31:58.497Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/33/40cd74219417e78b97c47802037cf2d87b91973e18bb968a7da48a96ea44/ml_dtypes-0.5.4-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:533ce891ba774eabf607172254f2e7260ba5f57bdd64030c9a4fcfbd99815d0d", size = 5010956, upload-time = "2025-11-17T22:31:59.931Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/8b/200088c6859d8221454825959df35b5244fa9bdf263fd0249ac5fb75e281/ml_dtypes-0.5.4-cp313-cp313-win_amd64.whl", hash = "sha256:f21c9219ef48ca5ee78402d5cc831bd58ea27ce89beda894428bc67a52da5328", size = 212224, upload-time = "2025-11-17T22:32:01.349Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/75/dfc3775cb36367816e678f69a7843f6f03bd4e2bcd79941e01ea960a068e/ml_dtypes-0.5.4-cp313-cp313-win_arm64.whl", hash = "sha256:35f29491a3e478407f7047b8a4834e4640a77d2737e0b294d049746507af5175", size = 160798, upload-time = "2025-11-17T22:32:02.864Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/74/e9ddb35fd1dd43b1106c20ced3f53c2e8e7fc7598c15638e9f80677f81d4/ml_dtypes-0.5.4-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:304ad47faa395415b9ccbcc06a0350800bc50eda70f0e45326796e27c62f18b6", size = 702083, upload-time = "2025-11-17T22:32:04.08Z" },
+    { url = "https://files.pythonhosted.org/packages/74/f5/667060b0aed1aa63166b22897fdf16dca9eb704e6b4bbf86848d5a181aa7/ml_dtypes-0.5.4-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6a0df4223b514d799b8a1629c65ddc351b3efa833ccf7f8ea0cf654a61d1e35d", size = 5354111, upload-time = "2025-11-17T22:32:05.546Z" },
+    { url = "https://files.pythonhosted.org/packages/40/49/0f8c498a28c0efa5f5c95a9e374c83ec1385ca41d0e85e7cf40e5d519a21/ml_dtypes-0.5.4-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:531eff30e4d368cb6255bc2328d070e35836aa4f282a0fb5f3a0cd7260257298", size = 5366453, upload-time = "2025-11-17T22:32:07.115Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/27/12607423d0a9c6bbbcc780ad19f1f6baa2b68b18ce4bddcdc122c4c68dc9/ml_dtypes-0.5.4-cp313-cp313t-win_amd64.whl", hash = "sha256:cb73dccfc991691c444acc8c0012bee8f2470da826a92e3a20bb333b1a7894e6", size = 225612, upload-time = "2025-11-17T22:32:08.615Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/80/5a5929e92c72936d5b19872c5fb8fc09327c1da67b3b68c6a13139e77e20/ml_dtypes-0.5.4-cp313-cp313t-win_arm64.whl", hash = "sha256:3bbbe120b915090d9dd1375e4684dd17a20a2491ef25d640a908281da85e73f1", size = 164145, upload-time = "2025-11-17T22:32:09.782Z" },
+    { url = "https://files.pythonhosted.org/packages/72/4e/1339dc6e2557a344f5ba5590872e80346f76f6cb2ac3dd16e4666e88818c/ml_dtypes-0.5.4-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:2b857d3af6ac0d39db1de7c706e69c7f9791627209c3d6dedbfca8c7e5faec22", size = 673781, upload-time = "2025-11-17T22:32:11.364Z" },
+    { url = "https://files.pythonhosted.org/packages/04/f9/067b84365c7e83bda15bba2b06c6ca250ce27b20630b1128c435fb7a09aa/ml_dtypes-0.5.4-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:805cef3a38f4eafae3a5bf9ebdcdb741d0bcfd9e1bd90eb54abd24f928cd2465", size = 5036145, upload-time = "2025-11-17T22:32:12.783Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/bb/82c7dcf38070b46172a517e2334e665c5bf374a262f99a283ea454bece7c/ml_dtypes-0.5.4-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:14a4fd3228af936461db66faccef6e4f41c1d82fcc30e9f8d58a08916b1d811f", size = 5010230, upload-time = "2025-11-17T22:32:14.38Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/93/2bfed22d2498c468f6bcd0d9f56b033eaa19f33320389314c19ef6766413/ml_dtypes-0.5.4-cp314-cp314-win_amd64.whl", hash = "sha256:8c6a2dcebd6f3903e05d51960a8058d6e131fe69f952a5397e5dbabc841b6d56", size = 221032, upload-time = "2025-11-17T22:32:15.763Z" },
+    { url = "https://files.pythonhosted.org/packages/76/a3/9c912fe6ea747bb10fe2f8f54d027eb265db05dfb0c6335e3e063e74e6e8/ml_dtypes-0.5.4-cp314-cp314-win_arm64.whl", hash = "sha256:5a0f68ca8fd8d16583dfa7793973feb86f2fbb56ce3966daf9c9f748f52a2049", size = 163353, upload-time = "2025-11-17T22:32:16.932Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/02/48aa7d84cc30ab4ee37624a2fd98c56c02326785750cd212bc0826c2f15b/ml_dtypes-0.5.4-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:bfc534409c5d4b0bf945af29e5d0ab075eae9eecbb549ff8a29280db822f34f9", size = 702085, upload-time = "2025-11-17T22:32:18.175Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/e7/85cb99fe80a7a5513253ec7faa88a65306be071163485e9a626fce1b6e84/ml_dtypes-0.5.4-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2314892cdc3fcf05e373d76d72aaa15fda9fb98625effa73c1d646f331fcecb7", size = 5355358, upload-time = "2025-11-17T22:32:19.7Z" },
+    { url = "https://files.pythonhosted.org/packages/79/2b/a826ba18d2179a56e144aef69e57fb2ab7c464ef0b2111940ee8a3a223a2/ml_dtypes-0.5.4-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0d2ffd05a2575b1519dc928c0b93c06339eb67173ff53acb00724502cda231cf", size = 5366332, upload-time = "2025-11-17T22:32:21.193Z" },
+    { url = "https://files.pythonhosted.org/packages/84/44/f4d18446eacb20ea11e82f133ea8f86e2bf2891785b67d9da8d0ab0ef525/ml_dtypes-0.5.4-cp314-cp314t-win_amd64.whl", hash = "sha256:4381fe2f2452a2d7589689693d3162e876b3ddb0a832cde7a414f8e1adf7eab1", size = 236612, upload-time = "2025-11-17T22:32:22.579Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/3f/3d42e9a78fe5edf792a83c074b13b9b770092a4fbf3462872f4303135f09/ml_dtypes-0.5.4-cp314-cp314t-win_arm64.whl", hash = "sha256:11942cbf2cf92157db91e5022633c0d9474d4dfd813a909383bd23ce828a4b7d", size = 168825, upload-time = "2025-11-17T22:32:23.766Z" },
+]
+
+[[package]]
+name = "mpmath"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f", size = 508106, upload-time = "2023-03-07T16:47:11.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c", size = 536198, upload-time = "2023-03-07T16:47:09.197Z" },
+]
+
+[[package]]
 name = "multidict"
 version = "6.7.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1907,6 +2202,15 @@ wheels = [
 ]
 
 [[package]]
+name = "namex"
+version = "0.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0c/c0/ee95b28f029c73f8d49d8f52edaed02a1d4a9acb8b69355737fdb1faa191/namex-0.1.0.tar.gz", hash = "sha256:117f03ccd302cc48e3f5c58a296838f6b89c83455ab8683a1e85f2a430aa4306", size = 6649, upload-time = "2025-05-26T23:17:38.918Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/bc/465daf1de06409cdd4532082806770ee0d8d7df434da79c76564d0f69741/namex-0.1.0-py3-none-any.whl", hash = "sha256:e2012a474502f1e2251267062aae3114611f07df4224b6e06334c57b0f2ce87c", size = 5905, upload-time = "2025-05-26T23:17:37.695Z" },
+]
+
+[[package]]
 name = "nbclient"
 version = "0.10.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1980,6 +2284,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/83/f8/51569ac65d696c8ecbee95938f89d4abf00f47d58d48f6fbabfe8f0baefe/nest_asyncio-1.6.0.tar.gz", hash = "sha256:6f172d5449aca15afd6c646851f4e31e02c598d553a667e38cafa997cfec55fe", size = 7418, upload-time = "2024-01-21T14:25:19.227Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl", hash = "sha256:87af6efd6b5e897c81050477ef65c62e2b2f35d51703cae01aff2905b1852e1c", size = 5195, upload-time = "2024-01-21T14:25:17.223Z" },
+]
+
+[[package]]
+name = "networkx"
+version = "3.6.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509", size = 2517025, upload-time = "2025-12-08T17:02:39.908Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl", hash = "sha256:d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762", size = 2068504, upload-time = "2025-12-08T17:02:38.159Z" },
 ]
 
 [[package]]
@@ -2081,6 +2394,155 @@ wheels = [
 ]
 
 [[package]]
+name = "nvidia-cublas"
+version = "13.1.0.3"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/a5/fce49e2ae977e0ccc084e5adafceb4f0ac0c8333cb6863501618a7277f67/nvidia_cublas-13.1.0.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:c86fc7f7ae36d7528288c5d88098edcb7b02c633d262e7ddbb86b0ad91be5df2", size = 542851226, upload-time = "2025-10-09T08:59:04.818Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/44/423ac00af4dd95a5aeb27207e2c0d9b7118702149bf4704c3ddb55bb7429/nvidia_cublas-13.1.0.3-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:ee8722c1f0145ab246bccb9e452153b5e0515fd094c3678df50b2a0888b8b171", size = 423133236, upload-time = "2025-10-09T08:59:32.536Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-cupti"
+version = "13.0.85"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/2a/80353b103fc20ce05ef51e928daed4b6015db4aaa9162ed0997090fe2250/nvidia_cuda_cupti-13.0.85-py3-none-manylinux_2_25_aarch64.whl", hash = "sha256:796bd679890ee55fb14a94629b698b6db54bcfd833d391d5e94017dd9d7d3151", size = 10310827, upload-time = "2025-09-04T08:26:42.012Z" },
+    { url = "https://files.pythonhosted.org/packages/33/6d/737d164b4837a9bbd202f5ae3078975f0525a55730fe871d8ed4e3b952b0/nvidia_cuda_cupti-13.0.85-py3-none-manylinux_2_25_x86_64.whl", hash = "sha256:4eb01c08e859bf924d222250d2e8f8b8ff6d3db4721288cf35d14252a4d933c8", size = 10715597, upload-time = "2025-09-04T08:26:51.312Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-nvrtc"
+version = "13.0.88"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/68/483a78f5e8f31b08fb1bb671559968c0ca3a065ac7acabfc7cee55214fd6/nvidia_cuda_nvrtc-13.0.88-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:ad9b6d2ead2435f11cbb6868809d2adeeee302e9bb94bcf0539c7a40d80e8575", size = 90215200, upload-time = "2025-09-04T08:28:44.204Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/dc/6bb80850e0b7edd6588d560758f17e0550893a1feaf436807d64d2da040f/nvidia_cuda_nvrtc-13.0.88-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d27f20a0ca67a4bb34268a5e951033496c5b74870b868bacd046b1b8e0c3267b", size = 43015449, upload-time = "2025-09-04T08:28:20.239Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-runtime"
+version = "13.0.96"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/4f/17d7b9b8e285199c58ce28e31b5c5bbaa4d8271af06a89b6405258245de2/nvidia_cuda_runtime-13.0.96-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ef9bcbe90493a2b9d810e43d249adb3d02e98dd30200d86607d8d02687c43f55", size = 2261060, upload-time = "2025-10-09T08:55:15.78Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/24/d1558f3b68b1d26e706813b1d10aa1d785e4698c425af8db8edc3dced472/nvidia_cuda_runtime-13.0.96-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7f82250d7782aa23b6cfe765ecc7db554bd3c2870c43f3d1821f1d18aebf0548", size = 2243632, upload-time = "2025-10-09T08:55:36.117Z" },
+]
+
+[[package]]
+name = "nvidia-cudnn-cu13"
+version = "9.19.0.56"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cublas", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/84/26025437c1e6b61a707442184fa0c03d083b661adf3a3eecfd6d21677740/nvidia_cudnn_cu13-9.19.0.56-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:6ed29ffaee1176c612daf442e4dd6cfeb6a0caa43ddcbeb59da94953030b1be4", size = 433781201, upload-time = "2026-02-03T20:40:53.805Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/22/0b4b932655d17a6da1b92fa92ab12844b053bb2ac2475e179ba6f043da1e/nvidia_cudnn_cu13-9.19.0.56-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:d20e1734305e9d68889a96e3f35094d733ff1f83932ebe462753973e53a572bf", size = 366066321, upload-time = "2026-02-03T20:44:52.837Z" },
+]
+
+[[package]]
+name = "nvidia-cufft"
+version = "12.0.0.61"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/2f/7b57e29836ea8714f81e9898409196f47d772d5ddedddf1592eadb8ab743/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6c44f692dce8fd5ffd3e3df134b6cdb9c2f72d99cf40b62c32dde45eea9ddad3", size = 214085489, upload-time = "2025-09-04T08:31:56.044Z" },
+]
+
+[[package]]
+name = "nvidia-cufile"
+version = "1.15.1.6"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/70/4f193de89a48b71714e74602ee14d04e4019ad36a5a9f20c425776e72cd6/nvidia_cufile-1.15.1.6-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:08a3ecefae5a01c7f5117351c64f17c7c62efa5fffdbe24fc7d298da19cd0b44", size = 1223672, upload-time = "2025-09-04T08:32:22.779Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/73/cc4a14c9813a8a0d509417cf5f4bdaba76e924d58beb9864f5a7baceefbf/nvidia_cufile-1.15.1.6-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:bdc0deedc61f548bddf7733bdc216456c2fdb101d020e1ab4b88d232d5e2f6d1", size = 1136992, upload-time = "2025-09-04T08:32:14.119Z" },
+]
+
+[[package]]
+name = "nvidia-curand"
+version = "10.4.0.35"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/72/7c2ae24fb6b63a32e6ae5d241cc65263ea18d08802aaae087d9f013335a2/nvidia_curand-10.4.0.35-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:133df5a7509c3e292aaa2b477afd0194f06ce4ea24d714d616ff36439cee349a", size = 61962106, upload-time = "2025-08-04T10:21:41.128Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/9f/be0a41ca4a4917abf5cb9ae0daff1a6060cc5de950aec0396de9f3b52bc5/nvidia_curand-10.4.0.35-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:1aee33a5da6e1db083fe2b90082def8915f30f3248d5896bcec36a579d941bfc", size = 59544258, upload-time = "2025-08-04T10:22:03.992Z" },
+]
+
+[[package]]
+name = "nvidia-cusolver"
+version = "12.0.4.66"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cublas", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-cusparse", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/67/cba3777620cdacb99102da4042883709c41c709f4b6323c10781a9c3aa34/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:0a759da5dea5c0ea10fd307de75cdeb59e7ea4fcb8add0924859b944babf1112", size = 200941980, upload-time = "2025-09-04T08:33:22.767Z" },
+]
+
+[[package]]
+name = "nvidia-cusparse"
+version = "12.6.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/18/623c77619c31d62efd55302939756966f3ecc8d724a14dab2b75f1508850/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2b3c89c88d01ee0e477cb7f82ef60a11a4bcd57b6b87c33f789350b59759360b", size = 145942937, upload-time = "2025-09-04T08:33:58.029Z" },
+]
+
+[[package]]
+name = "nvidia-cusparselt-cu13"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/10/8dcd1175260706a2fc92a16a52e306b71d4c1ea0b0cc4a9484183399818a/nvidia_cusparselt_cu13-0.8.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:400c6ed1cf6780fc6efedd64ec9f1345871767e6a1a0a552a1ea0578117ea77c", size = 220791277, upload-time = "2025-08-13T19:22:40.982Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/53/43b0d71f4e702fa9733f8b4571fdca50a8813f1e450b656c239beff12315/nvidia_cusparselt_cu13-0.8.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:25e30a8a7323935d4ad0340b95a0b69926eee755767e8e0b1cf8dd85b197d3fd", size = 169884119, upload-time = "2025-08-13T19:23:41.967Z" },
+]
+
+[[package]]
+name = "nvidia-nccl-cu13"
+version = "2.28.9"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/55/1920646a2e43ffd4fc958536b276197ed740e9e0c54105b4bb3521591fc7/nvidia_nccl_cu13-2.28.9-py3-none-manylinux_2_18_aarch64.whl", hash = "sha256:01c873ba1626b54caa12272ed228dc5b2781545e0ae8ba3f432a8ef1c6d78643", size = 196561677, upload-time = "2025-11-18T05:49:03.45Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/b4/878fefaad5b2bcc6fcf8d474a25e3e3774bc5133e4b58adff4d0bca238bc/nvidia_nccl_cu13-2.28.9-py3-none-manylinux_2_18_x86_64.whl", hash = "sha256:e4553a30f34195f3fa1da02a6da3d6337d28f2003943aa0a3d247bbc25fefc42", size = 196493177, upload-time = "2025-11-18T05:49:17.677Z" },
+]
+
+[[package]]
+name = "nvidia-nvjitlink"
+version = "13.0.88"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/56/7a/123e033aaff487c77107195fa5a2b8686795ca537935a24efae476c41f05/nvidia_nvjitlink-13.0.88-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:13a74f429e23b921c1109976abefacc69835f2f433ebd323d3946e11d804e47b", size = 40713933, upload-time = "2025-09-04T08:35:43.553Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/2c/93c5250e64df4f894f1cbb397c6fd71f79813f9fd79d7cd61de3f97b3c2d/nvidia_nvjitlink-13.0.88-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e931536ccc7d467a98ba1d8b89ff7fa7f1fa3b13f2b0069118cd7f47bff07d0c", size = 38768748, upload-time = "2025-09-04T08:35:20.008Z" },
+]
+
+[[package]]
+name = "nvidia-nvshmem-cu13"
+version = "3.4.5"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/0f/05cc9c720236dcd2db9c1ab97fff629e96821be2e63103569da0c9b72f19/nvidia_nvshmem_cu13-3.4.5-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6dc2a197f38e5d0376ad52cd1a2a3617d3cdc150fd5966f4aee9bcebb1d68fe9", size = 60215947, upload-time = "2025-09-06T00:32:20.022Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/35/a9bf80a609e74e3b000fef598933235c908fcefcef9026042b8e6dfde2a9/nvidia_nvshmem_cu13-3.4.5-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:290f0a2ee94c9f3687a02502f3b9299a9f9fe826e6d0287ee18482e78d495b80", size = 60412546, upload-time = "2025-09-06T00:32:41.564Z" },
+]
+
+[[package]]
+name = "nvidia-nvtx"
+version = "13.0.85"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/f3/d86c845465a2723ad7e1e5c36dcd75ddb82898b3f53be47ebd429fb2fa5d/nvidia_nvtx-13.0.85-py3-none-manylinux1_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:4936d1d6780fbe68db454f5e72a42ff64d1fd6397df9f363ae786930fd5c1cd4", size = 148047, upload-time = "2025-09-04T08:29:01.761Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/64/3708a90d1ebe202ffdeb7185f878a3c84d15c2b2c31858da2ce0583e2def/nvidia_nvtx-13.0.85-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cb7780edb6b14107373c835bf8b72e7a178bac7367e23da7acb108f973f157a6", size = 148878, upload-time = "2025-09-04T08:28:53.627Z" },
+]
+
+[[package]]
 name = "omegaconf"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2091,6 +2553,87 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/09/48/6388f1bb9da707110532cb70ec4d2822858ddfb44f1cdf1233c20a80ea4b/omegaconf-2.3.0.tar.gz", hash = "sha256:d5d4b6d29955cc50ad50c46dc269bcd92c6e00f5f90d23ab5fee7bfca4ba4cc7", size = 3298120, upload-time = "2022-12-08T20:59:22.753Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e3/94/1843518e420fa3ed6919835845df698c7e27e183cb997394e4a670973a65/omegaconf-2.3.0-py3-none-any.whl", hash = "sha256:7b4df175cdb08ba400f45cae3bdcae7ba8365db4d165fc65fd04b050ab63b46b", size = 79500, upload-time = "2022-12-08T20:59:19.686Z" },
+]
+
+[[package]]
+name = "opt-einsum"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/b9/2ac072041e899a52f20cf9510850ff58295003aa75525e58343591b0cbfb/opt_einsum-3.4.0.tar.gz", hash = "sha256:96ca72f1b886d148241348783498194c577fa30a8faac108586b14f1ba4473ac", size = 63004, upload-time = "2024-09-26T14:33:24.483Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/23/cd/066e86230ae37ed0be70aae89aabf03ca8d9f39c8aea0dec8029455b5540/opt_einsum-3.4.0-py3-none-any.whl", hash = "sha256:69bb92469f86a1565195ece4ac0323943e83477171b91d24c35afe028a90d7cd", size = 71932, upload-time = "2024-09-26T14:33:23.039Z" },
+]
+
+[[package]]
+name = "optree"
+version = "0.19.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/63/7b078bc36d5a206c21b03565a818ede38ff0fbf014e92085ec467ef10adb/optree-0.19.0.tar.gz", hash = "sha256:bc1991a948590756409e76be4e29efd4a487a185056d35db6c67619c19ea27a1", size = 175199, upload-time = "2026-02-23T01:56:37.752Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2d/bf/5cbbf61a27f94797c3d9786f6230223023a943b60f5e893d52368f10b8b1/optree-0.19.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7ec4b2ce49622c6be2c8634712b6c63cc274835bac89a56e3ab2ca863a32ff4b", size = 418100, upload-time = "2026-02-23T01:55:05.282Z" },
+    { url = "https://files.pythonhosted.org/packages/00/9e/65899e6470f5df289ccdbe9e228fb0cd0ae45ccda8e32c92d6efae1530ef/optree-0.19.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f0978603623b4b1f794f05f6bbed0645cb7e219f4a5a349b2a2bd4514d84ac82", size = 388582, upload-time = "2026-02-23T01:55:06.628Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/dc/f4826835be660181f1b4444ac92b51dda96d4634d3c2271e14598da7bf2a/optree-0.19.0-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8c9e52c50ed3f3f8b1cf4e47a20a7c5e77175b4f84b2ecf390a76f0d1dd91da6", size = 407457, upload-time = "2026-02-23T01:55:07.713Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/b0/89283ac1dd1ead3aa3d7a6b45a26846f457bded79a83b6828fc1ed9a6db3/optree-0.19.0-cp312-cp312-manylinux_2_26_i686.manylinux_2_28_i686.whl", hash = "sha256:3fe3e5f7a30a7d08ddba0a34e48f5483f6c4d7bb710375434ad3633170c73c48", size = 471230, upload-time = "2026-02-23T01:55:09.244Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/a2/47f620f87b0544b2e0eb0b3c661682bd0ea1c79f6e38f9147bc0f835c973/optree-0.19.0-cp312-cp312-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8315527e1f14a91173fe6871847da7b949048ec61ff8b3e507fc286e75b0aa3c", size = 469442, upload-time = "2026-02-23T01:55:10.387Z" },
+    { url = "https://files.pythonhosted.org/packages/84/e9/b9ae18404135de53809fb994b754ac0eac838d8c4dfa8a10a811d8dec91d/optree-0.19.0-cp312-cp312-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:938fb15d140ab65148f4e6975048facbef83a9210353fbedd471ac39e7544339", size = 468840, upload-time = "2026-02-23T01:55:11.419Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/e5/a77df15a62b37bb14c81b5757e2a0573f57e7c06d125a410ad2cd7cefb72/optree-0.19.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2b8209570340135a7e586c90f393f3c6359e8a49c40d783196721cc487e51d9c", size = 451408, upload-time = "2026-02-23T01:55:12.501Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/43/1aa431cee19cd98c4229e468767021f9a92195d9431857e28198a3a3ce2f/optree-0.19.0-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:1397dc925026917531a43fda32054ae1e77e5ed9bf8284bcae6354c19c26e14a", size = 412544, upload-time = "2026-02-23T01:55:14.048Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/b9/b94fd3a116b80951d692a82f4135ae84b3d78bd1b092250aff76a3366138/optree-0.19.0-cp312-cp312-win32.whl", hash = "sha256:68f58e8f8b75c76c51e61e3dc2d9e94609bafb0e1a6459e6d525ced905cd9a74", size = 312033, upload-time = "2026-02-23T01:55:15.101Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/7f/31fa1b2311038bfc355ad6e4e4e63d028719cb67fb3ebe6fb76ff2124105/optree-0.19.0-cp312-cp312-win_amd64.whl", hash = "sha256:5c44ca0f579ed3e0ca777a5711d4a6c1b374feacf1bb4fe9cfe85297b0c8d237", size = 335374, upload-time = "2026-02-23T01:55:16.094Z" },
+    { url = "https://files.pythonhosted.org/packages/09/86/863bc3f42f83113f5c6a5beaf4fec3c3481a76872f3244d0e64fb9ebd3b0/optree-0.19.0-cp312-cp312-win_arm64.whl", hash = "sha256:0461f796b4ade3fab519d821b0fa521f07e2af70206b76aac75fcfdc2e051fca", size = 345868, upload-time = "2026-02-23T01:55:18.006Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/61/d79c7eeb87e98d08bc8d95ed08dee83bedb4e55371a7d2ae3c874ec02608/optree-0.19.0-cp313-cp313-android_24_arm64_v8a.whl", hash = "sha256:1eea5b7be833c6d555d08ff68046d3dd2112dfb39e6f1eb09887ab6c617a6d64", size = 923043, upload-time = "2026-02-23T01:55:19.018Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/ed/e80504f65e7e80fdcd129258428d7976ea9f03bf9dad56a5293c44d563ad/optree-0.19.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:4d9cf9dfa0ac051e0ed82869d782f0affdbdb1daa5f2e851d37ea8625c60071a", size = 385597, upload-time = "2026-02-23T01:55:20.586Z" },
+    { url = "https://files.pythonhosted.org/packages/65/e5/d1926a2f0e0240f6800ff385c8486879f7da0a5a030b7aa5d84e44e9c9ca/optree-0.19.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:43c4f8ba5755d56d046be2cb1380cbc362234ad93fd9933384c6dd7fdebe6c4a", size = 392265, upload-time = "2026-02-23T01:55:21.662Z" },
+    { url = "https://files.pythonhosted.org/packages/61/88/9c598325e89bbed29b37a381ebb2b94f1d9d769c973b879b3e9766b4b16d/optree-0.19.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:36b1134680ee3f9768ede290da653e1604a8083bce69fef8fb4e46863346d5c8", size = 423763, upload-time = "2026-02-23T01:55:22.97Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/d2/fcba2a1826d362a64cb36ec9f675ed6dcddee47099948913122b0aafbe44/optree-0.19.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c9f7e7e7bf2ef011d0be1c2e87c96f5dc543dad1ac34430c2f606938c9ec5135", size = 392720, upload-time = "2026-02-23T01:55:24.107Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/43/5e6d51d8c203a79cff084efa9f04a745b8ef5cf4c86dbb127e7b192f14d9/optree-0.19.0-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bb5752f17afa017b08b0cbac8a383d4bb90035b353bef7a25fe03cda69a21d33", size = 411481, upload-time = "2026-02-23T01:55:25.215Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/dc/dc09347136876287b463b8599239d6fa338298fd322ac629817bd2f4def4/optree-0.19.0-cp313-cp313-manylinux_2_26_i686.manylinux_2_28_i686.whl", hash = "sha256:e9b6245993494b1aa54529eb7356aeefa6704c8b436e6e5f20b25c30f7af7620", size = 476695, upload-time = "2026-02-23T01:55:26.23Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/cc/5d2c9cf906bd3ae357e7221450bacefd0321d7b94e6171dec39552b346e6/optree-0.19.0-cp313-cp313-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7351a24b30568c963a92b19f543c9562b36b3222caed2a5ac3209ef910972bec", size = 471846, upload-time = "2026-02-23T01:55:27.288Z" },
+    { url = "https://files.pythonhosted.org/packages/64/7f/75b10f88da994fc3da3dc1ab7d54bab7bd3a6fa5eb81b586f13f8bd6ab0e/optree-0.19.0-cp313-cp313-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:2c6610a1d1d74af0f53c9bbabb7c265679a9a07e03783c8cc4a678ba3bb6f9a5", size = 473145, upload-time = "2026-02-23T01:55:28.941Z" },
+    { url = "https://files.pythonhosted.org/packages/78/fc/753bf69b907652d54b7c6012ccb320d8c1a3161454e415331058b6f04246/optree-0.19.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:37e07a5233be64329cbf41e20ab07c50da53bdc374109a2b376be49c4a34a37f", size = 456160, upload-time = "2026-02-23T01:55:30.515Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/a8/70640f9998438f50a0a1c57f2a12aac856cd937f2c4c4feef5a3cfe8e9c7/optree-0.19.0-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:c23a25caff6b096b62379adb99e2c401805141497ebb8131f271a4c93f5ed5dc", size = 417116, upload-time = "2026-02-23T01:55:31.591Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/05/0b8bf4abf5d1a7cd9a19ba680e1ec64ad38eec3204e4e16a769e8aeaa4a2/optree-0.19.0-cp313-cp313-win32.whl", hash = "sha256:045cf112adaebc76c9c7cabde857c01babfc9fae8aa0a28d48f7c565fadf0cb9", size = 312101, upload-time = "2026-02-23T01:55:33.002Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/c7/9ce83f115d7f4a47741827a037067b9026c29996ad7913bc40277924c773/optree-0.19.0-cp313-cp313-win_amd64.whl", hash = "sha256:bc0c6c9f99fb90e3a20a8b94c219e6b03e585f65ab9a11c9acd1511a5f885f79", size = 337944, upload-time = "2026-02-23T01:55:34.3Z" },
+    { url = "https://files.pythonhosted.org/packages/17/fd/97c27d6e51c8b958b29f5c7b4cdcae4f2e7c9ef5b5465be459811a48876b/optree-0.19.0-cp313-cp313-win_arm64.whl", hash = "sha256:48f492363fa0f9ffe5029d0ecafd2fa30ffe0d5d52c8dd414123f47b743bd42e", size = 347153, upload-time = "2026-02-23T01:55:35.331Z" },
+    { url = "https://files.pythonhosted.org/packages/46/45/9a2f05b5d033482b58ca36df6f41b0b28af3ccfa43267a82254c973dcd14/optree-0.19.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:d6362b9e9a0f4dd7c5b88debe182a90541aba7f1ad02d00922d01c4df4b3c933", size = 463985, upload-time = "2026-02-23T01:55:36.681Z" },
+    { url = "https://files.pythonhosted.org/packages/20/b7/5d0a013c5461e0933ce7385a06eed625358de12216c80da935138e6af205/optree-0.19.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:381096a293d385fd3135e5c707bb7e58c584bc9bd50f458237b49da21a621df3", size = 431307, upload-time = "2026-02-23T01:55:37.754Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/2c/d3f2674411c8e3338e91e7446af239597ae6efd23f14e2039f29ced3d73e/optree-0.19.0-cp313-cp313t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a9675007cc54371be544bb33fd7eb07b0773d88deacf8aa4cc72fa735c4a4d33", size = 426917, upload-time = "2026-02-23T01:55:39.122Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/e9/009964734f19d6996291e77f2c1da5d35a743defc4e89aefb01260e2f9d6/optree-0.19.0-cp313-cp313t-manylinux_2_26_i686.manylinux_2_28_i686.whl", hash = "sha256:406b355d6f29f99535efa97ea16eda70414968271a894c99f48cd91848723706", size = 490603, upload-time = "2026-02-23T01:55:40.123Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/4c/96706f855c6b623259e754f751020acfb3452e412f7c85330629ab4b9ecc/optree-0.19.0-cp313-cp313t-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d05e5bf6ce30258cda643ea50cc424038e5107905e9fc11d19a04453a8d2ee27", size = 486388, upload-time = "2026-02-23T01:55:41.746Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/e4/9b23a27c9bd211d22a2e55a5a66e62afe5c75ff98b81fc7d000d879e75e6/optree-0.19.0-cp313-cp313t-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b6e11479d98690fc9efd15d65195af37608269bb1e176b5a836b066440f9c52f", size = 489090, upload-time = "2026-02-23T01:55:42.913Z" },
+    { url = "https://files.pythonhosted.org/packages/15/3b/462582f0050508f1ce0734f1dffd19078fb013fa12ccf0761c208ab6f756/optree-0.19.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8d523ffc6d3e22851ed25bec806a6c78d68340259e79941059752209b07a75ec", size = 469601, upload-time = "2026-02-23T01:55:44.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/c6/843c6a33b700ef88407bd5840813e53c6986b6130d94c75c49ff7a2e31f9/optree-0.19.0-cp313-cp313t-manylinux_2_39_riscv64.whl", hash = "sha256:ca148527b6e5d59c25c733e66d4165fbcf85102f4ea10f096370fda533fe77d1", size = 436195, upload-time = "2026-02-23T01:55:45.147Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/ed/13f938444de70bec2ff0edef8917a08160d41436a3cad976e541d21747f5/optree-0.19.0-cp313-cp313t-win32.whl", hash = "sha256:40d067cf87e76ad21b8ee2e6ba0347c517c88c2ce7190d666b30b4057e4de5ba", size = 343123, upload-time = "2026-02-23T01:55:46.201Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/a2/5074dedbc1be5deca76fe57285ec3e7d5d475922572f92a90f3b3a4f21c5/optree-0.19.0-cp313-cp313t-win_amd64.whl", hash = "sha256:b133e1b9a30ec0bca3f875cfa68c2ce88c0b9e08b21f97f687bb669266411f4a", size = 376560, upload-time = "2026-02-23T01:55:47.58Z" },
+    { url = "https://files.pythonhosted.org/packages/49/3a/ea23a29f63d8eadab4e030ebc1329906d44f631076cd1da4751388649960/optree-0.19.0-cp313-cp313t-win_arm64.whl", hash = "sha256:45184b3c73e2147b26b139f34f15c2111cde54b8893b1104a00281c3f283b209", size = 381649, upload-time = "2026-02-23T01:55:48.709Z" },
+    { url = "https://files.pythonhosted.org/packages/81/46/643ea3d06c24d351888edfef387e611e550b64a14758169eaeb1d285e658/optree-0.19.0-cp314-cp314-android_24_arm64_v8a.whl", hash = "sha256:adf611b95d3159209c5d1eafcb2eb669733aaf75f9b6754f92d2d8b749192579", size = 921595, upload-time = "2026-02-23T01:55:49.779Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/10/8717b93d93fcc3c42a6ee0e0a1a222fe25bc749b32a9e353b039dab836ce/optree-0.19.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:bad7bb78baa83f950bb3c59b09d7ca93d30f6bb975a1a7ce8c5f3dfe65fc834d", size = 384552, upload-time = "2026-02-23T01:55:51.244Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/5e/8263600ef51ae2decb3e31776c810b8c6b5f8927697046c4434b17346d9d/optree-0.19.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:73f122e8acf2f1fd346e9c08f771bc1f7394359793fe632a8e1040733bdbcbec", size = 391280, upload-time = "2026-02-23T01:55:52.681Z" },
+    { url = "https://files.pythonhosted.org/packages/04/3c/40774378ebf423d7f074dfd7169f0466eb9de734f0ea5fbb368eddcb1e49/optree-0.19.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:36e426e96b3e1773e879189b12c306b58ae70052efc4087e3f14545701c7ac35", size = 421408, upload-time = "2026-02-23T01:55:54.171Z" },
+    { url = "https://files.pythonhosted.org/packages/08/67/2e19866a03a6e75eb62194a5b55e1e3154ca1517478c300232b0229f8c2a/optree-0.19.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:d22b947603be4768c2bd73a59652c94d63465f928b3099e9035f9c48dfc61953", size = 391712, upload-time = "2026-02-23T01:55:55.249Z" },
+    { url = "https://files.pythonhosted.org/packages/45/a5/7c059f643bc34c70cc5ebe63c82ae6c33b6b746219f96757d840ea1e2dcd/optree-0.19.0-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:14cc72d0c3a3c0d0b13c66801f2adc6583a01f8499fd151caaa649aabb7f99b9", size = 413471, upload-time = "2026-02-23T01:55:56.371Z" },
+    { url = "https://files.pythonhosted.org/packages/67/1a/2c5041cf476fb4b2a27f6644934ac2d079e3e4491f609cba411b3d890291/optree-0.19.0-cp314-cp314-manylinux_2_26_i686.manylinux_2_28_i686.whl", hash = "sha256:5369ac9584ef3fbb703699be694e84dbc78b730bd6d00c48c0c5a588617a1980", size = 477335, upload-time = "2026-02-23T01:55:57.478Z" },
+    { url = "https://files.pythonhosted.org/packages/40/a0/abcd7bc3218e1108d253d6783f3e610f0ac3d0e63b2720bff94eb4ed4689/optree-0.19.0-cp314-cp314-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:80b3dca5607f04316a9dcb2bb46df2f04abf4da71731bd4a53a1559c0bee6181", size = 473739, upload-time = "2026-02-23T01:55:58.842Z" },
+    { url = "https://files.pythonhosted.org/packages/82/49/7983e66210c78965bc75e386c329ec34854370d337a9ebdc4c8aede3a0b3/optree-0.19.0-cp314-cp314-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:1bb36da9b95b165c7b77fd3ff0af36a30b802cd1c020da3bcdc8aa029991c4ea", size = 475459, upload-time = "2026-02-23T01:55:59.882Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/16/00261f20f467b9e8950a76ec1749f01359bf47f2fc3dac5e206de99835c0/optree-0.19.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fb220bb85128c8de71aeffb9c38be817569e4bca413b38d5e0de11ba6471ef4a", size = 456859, upload-time = "2026-02-23T01:56:01.181Z" },
+    { url = "https://files.pythonhosted.org/packages/18/31/5e78a451ba9a6ed4b0903b10080dc028e3c9b9c5797cce0ca73990fb5604/optree-0.19.0-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:5d2b83a37f150f827b8b0bc2c486056f9b2203e7b0bee699d2ee96a36c090f3a", size = 418187, upload-time = "2026-02-23T01:56:02.474Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/03/1516cb4fdb753cd76e5dc595217f84df48372bdabe1a7fb740a5b2530f5c/optree-0.19.0-cp314-cp314-win32.whl", hash = "sha256:b0c23d50b7f6a7c80f642307c87eee841cf513239706f2f60bd9480304170054", size = 319744, upload-time = "2026-02-23T01:56:03.493Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/c3/587cc9aa8d4742cd690da79460081e7d834499e07e8b2bd2ccc4c66928df/optree-0.19.0-cp314-cp314-win_amd64.whl", hash = "sha256:ff773c852122cef6dcae68b5e252a20aaf5d2986f78e278d747e226e7829d44e", size = 345744, upload-time = "2026-02-23T01:56:04.898Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/9b/c17c74ef6b85ad1a2687de8a08d1b56e3a27154b4db6c3ef1e9c2c53a96c/optree-0.19.0-cp314-cp314-win_arm64.whl", hash = "sha256:259ac2a426816d53d576c143b8dca87176af45fc8efd5dfe09db50d74a2fa0a5", size = 355307, upload-time = "2026-02-23T01:56:06.115Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/4c/e881fb840cef2cead7582ee36c0e0348e66730cb2a2af1938338c72b1bf3/optree-0.19.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:428fdc8cf5dc43fa32496be6aa84fc0d8f549f899062dd9dd0aa7e3aa7f77ae9", size = 463079, upload-time = "2026-02-23T01:56:07.234Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/6b/0a8538815abe28e4307dd98385d4991d36555b841b060df3295a8408b856/optree-0.19.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:d1b497032b5823a09625b118fd4df84199fb0895afb78af536d638ce7645beb6", size = 431401, upload-time = "2026-02-23T01:56:08.336Z" },
+    { url = "https://files.pythonhosted.org/packages/71/0c/d70a513fa93dbaa0e3e8c9b218b3805efb7083369cd14e1340bd2c0bc910/optree-0.19.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e5f05fecbca17b48451ba3455198cec9db20802c0ffbbba51eaeb421bd846a1c", size = 426111, upload-time = "2026-02-23T01:56:09.376Z" },
+    { url = "https://files.pythonhosted.org/packages/77/04/bd30c9f4e694f7b6585f333208ac7894578c1fa30dc5c938f22155df7859/optree-0.19.0-cp314-cp314t-manylinux_2_26_i686.manylinux_2_28_i686.whl", hash = "sha256:a51d0ad4e9dd089f317c94d95b7fa360e87491324e2bfa83d9c4f18dd928d4e1", size = 489872, upload-time = "2026-02-23T01:56:10.538Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/17/aba83aa0e8bf31c00cdd3863c2a05854ce414426a69c094ae51210b76677/optree-0.19.0-cp314-cp314t-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:108ab83937d91658ef96c4f70a6c76b36038754f4779907ee8f127780575740f", size = 485172, upload-time = "2026-02-23T01:56:11.629Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/da/52e684c42dc29d3b4d52f2029545742ef43e151cea112d9093d2ad164f53/optree-0.19.0-cp314-cp314t-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a39fdd614f46bcaf810b2bb1ed940e82b8a19e654bc325df0cc6554e25c3b7eb", size = 484506, upload-time = "2026-02-23T01:56:12.723Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/f7/0d41edf484e11ba5357f91dba8d85ce06ca9d840ac7d95e58b856a49b13b/optree-0.19.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bfc1bcba22f182f39f1a80ae3ac511ebfa4daea62c3058edd021ce7a5cda3009", size = 468846, upload-time = "2026-02-23T01:56:13.826Z" },
+    { url = "https://files.pythonhosted.org/packages/79/5e/a8f49cfd6c3ae0e59dcb1155cd49f1e5ba41889c9388360264c8369589c6/optree-0.19.0-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:afe595a052cc45d3addb6045f04a3ca7e1fb664de032ecbbb2bfd76dfe1fcb61", size = 433899, upload-time = "2026-02-23T01:56:14.889Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/1b/4105e562d86b2de7eb3f240164a7dd3948e268878a9ee8925bfe1ad1da4f/optree-0.19.0-cp314-cp314t-win32.whl", hash = "sha256:b15ab972e2133e70570259386684624a17128daab7fb353a0a7435e9dd2c7354", size = 351719, upload-time = "2026-02-23T01:56:15.946Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/43/bbc4c7a1f37f1a0ed6efe07a5c44b2835e81d1f6ce1cca6a395a2339e60f/optree-0.19.0-cp314-cp314t-win_amd64.whl", hash = "sha256:c90c15a80c325c2c6e03e20c95350df5db4591d35e8e4a35a40d2f865c260193", size = 391937, upload-time = "2026-02-23T01:56:17.04Z" },
+    { url = "https://files.pythonhosted.org/packages/62/12/6758b43dbddc6911e3225a15ca686c913959fb63c267840b54f0002be503/optree-0.19.0-cp314-cp314t-win_arm64.whl", hash = "sha256:a1e7b358df8fc4b97a05380d446e87b08eac899c1f34d9846b9afa0be7f96bc7", size = 389259, upload-time = "2026-02-23T01:56:18.237Z" },
 ]
 
 [[package]]
@@ -2407,6 +2950,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/ef/3c6ecf8b317aa982f309835e8f96987466123c6e596646d4e6a1dfcd080f/propcache-0.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:990f6b3e2a27d683cb7602ed6c86f15ee6b43b1194736f9baaeb93d0016633b1", size = 46259, upload-time = "2025-10-08T19:48:34.226Z" },
     { url = "https://files.pythonhosted.org/packages/c4/2d/346e946d4951f37eca1e4f55be0f0174c52cd70720f84029b02f296f4a38/propcache-0.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:ecef2343af4cc68e05131e45024ba34f6095821988a9d0a02aa7c73fcc448aa9", size = 40428, upload-time = "2025-10-08T19:48:35.441Z" },
     { url = "https://files.pythonhosted.org/packages/5b/5a/bc7b4a4ef808fa59a816c17b20c4bef6884daebbdf627ff2a161da67da19/propcache-0.4.1-py3-none-any.whl", hash = "sha256:af2a6052aeb6cf17d3e46ee169099044fd8224cbaf75c76a2ef596e8163e2237", size = 13305, upload-time = "2025-10-08T19:49:00.792Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "7.34.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/6b/a0e95cad1ad7cc3f2c6821fcab91671bd5b78bd42afb357bb4765f29bc41/protobuf-7.34.1.tar.gz", hash = "sha256:9ce42245e704cc5027be797c1db1eb93184d44d1cdd71811fb2d9b25ad541280", size = 454708, upload-time = "2026-03-20T17:34:47.036Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/11/3325d41e6ee15bf1125654301211247b042563bcc898784351252549a8ad/protobuf-7.34.1-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:d8b2cc79c4d8f62b293ad9b11ec3aebce9af481fa73e64556969f7345ebf9fc7", size = 429247, upload-time = "2026-03-20T17:34:37.024Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/9d/aa69df2724ff63efa6f72307b483ce0827f4347cc6d6df24b59e26659fef/protobuf-7.34.1-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:5185e0e948d07abe94bb76ec9b8416b604cfe5da6f871d67aad30cbf24c3110b", size = 325753, upload-time = "2026-03-20T17:34:38.751Z" },
+    { url = "https://files.pythonhosted.org/packages/92/e8/d174c91fd48e50101943f042b09af9029064810b734e4160bbe282fa1caa/protobuf-7.34.1-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:403b093a6e28a960372b44e5eb081775c9b056e816a8029c61231743d63f881a", size = 340198, upload-time = "2026-03-20T17:34:39.871Z" },
+    { url = "https://files.pythonhosted.org/packages/53/1b/3b431694a4dc6d37b9f653f0c64b0a0d9ec074ee810710c0c3da21d67ba7/protobuf-7.34.1-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:8ff40ce8cd688f7265326b38d5a1bed9bfdf5e6723d49961432f83e21d5713e4", size = 324267, upload-time = "2026-03-20T17:34:41.1Z" },
+    { url = "https://files.pythonhosted.org/packages/85/29/64de04a0ac142fb685fd09999bc3d337943fb386f3a0ec57f92fd8203f97/protobuf-7.34.1-cp310-abi3-win32.whl", hash = "sha256:34b84ce27680df7cca9f231043ada0daa55d0c44a2ddfaa58ec1d0d89d8bf60a", size = 426628, upload-time = "2026-03-20T17:34:42.536Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/87/cb5e585192a22b8bd457df5a2c16a75ea0db9674c3a0a39fc9347d84e075/protobuf-7.34.1-cp310-abi3-win_amd64.whl", hash = "sha256:e97b55646e6ce5cbb0954a8c28cd39a5869b59090dfaa7df4598a7fba869468c", size = 437901, upload-time = "2026-03-20T17:34:44.112Z" },
+    { url = "https://files.pythonhosted.org/packages/88/95/608f665226bca68b736b79e457fded9a2a38c4f4379a4a7614303d9db3bc/protobuf-7.34.1-py3-none-any.whl", hash = "sha256:bb3812cd53aefea2b028ef42bd780f5b96407247f20c6ef7c679807e9d188f11", size = 170715, upload-time = "2026-03-20T17:34:45.384Z" },
 ]
 
 [[package]]
@@ -3368,12 +3926,70 @@ wheels = [
 ]
 
 [[package]]
+name = "sympy"
+version = "1.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mpmath" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
+]
+
+[[package]]
 name = "tenacity"
 version = "9.1.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0a/d4/2b0cd0fe285e14b36db076e78c93766ff1d529d70408bd1d2a5a84f1d929/tenacity-9.1.2.tar.gz", hash = "sha256:1169d376c297e7de388d18b4481760d478b0e99a777cad3a9c86e556f4b697cb", size = 48036, upload-time = "2025-04-02T08:25:09.966Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/30/643397144bfbfec6f6ef821f36f33e57d35946c44a2352d3c9f0ae847619/tenacity-9.1.2-py3-none-any.whl", hash = "sha256:f77bf36710d8b73a50b2dd155c97b870017ad21afe6ab300326b0371b3b05138", size = 28248, upload-time = "2025-04-02T08:25:07.678Z" },
+]
+
+[[package]]
+name = "tensorflow"
+version = "2.21.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "absl-py" },
+    { name = "astunparse" },
+    { name = "flatbuffers" },
+    { name = "gast" },
+    { name = "google-pasta" },
+    { name = "grpcio" },
+    { name = "h5py" },
+    { name = "keras" },
+    { name = "libclang" },
+    { name = "ml-dtypes" },
+    { name = "numpy" },
+    { name = "opt-einsum" },
+    { name = "packaging" },
+    { name = "protobuf" },
+    { name = "requests" },
+    { name = "setuptools" },
+    { name = "six" },
+    { name = "termcolor" },
+    { name = "typing-extensions" },
+    { name = "wrapt" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/59/27adba20bbd1088b00fc0e9232aa21493b4800af2299eb6005017a6053f4/tensorflow-2.21.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:56ecd7d47429acbe1df2694d50b75bf9fc3995ac92cb367cd9af6c4780ead712", size = 223488205, upload-time = "2026-03-06T17:24:03.48Z" },
+    { url = "https://files.pythonhosted.org/packages/20/a5/f139fbbd4e81a2e556170718698acf518a71a84927fa1dc1f5935b6ab3d2/tensorflow-2.21.0-cp312-cp312-manylinux_2_27_aarch64.whl", hash = "sha256:b07d15737406533898e36c7ef7944b1be18e9028dc521b9229952c537bbc5552", size = 281946471, upload-time = "2026-03-06T17:24:11.896Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/d7/6e71b4ded8ce99cd21add95611ca14af6e9ad4f2baeabdeb79a4a6b3cb1f/tensorflow-2.21.0-cp312-cp312-manylinux_2_27_x86_64.whl", hash = "sha256:b3b95643c4e70eb925839938fb35cbe142f317ec84af6844ee61513713bb13c0", size = 572611111, upload-time = "2026-03-06T17:24:26.209Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/0d/4ee4bc074597b41c9c00dc97b4418ef1eb8736fe9186ffdb3961efdfb730/tensorflow-2.21.0-cp312-cp312-win_amd64.whl", hash = "sha256:27ba0682572b1e50a0db1ee74cfb787eafcfdb1b751bbbf401fed62fe32a92e0", size = 350945509, upload-time = "2026-03-06T17:24:41.65Z" },
+    { url = "https://files.pythonhosted.org/packages/40/09/268b45a61be2bce136dabf3a3cd7099c8a984ae398198f71920b4c60c502/tensorflow-2.21.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:a145ed46c58192b7c3f9916d070caf4f6afc6dc7e5511f83dd97677f4c4947f4", size = 223766900, upload-time = "2026-03-06T17:24:51.349Z" },
+    { url = "https://files.pythonhosted.org/packages/72/72/343b86b4c9bfe28e81f749439f908c1e26aeac73d9f12b8dcdb996eb8ecb/tensorflow-2.21.0-cp313-cp313-manylinux_2_27_aarch64.whl", hash = "sha256:a10abdfb8b1189210c251021a3f153b7ccc52a8e6521351f3dc3331e8ba593e0", size = 282213003, upload-time = "2026-03-06T17:24:59.859Z" },
+    { url = "https://files.pythonhosted.org/packages/86/6c/10d075ffc09754c7f10e749ba3c9d46dd809fb007990c7f788128044180c/tensorflow-2.21.0-cp313-cp313-manylinux_2_27_x86_64.whl", hash = "sha256:e9d8da8dcab9650efb45f032ba70af2f016f907e6e0c6bda29dd101bba945406", size = 572881074, upload-time = "2026-03-06T17:25:14.453Z" },
+    { url = "https://files.pythonhosted.org/packages/86/91/dedad8403e7b0036d99be4878987693b7b7f62097eb8537fa6ce62ea131c/tensorflow-2.21.0-cp313-cp313-win_amd64.whl", hash = "sha256:76cccbe0a95d9392dee1ae501ae0656b6c73c1cac29a7f8f32d570e0670863f7", size = 351205371, upload-time = "2026-03-06T17:25:33.144Z" },
+]
+
+[[package]]
+name = "termcolor"
+version = "3.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/79/cf31d7a93a8fdc6aa0fbb665be84426a8c5a557d9240b6239e9e11e35fc5/termcolor-3.3.0.tar.gz", hash = "sha256:348871ca648ec6a9a983a13ab626c0acce02f515b9e1983332b17af7979521c5", size = 14434, upload-time = "2025-12-29T12:55:21.882Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/d1/8bb87d21e9aeb323cc03034f5eaf2c8f69841e40e4853c2627edf8111ed3/termcolor-3.3.0-py3-none-any.whl", hash = "sha256:cf642efadaf0a8ebbbf4bc7a31cec2f9b5f21a9f726f4ccbb08192c9c26f43a5", size = 7734, upload-time = "2025-12-29T12:55:20.718Z" },
 ]
 
 [[package]]
@@ -3438,6 +4054,49 @@ wheels = [
 ]
 
 [[package]]
+name = "torch"
+version = "2.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cuda-bindings", marker = "sys_platform == 'linux'" },
+    { name = "cuda-toolkit", extra = ["cublas", "cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "sys_platform == 'linux'" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx" },
+    { name = "nvidia-cudnn-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusparselt-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nccl-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvshmem-cu13", marker = "sys_platform == 'linux'" },
+    { name = "setuptools" },
+    { name = "sympy" },
+    { name = "triton", marker = "sys_platform == 'linux'" },
+    { name = "typing-extensions" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6f/8b/69e3008d78e5cee2b30183340cc425081b78afc5eff3d080daab0adda9aa/torch-2.11.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4b5866312ee6e52ea625cd211dcb97d6a2cdc1131a5f15cc0d87eec948f6dd34", size = 80606338, upload-time = "2026-03-23T18:11:34.781Z" },
+    { url = "https://files.pythonhosted.org/packages/13/16/42e5915ebe4868caa6bac83a8ed59db57f12e9a61b7d749d584776ed53d5/torch-2.11.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:f99924682ef0aa6a4ab3b1b76f40dc6e273fca09f367d15a524266db100a723f", size = 419731115, upload-time = "2026-03-23T18:11:06.944Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/c9/82638ef24d7877510f83baf821f5619a61b45568ce21c0a87a91576510aa/torch-2.11.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:0f68f4ac6d95d12e896c3b7a912b5871619542ec54d3649cf48cc1edd4dd2756", size = 530712279, upload-time = "2026-03-23T18:10:31.481Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/ff/6756f1c7ee302f6d202120e0f4f05b432b839908f9071157302cedfc5232/torch-2.11.0-cp312-cp312-win_amd64.whl", hash = "sha256:fbf39280699d1b869f55eac536deceaa1b60bd6788ba74f399cc67e60a5fab10", size = 114556047, upload-time = "2026-03-23T18:10:55.931Z" },
+    { url = "https://files.pythonhosted.org/packages/87/89/5ea6722763acee56b045435fb84258db7375c48165ec8be7880ab2b281c5/torch-2.11.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1e6debd97ccd3205bbb37eb806a9d8219e1139d15419982c09e23ef7d4369d18", size = 80606801, upload-time = "2026-03-23T18:10:18.649Z" },
+    { url = "https://files.pythonhosted.org/packages/32/d1/8ed2173589cbfe744ed54e5a73efc107c0085ba5777ee93a5f4c1ab90553/torch-2.11.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:63a68fa59de8f87acc7e85a5478bb2dddbb3392b7593ec3e78827c793c4b73fd", size = 419732382, upload-time = "2026-03-23T18:08:30.835Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e1/b73f7c575a4b8f87a5928f50a1e35416b5e27295d8be9397d5293e7e8d4c/torch-2.11.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:cc89b9b173d9adfab59fd227f0ab5e5516d9a52b658ae41d64e59d2e55a418db", size = 530711509, upload-time = "2026-03-23T18:08:47.213Z" },
+    { url = "https://files.pythonhosted.org/packages/66/82/3e3fcdd388fbe54e29fd3f991f36846ff4ac90b0d0181e9c8f7236565f82/torch-2.11.0-cp313-cp313-win_amd64.whl", hash = "sha256:4dda3b3f52d121063a731ddb835f010dc137b920d7fec2778e52f60d8e4bf0cd", size = 114555842, upload-time = "2026-03-23T18:09:52.111Z" },
+    { url = "https://files.pythonhosted.org/packages/db/38/8ac78069621b8c2b4979c2f96dc8409ef5e9c4189f6aac629189a78677ca/torch-2.11.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:8b394322f49af4362d4f80e424bcaca7efcd049619af03a4cf4501520bdf0fb4", size = 80959574, upload-time = "2026-03-23T18:10:14.214Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/6c/56bfb37073e7136e6dd86bfc6af7339946dd684e0ecf2155ac0eee687ae1/torch-2.11.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:2658f34ce7e2dabf4ec73b45e2ca68aedad7a5be87ea756ad656eaf32bf1e1ea", size = 419732324, upload-time = "2026-03-23T18:09:36.604Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f4/1b666b6d61d3394cca306ea543ed03a64aad0a201b6cd159f1d41010aeb1/torch-2.11.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:98bb213c3084cfe176302949bdc360074b18a9da7ab59ef2edc9d9f742504778", size = 530596026, upload-time = "2026-03-23T18:09:20.842Z" },
+    { url = "https://files.pythonhosted.org/packages/48/6b/30d1459fa7e4b67e9e3fe1685ca1d8bb4ce7c62ef436c3a615963c6c866c/torch-2.11.0-cp313-cp313t-win_amd64.whl", hash = "sha256:a97b94bbf62992949b4730c6cd2cc9aee7b335921ee8dc207d930f2ed09ae2db", size = 114793702, upload-time = "2026-03-23T18:09:47.304Z" },
+    { url = "https://files.pythonhosted.org/packages/26/0d/8603382f61abd0db35841148ddc1ffd607bf3100b11c6e1dab6d2fc44e72/torch-2.11.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:01018087326984a33b64e04c8cb5c2795f9120e0d775ada1f6638840227b04d7", size = 80573442, upload-time = "2026-03-23T18:09:10.117Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/86/7cd7c66cb9cec6be330fff36db5bd0eef386d80c031b581ec81be1d4b26c/torch-2.11.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:2bb3cc54bd0dea126b0060bb1ec9de0f9c7f7342d93d436646516b0330cd5be7", size = 419749385, upload-time = "2026-03-23T18:07:33.77Z" },
+    { url = "https://files.pythonhosted.org/packages/47/e8/b98ca2d39b2e0e4730c0ee52537e488e7008025bc77ca89552ff91021f7c/torch-2.11.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:4dc8b3809469b6c30b411bb8c4cad3828efd26236153d9beb6a3ec500f211a60", size = 530716756, upload-time = "2026-03-23T18:07:50.02Z" },
+    { url = "https://files.pythonhosted.org/packages/78/88/d4a4cda8362f8a30d1ed428564878c3cafb0d87971fbd3947d4c84552095/torch-2.11.0-cp314-cp314-win_amd64.whl", hash = "sha256:2b4e811728bd0cc58fb2b0948fe939a1ee2bf1422f6025be2fca4c7bd9d79718", size = 114552300, upload-time = "2026-03-23T18:09:05.617Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/46/4419098ed6d801750f26567b478fc185c3432e11e2cad712bc6b4c2ab0d0/torch-2.11.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:8245477871c3700d4370352ffec94b103cfcb737229445cf9946cddb7b2ca7cd", size = 80959460, upload-time = "2026-03-23T18:09:00.818Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/66/54a56a4a6ceaffb567231994a9745821d3af922a854ed33b0b3a278e0a99/torch-2.11.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:ab9a8482f475f9ba20e12db84b0e55e2f58784bdca43a854a6ccd3fd4b9f75e6", size = 419735835, upload-time = "2026-03-23T18:07:18.974Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/e7/0b6665f533aa9e337662dc190425abc0af1fe3234088f4454c52393ded61/torch-2.11.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:563ed3d25542d7e7bbc5b235ccfacfeb97fb470c7fee257eae599adb8005c8a2", size = 530613405, upload-time = "2026-03-23T18:08:07.014Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/bf/c8d12a2c86dbfd7f40fb2f56fbf5a505ccf2d9ce131eb559dfc7c51e1a04/torch-2.11.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b2a43985ff5ef6ddd923bbcf99943e5f58059805787c5c9a2622bf05ca2965b0", size = 114792991, upload-time = "2026-03-23T18:08:19.216Z" },
+]
+
+[[package]]
 name = "tornado"
 version = "6.5.4"
 source = { registry = "https://pypi.org/simple" }
@@ -3475,6 +4134,23 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/eb/79/72064e6a701c2183016abbbfedaba506d81e30e232a68c9f0d6f6fcd1574/traitlets-5.14.3.tar.gz", hash = "sha256:9ed0579d3502c94b4b3732ac120375cda96f923114522847de4b3bb98b96b6b7", size = 161621, upload-time = "2024-04-19T11:11:49.746Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl", hash = "sha256:b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f", size = 85359, upload-time = "2024-04-19T11:11:46.763Z" },
+]
+
+[[package]]
+name = "triton"
+version = "3.6.0"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/5d/08201db32823bdf77a0e2b9039540080b2e5c23a20706ddba942924ebcd6/triton-3.6.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:374f52c11a711fd062b4bfbb201fd9ac0a5febd28a96fb41b4a0f51dde3157f4", size = 176128243, upload-time = "2026-01-20T16:16:07.857Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/a8/cdf8b3e4c98132f965f88c2313a4b493266832ad47fb52f23d14d4f86bb5/triton-3.6.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:74caf5e34b66d9f3a429af689c1c7128daba1d8208df60e81106b115c00d6fca", size = 188266850, upload-time = "2026-01-20T16:00:43.041Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/12/34d71b350e89a204c2c7777a9bba0dcf2f19a5bfdd70b57c4dbc5ffd7154/triton-3.6.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:448e02fe6dc898e9e5aa89cf0ee5c371e99df5aa5e8ad976a80b93334f3494fd", size = 176133521, upload-time = "2026-01-20T16:16:13.321Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/0b/37d991d8c130ce81a8728ae3c25b6e60935838e9be1b58791f5997b24a54/triton-3.6.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:10c7f76c6e72d2ef08df639e3d0d30729112f47a56b0c81672edc05ee5116ac9", size = 188289450, upload-time = "2026-01-20T16:00:49.136Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/4e/41b0c8033b503fd3cfcd12392cdd256945026a91ff02452bef40ec34bee7/triton-3.6.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1722e172d34e32abc3eb7711d0025bb69d7959ebea84e3b7f7a341cd7ed694d6", size = 176276087, upload-time = "2026-01-20T16:16:18.989Z" },
+    { url = "https://files.pythonhosted.org/packages/35/f8/9c66bfc55361ec6d0e4040a0337fb5924ceb23de4648b8a81ae9d33b2b38/triton-3.6.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d002e07d7180fd65e622134fbd980c9a3d4211fb85224b56a0a0efbd422ab72f", size = 188400296, upload-time = "2026-01-20T16:00:56.042Z" },
+    { url = "https://files.pythonhosted.org/packages/49/55/5ecf0dcaa0f2fbbd4420f7ef227ee3cb172e91e5fede9d0ecaddc43363b4/triton-3.6.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ef5523241e7d1abca00f1d240949eebdd7c673b005edbbce0aca95b8191f1d43", size = 176138577, upload-time = "2026-01-20T16:16:25.426Z" },
+    { url = "https://files.pythonhosted.org/packages/df/3d/9e7eee57b37c80cec63322c0231bb6da3cfe535a91d7a4d64896fcb89357/triton-3.6.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a17a5d5985f0ac494ed8a8e54568f092f7057ef60e1b0fa09d3fd1512064e803", size = 188273063, upload-time = "2026-01-20T16:01:07.278Z" },
+    { url = "https://files.pythonhosted.org/packages/48/db/56ee649cab5eaff4757541325aca81f52d02d4a7cd3506776cad2451e060/triton-3.6.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0b3a97e8ed304dfa9bd23bb41ca04cdf6b2e617d5e782a8653d616037a5d537d", size = 176274804, upload-time = "2026-01-20T16:16:31.528Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/56/6113c23ff46c00aae423333eb58b3e60bdfe9179d542781955a5e1514cb3/triton-3.6.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:46bd1c1af4b6704e554cad2eeb3b0a6513a980d470ccfa63189737340c7746a7", size = 188397994, upload-time = "2026-01-20T16:01:14.236Z" },
 ]
 
 [[package]]
@@ -3619,12 +4295,88 @@ wheels = [
 ]
 
 [[package]]
+name = "wheel"
+version = "0.47.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/39/62/75f18a0f03b4219c456652c7780e4d749b929eb605c098ce3a5b6b6bc081/wheel-0.47.0.tar.gz", hash = "sha256:cc72bd1009ba0cf63922e28f94d9d83b920aa2bb28f798a31d0691b02fa3c9b3", size = 63854, upload-time = "2026-04-22T15:51:27.727Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/1b/9e33c09813d65e248f7f773119148a612516a4bea93e9c6f545f78455b7c/wheel-0.47.0-py3-none-any.whl", hash = "sha256:212281cab4dff978f6cedd499cd893e1f620791ca6ff7107cf270781e587eced", size = 32218, upload-time = "2026-04-22T15:51:26.296Z" },
+]
+
+[[package]]
 name = "widgetsnbextension"
 version = "4.0.15"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/bd/f4/c67440c7fb409a71b7404b7aefcd7569a9c0d6bd071299bf4198ae7a5d95/widgetsnbextension-4.0.15.tar.gz", hash = "sha256:de8610639996f1567952d763a5a41af8af37f2575a41f9852a38f947eb82a3b9", size = 1097402, upload-time = "2025-11-01T21:15:55.178Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/0e/fa3b193432cfc60c93b42f3be03365f5f909d2b3ea410295cf36df739e31/widgetsnbextension-4.0.15-py3-none-any.whl", hash = "sha256:8156704e4346a571d9ce73b84bee86a29906c9abfd7223b7228a28899ccf3366", size = 2196503, upload-time = "2025-11-01T21:15:53.565Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/64/925f213fdcbb9baeb1530449ac71a4d57fc361c053d06bf78d0c5c7cd80c/wrapt-2.1.2.tar.gz", hash = "sha256:3996a67eecc2c68fd47b4e3c564405a5777367adfd9b8abb58387b63ee83b21e", size = 81678, upload-time = "2026-03-06T02:53:25.134Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4c/b6/1db817582c49c7fcbb7df6809d0f515af29d7c2fbf57eb44c36e98fb1492/wrapt-2.1.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ff2aad9c4cda28a8f0653fc2d487596458c2a3f475e56ba02909e950a9efa6a9", size = 61255, upload-time = "2026-03-06T02:52:45.663Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/16/9b02a6b99c09227c93cd4b73acc3678114154ec38da53043c0ddc1fba0dc/wrapt-2.1.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6433ea84e1cfacf32021d2a4ee909554ade7fd392caa6f7c13f1f4bf7b8e8748", size = 61848, upload-time = "2026-03-06T02:53:48.728Z" },
+    { url = "https://files.pythonhosted.org/packages/af/aa/ead46a88f9ec3a432a4832dfedb84092fc35af2d0ba40cd04aea3889f247/wrapt-2.1.2-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:c20b757c268d30d6215916a5fa8461048d023865d888e437fab451139cad6c8e", size = 121433, upload-time = "2026-03-06T02:54:40.328Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/9f/742c7c7cdf58b59085a1ee4b6c37b013f66ac33673a7ef4aaed5e992bc33/wrapt-2.1.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:79847b83eb38e70d93dc392c7c5b587efe65b3e7afcc167aa8abd5d60e8761c8", size = 123013, upload-time = "2026-03-06T02:53:26.58Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/44/2c3dd45d53236b7ed7c646fcf212251dc19e48e599debd3926b52310fafb/wrapt-2.1.2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f8fba1bae256186a83d1875b2b1f4e2d1242e8fac0f58ec0d7e41b26967b965c", size = 117326, upload-time = "2026-03-06T02:53:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/74/e2/b17d66abc26bd96f89dec0ecd0ef03da4a1286e6ff793839ec431b9fae57/wrapt-2.1.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e3d3b35eedcf5f7d022291ecd7533321c4775f7b9cd0050a31a68499ba45757c", size = 121444, upload-time = "2026-03-06T02:54:09.5Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/62/e2977843fdf9f03daf1586a0ff49060b1b2fc7ff85a7ea82b6217c1ae36e/wrapt-2.1.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:6f2c5390460de57fa9582bc8a1b7a6c86e1a41dfad74c5225fc07044c15cc8d1", size = 116237, upload-time = "2026-03-06T02:54:03.884Z" },
+    { url = "https://files.pythonhosted.org/packages/88/dd/27fc67914e68d740bce512f11734aec08696e6b17641fef8867c00c949fc/wrapt-2.1.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7dfa9f2cf65d027b951d05c662cc99ee3bd01f6e4691ed39848a7a5fffc902b2", size = 120563, upload-time = "2026-03-06T02:53:20.412Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/9f/b750b3692ed2ef4705cb305bd68858e73010492b80e43d2a4faa5573cbe7/wrapt-2.1.2-cp312-cp312-win32.whl", hash = "sha256:eba8155747eb2cae4a0b913d9ebd12a1db4d860fc4c829d7578c7b989bd3f2f0", size = 58198, upload-time = "2026-03-06T02:53:37.732Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/b2/feecfe29f28483d888d76a48f03c4c4d8afea944dbee2b0cd3380f9df032/wrapt-2.1.2-cp312-cp312-win_amd64.whl", hash = "sha256:1c51c738d7d9faa0b3601708e7e2eda9bf779e1b601dce6c77411f2a1b324a63", size = 60441, upload-time = "2026-03-06T02:52:47.138Z" },
+    { url = "https://files.pythonhosted.org/packages/44/e1/e328f605d6e208547ea9fd120804fcdec68536ac748987a68c47c606eea8/wrapt-2.1.2-cp312-cp312-win_arm64.whl", hash = "sha256:c8e46ae8e4032792eb2f677dbd0d557170a8e5524d22acc55199f43efedd39bf", size = 58836, upload-time = "2026-03-06T02:53:22.053Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/7a/d936840735c828b38d26a854e85d5338894cda544cb7a85a9d5b8b9c4df7/wrapt-2.1.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:787fd6f4d67befa6fe2abdffcbd3de2d82dfc6fb8a6d850407c53332709d030b", size = 61259, upload-time = "2026-03-06T02:53:41.922Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/88/9a9b9a90ac8ca11c2fdb6a286cb3a1fc7dd774c00ed70929a6434f6bc634/wrapt-2.1.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4bdf26e03e6d0da3f0e9422fd36bcebf7bc0eeb55fdf9c727a09abc6b9fe472e", size = 61851, upload-time = "2026-03-06T02:52:48.672Z" },
+    { url = "https://files.pythonhosted.org/packages/03/a9/5b7d6a16fd6533fed2756900fc8fc923f678179aea62ada6d65c92718c00/wrapt-2.1.2-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:bbac24d879aa22998e87f6b3f481a5216311e7d53c7db87f189a7a0266dafffb", size = 121446, upload-time = "2026-03-06T02:54:14.013Z" },
+    { url = "https://files.pythonhosted.org/packages/45/bb/34c443690c847835cfe9f892be78c533d4f32366ad2888972c094a897e39/wrapt-2.1.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:16997dfb9d67addc2e3f41b62a104341e80cac52f91110dece393923c0ebd5ca", size = 123056, upload-time = "2026-03-06T02:54:10.829Z" },
+    { url = "https://files.pythonhosted.org/packages/93/b9/ff205f391cb708f67f41ea148545f2b53ff543a7ac293b30d178af4d2271/wrapt-2.1.2-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:162e4e2ba7542da9027821cb6e7c5e068d64f9a10b5f15512ea28e954893a267", size = 117359, upload-time = "2026-03-06T02:53:03.623Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/3d/1ea04d7747825119c3c9a5e0874a40b33594ada92e5649347c457d982805/wrapt-2.1.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f29c827a8d9936ac320746747a016c4bc66ef639f5cd0d32df24f5eacbf9c69f", size = 121479, upload-time = "2026-03-06T02:53:45.844Z" },
+    { url = "https://files.pythonhosted.org/packages/78/cc/ee3a011920c7a023b25e8df26f306b2484a531ab84ca5c96260a73de76c0/wrapt-2.1.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:a9dd9813825f7ecb018c17fd147a01845eb330254dff86d3b5816f20f4d6aaf8", size = 116271, upload-time = "2026-03-06T02:54:46.356Z" },
+    { url = "https://files.pythonhosted.org/packages/98/fd/e5ff7ded41b76d802cf1191288473e850d24ba2e39a6ec540f21ae3b57cb/wrapt-2.1.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6f8dbdd3719e534860d6a78526aafc220e0241f981367018c2875178cf83a413", size = 120573, upload-time = "2026-03-06T02:52:50.163Z" },
+    { url = "https://files.pythonhosted.org/packages/47/c5/242cae3b5b080cd09bacef0591691ba1879739050cc7c801ff35c8886b66/wrapt-2.1.2-cp313-cp313-win32.whl", hash = "sha256:5c35b5d82b16a3bc6e0a04349b606a0582bc29f573786aebe98e0c159bc48db6", size = 58205, upload-time = "2026-03-06T02:53:47.494Z" },
+    { url = "https://files.pythonhosted.org/packages/12/69/c358c61e7a50f290958809b3c61ebe8b3838ea3e070d7aac9814f95a0528/wrapt-2.1.2-cp313-cp313-win_amd64.whl", hash = "sha256:f8bc1c264d8d1cf5b3560a87bbdd31131573eb25f9f9447bb6252b8d4c44a3a1", size = 60452, upload-time = "2026-03-06T02:53:30.038Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/66/c8a6fcfe321295fd8c0ab1bd685b5a01462a9b3aa2f597254462fc2bc975/wrapt-2.1.2-cp313-cp313-win_arm64.whl", hash = "sha256:3beb22f674550d5634642c645aba4c72a2c66fb185ae1aebe1e955fae5a13baf", size = 58842, upload-time = "2026-03-06T02:52:52.114Z" },
+    { url = "https://files.pythonhosted.org/packages/da/55/9c7052c349106e0b3f17ae8db4b23a691a963c334de7f9dbd60f8f74a831/wrapt-2.1.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0fc04bc8664a8bc4c8e00b37b5355cffca2535209fba1abb09ae2b7c76ddf82b", size = 63075, upload-time = "2026-03-06T02:53:19.108Z" },
+    { url = "https://files.pythonhosted.org/packages/09/a8/ce7b4006f7218248dd71b7b2b732d0710845a0e49213b18faef64811ffef/wrapt-2.1.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:a9b9d50c9af998875a1482a038eb05755dfd6fe303a313f6a940bb53a83c3f18", size = 63719, upload-time = "2026-03-06T02:54:33.452Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/e5/2ca472e80b9e2b7a17f106bb8f9df1db11e62101652ce210f66935c6af67/wrapt-2.1.2-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2d3ff4f0024dd224290c0eabf0240f1bfc1f26363431505fb1b0283d3b08f11d", size = 152643, upload-time = "2026-03-06T02:52:42.721Z" },
+    { url = "https://files.pythonhosted.org/packages/36/42/30f0f2cefca9d9cbf6835f544d825064570203c3e70aa873d8ae12e23791/wrapt-2.1.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3278c471f4468ad544a691b31bb856374fbdefb7fee1a152153e64019379f015", size = 158805, upload-time = "2026-03-06T02:54:25.441Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/67/d08672f801f604889dcf58f1a0b424fe3808860ede9e03affc1876b295af/wrapt-2.1.2-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a8914c754d3134a3032601c6984db1c576e6abaf3fc68094bb8ab1379d75ff92", size = 145990, upload-time = "2026-03-06T02:53:57.456Z" },
+    { url = "https://files.pythonhosted.org/packages/68/a7/fd371b02e73babec1de6ade596e8cd9691051058cfdadbfd62a5898f3295/wrapt-2.1.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:ff95d4264e55839be37bafe1536db2ab2de19da6b65f9244f01f332b5286cfbf", size = 155670, upload-time = "2026-03-06T02:54:55.309Z" },
+    { url = "https://files.pythonhosted.org/packages/86/2d/9fe0095dfdb621009f40117dcebf41d7396c2c22dca6eac779f4c007b86c/wrapt-2.1.2-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:76405518ca4e1b76fbb1b9f686cff93aebae03920cc55ceeec48ff9f719c5f67", size = 144357, upload-time = "2026-03-06T02:54:24.092Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/b6/ec7b4a254abbe4cde9fa15c5d2cca4518f6b07d0f1b77d4ee9655e30280e/wrapt-2.1.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:c0be8b5a74c5824e9359b53e7e58bef71a729bacc82e16587db1c4ebc91f7c5a", size = 150269, upload-time = "2026-03-06T02:53:31.268Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/6b/2fabe8ebf148f4ee3c782aae86a795cc68ffe7d432ef550f234025ce0cfa/wrapt-2.1.2-cp313-cp313t-win32.whl", hash = "sha256:f01277d9a5fc1862f26f7626da9cf443bebc0abd2f303f41c5e995b15887dabd", size = 59894, upload-time = "2026-03-06T02:54:15.391Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/fb/9ba66fc2dedc936de5f8073c0217b5d4484e966d87723415cc8262c5d9c2/wrapt-2.1.2-cp313-cp313t-win_amd64.whl", hash = "sha256:84ce8f1c2104d2f6daa912b1b5b039f331febfeee74f8042ad4e04992bd95c8f", size = 63197, upload-time = "2026-03-06T02:54:41.943Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/1c/012d7423c95d0e337117723eb8ecf73c622ce15a97847e84cf3f8f26cd7e/wrapt-2.1.2-cp313-cp313t-win_arm64.whl", hash = "sha256:a93cd767e37faeddbe07d8fc4212d5cba660af59bdb0f6372c93faaa13e6e679", size = 60363, upload-time = "2026-03-06T02:54:48.093Z" },
+    { url = "https://files.pythonhosted.org/packages/39/25/e7ea0b417db02bb796182a5316398a75792cd9a22528783d868755e1f669/wrapt-2.1.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:1370e516598854e5b4366e09ce81e08bfe94d42b0fd569b88ec46cc56d9164a9", size = 61418, upload-time = "2026-03-06T02:53:55.706Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/0f/fa539e2f6a770249907757eaeb9a5ff4deb41c026f8466c1c6d799088a9b/wrapt-2.1.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:6de1a3851c27e0bd6a04ca993ea6f80fc53e6c742ee1601f486c08e9f9b900a9", size = 61914, upload-time = "2026-03-06T02:52:53.37Z" },
+    { url = "https://files.pythonhosted.org/packages/53/37/02af1867f5b1441aaeda9c82deed061b7cd1372572ddcd717f6df90b5e93/wrapt-2.1.2-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:de9f1a2bbc5ac7f6012ec24525bdd444765a2ff64b5985ac6e0692144838542e", size = 120417, upload-time = "2026-03-06T02:54:30.74Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/b7/0138a6238c8ba7476c77cf786a807f871672b37f37a422970342308276e7/wrapt-2.1.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:970d57ed83fa040d8b20c52fe74a6ae7e3775ae8cff5efd6a81e06b19078484c", size = 122797, upload-time = "2026-03-06T02:54:51.539Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/ad/819ae558036d6a15b7ed290d5b14e209ca795dd4da9c58e50c067d5927b0/wrapt-2.1.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3969c56e4563c375861c8df14fa55146e81ac11c8db49ea6fb7f2ba58bc1ff9a", size = 117350, upload-time = "2026-03-06T02:54:37.651Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/2d/afc18dc57a4600a6e594f77a9ae09db54f55ba455440a54886694a84c71b/wrapt-2.1.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:57d7c0c980abdc5f1d98b11a2aa3bb159790add80258c717fa49a99921456d90", size = 121223, upload-time = "2026-03-06T02:54:35.221Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/5b/5ec189b22205697bc56eb3b62aed87a1e0423e9c8285d0781c7a83170d15/wrapt-2.1.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:776867878e83130c7a04237010463372e877c1c994d449ca6aaafeab6aab2586", size = 116287, upload-time = "2026-03-06T02:54:19.654Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/2d/f84939a7c9b5e6cdd8a8d0f6a26cabf36a0f7e468b967720e8b0cd2bdf69/wrapt-2.1.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:fab036efe5464ec3291411fabb80a7a39e2dd80bae9bcbeeca5087fdfa891e19", size = 119593, upload-time = "2026-03-06T02:54:16.697Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/fe/ccd22a1263159c4ac811ab9374c061bcb4a702773f6e06e38de5f81a1bdc/wrapt-2.1.2-cp314-cp314-win32.whl", hash = "sha256:e6ed62c82ddf58d001096ae84ce7f833db97ae2263bff31c9b336ba8cfe3f508", size = 58631, upload-time = "2026-03-06T02:53:06.498Z" },
+    { url = "https://files.pythonhosted.org/packages/65/0a/6bd83be7bff2e7efaac7b4ac9748da9d75a34634bbbbc8ad077d527146df/wrapt-2.1.2-cp314-cp314-win_amd64.whl", hash = "sha256:467e7c76315390331c67073073d00662015bb730c566820c9ca9b54e4d67fd04", size = 60875, upload-time = "2026-03-06T02:53:50.252Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/c0/0b3056397fe02ff80e5a5d72d627c11eb885d1ca78e71b1a5c1e8c7d45de/wrapt-2.1.2-cp314-cp314-win_arm64.whl", hash = "sha256:da1f00a557c66225d53b095a97eace0fc5349e3bfda28fa34ffae238978ee575", size = 59164, upload-time = "2026-03-06T02:53:59.128Z" },
+    { url = "https://files.pythonhosted.org/packages/71/ed/5d89c798741993b2371396eb9d4634f009ff1ad8a6c78d366fe2883ea7a6/wrapt-2.1.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:62503ffbc2d3a69891cf29beeaccdb4d5e0a126e2b6a851688d4777e01428dbb", size = 63163, upload-time = "2026-03-06T02:52:54.873Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/8c/05d277d182bf36b0a13d6bd393ed1dec3468a25b59d01fba2dd70fe4d6ae/wrapt-2.1.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c7e6cd120ef837d5b6f860a6ea3745f8763805c418bb2f12eeb1fa6e25f22d22", size = 63723, upload-time = "2026-03-06T02:52:56.374Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/27/6c51ec1eff4413c57e72d6106bb8dec6f0c7cdba6503d78f0fa98767bcc9/wrapt-2.1.2-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3769a77df8e756d65fbc050333f423c01ae012b4f6731aaf70cf2bef61b34596", size = 152652, upload-time = "2026-03-06T02:53:23.79Z" },
+    { url = "https://files.pythonhosted.org/packages/db/4c/d7dd662d6963fc7335bfe29d512b02b71cdfa23eeca7ab3ac74a67505deb/wrapt-2.1.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a76d61a2e851996150ba0f80582dd92a870643fa481f3b3846f229de88caf044", size = 158807, upload-time = "2026-03-06T02:53:35.742Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/4d/1e5eea1a78d539d346765727422976676615814029522c76b87a95f6bcdd/wrapt-2.1.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:6f97edc9842cf215312b75fe737ee7c8adda75a89979f8e11558dfff6343cc4b", size = 146061, upload-time = "2026-03-06T02:52:57.574Z" },
+    { url = "https://files.pythonhosted.org/packages/89/bc/62cabea7695cd12a288023251eeefdcb8465056ddaab6227cb78a2de005b/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:4006c351de6d5007aa33a551f600404ba44228a89e833d2fadc5caa5de8edfbf", size = 155667, upload-time = "2026-03-06T02:53:39.422Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/99/6f2888cd68588f24df3a76572c69c2de28287acb9e1972bf0c83ce97dbc1/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:a9372fc3639a878c8e7d87e1556fa209091b0a66e912c611e3f833e2c4202be2", size = 144392, upload-time = "2026-03-06T02:54:22.41Z" },
+    { url = "https://files.pythonhosted.org/packages/40/51/1dfc783a6c57971614c48e361a82ca3b6da9055879952587bc99fe1a7171/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:3144b027ff30cbd2fca07c0a87e67011adb717eb5f5bd8496325c17e454257a3", size = 150296, upload-time = "2026-03-06T02:54:07.848Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/38/cbb8b933a0201076c1f64fc42883b0023002bdc14a4964219154e6ff3350/wrapt-2.1.2-cp314-cp314t-win32.whl", hash = "sha256:3b8d15e52e195813efe5db8cec156eebe339aaf84222f4f4f051a6c01f237ed7", size = 60539, upload-time = "2026-03-06T02:54:00.594Z" },
+    { url = "https://files.pythonhosted.org/packages/82/dd/e5176e4b241c9f528402cebb238a36785a628179d7d8b71091154b3e4c9e/wrapt-2.1.2-cp314-cp314t-win_amd64.whl", hash = "sha256:08ffa54146a7559f5b8df4b289b46d963a8e74ed16ba3687f99896101a3990c5", size = 63969, upload-time = "2026-03-06T02:54:39Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/99/79f17046cf67e4a95b9987ea129632ba8bcec0bc81f3fb3d19bdb0bd60cd/wrapt-2.1.2-cp314-cp314t-win_arm64.whl", hash = "sha256:72aaa9d0d8e4ed0e2e98019cea47a21f823c9dd4b43c7b77bba6679ffcca6a00", size = 60554, upload-time = "2026-03-06T02:53:14.132Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/c7/8528ac2dfa2c1e6708f647df7ae144ead13f0a31146f43c7264b4942bf12/wrapt-2.1.2-py3-none-any.whl", hash = "sha256:b8fd6fa2b2c4e7621808f8c62e8317f4aae56e59721ad933bac5239d913cf0e8", size = 43993, upload-time = "2026-03-06T02:53:12.905Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Status: DRAFT

This PR is opened in draft status so the spec and plan are reviewable on GitHub while implementation lands one task at a time via subagent-driven development. **Do not merge yet.** Implementation commits will follow.

## Summary

Post-S2 item D2 from `docs/superpowers/specs/2026-04-23-post-s2-findings.md` §5. Ships thin adapters that turn a `DatasetBag` into a PyTorch `Dataset` or a TensorFlow `tf.data.Dataset` without the ~35 lines of glue code users rewrite per project today. Keras (on either backend) is served as a consumer of the two native adapters, not a third parallel method. `restructure_assets` gets a coordinated signature update to share the same `targets` / `target_transform` / `missing` vocabulary as the adapters.

**Design reference:** `docs/superpowers/specs/2026-04-24-torch-dataset-adapter-design.md` — start here. 1200+ lines across 12 sections; every design decision has a paragraph.

**Implementation plan:** `docs/superpowers/plans/2026-04-24-torch-dataset-adapter-plan.md` — 8 tasks sequenced for subagent dispatch.

## What lands in this PR

Tasks 1-8 from the plan:

| Task | What |
|---|---|
| 1 | `src/deriva_ml/dataset/target_resolution.py` — shared `_resolve_targets` helper (framework-agnostic) |
| 2 | `pyproject.toml` — `torch` and `tf` optional-dependency extras |
| 3 | `src/deriva_ml/dataset/torch_adapter.py` + `DatasetBag.as_torch_dataset` + 3 test tiers |
| 4 | `src/deriva_ml/dataset/tf_adapter.py` + `DatasetBag.as_tf_dataset` + 3 test tiers |
| 5 | `DatasetBag.restructure_assets` clean-break rename to aligned vocabulary |
| 6 | User guide Chapter 5 section covering PyTorch / TensorFlow / Keras / ImageFolder |
| 7 | Cross-reference sweep across related docstrings + `CLAUDE.md` |
| 8 | Final verification |

## Breaking changes

**`DatasetBag.restructure_assets` signature changes (clean break, no deprecation window):**

| Before | After |
|---|---|
| `group_by=["Diagnosis"]` | `targets=["Diagnosis"]` |
| `group_by=["Classification.Label"]` (dotted syntax) | `targets=["Classification"], target_transform=lambda rec: rec.Label` |
| `value_selector=FeatureRecord.select_newest` | `targets={"Feature": FeatureRecord.select_newest}` |

Passing any of the old kwargs after this PR raises `TypeError` (standard Python behavior for removed kwargs). The `missing` default stays at `"unknown"` so unparameterized calls produce the same output tree as before. All other restructure parameters (`output_dir`, `asset_table`, `use_symlinks`, `type_selector`, `type_to_dir_map`, `enforce_vocabulary`, `file_transformer`) are unchanged.

**Sibling repo grep** (to be run during Task 5) will enumerate callers of the removed kwargs in `deriva-ml-model-template`, `deriva-ml-apps`, `deriva-ml-demo`, `deriva-ml-template-test` so template maintainers can update in lockstep.

## Design highlights

- **Five parameters aligned across all three methods** (`as_torch_dataset`, `as_tf_dataset`, `restructure_assets`) — same name, same type, same semantics (see spec §3.7). The only signature differences are where concepts genuinely diverge (e.g., `output_signature` is TF-specific; `output_dir` is restructure-specific).
- **Labels come from features** via the existing `bag.feature_values(...)` API. Users own the label-to-integer mapping through `target_transform`; library never holds a class-to-index table.
- **Torch and TensorFlow are optional dependencies.** Both are imported lazily inside their respective adapter builders. Library stays importable without either framework.
- **TF output_signature inferred from first sample** by default (matches Keras auto-inference); users can pass it explicitly for deterministic startup.
- **Shared `_resolve_targets` helper** enforces "same semantics" by shared code across all three methods.
- **Bag-only in v1.** Live-catalog variants (`Dataset.as_torch_dataset`, `Dataset.as_tf_dataset`) are named follow-ups, not shipped here.

## Test Plan

- [ ] Spec + plan read cleanly (this draft lets reviewers assess the design before implementation lands)
- [ ] Task 1 lands and the shared helper passes unit tests (framework-agnostic)
- [ ] Task 3 lands and the PyTorch adapter tests pass in three tiers
- [ ] Task 4 lands and the TensorFlow adapter tests pass in three tiers
- [ ] Task 5 lands and `restructure_assets` tests pass with the new signature (existing tests updated inline per plan Step 2)
- [ ] Task 6 lands and mkdocs --strict warnings stay at 27 (baseline)
- [ ] End-to-end tests (`test_*_adapter_e2e.py`) pass against a live catalog
- [ ] Sibling-repo grep completed and any callers flagged in a follow-up comment

## Related

- D1 (metrics_file + flake fix) shipped in PR #68
- Post-S2 A / C / E already merged to main
- Non-goal for this PR: metrics catalog tables (D1's file-as-asset shape stands), live-catalog adapter variants (v2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)