### PR TITLE
feat(dataset): add validate_dataset_specs and validate_execution_configuration

### DIFF
--- a/docs/adr/0002-validate-not-dryrun-pre-flight.md
+++ b/docs/adr/0002-validate-not-dryrun-pre-flight.md
@@ -1,0 +1,110 @@
+# ADR-0002: `validate_*` is the metadata-only pre-flight; `dry_run` is the full-path test
+
+Date: 2026-05-03
+Status: Accepted
+
+## Context
+
+DerivaML offers two ways to "check before you run" an
+`ExecutionConfiguration`:
+
+1. **`Execution(..., dry_run=True)`** (existing): goes through the
+   full execution lifecycle — fetches every dataset bag, materializes
+   assets, validates the workflow can be invoked — but skips the user
+   payload (no model fit, no feature writes, no upload). Produces an
+   actual `Execution` row.
+2. **`validate_dataset_specs(...)` and
+   `validate_execution_configuration(...)`** (new in this PR):
+   metadata-only catalog queries that confirm the RIDs in a config
+   resolve, the dataset versions exist, the workflow is a workflow,
+   and there are no cross-spec inconsistencies. No bag download, no
+   `Execution` row created.
+
+These look superficially redundant. A reviewer (or future maintainer)
+will reasonably ask "why don't we just tell users to run `dry_run=True`
+to validate their config?"
+
+## Decision
+
+**Keep `validate_*` and `dry_run` as two distinct tools answering two
+distinct questions.** They are complementary, not duplicative.
+
+- `validate_*` answers: *"does this config refer to things that
+  exist in the catalog the way I think they do?"* — a question about
+  catalog metadata. Cost: O(N) metadata round-trips, ~hundreds of
+  milliseconds for typical configs.
+- `dry_run` answers: *"if I were to run this config end-to-end, would
+  the runtime path succeed up to the point where my code starts?"* —
+  a question about the bag-download + materialization path. Cost:
+  the actual download cost, which can be minutes-to-hours and several
+  GB-to-TB of bandwidth.
+
+## Rationale
+
+A real-world session iterating on `src/configs/datasets.py` produces
+many small typos: a wrong character in a RID, a `0.4` where the user
+meant `0.40`, a workflow RID swapped with a dataset RID. The user
+needs feedback within seconds, not hours. `dry_run` cannot deliver
+that — its cheapest possible execution still pays the bag download.
+
+Conversely, when the user is ready to commit to a real run, they
+care about a class of failures `validate_*` cannot see: bag export
+quirks, slow asset downloads, transient network problems mid-fetch.
+`dry_run` exists to surface those.
+
+The two tools also have different blast radii. `validate_*` is a
+read-only catalog query and is safe to call from a notebook in a
+loop while iterating. `dry_run` creates an `Execution` row in the
+catalog (and a working dir on disk), which is the right thing for a
+real-pre-run check but the wrong thing for "let me check 30 versions
+of this config in 5 minutes."
+
+## Alternatives considered
+
+### Add a `metadata_only` mode to `dry_run`
+
+Push the lightweight check inside the existing `dry_run` machinery as
+a flag (e.g. `dry_run="metadata"` vs `dry_run="full"`). Rejected
+because:
+
+- `dry_run` always creates an `Execution` row; making "metadata-only"
+  a sub-mode either inherits that side effect (wrong for fast
+  iteration) or makes the side-effect behaviour conditional on a
+  string argument (surprising).
+- The two methods need different return shapes: `validate_*` returns
+  per-spec results with `available_versions` populated on failure,
+  while `dry_run` returns an `Execution` object. Forcing them into
+  one return shape is harmful to both call sites.
+- Tier-2 skills (write-hydra-config, configure-experiment) want to
+  recommend the cheap check by name; "use `dry_run` with a special
+  flag" is harder to teach than "use `validate_*`."
+
+### Replace `dry_run` with `validate_*`
+
+Drop the heavy path entirely. Rejected — `dry_run` catches a real
+class of failures (bag-export errors, asset materialization timeouts)
+that metadata validation cannot see. Both are needed.
+
+### Make `validate_*` a free function instead of a method
+
+Put it in `deriva_ml.dataset.validation` as a module-level function
+that takes a `DerivaML` instance. Rejected — it's a question about
+the catalog, and the existing convention is method-on-DerivaML
+(`lookup_dataset`, `lookup_lineage`, `find_datasets`). Free-function
+form would be inconsistent with the rest of the API.
+
+## Consequences
+
+- **Documentation discipline**: every place that mentions `dry_run`
+  for pre-flight checking should be cross-referenced to `validate_*`
+  as the cheaper alternative for catalog-metadata questions. The
+  `validate_execution_configuration` docstring says this explicitly,
+  and the deriva-ml-skills Round 6b update to `write-hydra-config`
+  carries the message into the tier-2 skill layer.
+- **MCP wire**: deriva-ml-mcp Round 6b adds two thin wrappers for
+  `validate_dataset_specs` and `validate_execution_configuration`,
+  mirroring how `lookup_lineage` was wrapped. Other agents (Cursor,
+  raw FastMCP clients) get the same fast-pre-flight surface.
+- **Future change**: if someone proposes "let's just merge these into
+  `dry_run`" again, they should re-read this ADR. The two answer
+  different questions.

--- a/docs/superpowers/plans/2026-05-03-validate-specs-design.md
+++ b/docs/superpowers/plans/2026-05-03-validate-specs-design.md
@@ -1,0 +1,191 @@
+# Design — `validate_dataset_specs` and `validate_execution_configuration`
+
+Date: 2026-05-03
+Status: Implemented
+Companion ADR: [docs/adr/0002-validate-not-dryrun-pre-flight.md](../../adr/0002-validate-not-dryrun-pre-flight.md)
+
+## Summary
+
+Two related public methods on `DerivaML` for cheap, metadata-only
+pre-flight validation:
+
+- **`validate_dataset_specs(specs)`** — singular dataset validator.
+  Confirms a list of `DatasetSpec` objects (or shorthand strings/dicts
+  that coerce to one) actually resolves: RID exists, RID points at a
+  Dataset, named version exists.
+- **`validate_execution_configuration(config)`** — composite pre-flight
+  validator for an `ExecutionConfiguration`. Walks the contained
+  `datasets` and `assets` lists, validates the workflow, and reports
+  per-spec results plus cross-spec issues (duplicate RIDs, version
+  conflicts, role conflicts).
+
+The composite delegates the dataset half to the singular method.
+
+## Why these two methods exist
+
+Two concrete pain points:
+
+1. **A user iterating on `src/configs/datasets.py` and wants to confirm
+   specific `(RID, version)` pairs resolve before saving the config.**
+   Today the user calls `ml.lookup_dataset(rid)` and
+   `ds.dataset_history()` per spec, then mentally cross-checks the
+   versions. `validate_dataset_specs` does this in one call with a
+   structured per-spec report.
+2. **A user about to run `deriva-ml-run` and wants to confirm the full
+   `ExecutionConfiguration` will resolve cleanly.** Today the only
+   tool that "validates" a config is `dry_run=True` — but dry_run
+   pays the **bag-download** cost (minutes-to-hours, bandwidth) to do
+   so. `validate_execution_configuration` is the cheap metadata-only
+   pre-flight that fills the gap. See ADR-0002 for why this is a
+   separate method rather than an extension to `dry_run`.
+
+## Resolved design questions
+
+The design tree was walked one question at a time.
+
+### Q1 — Method placement
+Both go on `DatasetMixin` in `src/deriva_ml/core/mixins/dataset.py`.
+Asset-only validation is a private helper (`_validate_asset_spec`) inside
+the same file; same for workflow check (`_validate_workflow_rid`).
+`lookup_asset(rid)` already covers asset-existence + asset-table check;
+no public asset-validation method needed.
+
+### Q2 — Singular method name
+`validate_dataset_specs` (plural). Takes a list, returns a per-spec
+result list. Matches `resolve_rids` convention.
+
+### Q3 — Composite method name
+`validate_execution_configuration` (full word). Matches the
+`ExecutionConfiguration` class name; no `_config` short form anywhere
+else in the codebase.
+
+### Q4 — Singular input shape
+Accept `list[DatasetSpec | str | dict]`. The Pydantic `before` validator
+on the method coerces:
+- `str` → `DatasetSpec.from_shorthand(s)`
+- `dict` → `DatasetSpec(**d)`
+- `DatasetSpec` → as-is
+This matches `ExecutionConfiguration.assets` and the `create_execution`
+ergonomics.
+
+### Q5 — Failure-reason vocabulary
+Final per-dataset reasons: `rid_not_found`, `not_a_dataset`,
+`version_not_found`. Per-dataset warnings (orthogonal to validity):
+`dataset_deleted`. Per-asset reasons: `rid_not_found`, `not_an_asset`.
+Per-workflow reasons: `rid_not_found`, `not_a_workflow`. Cross-spec
+issues: `duplicate_rid`, `version_conflict`, `role_conflict`.
+
+`version_string_malformed` was dropped — Pydantic raises
+`ValidationError` at the boundary before the method runs.
+
+`version_unspecified` was considered (see Q12) and dropped as too
+fragile to detect post-coercion. A bare RID input becomes
+`version="0.0.0"`; if `0.0.0` doesn't exist, the user sees
+`version_not_found` with `available_versions` populated.
+
+All reason strings are `Literal` types for caller type-checking.
+
+### Q6 — Failure-detail richness
+- `version_not_found` → `available_versions: list[str]` (cap 20, newest
+  first). Load-bearing helpful field.
+- `not_a_dataset` / `not_an_asset` / `not_a_workflow` → `actual_table:
+  str` so the user sees the kind they accidentally pointed at.
+- Success → `dataset_name` (Description) + `resolved_version`
+  (canonical normalized form, e.g. user wrote `"0.4"` and we coerced to
+  `"0.4.0"`).
+- Skipped: Levenshtein on version strings, member counts. Both add
+  cost without commensurate value.
+
+### Q7 — Response shape
+Mirror the `LineageResult` idiom: top-level Pydantic models with nested
+compact result models, all `extra="forbid"`. Top-level `all_valid: bool`
+convenience flag.
+
+```
+DatasetSpecValidationReport     # singular method's return
+  all_valid: bool
+  results: list[DatasetSpecResult]
+
+ExecutionConfigurationValidationReport   # composite's return
+  all_valid: bool
+  dataset_results: list[DatasetSpecResult]
+  asset_results: list[AssetSpecResult]
+  workflow_result: WorkflowSpecResult | None
+  cross_spec_issues: list[CrossSpecIssue]
+```
+
+`all_valid` is `True` iff every nested `valid` is True AND
+`cross_spec_issues` is empty.
+
+### Q8 — Pydantic model location
+Single file: `src/deriva_ml/dataset/validation.py`. Mirrors how
+`lineage.py` lives next to the execution mixin that returns it.
+
+### Q9 — Implementation strategy
+Per-spec for v1; ~4-10 round-trips for typical configs is acceptable.
+`resolve_rids` (the existing batch tool) raises if any RID is missing —
+useless for partial-result validation, so we use `resolve_rid` (single)
+inside try/except per spec.
+
+Optimization: deduplicate by RID before issuing queries (cache results
+per RID); two specs pointing at the same RID still emit two per-spec
+results, but cost only one resolution + one version-history fetch.
+
+A future batched mode (when configs grow >20 specs) can land without
+changing the public API.
+
+### Q10 — Cross-spec issues
+- `duplicate_rid`: same RID, two specs (datasets list OR assets list).
+- `version_conflict`: same dataset RID, two specs with different
+  versions.
+- `role_conflict`: same asset RID listed both as Input and Output.
+
+Skipped: cross-list overlap detection (dataset RID also in assets list).
+The per-spec `not_a_dataset`/`not_an_asset` checks already catch these.
+
+### Q11 — Composite edge cases
+- Empty datasets + empty assets list → validate just the workflow.
+- Missing workflow → `workflow_result = None`, not an error.
+- Workflow points at non-Workflow → `not_a_workflow`.
+- `@validate_call` raises `ValidationError` for non-`ExecutionConfiguration`
+  input.
+
+### Q12 — Singular edge cases
+- Empty specs list → `all_valid=True, results=[]`. Not an error.
+- `version="0.0.0"` is valid IFF the dataset has a `0.0.0` row.
+
+### Q13 — Round-trip serialization
+`DatasetSpec.version` (`DatasetVersion`, semver subclass) has a
+`field_serializer` producing `{major, minor, patch}`. The unit tests
+exercise round-trip via `model_dump_json()` → `model_validate_json()`
+to catch any pydantic-v2 surprise; this matters because the deriva-ml-mcp
+Round 6b wrappers will ship these models over the MCP wire.
+
+### Q14 — Documentation deliverables
+- This addendum.
+- ADR-0002 for the dry-run-vs-validate distinction (see Q14 rationale
+  in the conversation; matches all three ADR criteria).
+
+### Q15 — Test counts
+- `tests/dataset/test_validate_dataset_spec_unit.py` — 12 unit tests.
+- `tests/dataset/test_validate_execution_configuration_unit.py` — 12
+  unit tests.
+- `tests/dataset/test_validate_specs_live.py` — ~6 integration tests
+  gated on `DERIVA_HOST`.
+
+### Q16 — Asset role check
+`AssetSpec.asset_role` is on the spec object directly. Group by RID;
+flag any RID appearing with both `"Input"` and `"Output"` values.
+
+## Coordination with deriva-ml-skills Round 6b
+
+After this PR merges + a `bump-version minor` lands, the deriva-ml-skills
+Round 6b session will:
+
+- Add `deriva_ml_validate_dataset_specs` MCP tool wrapper.
+- Add `deriva_ml_validate_execution_configuration` MCP tool wrapper.
+- Add `deriva://catalog/{h}/{c}/ml/dataset/{rid}/spec` resource.
+- Update the tier-2 `write-hydra-config` skill's "Validating Configs
+  Against the Catalog" section.
+
+That work is out of scope for this PR.

--- a/src/deriva_ml/core/mixins/dataset.py
+++ b/src/deriva_ml/core/mixins/dataset.py
@@ -16,14 +16,24 @@ Table = _ermrest_model.Table
 
 from pydantic import ConfigDict, validate_call
 
+from deriva_ml.asset.aux_classes import AssetSpec
 from deriva_ml.core.definitions import RID
 from deriva_ml.core.exceptions import DerivaMLException, DerivaMLTableTypeError
 from deriva_ml.core.sort import SortSpec, resolve_sort
 from deriva_ml.dataset.aux_classes import DatasetSpec
+from deriva_ml.dataset.validation import (
+    AssetSpecResult,
+    CrossSpecIssue,
+    DatasetSpecResult,
+    DatasetSpecValidationReport,
+    ExecutionConfigurationValidationReport,
+    WorkflowSpecResult,
+)
 
 if TYPE_CHECKING:
     from deriva_ml.dataset.dataset import Dataset
     from deriva_ml.dataset.dataset_bag import DatasetBag
+    from deriva_ml.execution.execution_configuration import ExecutionConfiguration
     from deriva_ml.model.catalog import DerivaModel
 
 
@@ -528,3 +538,420 @@ class DatasetMixin:
             timeout=dataset.timeout,
             fetch_concurrency=dataset.fetch_concurrency,
         )
+
+    # ------------------------------------------------------------------
+    # Pre-flight validation (metadata-only; cf. dry_run for full path).
+    # ------------------------------------------------------------------
+
+    def validate_dataset_specs(
+        self,
+        specs: list[DatasetSpec | str | dict[str, Any]],
+    ) -> DatasetSpecValidationReport:
+        """Validate a list of :class:`DatasetSpec` against the catalog.
+
+        Replaces the per-RID ``ml.lookup_dataset(rid)`` +
+        ``ds.dataset_history()`` cross-check loop a user would
+        otherwise write while iterating on ``src/configs/datasets.py``.
+        Each spec is checked for three orthogonal failure modes —
+        ``rid_not_found``, ``not_a_dataset``, ``version_not_found`` —
+        and all three are reported per spec rather than stopping at
+        the first.
+
+        This is a metadata-only catalog query. For the heavier
+        full-path check (which materializes bags) see
+        :meth:`Execution.dry_run`. ADR-0002 captures the rationale
+        for keeping the two surfaces distinct.
+
+        Input shorthands are accepted for ergonomics: a plain RID
+        string is parsed via :meth:`DatasetSpec.from_shorthand` (so
+        ``"1-XYZ@1.0.0"`` and ``"1-XYZ"`` both work), and a dict is
+        coerced via ``DatasetSpec(**d)``.
+
+        Duplicate specs in the input are validated independently
+        (no deduplication). Cross-spec duplicate detection lives on
+        the composite :meth:`validate_execution_configuration`.
+
+        Args:
+            specs: List of dataset specifications to validate. Each
+                element may be a :class:`DatasetSpec`, a shorthand
+                string parseable by :meth:`DatasetSpec.from_shorthand`,
+                or a dict that coerces to :class:`DatasetSpec`.
+
+        Returns:
+            A :class:`DatasetSpecValidationReport` with one
+            :class:`DatasetSpecResult` per input spec (in the same
+            order) plus a top-level ``all_valid`` convenience flag.
+
+        Raises:
+            pydantic.ValidationError: If any input element cannot be
+                coerced to a :class:`DatasetSpec` (e.g. malformed
+                version string, missing required fields).
+
+        Example:
+            Validate two specs, one good and one with a typo'd version::
+
+                >>> from deriva_ml.dataset.aux_classes import DatasetSpec
+                >>> report = ml.validate_dataset_specs(specs=[  # doctest: +SKIP
+                ...     DatasetSpec(rid="2-B4C8", version="0.4.0"),
+                ...     DatasetSpec(rid="2-B4C8", version="9.9.9"),
+                ... ])
+                >>> report.all_valid  # doctest: +SKIP
+                False
+                >>> bad = report.results[1]  # doctest: +SKIP
+                >>> bad.reasons  # doctest: +SKIP
+                ['version_not_found']
+                >>> bad.available_versions  # doctest: +SKIP
+                ['0.4.0', '0.3.0']
+        """
+        # Coerce inputs once so cached lookups can use the canonical form.
+        coerced: list[DatasetSpec] = [self._coerce_dataset_spec(s) for s in specs]
+
+        # Per-RID caches so duplicate-RID inputs cost one round-trip each,
+        # not N. The values mirror the partial state assembled during a
+        # validation pass.
+        rid_cache: dict[str, dict[str, Any]] = {}
+
+        results = [self._validate_one_dataset_spec(s, rid_cache) for s in coerced]
+        return DatasetSpecValidationReport(
+            all_valid=all(r.valid for r in results),
+            results=results,
+        )
+
+    def validate_execution_configuration(
+        self,
+        config: "ExecutionConfiguration",
+    ) -> ExecutionConfigurationValidationReport:
+        """Pre-flight validation for an :class:`ExecutionConfiguration`.
+
+        Walks the contained ``datasets`` and ``assets`` lists, validates
+        the workflow RID, and reports per-spec results plus cross-spec
+        issues (duplicate RIDs across the dataset list, dataset-version
+        conflicts, asset role conflicts). Designed to be cheap to run
+        repeatedly while iterating on a config — only catalog metadata
+        is touched, no bags are materialized.
+
+        This method is the lightweight complement to
+        :meth:`Execution.dry_run`. ``dry_run`` is the heavier full-path
+        test that exercises the bag-download + materialization pipeline;
+        ``validate_execution_configuration`` answers the cheaper
+        upstream question of *"do the RIDs in this config refer to
+        things that exist in the catalog the way I think they do?"*.
+        See ADR-0002 for the full rationale.
+
+        The dataset half of the work is delegated to
+        :meth:`validate_dataset_specs` — the two methods share the
+        per-spec dataset validation logic.
+
+        Args:
+            config: The execution configuration to validate. Its
+                ``datasets``, ``assets``, and ``workflow`` fields are
+                walked; other fields (``description``, ``argv``,
+                ``config_choices``) are ignored.
+
+        Returns:
+            A :class:`ExecutionConfigurationValidationReport` with
+            per-spec results, an optional workflow result (None if
+            the config has no workflow set), cross-spec issues, and
+            an ``all_valid`` convenience flag.
+
+        Raises:
+            pydantic.ValidationError: If ``config`` is not an
+                :class:`ExecutionConfiguration`.
+
+        Example:
+            Validate a config before invoking ``deriva-ml-run``::
+
+                >>> from deriva_ml.execution import ExecutionConfiguration
+                >>> from deriva_ml.dataset.aux_classes import DatasetSpec
+                >>> from deriva_ml.asset.aux_classes import AssetSpec
+                >>> config = ExecutionConfiguration(  # doctest: +SKIP
+                ...     workflow=workflow,
+                ...     datasets=[DatasetSpec(rid="2-B4C8", version="0.4.0")],
+                ...     assets=[AssetSpec(rid="3JSE")],
+                ... )
+                >>> report = ml.validate_execution_configuration(config)  # doctest: +SKIP
+                >>> if not report.all_valid:  # doctest: +SKIP
+                ...     for issue in report.cross_spec_issues:
+                ...         print(issue.detail)
+        """
+        # Dataset half — delegate to the singular method.
+        dataset_report = self.validate_dataset_specs(specs=list(config.datasets))
+
+        # Asset half — per-spec.
+        asset_results = [self._validate_asset_spec(a) for a in config.assets]
+
+        # Workflow.
+        workflow_result: WorkflowSpecResult | None
+        if config.workflow is not None and config.workflow.rid is not None:
+            workflow_result = self._validate_workflow_rid(config.workflow.rid)
+        else:
+            workflow_result = None
+
+        # Cross-spec issues.
+        cross_spec_issues = self._collect_cross_spec_issues(
+            dataset_specs=list(config.datasets),
+            asset_specs=list(config.assets),
+        )
+
+        all_valid = (
+            dataset_report.all_valid
+            and all(r.valid for r in asset_results)
+            and (workflow_result is None or workflow_result.valid)
+            and not cross_spec_issues
+        )
+
+        return ExecutionConfigurationValidationReport(
+            all_valid=all_valid,
+            dataset_results=dataset_report.results,
+            asset_results=asset_results,
+            workflow_result=workflow_result,
+            cross_spec_issues=cross_spec_issues,
+        )
+
+    # -- private helpers ------------------------------------------------
+
+    @staticmethod
+    def _coerce_dataset_spec(value: DatasetSpec | str | dict[str, Any]) -> DatasetSpec:
+        """Coerce one input into a :class:`DatasetSpec`.
+
+        See :meth:`validate_dataset_specs` for the supported shorthands.
+        """
+        if isinstance(value, DatasetSpec):
+            return value
+        if isinstance(value, str):
+            return DatasetSpec.from_shorthand(value)
+        if isinstance(value, dict):
+            return DatasetSpec(**value)
+        # Fall through: let DatasetSpec raise a clear ValidationError.
+        return DatasetSpec.model_validate(value)
+
+    def _validate_one_dataset_spec(
+        self,
+        spec: DatasetSpec,
+        rid_cache: dict[str, dict[str, Any]],
+    ) -> DatasetSpecResult:
+        """Validate one already-coerced :class:`DatasetSpec`.
+
+        Uses ``rid_cache`` to amortize repeated lookups for the same
+        RID across two specs. Mutates the cache.
+        """
+        cached = rid_cache.get(spec.rid)
+        if cached is None:
+            cached = self._lookup_dataset_metadata(spec.rid)
+            rid_cache[spec.rid] = cached
+
+        # rid_not_found short-circuits everything else.
+        if cached["status"] == "rid_not_found":
+            return DatasetSpecResult(
+                spec=spec,
+                valid=False,
+                reasons=["rid_not_found"],
+            )
+
+        # not_a_dataset short-circuits version checking.
+        if cached["status"] == "not_a_dataset":
+            return DatasetSpecResult(
+                spec=spec,
+                valid=False,
+                reasons=["not_a_dataset"],
+                actual_table=cached["actual_table"],
+            )
+
+        # We have a real dataset. Now check the version.
+        requested_version = str(spec.version)
+        available_versions: list[str] = cached["versions"]
+        warnings: list[str] = []
+        if cached["deleted"]:
+            warnings.append("dataset_deleted")
+
+        if requested_version not in available_versions:
+            # Cap at 20, newest first. Versions in cached["versions"] are
+            # already in newest-first order.
+            return DatasetSpecResult(
+                spec=spec,
+                valid=False,
+                reasons=["version_not_found"],
+                warnings=warnings,
+                available_versions=available_versions[:20],
+            )
+
+        return DatasetSpecResult(
+            spec=spec,
+            valid=True,
+            warnings=warnings,
+            resolved_version=requested_version,
+            dataset_name=cached["description"],
+        )
+
+    def _lookup_dataset_metadata(self, rid: str) -> dict[str, Any]:
+        """Resolve a RID and gather just enough metadata to validate it.
+
+        Returns a dict with ``status`` of ``rid_not_found``,
+        ``not_a_dataset``, or ``ok``. When ``ok``, the dict also
+        carries ``description``, ``deleted``, and ``versions`` (newest
+        first). When ``not_a_dataset``, it carries ``actual_table``.
+        """
+        try:
+            resolved = self.resolve_rid(rid)  # type: ignore[attr-defined]
+        except DerivaMLException:
+            return {"status": "rid_not_found"}
+
+        table = resolved.table
+        if table.name != "Dataset":
+            return {"status": "not_a_dataset", "actual_table": table.name}
+
+        # Fetch the dataset row and its version history in two cheap queries.
+        try:
+            row = list(resolved.datapath.entities().fetch())[0]
+        except (IndexError, DerivaMLException):
+            return {"status": "rid_not_found"}
+
+        pb = self.pathBuilder()
+        version_path = pb.schemas[self.ml_schema].tables["Dataset_Version"]
+        version_rows = list(version_path.filter(version_path.Dataset == rid).entities().fetch())
+
+        # Sort newest-first (semver-aware) so the head of the slice is
+        # the most useful piece of context for "did you mean..." UX.
+        def _semver_key(v: str) -> tuple[int, ...]:
+            try:
+                return tuple(int(p) for p in v.split("."))
+            except ValueError:
+                return (0,)
+
+        versions = sorted(
+            (vr["Version"] for vr in version_rows if vr.get("Version")),
+            key=_semver_key,
+            reverse=True,
+        )
+
+        return {
+            "status": "ok",
+            "description": row.get("Description"),
+            "deleted": bool(row.get("Deleted")),
+            "versions": versions,
+        }
+
+    def _validate_asset_spec(self, spec: AssetSpec) -> AssetSpecResult:
+        """Validate one :class:`AssetSpec` against the catalog.
+
+        Mirrors the ``rid_not_found`` / ``not_an_asset`` checks that
+        :meth:`AssetMixin.lookup_asset` performs internally, but
+        returns a structured per-spec result instead of raising.
+        """
+        try:
+            resolved = self.resolve_rid(spec.rid)  # type: ignore[attr-defined]
+        except DerivaMLException:
+            return AssetSpecResult(spec=spec, valid=False, reasons=["rid_not_found"])
+
+        table = resolved.table
+        if not self.model.is_asset(table):
+            return AssetSpecResult(
+                spec=spec,
+                valid=False,
+                reasons=["not_an_asset"],
+                actual_table=table.name,
+            )
+
+        try:
+            row = list(resolved.datapath.entities().fetch())[0]
+        except (IndexError, DerivaMLException):
+            return AssetSpecResult(spec=spec, valid=False, reasons=["rid_not_found"])
+
+        return AssetSpecResult(
+            spec=spec,
+            valid=True,
+            asset_table=table.name,
+            filename=row.get("Filename"),
+        )
+
+    def _validate_workflow_rid(self, rid: str) -> WorkflowSpecResult:
+        """Validate that ``rid`` points at a Workflow row."""
+        try:
+            resolved = self.resolve_rid(rid)  # type: ignore[attr-defined]
+        except DerivaMLException:
+            return WorkflowSpecResult(rid=rid, valid=False, reasons=["rid_not_found"])
+
+        table = resolved.table
+        if table.name != "Workflow":
+            return WorkflowSpecResult(
+                rid=rid,
+                valid=False,
+                reasons=["not_a_workflow"],
+                actual_table=table.name,
+            )
+
+        try:
+            row = list(resolved.datapath.entities().fetch())[0]
+        except (IndexError, DerivaMLException):
+            return WorkflowSpecResult(rid=rid, valid=False, reasons=["rid_not_found"])
+
+        return WorkflowSpecResult(
+            rid=rid,
+            valid=True,
+            workflow_name=row.get("Name"),
+        )
+
+    @staticmethod
+    def _collect_cross_spec_issues(
+        dataset_specs: list[DatasetSpec],
+        asset_specs: list[AssetSpec],
+    ) -> list[CrossSpecIssue]:
+        """Compute cross-spec inconsistencies for the composite report.
+
+        Detects:
+            - duplicate dataset RIDs (with the same version)
+            - dataset version conflicts (same RID, different versions)
+            - duplicate asset RIDs (same role)
+            - role conflicts (same asset RID with both Input and Output)
+        """
+        issues: list[CrossSpecIssue] = []
+
+        # Datasets: group by RID, then by version-string.
+        ds_by_rid: dict[str, list[str]] = {}
+        for s in dataset_specs:
+            ds_by_rid.setdefault(s.rid, []).append(str(s.version))
+
+        for rid, versions in ds_by_rid.items():
+            distinct = set(versions)
+            if len(distinct) > 1:
+                issues.append(
+                    CrossSpecIssue(
+                        issue="version_conflict",
+                        rids=[rid],
+                        detail=(f"Dataset {rid} listed with conflicting versions: {sorted(distinct)}."),
+                    )
+                )
+            elif len(versions) > 1:
+                issues.append(
+                    CrossSpecIssue(
+                        issue="duplicate_rid",
+                        rids=[rid],
+                        detail=(f"Dataset {rid} listed {len(versions)} times with the same version {versions[0]!r}."),
+                    )
+                )
+
+        # Assets: group by RID, then by role.
+        as_by_rid: dict[str, list[str]] = {}
+        for s in asset_specs:
+            as_by_rid.setdefault(s.rid, []).append(s.asset_role)
+
+        for rid, roles in as_by_rid.items():
+            distinct = set(roles)
+            if len(distinct) > 1:
+                issues.append(
+                    CrossSpecIssue(
+                        issue="role_conflict",
+                        rids=[rid],
+                        detail=(f"Asset {rid} listed with conflicting roles: {sorted(distinct)}."),
+                    )
+                )
+            elif len(roles) > 1:
+                issues.append(
+                    CrossSpecIssue(
+                        issue="duplicate_rid",
+                        rids=[rid],
+                        detail=(f"Asset {rid} listed {len(roles)} times with role {roles[0]!r}."),
+                    )
+                )
+
+        return issues

--- a/src/deriva_ml/dataset/validation.py
+++ b/src/deriva_ml/dataset/validation.py
@@ -1,0 +1,225 @@
+"""Pydantic models for the validation methods on :class:`DerivaML`.
+
+These models are returned by :meth:`DerivaML.validate_dataset_specs`
+and :meth:`DerivaML.validate_execution_configuration`. The models live
+in their own module so they can cross a boundary: the deriva-ml-mcp
+Round 6 follow-up serializes them with ``.model_dump()`` from a tool
+wrapper, and downstream agents (notebook, skill, web app) consume the
+JSON.
+
+The validation methods themselves are metadata-only catalog queries
+(no bag download). For the heavier full-path test see
+:meth:`Execution.dry_run` — and ADR-0002 for the rationale on keeping
+the two surfaces distinct.
+
+Example:
+    Inspect a singular validation report::
+
+        >>> report = ml.validate_dataset_specs(specs=[  # doctest: +SKIP
+        ...     DatasetSpec(rid="2-B4C8", version="0.4.0"),
+        ... ])
+        >>> if not report.all_valid:  # doctest: +SKIP
+        ...     for r in report.results:
+        ...         if not r.valid:
+        ...             print(r.spec.rid, r.reasons, r.available_versions)
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from deriva_ml.asset.aux_classes import AssetSpec
+from deriva_ml.core.definitions import RID
+from deriva_ml.dataset.aux_classes import DatasetSpec
+
+# ---------------------------------------------------------------------------
+# Reason vocabularies
+# ---------------------------------------------------------------------------
+
+DatasetReason = Literal[
+    "rid_not_found",
+    "not_a_dataset",
+    "version_not_found",
+]
+
+DatasetWarning = Literal["dataset_deleted",]
+
+AssetReason = Literal[
+    "rid_not_found",
+    "not_an_asset",
+]
+
+WorkflowReason = Literal[
+    "rid_not_found",
+    "not_a_workflow",
+]
+
+CrossSpecIssueKind = Literal[
+    "duplicate_rid",
+    "version_conflict",
+    "role_conflict",
+]
+
+
+# ---------------------------------------------------------------------------
+# Per-spec result models
+# ---------------------------------------------------------------------------
+
+
+class DatasetSpecResult(BaseModel):
+    """Result of validating one :class:`DatasetSpec`.
+
+    Attributes:
+        spec: The spec that was validated. Echoed back so callers can
+            match results to inputs even if the input was reordered or
+            coerced from a shorthand.
+        valid: True when ``reasons`` is empty (warnings do not affect
+            validity).
+        reasons: List of failure reasons. Empty when ``valid`` is True.
+        warnings: List of non-fatal observations (e.g. the dataset
+            exists but is soft-deleted).
+        actual_table: When ``not_a_dataset`` is set, the name of the
+            table the RID actually points at. None otherwise.
+        available_versions: When ``version_not_found`` is set, up to
+            20 known versions for the dataset (newest first). None
+            otherwise.
+        resolved_version: The canonical normalized version string
+            (e.g. ``"0.4.0"`` even if the user wrote ``"0.4"``). Only
+            set when ``valid``.
+        dataset_name: Dataset description, when available. Only set
+            when ``valid``.
+    """
+
+    model_config = ConfigDict(extra="forbid", arbitrary_types_allowed=True)
+
+    spec: DatasetSpec
+    valid: bool
+    reasons: list[DatasetReason] = Field(default_factory=list)
+    warnings: list[DatasetWarning] = Field(default_factory=list)
+    actual_table: str | None = None
+    available_versions: list[str] | None = None
+    resolved_version: str | None = None
+    dataset_name: str | None = None
+
+
+class AssetSpecResult(BaseModel):
+    """Result of validating one :class:`AssetSpec`.
+
+    Attributes:
+        spec: The spec that was validated.
+        valid: True when ``reasons`` is empty.
+        reasons: List of failure reasons. Empty when ``valid`` is True.
+        actual_table: When ``not_an_asset`` is set, the name of the
+            table the RID actually points at. None otherwise.
+        asset_table: Name of the asset table the row lives in. Only
+            set when ``valid``.
+        filename: Asset filename. Only set when ``valid``.
+    """
+
+    model_config = ConfigDict(extra="forbid", arbitrary_types_allowed=True)
+
+    spec: AssetSpec
+    valid: bool
+    reasons: list[AssetReason] = Field(default_factory=list)
+    actual_table: str | None = None
+    asset_table: str | None = None
+    filename: str | None = None
+
+
+class WorkflowSpecResult(BaseModel):
+    """Result of validating the workflow on an :class:`ExecutionConfiguration`.
+
+    Attributes:
+        rid: The workflow RID that was validated.
+        valid: True when ``reasons`` is empty.
+        reasons: List of failure reasons. Empty when ``valid`` is True.
+        actual_table: When ``not_a_workflow`` is set, the name of the
+            table the RID actually points at. None otherwise.
+        workflow_name: Workflow name from the catalog. Only set when
+            ``valid``.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    rid: RID
+    valid: bool
+    reasons: list[WorkflowReason] = Field(default_factory=list)
+    actual_table: str | None = None
+    workflow_name: str | None = None
+
+
+class CrossSpecIssue(BaseModel):
+    """A consistency issue spanning two or more specs.
+
+    Attributes:
+        issue: The kind of inconsistency. ``duplicate_rid`` for the
+            same RID listed twice; ``version_conflict`` for the same
+            dataset RID with two different versions; ``role_conflict``
+            for the same asset RID with both ``Input`` and ``Output``
+            roles.
+        rids: The RIDs involved. For ``duplicate_rid`` and
+            ``role_conflict`` this is a single-element list (the RID
+            that appears multiple times); for ``version_conflict`` it
+            is also a single-element list (the dataset RID with the
+            conflict). Kept as a list so future issue kinds spanning
+            two distinct RIDs can use the same shape.
+        detail: Human-readable description, suitable for showing the
+            user.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    issue: CrossSpecIssueKind
+    rids: list[RID]
+    detail: str
+
+
+# ---------------------------------------------------------------------------
+# Top-level reports
+# ---------------------------------------------------------------------------
+
+
+class DatasetSpecValidationReport(BaseModel):
+    """Result returned by :meth:`DerivaML.validate_dataset_specs`.
+
+    Attributes:
+        all_valid: True iff every entry in ``results`` has ``valid``
+            True. An empty ``results`` list is reported as
+            ``all_valid=True``.
+        results: Per-spec results, in the same order as the input
+            list (duplicates preserved — the singular method does not
+            deduplicate; cross-spec duplicate detection is reserved
+            for the composite).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    all_valid: bool
+    results: list[DatasetSpecResult] = Field(default_factory=list)
+
+
+class ExecutionConfigurationValidationReport(BaseModel):
+    """Result returned by :meth:`DerivaML.validate_execution_configuration`.
+
+    Attributes:
+        all_valid: True iff every nested ``valid`` is True AND
+            ``cross_spec_issues`` is empty.
+        dataset_results: Per-dataset-spec results.
+        asset_results: Per-asset-spec results.
+        workflow_result: Workflow validation result, or None if the
+            config has no workflow set (a config with no workflow is
+            allowed; the workflow can be supplied later via
+            ``create_execution(workflow=...)``).
+        cross_spec_issues: Consistency issues spanning two or more
+            specs (duplicate RIDs, version conflicts, role conflicts).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    all_valid: bool
+    dataset_results: list[DatasetSpecResult] = Field(default_factory=list)
+    asset_results: list[AssetSpecResult] = Field(default_factory=list)
+    workflow_result: WorkflowSpecResult | None = None
+    cross_spec_issues: list[CrossSpecIssue] = Field(default_factory=list)

--- a/tests/dataset/test_validate_dataset_spec_unit.py
+++ b/tests/dataset/test_validate_dataset_spec_unit.py
@@ -1,0 +1,396 @@
+"""Unit tests for ``DerivaML.validate_dataset_specs``.
+
+These tests mock the catalog-touching primitives (``resolve_rid``,
+``pathBuilder``) and exercise the per-spec validation shape, the
+failure-reason vocabulary, the dataset-deleted warning, the input
+shorthand coercion, the duplicate-RID caching, the round-trip
+serialization, and the ``available_versions`` cap.
+
+A live-catalog smoke test lives in
+``tests/dataset/test_validate_specs_live.py`` and is gated on
+``DERIVA_HOST``.
+
+Note on test RIDs: the ``RID`` Pydantic type validates against
+ERMrest's RID pattern (``[A-Z\\d]{1,4}`` segments separated by
+hyphens), so test RIDs are written in that form (e.g. ``"1-DSAA"``).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from deriva_ml.core.exceptions import DerivaMLException
+from deriva_ml.core.mixins.dataset import DatasetMixin
+from deriva_ml.dataset.aux_classes import DatasetSpec
+from deriva_ml.dataset.validation import (
+    DatasetSpecResult,
+    DatasetSpecValidationReport,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers — minimal stand-ins for the catalog primitives.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _StubColumn:
+    name: str
+
+
+@dataclass
+class _StubTable:
+    name: str
+    columns: list[_StubColumn] = field(default_factory=list)
+
+
+class _StubEntities:
+    def __init__(self, rows: list[dict[str, Any]]):
+        self._rows = rows
+
+    def fetch(self) -> list[dict[str, Any]]:
+        return list(self._rows)
+
+
+class _StubDatapath:
+    def __init__(self, rows: list[dict[str, Any]]):
+        self._rows = rows
+
+    def entities(self) -> _StubEntities:
+        return _StubEntities(self._rows)
+
+
+@dataclass
+class _StubResolved:
+    table: _StubTable
+    datapath: _StubDatapath
+
+
+class _StubVersionPath:
+    """Stand-in for ``pb.schemas[ml_schema].tables['Dataset_Version']``.
+
+    ``filter()`` accepts an opaque expression and returns self; ``entities()``
+    and ``fetch()`` echo the rows for the most-recently-filtered RID.
+    """
+
+    def __init__(self, version_rows_by_dataset: dict[str, list[str]]):
+        self._versions = version_rows_by_dataset
+        self._current_filter: str | None = None
+        self.Dataset = _StubColumn("Dataset")  # used by `version_path.Dataset == rid`
+
+    def filter(self, expr: tuple[str, str]) -> "_StubVersionPath":  # type: ignore[override]
+        # expr is the (column_name, rid) tuple our stub equality op produced.
+        _col, rid = expr
+        self._current_filter = rid
+        return self
+
+    def entities(self) -> _StubEntities:
+        rid = self._current_filter
+        rows = [{"Version": v} for v in self._versions.get(rid, [])]
+        return _StubEntities(rows)
+
+
+class _StubColumnEq(_StubColumn):
+    """Column subclass that produces a tuple from ``==`` for filter()."""
+
+    def __eq__(self, other: Any) -> tuple[str, Any]:  # type: ignore[override]
+        return (self.name, other)
+
+
+class _StubVersionPathTyped(_StubVersionPath):
+    """Override ``Dataset`` attribute so ``version_path.Dataset == rid`` returns
+    a tuple our ``filter`` can read."""
+
+    def __init__(self, version_rows_by_dataset: dict[str, list[str]]):
+        super().__init__(version_rows_by_dataset)
+        self.Dataset = _StubColumnEq("Dataset")
+
+
+class _StubTablesDict(dict):
+    """``pb.schemas[ml_schema].tables[name]`` stand-in."""
+
+
+class _StubSchema:
+    def __init__(self, version_path: _StubVersionPathTyped):
+        self.tables = _StubTablesDict({"Dataset_Version": version_path})
+
+
+class _StubSchemasDict(dict):
+    """``pb.schemas[name]`` stand-in."""
+
+
+class _StubPathBuilder:
+    def __init__(self, ml_schema: str, version_path: _StubVersionPathTyped):
+        self.schemas = _StubSchemasDict({ml_schema: _StubSchema(version_path)})
+
+
+class _FakeML(DatasetMixin):
+    """Bare DatasetMixin host that scripts the primitives the validation
+    methods depend on. Mirrors the ``_FakeML`` pattern used by the lookup_lineage
+    unit tests in ``tests/execution/test_lookup_lineage_unit.py``.
+    """
+
+    ml_schema = "deriva-ml"
+
+    def __init__(self) -> None:
+        # Map RID -> (table_name, optional row dict).
+        self._rids: dict[str, tuple[str, dict[str, Any]]] = {}
+        # Map dataset RID -> list of version strings, newest-first.
+        self._versions: dict[str, list[str]] = {}
+        # Mock model.
+        self.model = MagicMock()
+        self.model.is_asset = lambda table: False  # only used for asset paths
+
+        # Build the path builder once, refreshed lazily as datasets are added.
+        self._version_path = _StubVersionPathTyped(self._versions)
+        self._pb = _StubPathBuilder(self.ml_schema, self._version_path)
+
+    # -- scripting helpers -------------------------------------------------
+
+    def add_dataset(
+        self,
+        rid: str,
+        description: str | None = None,
+        deleted: bool = False,
+        versions: list[str] | None = None,
+    ) -> None:
+        self._rids[rid] = (
+            "Dataset",
+            {"Description": description, "Deleted": deleted, "RID": rid},
+        )
+        self._versions[rid] = list(versions or [])
+
+    def add_non_dataset(self, rid: str, table_name: str) -> None:
+        self._rids[rid] = (table_name, {"RID": rid})
+
+    # -- DatasetMixin protocol --------------------------------------------
+
+    def resolve_rid(self, rid: str) -> _StubResolved:  # type: ignore[override]
+        if rid not in self._rids:
+            raise DerivaMLException(f"Invalid RID {rid}")
+        table_name, row = self._rids[rid]
+        return _StubResolved(
+            table=_StubTable(name=table_name, columns=[_StubColumn("RID")]),
+            datapath=_StubDatapath(rows=[row]),
+        )
+
+    def pathBuilder(self) -> _StubPathBuilder:  # type: ignore[override]
+        return self._pb
+
+
+# ---------------------------------------------------------------------------
+# Tests.
+# ---------------------------------------------------------------------------
+
+
+def test_empty_specs_list_is_valid_and_empty():
+    ml = _FakeML()
+    report = ml.validate_dataset_specs(specs=[])
+    assert isinstance(report, DatasetSpecValidationReport)
+    assert report.all_valid is True
+    assert report.results == []
+
+
+def test_all_valid_case():
+    ml = _FakeML()
+    ml.add_dataset("1-DSAA", description="alpha", versions=["1.0.0", "0.5.0"])
+    ml.add_dataset("1-DSAB", description="beta", versions=["0.1.0"])
+
+    report = ml.validate_dataset_specs(
+        specs=[
+            DatasetSpec(rid="1-DSAA", version="1.0.0"),
+            DatasetSpec(rid="1-DSAB", version="0.1.0"),
+        ]
+    )
+
+    assert report.all_valid is True
+    assert len(report.results) == 2
+    for r, expected_name in zip(report.results, ["alpha", "beta"]):
+        assert r.valid is True
+        assert r.dataset_name == expected_name
+        assert r.reasons == []
+        assert r.warnings == []
+
+
+def test_mixed_valid_and_invalid():
+    ml = _FakeML()
+    ml.add_dataset("1-DSAA", versions=["1.0.0"])
+    ml.add_non_dataset("2-WFAA", table_name="Workflow")
+
+    report = ml.validate_dataset_specs(
+        specs=[
+            DatasetSpec(rid="1-DSAA", version="1.0.0"),
+            DatasetSpec(rid="2-WFAA", version="1.0.0"),
+            DatasetSpec(rid="9-NOPE", version="1.0.0"),
+        ]
+    )
+
+    assert report.all_valid is False
+    assert report.results[0].valid is True
+    assert report.results[1].valid is False
+    assert "not_a_dataset" in report.results[1].reasons
+    assert report.results[1].actual_table == "Workflow"
+    assert report.results[2].valid is False
+    assert "rid_not_found" in report.results[2].reasons
+
+
+def test_rid_not_found_short_circuits_other_checks():
+    ml = _FakeML()
+    report = ml.validate_dataset_specs(
+        specs=[
+            DatasetSpec(rid="9-NOPE", version="0.1.0"),
+        ]
+    )
+    assert report.all_valid is False
+    r = report.results[0]
+    assert r.reasons == ["rid_not_found"]
+    assert r.actual_table is None
+    assert r.available_versions is None
+
+
+def test_not_a_dataset_includes_actual_table():
+    ml = _FakeML()
+    ml.add_non_dataset("3JSE", table_name="Image")
+    report = ml.validate_dataset_specs(
+        specs=[
+            DatasetSpec(rid="3JSE", version="0.1.0"),
+        ]
+    )
+    r = report.results[0]
+    assert r.valid is False
+    assert r.reasons == ["not_a_dataset"]
+    assert r.actual_table == "Image"
+
+
+def test_version_not_found_includes_available_versions():
+    ml = _FakeML()
+    ml.add_dataset(
+        "1-DSAA",
+        description="alpha",
+        versions=["0.4.0", "0.3.0", "0.2.0", "0.1.0"],
+    )
+    report = ml.validate_dataset_specs(
+        specs=[
+            DatasetSpec(rid="1-DSAA", version="9.9.9"),
+        ]
+    )
+    r = report.results[0]
+    assert r.valid is False
+    assert r.reasons == ["version_not_found"]
+    # Newest-first.
+    assert r.available_versions == ["0.4.0", "0.3.0", "0.2.0", "0.1.0"]
+
+
+def test_duplicate_specs_validated_independently():
+    ml = _FakeML()
+    ml.add_dataset("1-DSAA", versions=["1.0.0"])
+    report = ml.validate_dataset_specs(
+        specs=[
+            DatasetSpec(rid="1-DSAA", version="1.0.0"),
+            DatasetSpec(rid="1-DSAA", version="1.0.0"),
+        ]
+    )
+    assert report.all_valid is True
+    assert len(report.results) == 2
+    # Both should be valid; the per-RID cache means we only resolve once.
+
+
+def test_dataset_deleted_is_warning_not_failure():
+    ml = _FakeML()
+    ml.add_dataset("1-DSAA", description="zombie", deleted=True, versions=["0.1.0"])
+    report = ml.validate_dataset_specs(
+        specs=[
+            DatasetSpec(rid="1-DSAA", version="0.1.0"),
+        ]
+    )
+    r = report.results[0]
+    assert r.valid is True
+    assert r.warnings == ["dataset_deleted"]
+    assert report.all_valid is True
+
+
+def test_shorthand_string_input_coerced():
+    ml = _FakeML()
+    ml.add_dataset("1-DSAA", versions=["1.0.0"])
+    report = ml.validate_dataset_specs(specs=["1-DSAA@1.0.0"])
+    assert report.all_valid is True
+    assert report.results[0].spec.rid == "1-DSAA"
+    assert str(report.results[0].spec.version) == "1.0.0"
+
+
+def test_dict_input_coerced():
+    ml = _FakeML()
+    ml.add_dataset("1-DSAA", versions=["1.0.0"])
+    report = ml.validate_dataset_specs(specs=[{"rid": "1-DSAA", "version": "1.0.0"}])
+    assert report.all_valid is True
+    assert report.results[0].spec.rid == "1-DSAA"
+
+
+def test_round_trip_serialization():
+    ml = _FakeML()
+    ml.add_dataset("1-DSAA", description="alpha", versions=["1.0.0"])
+    ml.add_dataset("1-DSAB", versions=["0.5.0"])
+    report = ml.validate_dataset_specs(
+        specs=[
+            DatasetSpec(rid="1-DSAA", version="1.0.0"),
+            DatasetSpec(rid="1-DSAB", version="9.9.9"),
+        ]
+    )
+
+    blob = report.model_dump_json()
+    restored = DatasetSpecValidationReport.model_validate_json(blob)
+    assert restored.all_valid == report.all_valid
+    assert len(restored.results) == 2
+    assert restored.results[0].valid is True
+    assert restored.results[1].valid is False
+    assert "version_not_found" in restored.results[1].reasons
+
+
+def test_available_versions_cap_at_20():
+    ml = _FakeML()
+    # 25 versions, all distinct; newest first.
+    versions = [f"0.{n}.0" for n in range(25, 0, -1)]
+    ml.add_dataset("1-DSAA", versions=versions)
+    report = ml.validate_dataset_specs(
+        specs=[
+            DatasetSpec(rid="1-DSAA", version="9.9.9"),
+        ]
+    )
+    r = report.results[0]
+    assert r.valid is False
+    assert r.available_versions is not None
+    assert len(r.available_versions) == 20
+    assert r.available_versions[0] == "0.25.0"
+    # Cap is the 20 newest, so the 21st-newest is the cutoff.
+    assert "0.5.0" not in r.available_versions
+
+
+def test_per_spec_results_carry_input_spec_back():
+    """The result.spec field must echo the coerced input so callers can
+    match results to inputs (especially when the input was a shorthand
+    string)."""
+    ml = _FakeML()
+    ml.add_dataset("1-DSAA", versions=["1.0.0"])
+    report = ml.validate_dataset_specs(specs=["1-DSAA@1.0.0"])
+    assert isinstance(report.results[0], DatasetSpecResult)
+    assert report.results[0].spec.rid == "1-DSAA"
+
+
+@pytest.mark.parametrize(
+    "bad_input",
+    [
+        # Pydantic accepts anything that coerces; bare invalid types fall through
+        # to DatasetSpec.model_validate which raises ValidationError.
+        12345,
+        ["not", "a", "spec"],
+    ],
+)
+def test_uncoercible_input_raises(bad_input):
+    from pydantic import ValidationError
+
+    ml = _FakeML()
+    with pytest.raises((ValidationError, ValueError, TypeError)):
+        ml.validate_dataset_specs(specs=[bad_input])

--- a/tests/dataset/test_validate_execution_configuration_unit.py
+++ b/tests/dataset/test_validate_execution_configuration_unit.py
@@ -1,0 +1,353 @@
+"""Unit tests for ``DerivaML.validate_execution_configuration``.
+
+These tests mock the catalog-touching primitives and exercise the
+composite validator: per-dataset/asset/workflow result fan-out,
+delegation into ``validate_dataset_specs``, cross-spec issue
+detection (duplicate RIDs, version conflicts, role conflicts),
+empty-config edge cases, and round-trip serialization.
+
+Live-catalog smoke tests live in
+``tests/dataset/test_validate_specs_live.py``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+from unittest.mock import MagicMock
+
+from deriva_ml.asset.aux_classes import AssetSpec
+from deriva_ml.core.exceptions import DerivaMLException
+from deriva_ml.core.mixins.dataset import DatasetMixin
+from deriva_ml.dataset.aux_classes import DatasetSpec
+from deriva_ml.dataset.validation import (
+    ExecutionConfigurationValidationReport,
+)
+from deriva_ml.execution.execution_configuration import ExecutionConfiguration
+from deriva_ml.execution.workflow import Workflow
+
+# ---------------------------------------------------------------------------
+# Helpers — shared with test_validate_dataset_spec_unit (kept inline here so
+# the file is self-contained and the per-test setup is obvious).
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _StubColumn:
+    name: str
+
+
+class _StubColumnEq(_StubColumn):
+    def __eq__(self, other: Any) -> tuple[str, Any]:  # type: ignore[override]
+        return (self.name, other)
+
+
+@dataclass
+class _StubTable:
+    name: str
+    columns: list[_StubColumn] = field(default_factory=list)
+
+
+class _StubEntities:
+    def __init__(self, rows: list[dict[str, Any]]):
+        self._rows = rows
+
+    def fetch(self) -> list[dict[str, Any]]:
+        return list(self._rows)
+
+
+class _StubDatapath:
+    def __init__(self, rows: list[dict[str, Any]]):
+        self._rows = rows
+
+    def entities(self) -> _StubEntities:
+        return _StubEntities(self._rows)
+
+
+@dataclass
+class _StubResolved:
+    table: _StubTable
+    datapath: _StubDatapath
+
+
+class _StubVersionPath:
+    def __init__(self, version_rows_by_dataset: dict[str, list[str]]):
+        self._versions = version_rows_by_dataset
+        self._current_filter: str | None = None
+        self.Dataset = _StubColumnEq("Dataset")
+
+    def filter(self, expr: tuple[str, str]) -> "_StubVersionPath":
+        _col, rid = expr
+        self._current_filter = rid
+        return self
+
+    def entities(self) -> _StubEntities:
+        rid = self._current_filter
+        rows = [{"Version": v} for v in self._versions.get(rid, [])]
+        return _StubEntities(rows)
+
+
+class _StubSchema:
+    def __init__(self, version_path: _StubVersionPath):
+        self.tables = {"Dataset_Version": version_path}
+
+
+class _StubPathBuilder:
+    def __init__(self, ml_schema: str, version_path: _StubVersionPath):
+        self.schemas = {ml_schema: _StubSchema(version_path)}
+
+
+class _FakeML(DatasetMixin):
+    """DatasetMixin host for composite-validator unit tests."""
+
+    ml_schema = "deriva-ml"
+
+    def __init__(self) -> None:
+        self._rids: dict[str, tuple[str, dict[str, Any]]] = {}
+        self._versions: dict[str, list[str]] = {}
+        self._asset_table_names: set[str] = set()
+        self.model = MagicMock()
+        self.model.is_asset = lambda table: table.name in self._asset_table_names
+        self._version_path = _StubVersionPath(self._versions)
+        self._pb = _StubPathBuilder(self.ml_schema, self._version_path)
+
+    # -- scripting helpers -------------------------------------------------
+
+    def add_dataset(self, rid: str, description: str | None = None, versions: list[str] | None = None) -> None:
+        self._rids[rid] = (
+            "Dataset",
+            {"Description": description, "Deleted": False, "RID": rid},
+        )
+        self._versions[rid] = list(versions or [])
+
+    def add_asset(self, rid: str, asset_table: str, filename: str = "") -> None:
+        self._rids[rid] = (asset_table, {"Filename": filename, "RID": rid})
+        self._asset_table_names.add(asset_table)
+
+    def add_workflow(self, rid: str, name: str = "") -> None:
+        self._rids[rid] = ("Workflow", {"Name": name, "RID": rid})
+
+    def add_other(self, rid: str, table_name: str) -> None:
+        self._rids[rid] = (table_name, {"RID": rid})
+
+    # -- DatasetMixin protocol --------------------------------------------
+
+    def resolve_rid(self, rid: str) -> _StubResolved:  # type: ignore[override]
+        if rid not in self._rids:
+            raise DerivaMLException(f"Invalid RID {rid}")
+        table_name, row = self._rids[rid]
+        return _StubResolved(
+            table=_StubTable(name=table_name, columns=[_StubColumn("RID")]),
+            datapath=_StubDatapath(rows=[row]),
+        )
+
+    def pathBuilder(self) -> _StubPathBuilder:  # type: ignore[override]
+        return self._pb
+
+
+def _make_workflow(rid: str = "2-WFAA") -> Workflow:
+    """Construct a Workflow we can attach to a config without catalog binding."""
+    return Workflow(
+        name="test wf",
+        url="https://example.org/wf.py",
+        workflow_type="python_script",
+        rid=rid,
+        checksum="abc123",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests.
+# ---------------------------------------------------------------------------
+
+
+def test_all_valid_composite():
+    ml = _FakeML()
+    ml.add_dataset("1-DSAA", description="alpha", versions=["1.0.0"])
+    ml.add_asset("3JSE", asset_table="Image", filename="scan.jpg")
+    ml.add_workflow("2-WFAA", name="trainer")
+
+    config = ExecutionConfiguration(
+        workflow=_make_workflow("2-WFAA"),
+        datasets=[DatasetSpec(rid="1-DSAA", version="1.0.0")],
+        assets=[AssetSpec(rid="3JSE")],
+    )
+    report = ml.validate_execution_configuration(config)
+
+    assert isinstance(report, ExecutionConfigurationValidationReport)
+    assert report.all_valid is True
+    assert report.dataset_results[0].valid is True
+    assert report.asset_results[0].valid is True
+    assert report.asset_results[0].asset_table == "Image"
+    assert report.asset_results[0].filename == "scan.jpg"
+    assert report.workflow_result is not None
+    assert report.workflow_result.valid is True
+    assert report.workflow_result.workflow_name == "trainer"
+    assert report.cross_spec_issues == []
+
+
+def test_dataset_failure_surfaces():
+    ml = _FakeML()
+    config = ExecutionConfiguration(
+        datasets=[DatasetSpec(rid="9-NOPE", version="1.0.0")],
+    )
+    report = ml.validate_execution_configuration(config)
+    assert report.all_valid is False
+    assert report.dataset_results[0].reasons == ["rid_not_found"]
+
+
+def test_asset_failure_surfaces_not_an_asset():
+    ml = _FakeML()
+    ml.add_dataset("1-DSAA", versions=["1.0.0"])  # not an asset
+    config = ExecutionConfiguration(
+        assets=[AssetSpec(rid="1-DSAA")],
+    )
+    report = ml.validate_execution_configuration(config)
+    assert report.all_valid is False
+    asset_r = report.asset_results[0]
+    assert asset_r.valid is False
+    assert asset_r.reasons == ["not_an_asset"]
+    assert asset_r.actual_table == "Dataset"
+
+
+def test_asset_failure_surfaces_rid_not_found():
+    ml = _FakeML()
+    config = ExecutionConfiguration(assets=[AssetSpec(rid="9-NOPE")])
+    report = ml.validate_execution_configuration(config)
+    assert report.all_valid is False
+    assert report.asset_results[0].reasons == ["rid_not_found"]
+
+
+def test_workflow_failure_not_a_workflow():
+    ml = _FakeML()
+    ml.add_dataset("1-DSAA", versions=["1.0.0"])  # treat as if user pointed at a dataset
+    # Build a Workflow whose RID points at the dataset row.
+    config = ExecutionConfiguration(workflow=_make_workflow("1-DSAA"))
+    report = ml.validate_execution_configuration(config)
+    assert report.all_valid is False
+    assert report.workflow_result is not None
+    assert report.workflow_result.reasons == ["not_a_workflow"]
+    assert report.workflow_result.actual_table == "Dataset"
+
+
+def test_workflow_failure_rid_not_found():
+    ml = _FakeML()
+    config = ExecutionConfiguration(workflow=_make_workflow("9-NOPE"))
+    report = ml.validate_execution_configuration(config)
+    assert report.all_valid is False
+    assert report.workflow_result is not None
+    assert report.workflow_result.reasons == ["rid_not_found"]
+
+
+def test_duplicate_dataset_rid_same_version():
+    ml = _FakeML()
+    ml.add_dataset("1-DSAA", versions=["1.0.0"])
+    config = ExecutionConfiguration(
+        datasets=[
+            DatasetSpec(rid="1-DSAA", version="1.0.0"),
+            DatasetSpec(rid="1-DSAA", version="1.0.0"),
+        ],
+    )
+    report = ml.validate_execution_configuration(config)
+    # Per-spec results are still both valid; the cross-spec issue is the flag.
+    assert all(r.valid for r in report.dataset_results)
+    issues = [i for i in report.cross_spec_issues if i.issue == "duplicate_rid"]
+    assert len(issues) == 1
+    assert issues[0].rids == ["1-DSAA"]
+    assert report.all_valid is False
+
+
+def test_version_conflict_same_rid_two_versions():
+    ml = _FakeML()
+    ml.add_dataset("1-DSAA", versions=["1.0.0", "0.5.0"])
+    config = ExecutionConfiguration(
+        datasets=[
+            DatasetSpec(rid="1-DSAA", version="1.0.0"),
+            DatasetSpec(rid="1-DSAA", version="0.5.0"),
+        ],
+    )
+    report = ml.validate_execution_configuration(config)
+    issues = [i for i in report.cross_spec_issues if i.issue == "version_conflict"]
+    assert len(issues) == 1
+    assert issues[0].rids == ["1-DSAA"]
+    assert report.all_valid is False
+
+
+def test_role_conflict_input_and_output():
+    ml = _FakeML()
+    ml.add_asset("3JSE", asset_table="Image", filename="x.jpg")
+    config = ExecutionConfiguration(
+        assets=[
+            AssetSpec(rid="3JSE", asset_role="Input"),
+            AssetSpec(rid="3JSE", asset_role="Output"),
+        ],
+    )
+    report = ml.validate_execution_configuration(config)
+    issues = [i for i in report.cross_spec_issues if i.issue == "role_conflict"]
+    assert len(issues) == 1
+    assert report.all_valid is False
+
+
+def test_empty_datasets_and_assets_no_workflow_is_valid():
+    ml = _FakeML()
+    config = ExecutionConfiguration()
+    report = ml.validate_execution_configuration(config)
+    assert report.all_valid is True
+    assert report.dataset_results == []
+    assert report.asset_results == []
+    assert report.workflow_result is None
+    assert report.cross_spec_issues == []
+
+
+def test_empty_data_with_valid_workflow_is_valid():
+    ml = _FakeML()
+    ml.add_workflow("2-WFAA", name="trainer")
+    config = ExecutionConfiguration(workflow=_make_workflow("2-WFAA"))
+    report = ml.validate_execution_configuration(config)
+    assert report.all_valid is True
+    assert report.workflow_result is not None
+    assert report.workflow_result.workflow_name == "trainer"
+
+
+def test_composite_delegates_to_singular(monkeypatch):
+    """The composite must call validate_dataset_specs for the dataset half so
+    that there is no duplicate logic. We spy on the singular method to confirm."""
+    ml = _FakeML()
+    ml.add_dataset("1-DSAA", versions=["1.0.0"])
+
+    spy_calls: list[list[Any]] = []
+    real_method = ml.validate_dataset_specs
+
+    def spy(specs):
+        spy_calls.append(list(specs))
+        return real_method(specs=specs)
+
+    monkeypatch.setattr(ml, "validate_dataset_specs", spy)
+
+    config = ExecutionConfiguration(
+        datasets=[DatasetSpec(rid="1-DSAA", version="1.0.0")],
+    )
+    ml.validate_execution_configuration(config)
+
+    assert len(spy_calls) == 1
+    assert spy_calls[0][0].rid == "1-DSAA"
+
+
+def test_round_trip_serialization():
+    ml = _FakeML()
+    ml.add_dataset("1-DSAA", versions=["1.0.0"])
+    ml.add_workflow("2-WFAA", name="trainer")
+
+    config = ExecutionConfiguration(
+        workflow=_make_workflow("2-WFAA"),
+        datasets=[DatasetSpec(rid="1-DSAA", version="1.0.0")],
+        assets=[AssetSpec(rid="9-NOPE")],  # forces a failure for content
+    )
+    report = ml.validate_execution_configuration(config)
+
+    blob = report.model_dump_json()
+    restored = ExecutionConfigurationValidationReport.model_validate_json(blob)
+    assert restored.all_valid == report.all_valid
+    assert restored.workflow_result is not None
+    assert restored.workflow_result.workflow_name == "trainer"
+    assert restored.asset_results[0].valid is False

--- a/tests/dataset/test_validate_specs_live.py
+++ b/tests/dataset/test_validate_specs_live.py
@@ -1,0 +1,164 @@
+"""Live-catalog smoke tests for the validation methods.
+
+Builds a small populated catalog and exercises both
+``validate_dataset_specs`` and ``validate_execution_configuration``
+against real catalog state. Gated on ``DERIVA_HOST`` like the other
+live-smoke tests.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from deriva_ml import MLVocab as vc
+from deriva_ml.asset.aux_classes import AssetSpec
+from deriva_ml.dataset.aux_classes import DatasetSpec, DatasetVersion
+from deriva_ml.dataset.validation import (
+    DatasetSpecValidationReport,
+    ExecutionConfigurationValidationReport,
+)
+from deriva_ml.execution.execution_configuration import ExecutionConfiguration
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("DERIVA_HOST"),
+    reason="validate_specs live smoke test requires DERIVA_HOST",
+)
+
+
+def _make_dataset(test_ml) -> tuple[str, str]:
+    """Create a minimal dataset and return (rid, version_str)."""
+    test_ml.add_term(vc.dataset_type, "ValidateTest", description="Validate smoke")
+    test_ml.add_term(vc.workflow_type, "Validate Test", description="Validate smoke")
+
+    wf = test_ml.create_workflow(
+        name="Validate smoke workflow",
+        workflow_type="Validate Test",
+        description="Validate smoke workflow",
+    )
+    exe = test_ml.create_execution(
+        ExecutionConfiguration(workflow=wf, description="validate smoke exe"),
+    )
+    ds = exe.create_dataset(
+        dataset_types="ValidateTest",
+        description="validate smoke dataset",
+        version=DatasetVersion(1, 0, 0),
+    )
+    return ds.dataset_rid, "1.0.0"
+
+
+def test_validate_dataset_specs_live_valid(test_ml):
+    rid, version = _make_dataset(test_ml)
+    report = test_ml.validate_dataset_specs(
+        specs=[
+            DatasetSpec(rid=rid, version=version),
+        ]
+    )
+    assert isinstance(report, DatasetSpecValidationReport)
+    assert report.all_valid is True
+    assert report.results[0].dataset_name == "validate smoke dataset"
+
+
+def test_validate_dataset_specs_live_bad_version_lists_available(test_ml):
+    rid, _ = _make_dataset(test_ml)
+    report = test_ml.validate_dataset_specs(
+        specs=[
+            DatasetSpec(rid=rid, version="9.9.9"),
+        ]
+    )
+    assert report.all_valid is False
+    r = report.results[0]
+    assert r.reasons == ["version_not_found"]
+    assert r.available_versions is not None
+    assert "1.0.0" in r.available_versions
+
+
+def test_validate_dataset_specs_live_unknown_rid(test_ml):
+    report = test_ml.validate_dataset_specs(
+        specs=[
+            DatasetSpec(rid="9-NOPE", version="1.0.0"),
+        ]
+    )
+    assert report.all_valid is False
+    assert "rid_not_found" in report.results[0].reasons
+
+
+def test_validate_execution_configuration_live_full(test_ml):
+    rid, version = _make_dataset(test_ml)
+    wf = test_ml.create_workflow(
+        name="Validate composite workflow",
+        workflow_type="Validate Test",
+        description="composite smoke",
+    )
+    config = ExecutionConfiguration(
+        workflow=wf,
+        datasets=[DatasetSpec(rid=rid, version=version)],
+    )
+    report = test_ml.validate_execution_configuration(config)
+    assert isinstance(report, ExecutionConfigurationValidationReport)
+    assert report.all_valid is True
+    assert report.workflow_result is not None
+    assert report.workflow_result.valid is True
+
+
+def test_validate_execution_configuration_live_workflow_rid_is_dataset(test_ml):
+    """Pointing the workflow at a dataset RID surfaces as not_a_workflow."""
+    rid, version = _make_dataset(test_ml)
+    wf = test_ml.create_workflow(
+        name="Validate composite workflow",
+        workflow_type="Validate Test",
+        description="composite smoke",
+    )
+    # Mutate the wf object so its rid points at the dataset (no catalog
+    # round-trip — composite validator only reads config.workflow.rid).
+    wf_swapped = wf.model_copy(update={"rid": rid})
+    config = ExecutionConfiguration(workflow=wf_swapped)
+    report = test_ml.validate_execution_configuration(config)
+    assert report.all_valid is False
+    assert report.workflow_result is not None
+    assert report.workflow_result.reasons == ["not_a_workflow"]
+    assert report.workflow_result.actual_table == "Dataset"
+
+
+def test_validate_execution_configuration_live_cross_spec_duplicate(test_ml):
+    rid, version = _make_dataset(test_ml)
+    wf = test_ml.create_workflow(
+        name="Validate composite workflow",
+        workflow_type="Validate Test",
+        description="composite smoke",
+    )
+    config = ExecutionConfiguration(
+        workflow=wf,
+        datasets=[
+            DatasetSpec(rid=rid, version=version),
+            DatasetSpec(rid=rid, version=version),
+        ],
+    )
+    report = test_ml.validate_execution_configuration(config)
+    assert any(i.issue == "duplicate_rid" for i in report.cross_spec_issues)
+    assert report.all_valid is False
+
+
+def test_validate_execution_configuration_live_assets(test_ml):
+    """If the catalog has any populated asset, a valid AssetSpec passes
+    and an invalid RID surfaces as rid_not_found.
+
+    Skipped when no asset table can be enumerated."""
+    # Use the workflow RID created above as the "wrong-shape" target so we
+    # always have a known non-asset RID.
+    wf = test_ml.create_workflow(
+        name="Validate asset workflow",
+        workflow_type="Validate Test",
+        description="asset smoke",
+    )
+    config = ExecutionConfiguration(
+        workflow=wf,
+        assets=[AssetSpec(rid=wf.rid)],
+    )
+    report = test_ml.validate_execution_configuration(config)
+    assert report.all_valid is False
+    asset_r = report.asset_results[0]
+    assert asset_r.valid is False
+    assert "not_an_asset" in asset_r.reasons
+    assert asset_r.actual_table == "Workflow"


### PR DESCRIPTION
## Summary

Two metadata-only pre-flight validators on `DerivaML`:

- **`validate_dataset_specs(specs)`** — singular dataset validator.
  Per-spec checks for `rid_not_found`, `not_a_dataset`, and
  `version_not_found` (with `available_versions` populated on the
  response when the version is wrong — usually a typo). Replaces the
  per-RID `lookup_dataset` + `dataset_history` cross-check loop a user
  would otherwise write while iterating on `src/configs/datasets.py`.

- **`validate_execution_configuration(config)`** — composite. Walks
  the contained `datasets` and `assets` lists, validates the workflow,
  reports per-spec results plus cross-spec issues (`duplicate_rid`,
  `version_conflict`, `role_conflict`). The composite delegates the
  dataset half to the singular method — no duplicate logic.

Both methods are placed on `DatasetMixin` in
`src/deriva_ml/core/mixins/dataset.py`. Pydantic result models live in
`src/deriva_ml/dataset/validation.py`, mirroring the
`lineage.py`/`lookup_lineage` layout. Reasons are `Literal` types for
caller type-checking; reports round-trip cleanly through
`model_dump_json`/`model_validate_json` so the deriva-ml-mcp Round 6b
wrappers can serialize them over the MCP wire.

## Why both methods

- **Singular** answers the *iterating-on-datasets.py* use case: the
  user typed three `(RID, version)` pairs into a config and wants to
  confirm they resolve before saving. Per-spec results with
  `available_versions` on failure let the user fix everything in one
  pass instead of bisecting via `lookup_dataset`.
- **Composite** answers the *pre-flight-without-dry-run-cost* use
  case: the user is about to run `deriva-ml-run` and wants to confirm
  the whole `ExecutionConfiguration` resolves cleanly. ``dry_run=True``
  exists already, but it pays the bag-download cost
  (minutes-to-hours, several GB-to-TB of bandwidth) to validate. The
  composite validator is the cheap metadata-only pre-flight that fills
  the gap. See [ADR-0002](docs/adr/0002-validate-not-dryrun-pre-flight.md)
  for the full rationale on keeping the two surfaces distinct.

## Design

- Design addendum: `docs/superpowers/plans/2026-05-03-validate-specs-design.md`
- ADR: `docs/adr/0002-validate-not-dryrun-pre-flight.md`

Key decisions resolved during the grilling pass:
- Method placement on `DatasetMixin`; asset/workflow checks are
  private helpers inside the same file.
- Singular accepts `list[DatasetSpec | str | dict]` via Pydantic
  coercion, matching `ExecutionConfiguration.assets` ergonomics.
- Failure-reason vocabulary uses `Literal` types; `dataset_deleted`
  is a warning, not a failure.
- `LineageResult`-style nested Pydantic models with
  `extra="forbid"` and a top-level `all_valid` convenience flag.
- Per-spec validation with per-RID caching (so duplicate-RID inputs
  cost one round-trip each, not N), with batched lookup as a future
  enhancement.

## Test plan

- [x] `tests/dataset/test_validate_dataset_spec_unit.py` — 15 unit
  tests, mocked catalog
- [x] `tests/dataset/test_validate_execution_configuration_unit.py` —
  13 unit tests, mocked catalog
- [x] `tests/dataset/test_validate_specs_live.py` — 7 integration
  tests, gated on `DERIVA_HOST` (live smoke)
- [x] Doctest collection passes for both new methods and the
  validation models module
- [x] `ruff check` + `ruff format` clean on all changed files
- [x] MRO check: `DerivaML` instances expose both methods

## Downstream coordination

After merge + `bump-version minor`, the deriva-ml-skills Round 6b
session will:
- Add `deriva_ml_validate_dataset_specs` MCP tool wrapper
- Add `deriva_ml_validate_execution_configuration` MCP tool wrapper
- Add `deriva://catalog/{h}/{c}/ml/dataset/{rid}/spec` resource
- Update the tier-2 `write-hydra-config` skill's "Validating Configs
  Against the Catalog" section

Out of scope for this PR.