### PR TITLE
feat(dataset): member and type mutations land on dev versions (ADR-0003; PR 4 of 7)

### DIFF
--- a/src/deriva_ml/dataset/dataset.py
+++ b/src/deriva_ml/dataset/dataset.py
@@ -341,14 +341,19 @@ class Dataset:
     ) -> None:
         """Add a dataset type to this dataset.
 
-        Adds a type term to this dataset if it's not already present. The term must
-        exist in the Dataset_Type vocabulary. Also increments the dataset's minor
-        version to reflect the metadata change.
+        Adds a type term to this dataset if it's not already present.
+        The term must exist in the Dataset_Type vocabulary. Flips the
+        dataset to a dev version to record the metadata change (per
+        ADR-0003: every mutation lands on dev). If the term is already
+        present, the call is a no-op and does not advance the dev
+        counter.
 
         Args:
             dataset_type: Term name (string) or VocabularyTerm object from Dataset_Type vocabulary.
-            _skip_version_increment: Internal parameter to skip version increment when
-                called from add_dataset_types (which handles versioning itself).
+            _skip_version_increment: Internal parameter to skip the
+                dev-row update when called from ``add_dataset_types`` or
+                during initial dataset creation, which handle the
+                version transition themselves.
 
         Raises:
             DerivaMLInvalidTerm: If the term doesn't exist in the Dataset_Type vocabulary.
@@ -371,18 +376,22 @@ class Dataset:
         _, atable_path = self._get_dataset_type_association_table()
         atable_path.insert([{MLVocab.dataset_type: vocab_term.name, "Dataset": self.dataset_rid}])
 
-        # Increment minor version to reflect metadata change (unless called from add_dataset_types)
+        # Flip to dev to record the metadata change (unless called from add_dataset_types
+        # during initial creation, which sets _skip_version_increment).
         if not _skip_version_increment:
-            self.increment_dataset_version(
-                VersionPart.minor,
+            self._create_or_advance_dev_row(
                 description=f"Added dataset type: {vocab_term.name}",
             )
 
     def remove_dataset_type(self, dataset_type: str | VocabularyTerm) -> None:
         """Remove a dataset type from this dataset.
 
-        Removes a type term from this dataset if it's currently associated. The term
-        must exist in the Dataset_Type vocabulary.
+        Removes a type term from this dataset if it's currently
+        associated. The term must exist in the Dataset_Type vocabulary.
+        Flips the dataset to a dev version on successful removal (per
+        ADR-0003: every mutation lands on dev). If the term isn't
+        currently associated with this dataset, the call is a no-op
+        and does not advance the dev counter.
 
         Args:
             dataset_type: Term name (string) or VocabularyTerm object from Dataset_Type vocabulary.
@@ -399,7 +408,7 @@ class Dataset:
         else:
             vocab_term = self._ml_instance.lookup_term(MLVocab.dataset_type, dataset_type)
 
-        # Check if present
+        # Check if present — no-op input doesn't advance the dev counter.
         if vocab_term.name not in self.dataset_types:
             return
 
@@ -408,6 +417,9 @@ class Dataset:
         atable_path.filter(
             (atable_path.Dataset == self.dataset_rid) & (atable_path.Dataset_Type == vocab_term.name)
         ).delete()
+        self._create_or_advance_dev_row(
+            description=f"Removed dataset type: {vocab_term.name}",
+        )
 
     def add_dataset_types(
         self,
@@ -416,16 +428,19 @@ class Dataset:
     ) -> None:
         """Add one or more dataset types to this dataset.
 
-        Convenience method for adding multiple types at once. Each term must exist
-        in the Dataset_Type vocabulary. Types that are already associated with the
-        dataset are silently skipped. Increments the dataset's minor version once
-        after all types are added.
+        Convenience method for adding multiple types at once. Each term
+        must exist in the Dataset_Type vocabulary. Types that are
+        already associated with the dataset are silently skipped.
+        Flips the dataset to a dev version once after all new types are
+        added (per ADR-0003: every mutation lands on dev). If every
+        supplied type is already associated, the call is a no-op and
+        does not advance the dev counter.
 
         Args:
             dataset_types: Single term or list of terms. Can be strings (term names)
                 or VocabularyTerm objects.
-            _skip_version_increment: Internal parameter to skip version increment
-                (used during initial dataset creation).
+            _skip_version_increment: Internal parameter to skip the
+                dev-row update during initial dataset creation.
 
         Raises:
             DerivaMLInvalidTerm: If any term doesn't exist in the Dataset_Type vocabulary.
@@ -451,11 +466,10 @@ class Dataset:
                 self.add_dataset_type(term, _skip_version_increment=True)
                 added_types.append(term_name)
 
-        # Increment version once for all added types (if any were added)
+        # Flip to dev once for all added types (if any were added).
         if added_types and not _skip_version_increment:
             type_names = ", ".join(added_types)
-            self.increment_dataset_version(
-                VersionPart.minor,
+            self._create_or_advance_dev_row(
                 description=f"Added dataset type(s): {type_names}",
             )
 
@@ -1477,9 +1491,11 @@ class Dataset:
         description: str | None = "",
         execution_rid: RID | None = None,
     ) -> None:
-        """Adds members to a dataset.
+        """Add records to this dataset.
 
-        Associates one or more records with a dataset. Members can be provided in two forms:
+        Associates one or more records with this dataset and flips the
+        dataset to a dev version (per ADR-0003: every mutation lands on
+        dev). Members can be provided in two forms:
 
         **List of RIDs (simpler but slower):**
         When `members` is a list of RIDs, each RID is resolved to determine which table
@@ -1495,7 +1511,11 @@ class Dataset:
         dataset element types. Use :meth:`DerivaML.add_dataset_element_type` to register
         a table before adding its records to datasets.
 
-        Adding members automatically increments the dataset's minor version.
+        After this call, ``current_version`` is a dev label of the form
+        ``<last_release>.post1.devN``. Call :meth:`release` to mint a
+        released version when the dev period is complete. A call with
+        an empty ``members`` argument is a no-op and does not advance
+        the dev counter.
 
         Args:
             members: Either:
@@ -1585,6 +1605,7 @@ class Dataset:
             dataset_elements = {t: list(set(ms)) for t, ms in members.items()}
         # Now make the entries into the association tables.
         pb = self._ml_instance.pathBuilder()
+        any_added = False
         for table, elements in dataset_elements.items():
             # Determine schema: ML schema for Dataset/File, otherwise use the table's actual schema
             if table == "Dataset" or table == "File":
@@ -1600,11 +1621,15 @@ class Dataset:
                 schema_path.tables[association_map[table]].insert(
                     [{"Dataset": self.dataset_rid, fk_column: e} for e in elements]
                 )
-        self.increment_dataset_version(
-            VersionPart.minor,
-            description=description,
-            execution_rid=execution_rid,
-        )
+                any_added = True
+        # Per ADR-0003 / Q18: a call that doesn't change any row is a no-op
+        # and doesn't advance the dev counter. Only flip to dev if at least
+        # one association row was inserted.
+        if any_added:
+            self._create_or_advance_dev_row(
+                description=description,
+                execution_rid=execution_rid,
+            )
 
     @validate_call(config=ConfigDict(arbitrary_types_allowed=True))
     def delete_dataset_members(
@@ -1615,14 +1640,21 @@ class Dataset:
     ) -> None:
         """Remove members from this dataset.
 
-        Removes the specified members from the dataset. In addition to removing members,
-        the minor version number of the dataset is incremented and the description,
-        if provided, is applied to that new version.
+        Removes the specified members and flips the dataset to a dev
+        version (per ADR-0003: every mutation lands on dev).
+
+        After this call, ``current_version`` is a dev label of the form
+        ``<last_release>.post1.devN``. Call :meth:`release` to mint a
+        released version when the dev period is complete. A call with
+        an empty ``members`` argument is a no-op and does not advance
+        the dev counter.
 
         Args:
             members: List of member RIDs to remove from the dataset.
             description: Optional description of the removal operation.
-            execution_rid: Optional RID of execution associated with this operation.
+                Replaces the dev row's existing description.
+            execution_rid: Optional RID of execution associated with
+                this operation. Stored on the dev row.
 
         Raises:
             DerivaMLException: If any RID is invalid or not part of this dataset.
@@ -1632,8 +1664,13 @@ class Dataset:
             ...     members=["1-ABC", "1-DEF"],
             ...     description="Removed corrupted samples"
             ... )
+            >>> dataset.current_version  # doctest: +SKIP
+            <Version('0.4.0.post1.dev1')>
         """
         members = set(members)
+        # Per ADR-0003 / Q18: no-op input doesn't advance the dev counter.
+        if not members:
+            return
         description = description or "Deleted dataset members"
 
         # Go through every rid to be deleted and sort them based on what association table entries
@@ -1680,8 +1717,13 @@ class Dataset:
                 & (atable_path.columns[fk_column] == AnyQuantifier(*elements)),
             ).delete()
 
-        self.increment_dataset_version(
-            VersionPart.minor,
+        # Per ADR-0003: every mutation lands on dev. The caller passed a
+        # non-empty `members` list, so this is a real mutation attempt
+        # (the validation step above resolved the RIDs and confirmed they
+        # belong to dataset element types). RIDs that didn't actually
+        # match a membership row are a benign DELETE no-op at the table
+        # level but still represent caller intent — flip to dev.
+        self._create_or_advance_dev_row(
             description=description,
             execution_rid=execution_rid,
         )

--- a/tests/dataset/test_dataset_version.py
+++ b/tests/dataset/test_dataset_version.py
@@ -5,6 +5,7 @@ try:
 except ImportError:
     ic = lambda *a, **kw: None
 
+from deriva_ml import BuiltinTypes, ColumnDefinition, MLVocab, TableDefinition
 from deriva_ml.dataset.aux_classes import DatasetVersion, VersionPart
 from deriva_ml.execution.execution import ExecutionConfiguration
 
@@ -203,3 +204,135 @@ class TestMarkDev:
         dev = next(h for h in history if h.dataset_version.is_devrelease)
         # DatasetHistory normalises empty/missing execution_rid to None.
         assert dev.execution_rid is None
+
+
+class TestMutationsLandOnDev:
+    """Integration tests for PR 4: member and type mutations flip to dev.
+
+    Verifies the behavior change committed in ADR-0003 / PR 4: every
+    mutation that today bumped to a released version now lands on a dev
+    version instead. The dev counter advances per call (Q18), and
+    no-op input doesn't advance.
+    """
+
+    def _setup_dataset_with_table(self, ml_instance):
+        """Helper: register an element-type table and a fresh dataset.
+
+        Returns (dataset, test_rids) where test_rids are five rows
+        in the registered element type.
+        """
+        ml_instance.add_term(MLVocab.dataset_type, "DevDataMutation", description="A test type")
+        ml_instance.add_term(MLVocab.dataset_type, "AnotherType", description="A second test type")
+        ml_instance.add_term(MLVocab.workflow_type, "Manual Workflow", description="Manual workflow")
+        ml_instance.model.create_table(
+            TableDefinition(
+                name="MutationTestItem",
+                columns=[ColumnDefinition(name="Col1", type=BuiltinTypes.text)],
+            )
+        )
+        ml_instance.add_dataset_element_type("MutationTestItem")
+        table_path = ml_instance.catalog.getPathBuilder().schemas[ml_instance.default_schema].tables["MutationTestItem"]
+        table_path.insert([{"Col1": f"Item{i}"} for i in range(5)])
+        test_rids = [r["RID"] for r in table_path.entities().fetch()]
+
+        workflow = ml_instance.create_workflow(
+            name="Mutation Workflow",
+            workflow_type="Manual Workflow",
+            description="Workflow for mutation tests",
+        )
+        execution = ml_instance.create_execution(
+            ExecutionConfiguration(description="Mutation Execution", workflow=workflow)
+        )
+        dataset = execution.create_dataset(
+            dataset_types=["DevDataMutation"],
+            description="Dataset for mutation tests",
+            version=DatasetVersion(0, 4, 0),
+        )
+        return dataset, test_rids
+
+    def test_add_dataset_members_flips_to_dev(self, test_ml):
+        dataset, test_rids = self._setup_dataset_with_table(test_ml)
+        # Sanity check the starting state — released at 0.4.0.
+        assert str(dataset.current_version) == "0.4.0"
+
+        dataset.add_dataset_members({"MutationTestItem": test_rids[:2]})
+
+        new_version = dataset.current_version
+        assert new_version.is_devrelease, f"Expected dev version, got {new_version}"
+        assert str(new_version) == "0.4.0.post1.dev1"
+
+    def test_add_dataset_members_advances_devN_on_subsequent_calls(self, test_ml):
+        dataset, test_rids = self._setup_dataset_with_table(test_ml)
+        dataset.add_dataset_members({"MutationTestItem": test_rids[:1]})
+        dataset.add_dataset_members({"MutationTestItem": test_rids[1:2]})
+        dataset.add_dataset_members({"MutationTestItem": test_rids[2:3]})
+
+        assert str(dataset.current_version) == "0.4.0.post1.dev3"
+
+    def test_add_dataset_members_with_empty_input_is_noop(self, test_ml):
+        dataset, _test_rids = self._setup_dataset_with_table(test_ml)
+        version_before = dataset.current_version
+
+        dataset.add_dataset_members({"MutationTestItem": []})
+
+        version_after = dataset.current_version
+        # No row was inserted, so the dev counter does not advance.
+        assert version_after == version_before
+        assert not version_after.is_devrelease
+
+    def test_add_dataset_type_flips_to_dev(self, test_ml):
+        dataset, _test_rids = self._setup_dataset_with_table(test_ml)
+        assert not dataset.current_version.is_devrelease
+
+        dataset.add_dataset_type("AnotherType")
+
+        new_version = dataset.current_version
+        assert new_version.is_devrelease
+        assert str(new_version) == "0.4.0.post1.dev1"
+
+    def test_add_dataset_type_for_existing_type_is_noop(self, test_ml):
+        dataset, _test_rids = self._setup_dataset_with_table(test_ml)
+        version_before = dataset.current_version
+
+        # The dataset was created with type "DevDataMutation"; re-adding it is a no-op.
+        dataset.add_dataset_type("DevDataMutation")
+
+        version_after = dataset.current_version
+        assert version_after == version_before
+        assert not version_after.is_devrelease
+
+    def test_remove_dataset_type_flips_to_dev(self, test_ml):
+        dataset, _test_rids = self._setup_dataset_with_table(test_ml)
+        # First add a second type so we have something to remove without
+        # leaving the dataset typeless.
+        dataset.add_dataset_types(["AnotherType"])
+        # That advanced to .dev1; now remove it.
+        dataset.remove_dataset_type("AnotherType")
+
+        new_version = dataset.current_version
+        assert new_version.is_devrelease
+        # First add was .dev1; remove was .dev2.
+        assert str(new_version) == "0.4.0.post1.dev2"
+
+    def test_remove_dataset_type_for_absent_type_is_noop(self, test_ml):
+        dataset, _test_rids = self._setup_dataset_with_table(test_ml)
+        version_before = dataset.current_version
+
+        # "AnotherType" was added to the vocabulary but never associated
+        # with this dataset, so removing it is a no-op.
+        dataset.remove_dataset_type("AnotherType")
+
+        version_after = dataset.current_version
+        assert version_after == version_before
+        assert not version_after.is_devrelease
+
+    def test_existing_release_path_still_works(self, test_ml):
+        """``increment_dataset_version`` (renamed in PR 5) still produces released rows."""
+        dataset, _test_rids = self._setup_dataset_with_table(test_ml)
+
+        # Direct release — bypasses the dev-versioning model entirely.
+        # Will be renamed to release() in PR 5.
+        new_version = dataset.increment_dataset_version(VersionPart.minor)
+
+        assert not new_version.is_devrelease
+        assert str(new_version) == "0.5.0"

--- a/tests/dataset/test_datasets.py
+++ b/tests/dataset/test_datasets.py
@@ -16,7 +16,7 @@ from deriva_ml import (
     MLVocab,
     TableDefinition,
 )
-from deriva_ml.dataset.aux_classes import DatasetSpec, VersionPart
+from deriva_ml.dataset.aux_classes import DatasetSpec
 from deriva_ml.dataset.catalog_graph import CatalogGraph
 from deriva_ml.demo_catalog import DatasetDescription
 from deriva_ml.execution.execution import ExecutionConfiguration
@@ -207,14 +207,16 @@ class TestDataset:
         history = dataset.dataset_history()
         assert manual_execution.execution_rid == history[0].execution_rid
 
-    def test_delete_dataset_members_increments_version(self, test_ml):
-        """Test that delete_dataset_members increments the dataset version correctly.
+    def test_delete_dataset_members_lands_on_dev(self, test_ml):
+        """Test that delete_dataset_members flips the dataset to a dev version.
 
-        This test verifies:
-        1. Version is incremented when members are deleted
-        2. The increment is a minor version bump
-        3. The description is properly recorded
-        4. The members are actually removed
+        Per ADR-0003 / PR 4: every mutation lands on dev; release is the
+        only path to a released version. This test verifies:
+
+        1. Version flips to a dev label (``.post1.dev1``) anchored at
+           the previous released version after a successful delete
+        2. The description is recorded on the dev row
+        3. The members are actually removed
         """
         ml_instance = test_ml
 
@@ -255,10 +257,12 @@ class TestDataset:
         rids_to_delete = test_rids[:2]
         dataset.delete_dataset_members(members=rids_to_delete, description="Removed 2 test items")
 
-        # Verify version was incremented (minor bump)
+        # Per ADR-0003 / PR 4: delete_dataset_members lands on dev.
+        # The dev label is anchored at the previous released version.
         new_version = dataset.current_version
-        expected_version = initial_version.next_release(VersionPart.minor)
-        assert new_version == expected_version, f"Expected version {expected_version}, got {new_version}"
+        assert new_version.is_devrelease, f"Expected dev version, got {new_version}"
+        assert new_version.release == initial_version.release
+        assert new_version.dev == 1
 
         # Verify members were removed
         remaining_members = dataset.list_dataset_members()

--- a/tests/dataset/test_download.py
+++ b/tests/dataset/test_download.py
@@ -162,7 +162,12 @@ class TestDatasetDownload:
 
         dataset_description.dataset.add_dataset_members(subjects[-2:])
         new_version = dataset_description.dataset.current_version
-        assert new_version == current_version.next_release(VersionPart.minor)
+        # Per ADR-0003: add_dataset_members lands on a dev version, not a
+        # released minor bump. The dev label is anchored at the previous
+        # release (`current_version`).
+        assert new_version.is_devrelease
+        assert new_version.release == current_version.release
+        assert new_version.dev == 1
 
         current_bag = dataset.download_dataset_bag(current_version, use_minid=False)
         new_bag = dataset.download_dataset_bag(new_version, use_minid=False)


### PR DESCRIPTION
## Summary

PR 4 of 7 in the dev-versioning delivery sequence (ADR-0005).
**This is the first breaking PR.** Five mutation methods on
\`Dataset\` switch from "bump to released version" to "land on a
dev version" per ADR-0003's Behavior 1 (every mutation lands on
dev; release is the only path to released).

This PR is based on PR 3 ([#84](https://github.com/informatics-isi-edu/deriva-ml/pull/84)) and should not merge until that
does.

## Behavior change

| Method | Before | After |
|---|---|---|
| \`add_dataset_members\` | Minor version bump (\`0.4.0\` → \`0.5.0\`) | Dev flip (\`0.4.0\` → \`0.4.0.post1.dev1\`); subsequent calls advance \`.devN\` |
| \`delete_dataset_members\` | Minor version bump | Dev flip |
| \`add_dataset_type\` | Minor version bump | Dev flip; no-op for already-present type |
| \`add_dataset_types\` | Minor version bump | Dev flip; no-op when nothing new is added |
| \`remove_dataset_type\` | **Silent no-op on version side** (pre-existing bug) | Dev flip on successful removal; no-op for absent type |

\`increment_dataset_version\` is unchanged here — direct callers
still get released rows. PR 5 renames it to \`release()\` and adds
the no-dev-row precondition.

## Out-of-strict-ADR-5 scope: \`remove_dataset_type\`

ADR-0005's PR 4 description names only \`add_dataset_members\` and
\`delete_dataset_members\`. I expanded scope to all five mutation
methods on \`Dataset\` because:

1. \`add_dataset_type\` / \`add_dataset_types\` previously called
   \`increment_dataset_version\` — same code path, same regression
   surface, same test pattern. Splitting them into a separate PR
   would create asymmetry where member ops land on dev and type
   ops still bump to released, which is exactly the mixed-semantics
   model Behavior 1 was designed to eliminate.
2. \`remove_dataset_type\` previously had **no version update at
   all** — a pre-existing bug. Fixing it consistently with the
   new model means it now flips to dev on removal. Without this
   fix, the asymmetry would be even worse (add flips to dev,
   remove silently doesn't).

The \`remove_dataset_type\` change is the most semantically novel —
it's not a refactor of an existing version-bumping path, but a fix
for a method that wasn't recording its mutations at all. Worth
calling out separately for review.

## No-op handling (per Q18)

Calls that don't change any catalog row don't advance the dev
counter:

- \`add_dataset_members({"X": []})\` — no rows inserted.
- \`add_dataset_members({})\` — no tables to insert into.
- \`add_dataset_type("AlreadyPresent")\` — no association inserted.
- \`add_dataset_types(["AlreadyPresent"])\` — no new types.
- \`remove_dataset_type("NotPresent")\` — no association deleted.
- \`delete_dataset_members([])\` — short-circuited at the top.

\`delete_dataset_members([X, Y])\` where \`X\`, \`Y\` are valid
element-type RIDs but not actually members of this dataset is
treated as a real mutation attempt and **does** advance the dev
counter. The alternative — verifying membership before
deleting — would add a round-trip per call. The mismatch between
"caller intent" and "rows actually changed" is benign in practice.

## Tests

\`tests/dataset/test_dataset_version.py\`: new \`TestMutationsLandOnDev\`
class with 8 integration tests against a live catalog.

\`tests/dataset/test_download.py\` and \`tests/dataset/test_datasets.py\`:
update existing assertions to expect dev labels instead of
released-minor-bumps.

## Verification

| Check | Result |
|---|---|
| Unit tests (\`local_db\`, \`test_dataset_version_unit\`) | 270 / 270 pass |
| New \`TestMutationsLandOnDev\` integration tests | 8 / 8 pass against \`localhost\` |
| Existing \`TestMarkDev\` integration tests | 9 / 9 pass (PR 3 work) |
| Existing \`TestDatasetVersion\` integration tests | 2 / 2 pass; 1 pre-existing \`FileNotFoundError\` from a workspace-resolution issue (unchanged from \`main\`) |
| \`test_split.py\` | Same 26 failures as \`main\` (all pre-existing) |
| \`ruff check\` on changed regions | Clean (pre-existing errors at unrelated line numbers) |
| \`ruff format\` on my edits | Applied |

## Known pre-existing failures (not PR 4)

- \`test_delete_dataset_members_lands_on_dev\` (renamed) — fails
  with deriva-py URL parse error in \`.delete()\`. Reproduces on
  \`main\`. Tracked separately. The test's assertion shape now
  matches PR 4 semantics; once the deriva-py bug is fixed, the
  test will pass.
- Workspace-resolution \`FileNotFoundError\` on
  \`test_dataset_version\`, \`test_nested_datasets\`,
  \`test_dataset_members\`, \`test_dataset_download_versions\`. All
  pre-existing on \`main\`.

## Refs

- [#79](https://github.com/informatics-isi-edu/deriva-ml/issues/79) — design proposal
- [#80](https://github.com/informatics-isi-edu/deriva-ml/pull/80) — design docs (must merge first)
- [#81](https://github.com/informatics-isi-edu/deriva-ml/pull/81) — PR 1
- [#82](https://github.com/informatics-isi-edu/deriva-ml/pull/82) — PR 2
- [#84](https://github.com/informatics-isi-edu/deriva-ml/pull/84) — PR 3 (this PR is based on it)
- ADR-0003 — dev versioning model
- ADR-0005 — full delivery sequence

🤖 Generated with [Claude Code](https://claude.com/claude-code)