### PR TITLE
fix(execution): __del__ no longer re-aborts terminal executions

### DIFF
--- a/src/deriva_ml/core/base.py
+++ b/src/deriva_ml/core/base.py
@@ -381,17 +381,30 @@ class DerivaML(
     def __del__(self) -> None:
         """Cleanup method to handle incomplete executions.
 
-        Best-effort abort on DerivaML shutdown. The previous implementation
-        used the legacy `Status` enum; the new `ExecutionStatus` lifecycle
-        separates Stopped/Uploaded/Aborted/Failed. Here we only attempt to
-        abort if the execution hasn't already reached a terminal state —
-        InvalidTransitionError from the state machine covers the rest.
+        Best-effort abort on DerivaML shutdown — only for executions that
+        died mid-flight (i.e., still in ``Created`` or ``Running``). Any
+        post-Running status (``Stopped``, ``Failed``, ``Pending_Upload``,
+        ``Uploaded``, ``Aborted``) is treated as terminal here: the user
+        has either committed cleanly via the context manager or
+        explicitly transitioned the execution, and a forced abort would
+        either be a no-op or a wrongful state change.
+
+        Forcing a transition during ``__del__`` is also unsafe at object-
+        teardown time: Python's GC ordering means the underlying
+        ``ErmrestCatalog`` HTTP session may already be finalized, in
+        which case the catalog PUT would crash with ``'NoneType' object
+        has no attribute 'get'`` (the catalog's ``_session`` reads as
+        ``None``). Limiting the abort to non-terminal states avoids the
+        common case where ``__exit__`` already moved the execution to
+        ``Stopped`` and ``__del__`` would otherwise re-transition to
+        ``Aborted`` against a dead session.
         """
         # Inline import to avoid a circular (core.base ↔ execution.state_store) import.
         try:
             from deriva_ml.execution.state_store import ExecutionStatus
 
-            if self._execution and self._execution.status is not ExecutionStatus.Aborted:
+            non_terminal = {ExecutionStatus.Created, ExecutionStatus.Running}
+            if self._execution and self._execution.status in non_terminal:
                 self._execution.update_status(ExecutionStatus.Aborted, error="Execution Aborted")
         except Exception:
             # Any failure here (catalog unreachable, InvalidTransition, etc.)

--- a/tests/core/test_del_no_abort_terminal.py
+++ b/tests/core/test_del_no_abort_terminal.py
@@ -1,0 +1,89 @@
+"""Tests for DerivaML.__del__'s status-check logic.
+
+The finalizer must only force-abort executions that died mid-flight
+(``Created`` / ``Running``). For any post-Running status — ``Stopped``,
+``Failed``, ``Pending_Upload``, ``Uploaded``, ``Aborted`` — it must do
+nothing. Otherwise it re-transitions a cleanly-stopped execution to
+``Aborted``, against an HTTP session that may already be torn down by
+GC ordering, producing the ``'NoneType' object has no attribute 'get'``
+crash that ``__del__`` then silently swallows but ``state_machine``
+logs as ``catalog sync FAILED``.
+
+These tests call ``__del__`` directly via the bound method rather than
+relying on GC, since CPython's GC ordering is undefined.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from deriva_ml.core.base import DerivaML
+from deriva_ml.execution.state_store import ExecutionStatus
+
+
+@pytest.mark.parametrize(
+    "terminal_status",
+    [
+        ExecutionStatus.Stopped,
+        ExecutionStatus.Failed,
+        ExecutionStatus.Pending_Upload,
+        ExecutionStatus.Uploaded,
+        ExecutionStatus.Aborted,
+    ],
+)
+def test_del_does_not_abort_post_running_states(terminal_status):
+    """__del__ must be a no-op for any state past Running.
+
+    Re-transitioning a Stopped/Uploaded/etc. execution to Aborted is a
+    state-machine violation and historically (before this fix) crashed
+    against a torn-down catalog session — the symptom users saw as a
+    spurious "catalog sync FAILED" warning on every clean exit.
+    """
+    fake_exe = SimpleNamespace(status=terminal_status, update_status=MagicMock())
+    dml = SimpleNamespace(_execution=fake_exe)
+
+    DerivaML.__del__(dml)
+
+    fake_exe.update_status.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "non_terminal_status",
+    [ExecutionStatus.Created, ExecutionStatus.Running],
+)
+def test_del_aborts_non_terminal_states(non_terminal_status):
+    """__del__ must abort executions that died mid-flight.
+
+    The original cleanup intent — catching abandoned ``with``-block
+    exits — still applies for ``Created``/``Running`` so the audit
+    trail reflects "this execution was killed, not committed."
+    """
+    fake_exe = SimpleNamespace(status=non_terminal_status, update_status=MagicMock())
+    dml = SimpleNamespace(_execution=fake_exe)
+
+    DerivaML.__del__(dml)
+
+    fake_exe.update_status.assert_called_once_with(ExecutionStatus.Aborted, error="Execution Aborted")
+
+
+def test_del_swallows_update_status_errors():
+    """__del__ must never raise — finalizers that raise crash the interpreter."""
+    fake_exe = SimpleNamespace(
+        status=ExecutionStatus.Running,
+        update_status=MagicMock(side_effect=RuntimeError("boom")),
+    )
+    dml = SimpleNamespace(_execution=fake_exe)
+
+    # Should not raise.
+    DerivaML.__del__(dml)
+
+
+def test_del_no_execution_is_noop():
+    """__del__ does nothing when no execution is attached (e.g. catalog-only use)."""
+    dml = SimpleNamespace(_execution=None)
+
+    # Should not raise.
+    DerivaML.__del__(dml)


### PR DESCRIPTION
## Summary

- `DerivaML.__del__` was force-transitioning any execution that hadn't already reached `Aborted` to `Aborted` — including cleanly `Stopped` executions. This produced a spurious `catalog sync FAILED ('NoneType' object has no attribute 'get')` warning on every clean `with ml.create_execution(...): pass` exit and left the catalog row's `Status` column as `None`.
- Root cause is two-fold: (1) re-transitioning `Stopped` → `Aborted` is a wrongful state change, and (2) `__del__` runs at GC time when the underlying `ErmrestCatalog._session` may already be torn down, so the catalog PUT crashes inside `getCatalogModel`.
- Fix narrows the auto-abort to actual mid-flight states (`Created`, `Running`). Anything post-Running is left alone.

## Repro (before fix)

```python
from deriva_ml import DerivaML
from deriva_ml.execution import ExecutionConfiguration

ml = DerivaML(hostname=..., catalog_id=..., project_name=...)
wf = ml.create_workflow(name="test", workflow_type="...", description="x")
with ml.create_execution(ExecutionConfiguration(workflow=wf)):
    pass
# WARNING: execution <RID>: catalog sync FAILED ('NoneType' object has no attribute 'get');
# body=[{'RID': '<RID>', 'Status': 'Aborted', 'Status_Detail': 'Execution Aborted'}]; ...
```

## Test plan

- [x] New unit tests in `tests/core/test_del_no_abort_terminal.py` (9 cases) — all pass
- [x] `tests/execution/test_state_machine.py`, `test_update_status.py`, `test_state_store.py`, `test_status_migration.py` — 65/65 pass with `DERIVA_ML_ALLOW_DIRTY=true`
- [x] Broader sweep `tests/execution/ tests/core/` — 476 pass; the 5 errors + 1 failure are pre-existing on `main` (verified by stashing the change and re-running)
- [x] End-to-end: dry-run of `deriva-ml-sandbox/src/scripts/load_cifar10.py` against a fresh localhost catalog — warning no longer appears (will re-verify after this PR lands)

🤖 Generated with [Claude Code](https://claude.com/claude-code)