### PR TITLE
docs(dataset): ADRs and CONTEXT for dev-versioning design (issue #79)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,133 @@
+# DerivaML Domain Context
+
+DerivaML is a reproducible-ML layer over Deriva catalogs. This file
+captures the vocabulary specific to that layer — terms whose meaning
+is project-specific and not derivable from the code or from generic
+Deriva concepts.
+
+## Language
+
+### Versioning
+
+**Released version**:
+A `Dataset_Version` row with a stamped catalog `Snapshot`, an
+immutable PEP 440 label of the form `MAJOR.MINOR.PATCH`. The
+canonical reference for an execution that consumed the dataset.
+_Avoid_: "real version", "pinned version", "frozen version".
+
+**Dev version**:
+A `Dataset_Version` row with `Snapshot=NULL` and a PEP 440 label of
+the form `<last_release>.post1.devN`. Represents drift since the
+last release; never used as the recorded version of an execution's
+consumed dataset. Mutable: `.devN` advances and `Description` is
+replaced on each mutation. A dev label resolves *only when it
+matches the dataset's current dev row's `Version`* — the row is the
+same row whose label keeps changing, so `.dev2` is addressable
+only at the moment it is current. Stale or post-release dev labels
+error.
+_Avoid_: "pre-release version", "draft version", "dirty version" (as
+a label — "dirty" is a state of the dataset, not a kind of version).
+
+**Dev period**:
+The span from a dataset's first mutation after a release to the next
+`release()` call. During a dev period, the dataset has exactly one
+dev row; it is updated, not duplicated, on each mutation.
+
+**Drift**:
+A change to any catalog row reachable from a dataset's `Dataset` row
+via the FK paths that `CatalogGraph` enumerates for export. Drift
+happens whether or not the dataset row itself was touched — adding a
+feature value to a member is drift.
+_Avoid_: "modification", "update" (too generic).
+
+**Dirty**:
+A property of a dataset, not of a version: "this dataset has drift
+since its last released version." Detected via
+`Dataset.is_dirty()` by walking `CatalogGraph`'s FK paths with an
+`RMT > T_release` filter. The drift walk *is* the bag walk plus an
+`RMT` filter.
+_Avoid_: "modified", "stale", "out-of-date".
+
+**Mark dev**:
+The user action `Dataset.mark_dev(description)` that flips a
+released dataset to a dev version. Used when drift was caused by an
+operation that didn't auto-flip (e.g., a feature value added by a
+separate execution, or a deletion not visible to `is_dirty`).
+
+**Release**:
+The user action `Dataset.release(component, description)` that
+promotes a dev row to a released row in place: `Version` is rewritten
+to the new released label, `Snapshot` is stamped, `Description` is
+replaced with release notes. The only operation that produces a
+released version.
+_Avoid_: "publish", "tag", "freeze" (overloaded with other Deriva
+concepts).
+
+## Relationships
+
+- A **Dataset** has at most one **Dev version** at any time, and any
+  number of **Released versions**.
+- A **Mutation** during a **Dev period** advances the dev row's
+  `.devN` counter; it never inserts a new row.
+- A **Release** transforms the dev row into a released row in place;
+  the dev period ends.
+- An **Execution** consumes **Released versions** only. Recording a
+  dev version on an execution's input is a category error.
+- A **Cite URL** for a **Released version** is snapshot-pinned. A
+  **Cite URL** for a **Dev version** carries no `@snaptime` — it
+  resolves to live state.
+
+## Example dialogue
+
+> **Dev:** When a feature value is added to an image that's a member
+> of dataset D, does D's version change automatically?
+>
+> **Project lead:** No. D is now *dirty* — `D.is_dirty()` would
+> return true — but its `current_version` is still the last
+> released version. The user has to call `D.mark_dev("...")` to flip
+> D to a dev version. We considered automatic detection-and-flip,
+> but the user owns the decision: not every drift warrants release
+> attention.
+
+> **Dev:** If I run `D.add_dataset_members([...])` on a dataset at
+> `0.4.0`, what's `current_version` after?
+>
+> **Project lead:** `0.4.0.post1.dev1`. The mutation auto-flipped D
+> to a dev version. Run `add_dataset_members` again and you'll get
+> `0.4.0.post1.dev2`. Call `D.release(VersionPart.minor, "...")` to
+> promote to `0.5.0`.
+
+> **Dev:** The dev label says `post1.dev3` after three mutations.
+> Why not just `dev3`?
+>
+> **Project lead:** PEP 440 requires the `.post1` segment to make
+> the label sort *after* `0.4.0`. Without it, `0.4.0.dev3` would
+> sort *before* `0.4.0`, which is wrong — dev state is post-release,
+> not pre-release. We borrowed the convention from setuptools-scm,
+> which produces the same form between tagged releases.
+
+> **Dev:** I noted the version was `0.4.0.post1.dev2` yesterday.
+> Can I download the dataset at that exact label today?
+>
+> **Project lead:** Only if today's dev row still says `.dev2`.
+> If anything mutated the dataset overnight, the dev row's
+> `Version` is now `.dev3` (or later), and `.dev2` no longer
+> resolves — the system errors out. The rule is: a dev label
+> resolves to live state if and only if it matches the dataset's
+> current dev row. Want a stable reference that survives further
+> mutations? Call `release()` to cut a real released version
+> (snapshot-pinned). Dev labels are notational, not citational.
+
+## Flagged ambiguities
+
+- **"Version"** was used to mean both the `Version` *column* on a
+  `Dataset_Version` row (a string) and the `DatasetVersion`
+  *object* (a parsed PEP 440 type). Resolved: the column is
+  `Version` (text); the object is `DatasetVersion`. The label
+  inside either is a *PEP 440 version*, never "a semver".
+- **"Snapshot"** is a Deriva concept (catalog snapshot ID,
+  timestamp-keyed) but appears in DerivaML in two places: the
+  `Dataset_Version.Snapshot` column (nullable; populated only on
+  released rows) and the catalog-cloning machinery
+  (`_version_snapshot_catalog`). Same concept; the dev-versioning
+  work makes the *nullability* on `Dataset_Version` load-bearing.

--- a/docs/adr/0003-dataset-dev-versioning-model.md
+++ b/docs/adr/0003-dataset-dev-versioning-model.md
@@ -1,0 +1,338 @@
+# ADR-0003: Dataset dev versioning — every mutation lands on dev, release is the only path to a released version
+
+Date: 2026-05-09
+Status: Accepted
+
+## Context
+
+DerivaML datasets carry a semantic version (`current_version`) that
+points at a row in `Dataset_Version`. Today, every member-mutation
+operation (`add_dataset_members`, `delete_dataset_members`) auto-bumps
+to a new released `Dataset_Version` row with a stamped catalog
+`Snapshot`. Three problems with that model:
+
+1. **No representation of "modified since last release but not yet
+   re-released."** Every mutation is its own release, so the dataset
+   is always pointing at a frozen snapshot — there's no notational
+   space for "the dataset has drifted, but I haven't decided what kind
+   of release that warrants."
+2. **No way to record indirect drift.** When a feature value is added
+   to a member of a dataset, the dataset's `Dataset` row and member
+   list are unchanged, but the bag's content has changed. Today's
+   model has nowhere to put that fact.
+3. **`Dataset.cite()` cannot distinguish frozen from live state.** A
+   citation URL for "the current version" can only ever be a
+   snapshot-pinned URL, even when the catalog has drifted underneath.
+
+The shape of the fix: introduce a *dev* version state, separate from
+released versions. The hard design questions are *which mutations
+land on dev versus release*, *how dev rows are stored*, and *what
+happens at release time*.
+
+## Decision
+
+**Every mutation lands on the dev version. Release is the only
+operation that produces a released version.**
+
+Concretely:
+
+- A dataset's `current_version` is either a *released* PEP 440
+  version (`0.4.0`) pinning a catalog `Snapshot`, or a *dev* PEP 440
+  version (`0.4.0.post1.devN`) with `Snapshot=NULL`.
+- `add_dataset_members`, `delete_dataset_members`, `mark_dev`, and
+  any future drift-recording operation flip the dataset to a dev
+  version. They never produce a released version.
+- `release(bump, description, execution=None)` is the only
+  operation that produces a released version. It promotes the dev
+  row in place by setting `Version` to the released label, stamping
+  `Snapshot`, replacing `Description` with release notes, and
+  overwriting the dev row's `Execution` link with the supplied
+  `execution` (or `NULL` if none). The released row's `Execution`
+  link records "the execution that called `release()`", not "the
+  most recent mutator" — mutator authorship during the dev period
+  is recoverable from the audit trail (`RMT`, per-feature-value
+  provenance) and doesn't need the version row to carry it.
+- `release()` raises `DerivaMLValidationError` when called on a
+  dataset with no dev row. Users wanting a no-op release call
+  `mark_dev` first to declare a dev period, then `release` to
+  promote it. The error message points at this resolution path.
+- Dev rows are *lazy*: a dev row exists only while the dataset is
+  in dev state. Releases do not preemptively create the next dev row.
+- Dev rows are *mutable*: one row per (dataset, dev period). The
+  `.devN` counter advances by `UPDATE`, not by `INSERT`. The
+  `Description` column is **replaced** on each mutation with the
+  most recently supplied description (not appended). Prior values
+  are recoverable from the catalog's audit log if needed.
+- **A dev label resolves if and only if it matches the dataset's
+  current dev row's `Version`.** The dev row is mutable, so
+  `Version="0.4.0.post1.dev2"` is observable only at the moment
+  that's its current value; afterward, the same row's `Version`
+  says `.dev3`, `.dev4`, etc. The rule is "dev labels resolve to
+  the live present, and only when they describe it accurately" —
+  not "dev labels never resolve". As a corollary: methods that
+  produce a dev label (e.g., `mark_dev`) **return `None`, not
+  `DatasetVersion`** — a returned dev label can't be passed to
+  any version-accepting API later (the next mutation makes it
+  unaddressable), so returning it would invite caller mistakes.
+  Callers who want to display the new label read
+  `current_version` after the call. `release()`, by contrast,
+  returns `DatasetVersion` because a released label *is*
+  addressable across time.
+  APIs that accept a `version=` argument:
+   - Treat `version=None` (or omitted) as "current version" —
+     whichever the dataset has at request time, dev or released.
+   - Accept any released label as today (snapshot-pinned).
+   - Accept the current dev label (matches the dev row's current
+     `Version`) and resolve it to the live catalog (no
+     `@snaptime`).
+   - Reject a dev label that does **not** match the current dev
+     row's `Version` — raise a clear error: dev versions are
+     mutable and historical or post-release `.devN` values are
+     not addressable.
+- The `.devN` counter is a generation number, not a handle to
+  historical state. Its purpose is notational change-detection —
+  two reads of `current_version` at different times can be told
+  apart by their `.devN`. It is not a stable identifier across
+  time.
+- Bag downloads of the current dev version use live catalog
+  state with no `@snaptime` pin. Two downloads of the same dev
+  label may differ if the catalog drifted between them. The
+  cite-URL form follows the same rule (no `@snaptime` for dev
+  versions).
+- The `.devN` counter advances **per call** that actually changes
+  at least one row — `add_dataset_members`, `delete_dataset_members`,
+  `mark_dev`, or any future drift-recording operation. A call that
+  no-ops (e.g., `add_dataset_members([])`) does not advance the
+  counter and does not create a dev row. The first effective
+  mutation after a release creates the dev row at `.dev1`; there
+  is no `.dev0`. Per-call granularity matches setuptools-scm's
+  `.devN` semantics — one commit equals one increment regardless
+  of how many files it touched.
+- `create_dataset` initializes a new dataset at `0.1.0` released
+  (no dev row). The "every mutation lands on dev" rule applies after
+  creation, where it's load-bearing — at creation time there's no
+  drift to record.
+- **A dev version must never appear as the recorded version of an
+  `Execution`'s consumed dataset.** Dev versions are notational, not
+  citational. Executions consume released versions; live-state
+  consumption is recorded as live, not as a moving dev label.
+
+There is **no schema migration**.
+`Dataset_Version.Snapshot` is already nullable in the existing
+schema (verified in `create_schema.py` and `validation.py`); the
+dev-versioning work just makes that nullability load-bearing
+instead of incidental. No DDL change. No data migration (no dev
+rows exist yet, so nothing to backfill). The relevant code change
+in `create_schema.py` is to update the `Snapshot` column's comment
+to reflect its new contract — `NULL` means "live state, dev row" —
+and to update the schema-validator's expected-columns map
+(`validation.py`) where any expectations need sharpening.
+
+## Considered Options
+
+### Option B (rejected): Computed dev versions, no persistence
+
+`Dataset_Version` would be unchanged. `current_version` would return
+a synthetic dev label after every released bump. **Rejected**
+because there'd be nothing to attach a description, an execution
+link, or accumulated drift information to. The "notational clarity"
+that motivated the work would be lost — the version label would
+exist in name only.
+
+### Option C (rejected): Explicit dev-mode entry
+
+Member-mutations would keep auto-bumping to a real release as today;
+dev versions would only be reached via an explicit `start_dev()`
+call. **Rejected** because mixed semantics (mutations bump to
+release, but feature drift bumps to dev) are impossible to remember,
+and the `start_dev`/`end_dev` API surface is the same shape as
+`mark_dev` once we already need that — the explicit mode entry
+collapses into something we already have.
+
+### Option A.b/A.c (rejected): Insert new released row at release;
+delete or archive the dev row
+
+`release()` would `INSERT` a new released `Dataset_Version` row and
+either delete the dev row or keep it as a "superseded" record.
+**Rejected** because dev rows are already established as mutable
+(advancing `.devN` is a row update). One more update at release —
+to set `Version` to released and stamp `Snapshot` — is consistent
+with that pattern. Insert-and-delete tells the same story with
+extra steps; archive-superseded is the over-engineering the
+notational-clarity goal was supposed to avoid.
+
+## Consequences
+
+- `increment_dataset_version` is renamed to `release(bump,
+  description, execution=None)` and moves to `Dataset` as an
+  instance method. The argument formerly known as `component` is
+  renamed to `bump` to match the workspace's `bump-version` CLI
+  vocabulary. The `execution` argument changes type from `RID |
+  None` to `Execution | None` to match the rest of the new API
+  surface (typed objects, not bare RIDs). This is a breaking
+  change for callers of the previous public API and belongs in a
+  2.0 release. No deprecated alias is provided — CLAUDE.md's "no
+  backwards-compat shims" rule applies.
+- A new `Dataset.is_dirty()` / `Dataset.release_diff()` /
+  `Dataset.compare_versions(v_a, v_b)` trio detects catalog drift
+  by walking the same FK paths used to generate the dataset bag
+  (via `CatalogGraph`), filtering by an `RMT` time predicate. The
+  drift walk *is* the bag walk plus an `RMT` filter. The three
+  methods all flow through one internal
+  `_diff_between(t_lower, t_upper)` helper; they differ only in
+  what they pass to it:
+   - `is_dirty()` — fast `bool` predicate, short-circuits on first
+     non-zero count. Calls `_diff_between(t_last_release, None)`
+     where `None` means "live state, no upper bound."
+   - `release_diff()` — per-table change counts. **Implemented as
+     a thin wrapper around** `compare_versions(self.last_released_version,
+     self.current_version)`. When the dataset is in dev,
+     `current_version` is the dev label, which resolves to live
+     state. When the dataset is at its last release with no
+     drift, both endpoints coincide and the result is `{}`. This
+     is the right answer in both cases.
+   - `compare_versions(v_a, v_b)` — per-table change counts
+     between any two endpoints. Each argument may independently
+     be a released label (resolves to that snapshot's timestamp)
+     or the current dev label (resolves to live state). Stale or
+     post-release dev labels error per the addressability rule.
+     The predicate is `min(t_a, t_b) < RMT <= max(t_a, t_b)`;
+     order is symmetric for the result set.
+
+  All three live on `Dataset` only, not on `DatasetLike` — bags
+  can never be dirty.
+- Deletions of catalog rows referenced by a dataset are **not**
+  detected by any of these methods (a deleted row is invisible to
+  the bag walk too). Users who delete content rows must call
+  `mark_dev` manually. Closing this gap would require querying
+  the snapshots' RID sets directly and computing set differences
+  — a separate, deferred operation with a different cost profile.
+- Cite-URL routing falls out: released versions get
+  snapshot-pinned URLs; dev versions get no-snapshot URLs. The
+  check is the PEP 440 `is_devrelease` property — see ADR-0004 for
+  why we use PEP 440.
+
+## Read-side surface
+
+`dataset_history()` and `current_version` are unchanged in shape but
+gain new behaviors implied by dev rows being first-class
+`Dataset_Version` entries:
+
+- `dataset_history()` returns **all** `Dataset_Version` rows for
+  the dataset, dev or released, with no filtering. Callers who want
+  released-only filter by the PEP 440 typed property:
+  `[h for h in ds.dataset_history() if not
+  h.dataset_version.is_devrelease]`. Hiding the filter inside the
+  method would make the API disagree with the catalog; we don't.
+- `dataset_history()` results are **sorted by `dataset_version`
+  ascending**. Reads forward in time; `[0.1.0, 0.2.0, ...,
+  0.4.0.post1.dev3]`. Today's order is whatever the catalog
+  returns — that's a fragile contract and the change is net
+  positive.
+- `current_version` keeps using `max(history)`. Under PEP 440
+  ordering (ADR-0004), the dev version sorts after the last
+  released version, so `max` correctly returns the dev version
+  when there is one.
+- `current_version`'s defensive fallback to `DatasetVersion(0, 1,
+  0)` for empty history is **removed**. `create_dataset` always
+  inserts a version row, so empty history is a catalog
+  inconsistency — raise rather than silently invent a version.
+  This matches CLAUDE.md's "no defensive code for impossible
+  cases" rule.
+- No new read methods. No `current_dev_version()`, no
+  `released_history()` filter helper. Dev rows are not
+  second-class; they're a different state of the same row type.
+- Display methods (`to_markdown`, etc.) render PEP 440 version
+  strings literally. `"0.4.0.post1.dev3"` is what the version
+  *is*; introducing a separate display form would require keeping
+  it in sync with the canonical form.
+
+## Concurrency model
+
+`release()` and dev-row mutations both modify the same row (the
+dev row). Concurrent writers are reconciled at the database level
+via ERMrest's row-level conditional updates, not by application
+locking:
+
+- Each writer reads the dev row's `RMT` (row-modified time) before
+  acting.
+- Each writer's `UPDATE` carries `WHERE RID=<dev_row_rid> AND
+  RMT=<observed>`. If a competing writer landed first, the
+  predicate matches zero rows; the update is a no-op and the
+  caller raises a clear "concurrent modification" error pointing
+  at re-reading the dataset.
+- The framework does **not** auto-retry. A concurrent release
+  between read and write may change the *meaning* of the caller's
+  operation (they thought they were mutating the dev period after
+  `0.4.0`; the dataset has since been released to `0.5.0` and any
+  new mutation would land on a fresh dev period after that). The
+  caller decides whether the new state is still what they want.
+- A mutation that arrives on a *just-released* dataset is **not** a
+  conflict — it's the normal lazy-dev-row case. The mutation
+  observes a released row, creates a new dev row at
+  `<just_released>.post1.dev1`, and proceeds.
+
+The key reason for using ERMrest's row-level concurrency rather
+than an application-level `Status` column or a `Dataset` row
+generation counter: the database already solves this; introducing
+a parallel locking scheme adds schema and bug surface for a corner
+that the conditional-update primitive handles cleanly.
+
+## Migration impact
+
+This work is a 2.0 breaking change. There is no DDL change (the
+schema's `Snapshot` column is already nullable), but the
+*semantics* of several existing public methods change. The
+behavior-change inventory:
+
+| Existing call | Today | New |
+| --- | --- | --- |
+| `add_dataset_members` / `delete_dataset_members` | Bumps to a new released version | Lands on a dev version (creates `.dev1` if needed, advances `.devN` if existing) |
+| `increment_dataset_version(component, description, execution_rid=None)` | Public mixin method on `DerivaML`, creates a released row | Renamed to `Dataset.release(bump, description, execution=None)`. Instance method on `Dataset`. Errors if no dev row. `execution_rid: RID` → `execution: Execution`. |
+| `Dataset.current_version` | Returns latest released | Returns dev when present, else latest released |
+| `Dataset.dataset_history()` | Released rows in unspecified order | All rows (dev + released) sorted ascending |
+
+Downstream callers must:
+
+1. **Find every call to `increment_dataset_version`** and rewrite
+   to `Dataset.release()`. Mechanical rename plus signature
+   update.
+2. **Audit any logic that assumes "the version after a mutation
+   is the released version"** — that's no longer true. To produce
+   a released version, follow the mutation with an explicit
+   `release()` call.
+3. **Audit any `find_datasets`/`dataset_history` consumers** that
+   filter on "released versions" — they'll need to add an explicit
+   `is_devrelease` filter rather than relying on every version
+   being released.
+
+Out-of-repo blast radius (handled in dependent PRs, not this ADR):
+`deriva-ml-mcp`'s tool that exposes `increment_dataset_version`,
+the model-template workflows, and any user notebooks. The 2.0
+changelog and migration guide are written at PR-ready time and
+point users at this ADR.
+
+## Schema-creation and validation touch points
+
+Implementation must update these places to reflect the new
+contract on `Dataset_Version`, even though the column types do not
+change:
+
+- **`src/deriva_ml/schema/create_schema.py`** — the `Snapshot`
+  column's `comment` should make the new contract explicit:
+  populated for released rows, `NULL` for dev rows. The comment
+  today is "Catalog Snapshot ID for dataset", which is silent on
+  the nullable case.
+- **`src/deriva_ml/schema/create_schema.py`** — the `Version`
+  column's `comment` ("Semantic version of dataset") and `default`
+  ("0.1.0") should be updated. The label is no longer "semantic
+  version" (that's semver-specific); it's a PEP 440 version string.
+  Released rows carry `MAJOR.MINOR.PATCH`; dev rows carry
+  `<last_release>.post1.devN`.
+- **`src/deriva_ml/schema/validation.py`** —
+  `EXPECTED_TABLE_COLUMNS[MLTable.dataset_version]["Snapshot"]` is
+  already `("text", True)` (nullable). Confirm this is the expected
+  contract; no change needed unless a stricter expectation is
+  desired for released rows (which would require splitting the
+  validator's view into "released-row expectation" vs
+  "dev-row expectation" — out of scope for this ADR).

--- a/docs/adr/0004-dataset-version-uses-pep440.md
+++ b/docs/adr/0004-dataset-version-uses-pep440.md
@@ -1,0 +1,77 @@
+# ADR-0004: `DatasetVersion` uses PEP 440, not semver
+
+Date: 2026-05-09
+Status: Accepted
+
+## Context
+
+`DatasetVersion` historically extended `semver.Version`. Released
+versions are written as `0.4.0`, which parses identically under
+semver and PEP 440, so the choice didn't matter while every version
+was a release.
+
+ADR-0003 introduces *dev versions* — a labelled state for "the
+dataset has drifted since the last release but no new release has
+been declared." That label needs to:
+
+1. Sort *after* the last released version, so version-comparison
+   queries (`version > '0.4.0'`) catch dev state.
+2. Not lie about what the next release will be — the user typically
+   doesn't know at mutation time whether the eventual release will
+   be a patch, minor, or major bump.
+3. Be queryable: code needs to ask "is this version a dev version?"
+   without string-matching.
+4. Match the vocabulary the project already uses for its own
+   package versioning, so users have one mental model across
+   `bump-version`, setuptools-scm, and `Dataset.current_version`.
+
+Semver pre-release suffixes (`0.5.0-dev`) fail (1) and (2): they
+sort *before* `0.5.0`, not after `0.4.0`; and they bake in a
+forward claim about which next version they precede.
+
+Semver build metadata (`0.4.0+dev`) fails (1): build metadata is
+ignored for ordering per RFC 5.4, so `0.4.0+dev` and `0.4.0` compare
+as equal.
+
+PEP 440 post-release-with-dev (`0.4.0.post1.dev3`) satisfies all
+four. The label is anchored to the *last* released version, makes
+no forward claim, sorts after `0.4.0`, and exposes `is_devrelease`
+as a typed property. It is also the form `setuptools_scm` produces
+between releases — the project's own package versioning vocabulary.
+
+## Decision
+
+**`DatasetVersion` is reimplemented on top of `packaging.Version`
+(PEP 440), replacing the previous `semver.Version` base class.**
+
+- Released versions are formatted as `MAJOR.MINOR.PATCH`. The wire
+  format is identical to today; existing data does not need to
+  migrate.
+- Dev versions are formatted as `<last_release>.post1.devN`, where
+  `N` advances on each mutation during the dev period. The label
+  makes no claim about which next-released version it precedes —
+  release picks fresh from the user-supplied `VersionPart`.
+- `bump_major`, `bump_minor`, `bump_patch` (semver-only) are
+  replaced by a `DatasetVersion.next_release(component:
+  VersionPart)` method that walks `(major, minor, patch)` directly.
+- The `semver` dependency is dropped.
+
+## Consequences
+
+- The wire format for *released* versions is unchanged. No data
+  migration is needed. Catalogs at `0.4.0` keep reading as `0.4.0`.
+- Dev label form is novel: `0.4.0.post1.dev3` instead of any
+  semver-style suffix. Documentation, MCP responses, and the
+  bundle resource format must use this form.
+- The property `version.is_devrelease` (PEP 440) replaces any
+  string-pattern check for dev-ness. Cite-URL routing keys off
+  this property: dev versions emit no-snapshot URLs, released
+  versions emit snapshot-pinned URLs.
+- `DatasetVersion.parse` continues to accept `"0.4.0"`-style
+  strings; it additionally accepts `"0.4.0.post1.dev3"`-style
+  strings.
+- The project now has one versioning vocabulary: `bump-version`
+  produces PEP 440 release tags; setuptools-scm produces PEP 440
+  post-release labels between tags; `DatasetVersion` produces PEP
+  440 release and post-release labels for dataset state. Same
+  rules everywhere.

--- a/docs/adr/0005-dev-versioning-delivery-sequence.md
+++ b/docs/adr/0005-dev-versioning-delivery-sequence.md
@@ -1,0 +1,194 @@
+# ADR-0005: Dev-versioning delivery — seven sequenced PRs
+
+Date: 2026-05-09
+Status: Accepted
+
+## Context
+
+The dev-versioning work (ADR-0003) and the PEP 440 rebase
+(ADR-0004) together define a 2.0 breaking change for `deriva-ml`.
+The diff is sizeable and touches multiple concerns — versioning
+arithmetic, schema documentation, dev-row creation, mutation
+behavior, the public method rename, drift detection, and the
+release ceremony. Landing it as a single PR would be unreviewable
+and would gate the version bump on tests passing for everything at
+once. This ADR records the slicing.
+
+## Decision
+
+The work lands as **seven sequenced PRs**, each leaving the
+codebase in a working state, with breaking changes confined to
+PR 4 and PR 5. The version bump to 2.0 is deferred to PR 7.
+
+| # | Title | Breaking? |
+| --- | --- | --- |
+| 1 | `DatasetVersion` rebases on PEP 440 (ADR-0004) | No |
+| 2 | Schema column comments — `Snapshot` and `Version` contracts | No |
+| 3 | `mark_dev` + `current_version`/`dataset_history` updates | No |
+| 4 | Member mutations land on dev versions | **Yes** |
+| 5 | Rename `increment_dataset_version` → `Dataset.release()` | **Yes** |
+| 6 | `is_dirty` / `release_diff` / `compare_versions` drift detection | No |
+| 7 | Migration guide, changelog, `bump-version major` to 2.0 | (release) |
+
+### PR 1 — PEP 440 rebase
+
+`DatasetVersion` switches its parent class from `semver.Version` to
+`packaging.Version`. `bump_major`/`bump_minor`/`bump_patch` are
+replaced by `next_release(bump: VersionPart)`. The `semver`
+dependency is dropped. **Non-breaking** at the public API surface
+— released-version strings parse and serialise identically.
+
+### PR 2 — Schema column comments
+
+`Snapshot.comment` spells out the dev-row contract: populated for
+released rows, `NULL` for dev rows. `Version.comment` references
+PEP 440 rather than "semantic versioning". **Non-breaking** — comments
+only.
+
+### PR 3 — `mark_dev` and read-side updates
+
+Adds `Dataset.mark_dev(description, execution=None)`. Adds the
+shared `_create_or_advance_dev_row` helper. Updates
+`current_version` and `dataset_history()` per ADR-0003's Read-side
+surface section: drop the empty-history fallback, sort history
+ascending. **Non-breaking** — additive plus minor read-side
+behavior changes that don't break correct callers.
+
+### PR 4 — Member mutations land on dev
+
+`add_dataset_members` and `delete_dataset_members` replace their
+`increment_dataset_version` tail call with the
+`_create_or_advance_dev_row` helper from PR 3. Tests for these
+methods are rewritten — they currently assert the post-mutation
+version is the next released version; they will now assert it is a
+dev version. **Breaking.**
+
+### PR 5 — Rename to `Dataset.release()`
+
+`increment_dataset_version` (mixin method on `DerivaML`) is
+removed. `Dataset.release(bump, description, execution=None)` is
+added. The method errors when called on a dataset with no dev row.
+In-repo callers are updated in this PR; out-of-repo callers
+(deriva-ml-mcp, model-template, user notebooks) are filed as
+follow-ups. **Breaking.**
+
+### PR 6 — `is_dirty` / `release_diff` / `compare_versions`
+
+The drift-detection methods. Reuse `CatalogGraph`'s path
+enumeration; differ only in the `RMT` time predicate. All three
+share one internal `_diff_between(t_lower, t_upper)` helper:
+
+- `is_dirty()` — `bool`; predicate `RMT > T_last_release`;
+  short-circuits on first non-zero count.
+- `release_diff()` — per-table change counts; same predicate as
+  `is_dirty`; walks full closure.
+- `compare_versions(v_a, v_b)` — per-table change counts between
+  two released versions; predicate spans both endpoints.
+
+All three live on `Dataset` only, not on `DatasetLike` (bags are
+never dirty by construction). **Non-breaking** — additive.
+
+The shared helper means the marginal cost of including
+`compare_versions` in this PR is small — the same walk is reused;
+only the predicate changes. Deferring it would cost more in
+context re-establishment than landing it now.
+
+### PR 7 — User guide, migration guide, and 2.0 bump
+
+Updates the user guide pages whose content is invalidated by the
+new model:
+
+- `docs/user-guide/datasets.md` — the "How to version a dataset"
+  section. Rewrite the worked example using `release()`,
+  `mark_dev()`, `is_dirty()`, `release_diff()`. Replace the
+  "every `add_dataset_members` call increments the version" claim
+  with the dev-version model. Refresh the surrounding prose so
+  the chapter teaches the model, not the old API.
+- `docs/user-guide/reproducibility.md` — the version-pinning story.
+  Released versions stay reproducible (snapshot-pinned); the new
+  thing to teach is that dev versions are *not* reproducible
+  references and shouldn't be passed to executions.
+- `docs/user-guide/migration.md` — extend with the 2.0 migration
+  story: the rename, the behavior change for `add_dataset_members`,
+  the addition of `mark_dev`/`is_dirty`/`release_diff`/`compare_versions`.
+  Worked before/after examples for the common cases.
+- `docs/api-reference/*.md` — these pages are mkdocstrings-driven
+  and pick up changes from the docstrings; no direct edits beyond
+  ensuring the source docstrings are right.
+
+(`docs/concepts/datasets.md` was checked and does not currently
+reference versioning, so no edit is needed there. Re-verify before
+2.0 ships in case it has changed.)
+
+Changelog entries reference the migration guide. `uv run bump-version
+major` produces 2.0 once PRs 1–6 have all merged, the user-guide
+edits are in, and `main` is green.
+
+## Documentation as a deliverable
+
+Every method whose behavior changes in PRs 3–6 ships **with** an
+updated docstring in the same PR. No "I'll update the docs in a
+follow-up." The docstring bar:
+
+- **Updated** — rewritten to match the new contract, not patched
+  on top of the old one.
+- **Accurate** — matches the implementation and the ADR.
+- **Understandable without ADR context** — written for a notebook
+  user who hasn't read the design history. The ADR explains *why*;
+  the docstring explains *what does this do*.
+
+Each docstring follows the template the `release_diff` docstring
+(in ADR-0003 / commit message of PR 6) sets:
+
+1. One-line summary that names the method's purpose.
+2. Paragraph explaining the meaning (what counts, what doesn't).
+3. Paragraph naming the use case (when you'd reach for this).
+4. Paragraph on mechanism (demoted, for readers who need it).
+5. Limitations explicitly listed.
+6. `Args` / `Returns` / `Raises` sections per the workspace's
+   Google-style policy.
+7. `Example` block — runnable, or `# doctest: +SKIP` for
+   catalog-dependent examples.
+
+Methods that need a fresh docstring under this bar:
+`add_dataset_members`, `delete_dataset_members`,
+`Dataset.current_version`, `Dataset.dataset_history`,
+`Dataset.release` (new), `Dataset.mark_dev` (new),
+`Dataset.is_dirty` (new), `Dataset.release_diff` (new),
+`Dataset.compare_versions` (new). Each lands in the PR that adds
+or changes the corresponding behavior — not in PR 7.
+
+## Out-of-repo follow-ups
+
+Filed as dependent issues, fired after the relevant PRs land:
+
+- **deriva-ml-mcp** — rename the `deriva_ml_increment_dataset_version`
+  tool to `deriva_ml_release`, update its signature and bundle
+  resource shape. Blocked on PR 5.
+- **Cite URL plumbing** — `cite_url` field on `ExecutionAssetRef`,
+  `ExecutionInputDatasetRef`, and `DatasetDetail`, plus
+  `Dataset.cite()`. Blocked on PR 5 + PR 6 (needs both `is_devrelease`
+  and the released-version contract).
+- **Deletion-aware diff** — closes the deletion-detection gap in
+  `release_diff` and `compare_versions` by querying the relevant
+  snapshots for RID sets and computing set differences. Different
+  cost profile (proportional to reachable rows on each endpoint,
+  not just to changes). Filed separately when the need is
+  concrete.
+
+## Rationale
+
+- **Two breaking PRs (4 and 5) rather than one.** PR 4 changes
+  what `add_dataset_members` does; PR 5 renames the release verb.
+  Bundling them would make the breaking diff harder to review and
+  harder to revert if either turned out to be wrong. Splitting
+  also lets PR 4's tests be reviewed before PR 5's signature work
+  layers on top.
+- **The 2.0 bump is its own PR.** Landing the bump in the same PR
+  as one of the breaking changes would couple the release ceremony
+  to that PR's review cycle. PR 7 is small, mechanical, and lands
+  only when `main` is green.
+- **Non-breaking PRs flank the breaking ones.** PRs 1–3 prepare
+  the ground; PRs 4–5 do the breaking work; PR 6 builds on it; PR
+  7 closes it out. A reviewer reading the sequence sees the design
+  unfold, not just the final state.


### PR DESCRIPTION
## Summary

Captures the design for the dataset dev-versioning work proposed in
[#79](https://github.com/informatics-isi-edu/deriva-ml/issues/79).
**No code changes** — pure documentation. Implementation begins
with PR 1 (PEP 440 rebase of \`DatasetVersion\`) per the sequence
in ADR-0005.

The design extends dataset semantic versioning with a *dev version*
concept: a mutable, snapshot-NULL row that accumulates changes
between releases. Every mutation lands on dev; \`release()\` is the
only operation that produces a released version. \`is_dirty()\`,
\`release_diff()\`, and \`compare_versions(v_a, v_b)\` detect catalog
drift. Versioning vocabulary aligns with \`setuptools-scm\` (PEP 440
\`<release>.post1.devN\` form) so the project has one mental model
for package and dataset versions.

## What's in this PR

- **ADR-0003** — Dataset dev versioning model. The load-bearing
  decision plus all mechanics: storage (no DDL change),
  mutation behavior, granularity, conditional-update concurrency,
  read-side surface, addressability rules, drift-detection trio,
  schema-creation touch points, migration impact.
- **ADR-0004** — \`DatasetVersion\` uses PEP 440. Why we abandoned
  semver pre-release (\`0.5.0-dev\`) for setuptools-scm-style
  post-release labels (\`0.4.0.post1.devN\`).
- **ADR-0005** — Seven-PR delivery sequence. Breaking changes
  confined to PRs 4 and 5. Docstrings and user-guide updates land
  with the PRs that change behavior, not deferred to PR 7.
- **CONTEXT.md** — First CONTEXT.md for this repo. Captures the
  vocabulary that's now load-bearing: released version, dev
  version, dev period, drift, dirty, mark dev, release.

## Why a separate PR for docs

Per ADR-0005, this work is a 2.0 breaking change delivered as
seven sequenced PRs. The design docs cover all seven PRs, not just
the first one — bundling them with PR 1 would conflate
"why we're doing this" with "the first slice." Landing them
separately gives reviewers a clean place to grill the design
without code churn distracting.

## Test plan

- [ ] Reviewers read ADR-0003 and confirm the dev-versioning model
      is sound (every mutation lands on dev; release is the only
      path to released; lazy mutable dev rows).
- [ ] Reviewers read ADR-0004 and confirm the PEP 440 vocabulary
      is the right call vs. semver pre-release suffixes.
- [ ] Reviewers read ADR-0005 and confirm the PR sequencing makes
      sense (especially PR 4/PR 5 being two breaking PRs rather
      than one).
- [ ] CONTEXT.md vocabulary matches what the team uses verbally.
- [ ] No CI failures (pure docs, no code touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)