### PR TITLE
feat(dataset): mark_dev, dev-row helper, and read-side updates (ADR-0003; PR 3 of 7)

### DIFF
--- a/src/deriva_ml/dataset/dataset.py
+++ b/src/deriva_ml/dataset/dataset.py
@@ -662,34 +662,42 @@ class Dataset:
         return self._ml_instance.list_workflow_executions(workflow)
 
     def dataset_history(self) -> list[DatasetHistory]:
-        """Retrieves the version history of a dataset.
+        """List every ``Dataset_Version`` row for this dataset, oldest first.
 
-        Returns a chronological list of dataset versions, including their version numbers,
-        creation times, and associated metadata.
+        Returns one entry per row, including the dev row when one exists.
+        Released and dev rows are not separated — they are different states
+        of the same row type, and filtering belongs at the call site.
+        Callers who want released-only filter on the typed property::
+
+            released = [
+                h for h in ds.dataset_history()
+                if not h.dataset_version.is_devrelease
+            ]
+
+        Results are sorted by ``dataset_version`` in ascending PEP 440
+        order. With the dev-versioning model, that reads
+        chronologically: ``[0.1.0, ..., 0.4.0, 0.4.0.post1.devN]``.
 
         Returns:
-            list[DatasetHistory]: List of history entries, each containing:
-                - dataset_version: Version number (major.minor.patch)
-                - minid: Minimal Viable Identifier
-                - snapshot: Catalog snapshot time
-                - dataset_rid: Dataset Resource Identifier
-                - version_rid: Version Resource Identifier
-                - description: Version description
-                - execution_rid: Associated execution RID
+            A list of :class:`DatasetHistory` entries. Each carries the
+            parsed version, the version row's RID, the dataset's RID,
+            the description and execution link, and the snapshot ID
+            (``None`` for dev rows).
 
         Raises:
-            DerivaMLException: If dataset_rid is not a valid dataset RID.
+            DerivaMLException: If this dataset's RID is not a valid
+                dataset RID.
 
         Example:
-            >>> history = ml.dataset_history("1-abc123")  # doctest: +SKIP
+            >>> history = dataset.dataset_history()  # doctest: +SKIP
             >>> for entry in history:  # doctest: +SKIP
-            ...     print(f"Version {entry.dataset_version}: {entry.description}")
+            ...     mark = " (dev)" if entry.dataset_version.is_devrelease else ""
+            ...     print(f"v{entry.dataset_version}{mark}: {entry.description}")
         """
-
         if not self._ml_instance.model.is_dataset_rid(self.dataset_rid):
             raise DerivaMLException(f"RID is not for a data set: {self.dataset_rid}")
         version_path = self._ml_instance.pathBuilder().schemas[self._ml_instance.ml_schema].tables["Dataset_Version"]
-        return [
+        entries = [
             DatasetHistory(
                 dataset_version=DatasetVersion.parse(v["Version"]),
                 minid=v["Minid"],
@@ -702,36 +710,51 @@ class Dataset:
             )
             for v in version_path.filter(version_path.Dataset == self.dataset_rid).entities().fetch()
         ]
+        entries.sort(key=lambda h: h.dataset_version)
+        return entries
 
     @property
     @validate_call(config=ConfigDict(arbitrary_types_allowed=True))
     def current_version(self) -> DatasetVersion:
-        """Retrieve the current (most recent) version of this dataset.
+        """Return the dataset's current version label.
 
-        Returns the highest semantic version from the dataset's version history.
-        If the dataset has no version history, returns ``0.1.0`` as the default.
+        The current version is the highest entry in
+        :meth:`dataset_history` under PEP 440 ordering. When a dev row
+        exists, the dev label sorts after every released label and is
+        returned. Otherwise the latest released label is returned.
 
-        Note that each version captures the state of the catalog at the time the
-        version was created, not the current state. Values associated with an
-        object in the catalog may differ from the values in a given dataset version.
+        Released versions pin a catalog snapshot — reading the dataset
+        at a released version always returns the same content. Dev
+        versions track live catalog state — the row's ``Snapshot`` is
+        ``NULL`` and reads resolve against the current catalog. Callers
+        who want a stable reference should use a released version, not
+        a dev version.
 
         Returns:
-            DatasetVersion: The most recent semantic version of this dataset.
+            The most recent ``DatasetVersion``, dev or released.
 
         Raises:
-            DerivaMLException: If the catalog query fails.
+            DerivaMLException: If the dataset has no ``Dataset_Version``
+                rows. ``create_dataset`` always inserts an initial
+                released row, so an empty history indicates a catalog
+                inconsistency rather than a normal state.
 
         Example:
-            >>> ver = dataset.current_version  # doctest: +SKIP
-            >>> print(str(ver))  # doctest: +SKIP
+            >>> v = dataset.current_version  # doctest: +SKIP
+            >>> if v.is_devrelease:  # doctest: +SKIP
+            ...     print(f"in dev period at {v}; call release() to mint a release")
+            ... else:  # doctest: +SKIP
+            ...     print(f"at released {v}")
         """
         history = self.dataset_history()
         if not history:
-            return DatasetVersion(0, 1, 0)
-        else:
-            # Ensure we return a DatasetVersion, not a string
-            versions = [h.dataset_version for h in history]
-            return max(versions) if versions else DatasetVersion(0, 1, 0)
+            raise DerivaMLException(
+                f"Dataset {self.dataset_rid} has no Dataset_Version rows. "
+                "Every dataset is initialised with an initial released row "
+                "at creation time; an empty history indicates a catalog "
+                "inconsistency."
+            )
+        return max(h.dataset_version for h in history)
 
     def get_chaise_url(self) -> str:
         """Get the Chaise URL for viewing this dataset in the browser.
@@ -899,6 +922,177 @@ class Dataset:
             self._ml_instance, version_update_list, description=description, execution_rid=execution_rid
         )
         return next((d.version for d in version_update_list if d.rid == self.dataset_rid))
+
+    def _create_or_advance_dev_row(
+        self,
+        description: str,
+        execution_rid: RID | None = None,
+    ) -> None:
+        """Create or advance this dataset's dev row.
+
+        Internal primitive that backs :meth:`mark_dev` and (in a later
+        PR) the member-mutation operations. Implements the dev-row
+        lifecycle from ADR-0003:
+
+        * If the dataset has no dev row, INSERT one at
+          ``<last_released>.post1.dev1`` with ``Snapshot=NULL``,
+          ``Description`` set to *description*, and ``Execution`` set to
+          *execution_rid* (or ``NULL`` if not supplied). Update the
+          dataset's ``Version`` FK to point at the new row.
+        * If the dataset has a dev row, UPDATE that row in place:
+          advance ``.devN`` by 1, replace ``Description``, overwrite
+          ``Execution``. Use a conditional update on the row's observed
+          ``RMT`` so concurrent writers can be detected.
+
+        Concurrency: a competing writer that landed between this
+        method's read and write is detected by the ``RMT`` predicate
+        on the UPDATE — if zero rows match, the call raises
+        :class:`DerivaMLException` rather than silently overwriting
+        the other writer's work.
+
+        Args:
+            description: Description of the change being recorded.
+                Replaces any existing dev-row description (not
+                appended — the catalog's audit log preserves prior
+                values).
+            execution_rid: Optional RID of the calling execution.
+                Stored on the dev row's ``Execution`` column.
+
+        Raises:
+            DerivaMLException: If a concurrent writer modified the dev
+                row between this call's read and write.
+        """
+        history = self.dataset_history()
+        dev_entries = [h for h in history if h.dataset_version.is_devrelease]
+        schema_path = self._ml_instance.pathBuilder().schemas[self._ml_instance.ml_schema]
+        version_table = schema_path.tables["Dataset_Version"]
+
+        if not dev_entries:
+            # No dev row yet: anchor a new one at the latest release.
+            released = max(
+                (h.dataset_version for h in history if not h.dataset_version.is_devrelease),
+                default=None,
+            )
+            if released is None:
+                # Defensive: every dataset has at least one released row at
+                # creation time. If this fires, the catalog is in an
+                # inconsistent state that this method cannot fix.
+                raise DerivaMLException(
+                    f"Dataset {self.dataset_rid} has no released version to anchor a dev row against."
+                )
+            new_label = f"{released}.post1.dev1"
+            inserted = list(
+                version_table.insert(
+                    [
+                        {
+                            "Dataset": self.dataset_rid,
+                            "Version": new_label,
+                            "Description": description,
+                            "Execution": execution_rid,
+                        }
+                    ]
+                )
+            )
+            new_rid = inserted[0]["RID"]
+            schema_path.tables["Dataset"].update([{"RID": self.dataset_rid, "Version": new_rid}])
+            return
+
+        # Dev row exists: advance .devN, replace description, overwrite
+        # execution. Use a conditional update keyed on the row's observed
+        # RMT so a concurrent writer can be detected.
+        if len(dev_entries) > 1:
+            # Should be impossible — at most one dev row per dev period.
+            raise DerivaMLException(
+                f"Dataset {self.dataset_rid} has {len(dev_entries)} dev rows; expected at most one."
+            )
+        current_dev = dev_entries[0]
+        # Re-fetch the row by RID to capture its RMT for the conditional
+        # update. dataset_history doesn't expose RMT.
+        current_rows = list(version_table.filter(version_table.RID == current_dev.version_rid).entities().fetch())
+        if not current_rows:
+            raise DerivaMLException(
+                f"Dev version row {current_dev.version_rid} disappeared between read and update — concurrent deletion?"
+            )
+        observed_rmt = current_rows[0]["RMT"]
+        next_n = current_dev.dataset_version.dev + 1
+        next_label = (
+            f"{current_dev.dataset_version.major}."
+            f"{current_dev.dataset_version.minor}."
+            f"{current_dev.dataset_version.micro}"
+            f".post{current_dev.dataset_version.post}.dev{next_n}"
+        )
+        updated = list(
+            version_table.update(
+                [
+                    {
+                        "RID": current_dev.version_rid,
+                        "RMT": observed_rmt,
+                        "Version": next_label,
+                        "Description": description,
+                        "Execution": execution_rid,
+                    }
+                ],
+                correlation={"RID", "RMT"},
+            )
+        )
+        if not updated:
+            raise DerivaMLException(
+                f"Concurrent modification of dev row {current_dev.version_rid} "
+                "for dataset {self.dataset_rid}: another writer advanced the "
+                "row between this call's read and write. Re-read the dataset "
+                "and retry if the new state is still what you intended."
+            )
+
+    def mark_dev(
+        self,
+        description: str,
+        execution: "Execution | None" = None,
+    ) -> None:
+        """Flip this dataset to a dev version, recording catalog drift.
+
+        Use ``mark_dev`` when the catalog has changed in a way that
+        affects this dataset's contents, but no dataset-API operation
+        flipped the dataset to dev automatically. Typical case: a
+        feature value was added by a separate execution against a row
+        that's a member of this dataset — the dataset's own row and
+        member list are untouched, but the bag the dataset would
+        download today differs from the last release.
+
+        On the first call after a release, a new dev row is created at
+        ``<last_release>.post1.dev1`` with ``Snapshot=NULL``. Subsequent
+        calls during the same dev period advance the ``.devN`` counter
+        (the dev row is mutable; one row per dev period). The
+        ``Description`` is replaced on each call — prior values are
+        recoverable from the catalog's audit log.
+
+        ``mark_dev`` returns ``None`` rather than the new dev label
+        because dev labels are not addressable across time: by the
+        time a caller might use a returned label for anything, the
+        next mutation has advanced ``.devN`` and the returned value no
+        longer resolves. Callers who want to display the new label
+        read :attr:`current_version` after the call.
+
+        Args:
+            description: What changed. Replaces any existing dev-row
+                description.
+            execution: Optional execution that observed the drift.
+                Stored on the dev row's ``Execution`` column.
+
+        Raises:
+            DerivaMLException: If a concurrent writer modified the dev
+                row between this call's read and write.
+
+        Example:
+            >>> # A separate execution recorded labels for some images  # doctest: +SKIP
+            >>> # that are members of this dataset. Flag the drift:
+            >>> dataset.mark_dev("Picked up classifier output for the test split")
+            >>> str(dataset.current_version)  # e.g. "0.4.0.post1.dev1"
+        """
+        execution_rid = execution.execution_rid if execution is not None else None
+        self._create_or_advance_dev_row(
+            description=description,
+            execution_rid=execution_rid,
+        )
 
     @validate_call(config=ConfigDict(arbitrary_types_allowed=True))
     def list_dataset_members(

--- a/tests/dataset/test_dataset_version.py
+++ b/tests/dataset/test_dataset_version.py
@@ -85,3 +85,121 @@ class TestDatasetVersion:
         ic(new_versions)
         assert new_versions["d0"].major == 2
         assert new_versions["d2"][0].major == 2
+
+
+class TestMarkDev:
+    """Integration tests for ``Dataset.mark_dev`` and the dev-row lifecycle.
+
+    Covers ADR-0003's lazy-mutable-dev-row contract: first call after a
+    release creates the dev row at ``.dev1``; subsequent calls advance
+    ``.devN`` in place; ``Description`` is replaced (not appended);
+    ``current_version`` and ``dataset_history`` reflect the dev state.
+    """
+
+    def _setup_dataset(self, ml_instance):
+        """Helper: register vocabulary, create workflow+execution, return a fresh dataset."""
+        ml_instance.add_term("Dataset_Type", "DevTest", description="A test")
+        ml_instance.add_term("Workflow_Type", "Manual Workflow", description="A manual workflow")
+        workflow = ml_instance.create_workflow(
+            name="MarkDev Workflow",
+            workflow_type="Manual Workflow",
+            description="Workflow for mark_dev tests",
+        )
+        execution = ml_instance.create_execution(
+            ExecutionConfiguration(description="MarkDev Execution", workflow=workflow)
+        )
+        dataset = execution.create_dataset(
+            dataset_types="DevTest",
+            description="Dataset for mark_dev tests",
+            version=DatasetVersion(0, 4, 0),
+        )
+        return dataset, execution
+
+    def test_first_mark_dev_creates_dev1(self, test_ml):
+        dataset, _execution = self._setup_dataset(test_ml)
+        assert str(dataset.current_version) == "0.4.0"
+
+        dataset.mark_dev("Picked up classifier output")
+
+        assert str(dataset.current_version) == "0.4.0.post1.dev1"
+        assert dataset.current_version.is_devrelease
+
+    def test_subsequent_mark_dev_advances_devN(self, test_ml):
+        dataset, _execution = self._setup_dataset(test_ml)
+        dataset.mark_dev("First drift")
+        dataset.mark_dev("Second drift")
+        dataset.mark_dev("Third drift")
+
+        assert str(dataset.current_version) == "0.4.0.post1.dev3"
+
+    def test_dev_row_snapshot_is_null(self, test_ml):
+        dataset, _execution = self._setup_dataset(test_ml)
+        dataset.mark_dev("Some drift")
+
+        history = dataset.dataset_history()
+        dev_entries = [h for h in history if h.dataset_version.is_devrelease]
+        assert len(dev_entries) == 1
+        assert dev_entries[0].snapshot is None
+
+    def test_dev_row_count_stays_one(self, test_ml):
+        """Mutable dev row: advancing .devN updates the same row."""
+        dataset, _execution = self._setup_dataset(test_ml)
+        dataset.mark_dev("First")
+        dataset.mark_dev("Second")
+        dataset.mark_dev("Third")
+
+        history = dataset.dataset_history()
+        dev_entries = [h for h in history if h.dataset_version.is_devrelease]
+        assert len(dev_entries) == 1, "expected exactly one dev row across calls"
+
+    def test_description_is_replaced_not_appended(self, test_ml):
+        dataset, _execution = self._setup_dataset(test_ml)
+        dataset.mark_dev("First description")
+        dataset.mark_dev("Second description")
+
+        history = dataset.dataset_history()
+        dev = next(h for h in history if h.dataset_version.is_devrelease)
+        assert dev.description == "Second description"
+        assert "First description" not in (dev.description or "")
+
+    def test_history_includes_dev_row(self, test_ml):
+        dataset, _execution = self._setup_dataset(test_ml)
+        history_before = dataset.dataset_history()
+        assert len(history_before) == 1
+
+        dataset.mark_dev("Some drift")
+
+        history_after = dataset.dataset_history()
+        assert len(history_after) == 2
+        assert any(h.dataset_version.is_devrelease for h in history_after)
+
+    def test_history_is_sorted_ascending(self, test_ml):
+        dataset, _execution = self._setup_dataset(test_ml)
+        # Make a few releases plus a dev row.
+        dataset.increment_dataset_version(VersionPart.minor, "first bump")
+        dataset.increment_dataset_version(VersionPart.minor, "second bump")
+        dataset.mark_dev("then dev")
+
+        history = dataset.dataset_history()
+        labels = [str(h.dataset_version) for h in history]
+        # Released ones first, dev label last (sorts after its anchor release).
+        assert labels == sorted(labels, key=lambda s: DatasetVersion.parse(s))
+        # And the last entry is the dev label.
+        assert history[-1].dataset_version.is_devrelease
+
+    def test_mark_dev_with_execution_attaches_execution(self, test_ml):
+        dataset, execution = self._setup_dataset(test_ml)
+        dataset.mark_dev("With execution", execution=execution)
+
+        history = dataset.dataset_history()
+        dev = next(h for h in history if h.dataset_version.is_devrelease)
+        assert dev.execution_rid == execution.execution_rid
+
+    def test_mark_dev_without_execution_leaves_null(self, test_ml):
+        dataset, _execution = self._setup_dataset(test_ml)
+        dataset.mark_dev("Without execution")
+
+        history = dataset.dataset_history()
+        dev = next(h for h in history if h.dataset_version.is_devrelease)
+        # DatasetHistory normalises empty/missing execution_rid to None.
+        assert dev.execution_rid is None


### PR DESCRIPTION
## Summary

PR 3 of 7 in the dev-versioning delivery sequence (ADR-0005).
Introduces the load-bearing dev-versioning machinery as **additive
code** — \`add_dataset_members\` and \`delete_dataset_members\` continue
to bump to released versions (that behavior flips in PR 4).

This PR is based on PR 2 ([#82](https://github.com/informatics-isi-edu/deriva-ml/pull/82)) and should not merge until that
does. The compare-base will rebase up the chain as upstream PRs land.

## What's new

**New public API** (\`src/deriva_ml/dataset/dataset.py\`):

- \`Dataset.mark_dev(description, execution=None) -> None\` — the
  explicit user-facing flip-to-dev. Used when the catalog drifted
  via a path the dataset API didn't see (a separate execution
  recorded a feature value, an asset's metadata changed, etc.).
  Returns \`None\` because dev labels are not addressable across time
  per ADR-0003 — the next mutation makes them unaddressable, so
  returning one would invite caller mistakes.

**New private helper**:

- \`Dataset._create_or_advance_dev_row(description, execution_rid)\` —
  the primitive that backs \`mark_dev\` (and in PR 4, the member
  mutations). Implements the lazy mutable dev-row contract:
  - **No dev row**: \`INSERT\` at \`<last_release>.post1.dev1\` with
    \`Snapshot=NULL\`; update the dataset's \`Version\` FK to point
    at the new row.
  - **Dev row exists**: \`UPDATE\` in place — advance \`.devN\` by 1,
    replace \`Description\`, overwrite \`Execution\`. The \`UPDATE\`
    uses a conditional predicate on the row's observed \`RMT\`
    (\`correlation={'RID', 'RMT'}\` in datapath) so concurrent writers
    are detected and raise \`DerivaMLException\` rather than silently
    overwriting.

**Read-side updates**:

- \`dataset_history()\`: returns **all** \`Dataset_Version\` rows for
  this dataset, sorted by version ascending. No dev/released
  filtering — callers filter by \`is_devrelease\` at the call site
  if they want released-only. Per ADR-0003.
- \`current_version\`: drops the empty-history fallback to
  \`DatasetVersion(0, 1, 0)\`. \`create_dataset\` always inserts an
  initial release row, so empty history indicates a catalog
  inconsistency — raise rather than silently invent a version.
  Per CLAUDE.md's "no defensive code for impossible cases".

## Tests

\`tests/dataset/test_dataset_version.py\`: adds \`TestMarkDev\` with 9
integration tests against a live catalog:

| Test | Verifies |
|---|---|
| \`test_first_mark_dev_creates_dev1\` | First call after release creates dev row at \`.dev1\` |
| \`test_subsequent_mark_dev_advances_devN\` | \`.devN\` advances on each call |
| \`test_dev_row_snapshot_is_null\` | Dev row has \`Snapshot=NULL\` |
| \`test_dev_row_count_stays_one\` | Mutable: never more than one dev row |
| \`test_description_is_replaced_not_appended\` | Description overwritten, not appended (per Q20 reversal of Q11) |
| \`test_history_includes_dev_row\` | \`dataset_history\` includes dev rows |
| \`test_history_is_sorted_ascending\` | Sorted by PEP 440 version ascending |
| \`test_mark_dev_with_execution_attaches_execution\` | \`Execution\` link recorded |
| \`test_mark_dev_without_execution_leaves_null\` | \`Execution\` is \`None\` if not supplied |

## Test results

| Check | Result |
|---|---|
| Unit tests (\`local_db\`, \`test_dataset_version_unit\`) | 270 / 270 pass |
| New integration tests (\`TestMarkDev\`) | 9 / 9 pass against \`localhost\` |
| Existing \`TestDatasetVersion\` integration tests | 2 / 2 pass; 1 pre-existing \`FileNotFoundError\` from a workspace-resolution issue |
| \`test_dataset_spec\`, \`test_dataset_list_executions\` | Pass (regressions caught and fixed in PR 1, propagated up the stack) |
| \`ruff check\` on changed regions | Clean (pre-existing errors at unrelated line numbers) |
| \`ruff format\` on changed files | Applied |

## Concurrency note

This PR's \`_create_or_advance_dev_row\` already implements the
conditional-update concurrency rule from ADR-0003 — even though
\`mark_dev\` is a low-volume operation, getting the helper right now
means PR 4's higher-volume callers (member mutations) inherit
correctness rather than retrofit it.

## Refs

- [#79](https://github.com/informatics-isi-edu/deriva-ml/issues/79) — design proposal
- [#80](https://github.com/informatics-isi-edu/deriva-ml/pull/80) — design docs (must merge first)
- [#81](https://github.com/informatics-isi-edu/deriva-ml/pull/81) — PR 1
- [#82](https://github.com/informatics-isi-edu/deriva-ml/pull/82) — PR 2 (this PR is based on it)
- ADR-0003 — dev versioning model
- ADR-0005 — full delivery sequence

🤖 Generated with [Claude Code](https://claude.com/claude-code)