### PR TITLE
docs(lineage): user-guide for lookup_lineage; PR convention in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -316,6 +316,30 @@ When in doubt, pick Pydantic — "too many interfaces" is the failure mode to av
 
 ## Best Practices & Patterns
 
+### Pull-Request Workflow (required)
+
+**All changes to `deriva-ml` go through a pull request — including
+spawned-agent work.** Do not commit directly to `main`. The standard
+sequence:
+
+```bash
+git checkout -b feature/<short-name>
+# ... commit work on the branch ...
+git push -u origin feature/<short-name>
+gh pr create --title "..." --body "..."
+# wait for review or self-merge with:
+gh pr merge --squash --delete-branch
+```
+
+The PR is part of the deliverable; "shipped without a PR" is
+incomplete work. This applies even for solo developers and even for
+spawned subagents — the PR creates the durable review record that
+`git log` alone doesn't.
+
+The `bump-version` step happens AFTER merge, on `main`, in a clean
+working tree (so the bump-commit lands on `main` directly and the
+tag points at it). Never bump from a feature branch.
+
 ### Version Bumping
 
 Use the `bump-version` script for releases - it handles the complete workflow:
@@ -324,6 +348,8 @@ uv run bump-version patch  # or minor, major
 ```
 This fetches tags, bumps the version, creates a tag, and pushes everything in one command.
 Don't use `bump-my-version` directly as it doesn't push changes.
+
+Run `bump-version` only on `main`, after the feature PR has merged.
 
 ### Asset Upload
 

--- a/docs/api-reference/lineage.md
+++ b/docs/api-reference/lineage.md
@@ -1,0 +1,17 @@
+# Documentation for Lineage models in DerivaML
+
+The `lookup_lineage()` method on `DerivaML` returns a tree of provenance
+information for any artifact RID (Dataset, Asset, Feature value, or
+Execution). The Pydantic models that shape the response are defined in
+`deriva_ml.execution.lineage`.
+
+For the user-guide walkthrough — including common patterns, depth
+control, cycle handling, and the data-flow-vs-orchestration distinction
+(see ADR-0001) — see
+[Running an experiment — How to trace an artifact's lineage](../user-guide/executions.md#how-to-trace-an-artifacts-lineage).
+
+The method itself is documented on the `DerivaML` class:
+[DerivaML — lookup_lineage](deriva_ml_base.md).
+
+::: deriva_ml.execution.lineage
+    handler: python

--- a/docs/user-guide/executions.md
+++ b/docs/user-guide/executions.md
@@ -502,6 +502,66 @@ The CLI tools handle Jupyter kernel detection, `nbstripout`-based checksum compu
     Commit before running. `DERIVA_ML_ALLOW_DIRTY=true` suppresses the warning but is
     intended for tests only — using it in production pollutes your provenance record.
 
+## How to trace an artifact's lineage
+
+DerivaML records the full provenance graph for every artifact: which Execution produced
+it, what inputs that Execution consumed, what Executions produced those inputs, and so
+on back to the original raw data. To answer "how did this come to exist?" for any
+Dataset, Asset, Feature value, or Execution RID, use `lookup_lineage()`:
+
+```python
+from deriva_ml import DerivaML
+
+ml = DerivaML(hostname="data.example.org", catalog_id="1")
+
+# Single call walks the full chain back to the root.
+lineage = ml.lookup_lineage("2-PRED1")    # the predictions.csv asset RID
+
+print(lineage.root.type, lineage.root.description)
+# Asset Trained-model predictions on test set v0.4.0
+
+print(f"Walked {lineage.executions_visited} executions; complete={lineage.walked_complete}")
+```
+
+The returned `LineageResult` is a Pydantic tree where each `LineageNode` carries a
+summary of its producing Execution (RID, description, workflow name, status), the
+input Datasets and Assets that Execution consumed, and the recursive `parents` list of
+producing Executions for each input.
+
+**Common patterns.**
+
+| Question | Call |
+|---|---|
+| What produced this asset/dataset/feature? | `ml.lookup_lineage(rid)` — read `lineage.root.producing_execution` |
+| What's the full chain back to the raw data? | `ml.lookup_lineage(rid)` — walk `lineage.lineage.parents` recursively |
+| Just the immediate producer, no parent chain | `ml.lookup_lineage(rid, depth=0)` |
+| Two generations back, no further | `ml.lookup_lineage(rid, depth=2)` |
+
+**Bounds and safety.** The walk is unbounded by default — provenance traversal is an
+infrequent, deliberate request, not a hot path. Cycle detection is mandatory: if the
+catalog is corrupted with a true execution-chain cycle, the response sets
+`cycle_detected=True` and the walk aborts on that branch. A `max_executions=500` hard
+cap prevents pathological runaway walks; if hit, `walked_complete=False`.
+
+**Diamond DAGs.** When the same parent Execution is reachable via two different
+inputs, it appears once in the tree and subsequent encounters are marked
+`already_shown=True` to keep the response compact and the structure honest.
+
+**Data-flow only.** `lookup_lineage` walks data-flow parents (the Executions that
+produced this Execution's consumed inputs). It does **not** walk
+`Execution_Execution` (orchestration parent-child links — the "this Execution called
+that Execution" relationship). For the orchestration view, use
+`list_nested_executions` instead. The two views answer different questions and are
+kept separate by design (see ADR-0001 in `docs/adr/`).
+
+**No producer.** If the artifact has no producing-execution link (manually-inserted
+data, or data loaded outside an execution), the call still succeeds:
+`lineage.root.producing_execution` is `None` and `lineage.lineage` is `None`. "It has
+no recorded producer" is a valid answer to "how did this come to exist?".
+
+For the full method signature and the Pydantic model definitions, see
+[API Reference — Lineage](../api-reference/lineage.md).
+
 ## See also
 
 - [Chapter 3 — Defining and using features](features.md): creating feature definitions, `FeatureRecord` classes, and asset-based features.

--- a/docs/user-guide/reproducibility.md
+++ b/docs/user-guide/reproducibility.md
@@ -264,6 +264,40 @@ uv run deriva-ml-run \
 - The reproduced execution gets a new RID — it is a new record linked to the same workflow and dataset versions, not an alias of the original.
 - If the original execution used input assets (`AssetSpec`), include those in the new configuration using their RIDs.
 
+## How to trace what an artifact was produced from
+
+Reproducing a run is one direction; tracing an artifact backwards through its
+provenance chain is the other. When you're staring at a model output and want to
+verify "did this prediction trace back to the dataset I expected?", use
+`lookup_lineage()`:
+
+```python
+ml = DerivaML(hostname="catalog.example.org", catalog_id="1")
+lineage = ml.lookup_lineage("2-PRED1")    # the prediction asset RID
+
+# What was the immediate producing execution?
+print(lineage.root.producing_execution.description)
+# "Train ResNet-50 on chest X-ray dataset 1-ABC4 v1.2.0..."
+
+# What dataset versions did that execution actually consume?
+for ds in lineage.lineage.consumed_datasets:
+    print(f"  {ds.rid} {ds.version} — {ds.name}")
+
+# Walk further back: which executions produced those datasets?
+for parent in lineage.lineage.parents:
+    print(parent.execution.description)
+```
+
+The full chain is walked server-side in one call, replacing what would otherwise be
+5–15 manual `lookup_execution` / `find_executions` round-trips. Lineage is the
+**verification** half of reproducibility: re-running gives you a new artifact;
+tracing tells you which inputs and code produced an existing artifact, so you can
+confirm a reproduction matches the original.
+
+See [Running an experiment — How to trace an artifact's lineage](executions.md#how-to-trace-an-artifacts-lineage)
+for the full reference, including depth control, cycle handling, and the
+data-flow-vs-orchestration distinction (recorded in ADR-0001).
+
 !!! note "Common pitfalls"
     **`DERIVA_ML_ALLOW_DIRTY=true` in production.** This is the most dangerous reproducibility mistake. The execution record looks complete, but the workflow URL does not match the code that ran. Future auditors (including you) cannot tell. Reserve it for tests.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -72,6 +72,7 @@ nav:
           - Execution: api-reference/execution.md
           - ExecutionConfiguration: api-reference/execution_configuration.md
           - Workflow: api-reference/workflow.md
+          - Lineage: api-reference/lineage.md
       - Features:
           - Feature: api-reference/feature.md
       - Utilities:


### PR DESCRIPTION
## Summary

- Adds user-facing documentation for `lookup_lineage()` (shipped in v1.32.0 without docs)
- Adds a Pull-Request Workflow section to `CLAUDE.md` requiring PR-based merges to `main` for `deriva-ml`, including spawned-agent work

## Background

`lookup_lineage()` shipped as v1.32.0 in commits 301d0ac → 2ef7c3a, but two things were missed:

1. **No user-facing documentation.** The implementation, design doc (`docs/superpowers/plans/2026-05-03-get-lineage-design.md`), and ADR-0001 (`docs/adr/0001-lineage-walks-data-flow-not-orchestration.md`) all landed, but nothing in `docs/user-guide/` or `docs/api-reference/` mentioned the new method. A user reading the docs site would not know it exists.
2. **No PR.** The four commits were pushed directly to `main`. The deriva-ml repo doesn't have an explicit PR rule documented anywhere a spawned agent would see, so the agent defaulted to direct-push.

This PR closes both gaps.

## Documentation changes

- **`docs/user-guide/executions.md`** — new "How to trace an artifact's lineage" section (~60 lines). Walkthrough of `lookup_lineage(rid)`, the `LineageResult` tree, four common patterns (full chain / immediate producer / depth-capped / depth=0), cycle/diamond/bounds semantics, the data-flow-vs-orchestration distinction (cross-references ADR-0001), and the no-producer case.
- **`docs/user-guide/reproducibility.md`** — new "How to trace what an artifact was produced from" section. Frames lineage as the verification half of reproducibility.
- **`docs/api-reference/lineage.md`** — new file using the project's `mkdocstrings` convention to surface the `deriva_ml.execution.lineage` Pydantic models.
- **`mkdocs.yml`** — adds "Lineage" entry under `API Reference → Execution` so the new file appears in the rendered docs nav.

## CLAUDE.md change

Adds a "Pull-Request Workflow (required)" subsection under "Best Practices & Patterns". Three points:

1. All changes to `deriva-ml` go through a PR — including spawned-agent work.
2. The PR is part of the deliverable; "shipped without a PR" is incomplete.
3. `bump-version` runs only on `main`, in a clean working tree, after the feature PR has merged.

The companion workspace-level `/Users/carl/GitHub/DerivaML/CLAUDE.md` (outside any git repo) was also updated with a per-repo PR conventions table so spawned agents reading only the workspace file see the rule too.

## Test plan

- [ ] Render the mkdocs site locally and verify the new "Lineage" entry appears under `API Reference → Execution`
- [ ] Verify the new "How to trace an artifact's lineage" section renders correctly under "Running an experiment"
- [ ] Confirm the cross-reference from `reproducibility.md` to the executions-page anchor resolves
- [ ] Spot-check the `mkdocstrings` directive in `lineage.md` actually pulls the LineageResult / LineageNode / etc. docstrings (run `mkdocs serve` locally if available)

## This PR is itself the first to follow the new rule

Created on a feature branch, opened as a PR, will self-merge after review/approval. The workflow it documents is the workflow it used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)