### PR TITLE
docs(schema): clarify Dataset_Version Snapshot/Version contracts (ADR-0003; PR 2 of 7)

### DIFF
--- a/src/deriva_ml/schema/create_schema.py
+++ b/src/deriva_ml/schema/create_schema.py
@@ -105,7 +105,14 @@ def define_table_dataset_version(sname: str, annotation: Optional[dict] = None) 
                 name="Version",
                 type=BuiltinType.text,
                 default="0.1.0",
-                comment="Semantic version of dataset",
+                comment=(
+                    "PEP 440 version label for this dataset version. "
+                    "Released rows carry `MAJOR.MINOR.PATCH` (e.g. `0.4.0`). "
+                    "Dev rows carry `<last_release>.post1.devN` "
+                    "(e.g. `0.4.0.post1.dev3`) to denote drift since the "
+                    "last release. The default `0.1.0` applies to the "
+                    "initial release row created at dataset creation time."
+                ),
             ),
             ColumnDef("Description", BuiltinType.markdown),
             ColumnDef("Dataset", BuiltinType.text, comment="RID of dataset"),
@@ -120,7 +127,14 @@ def define_table_dataset_version(sname: str, annotation: Optional[dict] = None) 
             ColumnDef(
                 name="Snapshot",
                 type=BuiltinType.text,
-                comment="Catalog Snapshot ID for dataset",
+                comment=(
+                    "Catalog snapshot ID this version row pins. Populated for "
+                    "released rows (the snapshot stamped at release time). "
+                    "`NULL` on dev rows, denoting that the row tracks live "
+                    "catalog state with no pinned snapshot — the bag this "
+                    "dataset would download right now is whatever the "
+                    "catalog has at request time."
+                ),
             ),
         ],
         annotations=annotation if annotation else {},

--- a/src/deriva_ml/schema/deriva-ml-reference.json
+++ b/src/deriva_ml/schema/deriva-ml-reference.json
@@ -4414,7 +4414,7 @@
               "acls": {},
               "acl_bindings": {},
               "annotations": {},
-              "comment": "Semantic version of dataset",
+              "comment": "PEP 440 version label for this dataset version. Released rows carry `MAJOR.MINOR.PATCH` (e.g. `0.4.0`). Dev rows carry `<last_release>.post1.devN` (e.g. `0.4.0.post1.dev3`) to denote drift since the last release. The default `0.1.0` applies to the initial release row created at dataset creation time.",
               "type": {
                 "typename": "text"
               },
@@ -4478,7 +4478,7 @@
               "acls": {},
               "acl_bindings": {},
               "annotations": {},
-              "comment": "Catalog Snapshot ID for dataset",
+              "comment": "Catalog snapshot ID this version row pins. Populated for released rows (the snapshot stamped at release time). `NULL` on dev rows, denoting that the row tracks live catalog state with no pinned snapshot — the bag this dataset would download right now is whatever the catalog has at request time.",
               "type": {
                 "typename": "text"
               },

--- a/tests/dataset/deriva-ml-reference.json
+++ b/tests/dataset/deriva-ml-reference.json
@@ -4414,7 +4414,7 @@
               "acls": {},
               "acl_bindings": {},
               "annotations": {},
-              "comment": "Semantic version of dataset",
+              "comment": "PEP 440 version label for this dataset version. Released rows carry `MAJOR.MINOR.PATCH` (e.g. `0.4.0`). Dev rows carry `<last_release>.post1.devN` (e.g. `0.4.0.post1.dev3`) to denote drift since the last release. The default `0.1.0` applies to the initial release row created at dataset creation time.",
               "type": {
                 "typename": "text"
               },
@@ -4478,7 +4478,7 @@
               "acls": {},
               "acl_bindings": {},
               "annotations": {},
-              "comment": "Catalog Snapshot ID for dataset",
+              "comment": "Catalog snapshot ID this version row pins. Populated for released rows (the snapshot stamped at release time). `NULL` on dev rows, denoting that the row tracks live catalog state with no pinned snapshot — the bag this dataset would download right now is whatever the catalog has at request time.",
               "type": {
                 "typename": "text"
               },


### PR DESCRIPTION
## Summary

PR 2 of 7 in the dev-versioning delivery sequence (ADR-0005).
Updates the column comments on \`Dataset_Version.Version\` and
\`Dataset_Version.Snapshot\` to spell out the dev-row contract that's
load-bearing in ADR-0003.

**No DDL change** — both columns are already nullable and remain
so. This PR is documentation-only at the schema layer, but it's
documentation that's literally embedded in the database (visible
in Chaise tooltips and \`describe\` output), so it ships with code,
not in the user guide.

This PR is based on PR 1 ([#81](https://github.com/informatics-isi-edu/deriva-ml/pull/81)) and should not merge until that
does. The compare-base will rebase up the chain as upstream PRs
land.

## What changed

- **\`src/deriva_ml/schema/create_schema.py\`** — the comments on
  \`Dataset_Version.Version\` and \`Dataset_Version.Snapshot\` now
  describe the released-vs-dev label forms and the
  populated-vs-NULL snapshot contract, respectively. The defaults
  on both columns are preserved.
- **\`src/deriva_ml/schema/deriva-ml-reference.json\`** and
  **\`tests/dataset/deriva-ml-reference.json\`** — updated to match
  the new comments so \`check_ml_schema\` (which diffs a live
  catalog against this reference) doesn't flag the change as a
  drift from the reference.

## Why update the reference JSON by hand

The two reference JSON files are the snapshot \`check_ml_schema\`
diffs against. They're normally regenerated via
\`dump_ml_schema(...)\` from a freshly-installed catalog, but that
requires \`DERIVA_HOST\` and a running catalog, which is not
available from this environment. The hand edit is mechanical (two
literal comment strings, in two files, no other JSON structure
changed) and verified to leave both files JSON-parseable.

If desired, a follow-up commit could regenerate the reference
files via \`dump_ml_schema\` to confirm there's no drift between
the hand edit and what a fresh catalog would actually produce.

## Test plan

- [x] Unit tests pass (\`tests/dataset/test_dataset_version_unit.py\`
      and \`tests/local_db/\`): 270 passed.
- [x] JSON files parse and round-trip via \`json.load\` / \`json.dump\`.
- [x] \`ruff check\` on \`create_schema.py\`: 14 errors, all
      pre-existing (line numbers far from my edit range at lines
      ~100-130).
- [ ] \`check_ml_schema\` runs cleanly against a freshly-created
      catalog (requires \`DERIVA_HOST\`; reviewer to verify).

## Refs

- [#79](https://github.com/informatics-isi-edu/deriva-ml/issues/79) — design proposal
- [#80](https://github.com/informatics-isi-edu/deriva-ml/pull/80) — design docs (must merge first)
- [#81](https://github.com/informatics-isi-edu/deriva-ml/pull/81) — PR 1, PEP 440 rebase (this PR is based on it)
- ADR-0003 — dev versioning model (the contract these comments document)
- ADR-0005 — full delivery sequence

🤖 Generated with [Claude Code](https://claude.com/claude-code)