### PR TITLE
feat(dataset): add Dataset.release(); rename increment_dataset_version to private (ADR-0003; PR 5 of 7)

### DIFF
--- a/src/deriva_ml/catalog/clone.py
+++ b/src/deriva_ml/catalog/clone.py
@@ -1642,7 +1642,11 @@ def _reinitialize_dataset_versions(
 
         for dataset in ml.find_datasets():
             try:
-                dataset.increment_dataset_version(
+                # Catalog clone reinitialises versions on every dataset to
+                # stamp fresh snapshot pointers. This is structural, not a
+                # user-facing release — bypass the dev-versioning model
+                # via the internal force-bump primitive.
+                dataset._increment_dataset_version(
                     component=VersionPart.patch,
                     description=description,
                 )

--- a/src/deriva_ml/dataset/dataset.py
+++ b/src/deriva_ml/dataset/dataset.py
@@ -20,8 +20,8 @@ Typical usage example:
     ...         description='Experimental data'
     ...     )
     ...     dataset.add_dataset_members(members=['1-abc123', '1-def456'])
-    ...     dataset.increment_dataset_version(
-    ...         component=VersionPart.minor,
+    ...     dataset.release(
+    ...         bump=VersionPart.minor,
     ...         description='Added new samples'
     ...     )
 """
@@ -152,10 +152,10 @@ class Dataset:
         ...         dataset_types=["training_data"],
         ...         description="Image classification training set"
         ...     )
-        ...     # Add members to the dataset
+        ...     # Add members to the dataset (lands on a dev version)
         ...     dataset.add_dataset_members(members=["1-abc", "1-def"])
-        ...     # Increment version after changes
-        ...     new_version = dataset.increment_dataset_version(VersionPart.minor, "Added samples")
+        ...     # Promote the dev period to a released version
+        ...     new_version = dataset.release(VersionPart.minor, "Added samples")
         >>> # Download for offline use
         >>> bag = dataset.download_dataset_bag(version=new_version)  # doctest: +SKIP
     """
@@ -891,36 +891,38 @@ class Dataset:
             parent._build_dataset_graph_1(ts, visited)
 
     @validate_call(config=ConfigDict(arbitrary_types_allowed=True))
-    def increment_dataset_version(
+    def _increment_dataset_version(
         self,
         component: VersionPart,
         description: str | None = "",
         execution_rid: RID | None = None,
     ) -> DatasetVersion:
-        """Increments a dataset's version number.
+        """Force a release-version bump on this dataset and its related datasets.
 
-        Creates a new version of the dataset by incrementing the specified version component
-        (major, minor, or patch). The new version is recorded with an optional description
-        and execution reference.
+        Internal helper preserved from the pre-dev-versioning model.
+        Walks the dataset graph (parents/children) and inserts a new
+        released ``Dataset_Version`` row for each, with the supplied
+        component bumped and a stamped catalog snapshot. Bypasses the
+        dev-versioning model entirely — there's no precondition that
+        the dataset be in a dev period.
+
+        Used internally by the catalog-clone path, where dataset
+        versions need to be reinitialised after a catalog snapshot is
+        copied. Not for user-facing release work; use :meth:`release`
+        for that.
 
         Args:
-            component: Which version component to increment ('major', 'minor', or 'patch').
-            description: Optional description of the changes in this version.
-            execution_rid: Optional execution RID to associate with this version.
+            component: Which release-segment part to bump.
+            description: Optional description for the new version row.
+            execution_rid: Optional RID of the calling execution.
 
         Returns:
-            DatasetVersion: The new version number.
+            The new ``DatasetVersion`` for this dataset (related
+            datasets are also bumped but their versions are not in the
+            return).
 
         Raises:
-            DerivaMLException: If dataset_rid is invalid or version increment fails.
-
-        Example:
-            >>> new_version = ml.increment_dataset_version(  # doctest: +SKIP
-            ...     dataset_rid="1-abc123",
-            ...     component="minor",
-            ...     description="Added new samples"
-            ... )
-            >>> print(f"New version: {new_version}")  # e.g., "1.2.0"  # doctest: +SKIP
+            DerivaMLException: If the catalog write fails.
         """
 
         # Find all the datasets that are reachable from this dataset and determine their new version numbers.
@@ -936,6 +938,131 @@ class Dataset:
             self._ml_instance, version_update_list, description=description, execution_rid=execution_rid
         )
         return next((d.version for d in version_update_list if d.rid == self.dataset_rid))
+
+    def release(
+        self,
+        bump: VersionPart,
+        description: str,
+        execution: "Execution | None" = None,
+    ) -> DatasetVersion:
+        """Promote this dataset's dev period to a released version.
+
+        Per ADR-0003, ``release`` is the only operation that produces
+        a released ``Dataset_Version`` row. It promotes the existing
+        dev row in place: rewrites ``Version`` to the released label,
+        stamps ``Snapshot`` with the catalog snapshot at release time,
+        replaces ``Description`` with release notes, and overwrites
+        the row's ``Execution`` link with the supplied execution (or
+        ``NULL`` if none).
+
+        Concurrency: the promotion uses a conditional update on the
+        dev row's observed ``RMT``. If a competing writer landed
+        between this method's read and write — another mutation, or
+        another concurrent ``release`` — the call raises
+        :class:`DerivaMLException` with a clear retry message rather
+        than silently overwriting the other writer's work.
+
+        Args:
+            bump: Which release-segment part to advance from the
+                last released version. ``VersionPart.minor`` is the
+                common case; ``VersionPart.major`` for
+                schema-breaking changes; ``VersionPart.patch`` for
+                small clean-ups.
+            description: Release notes. **Replaces** the dev row's
+                accumulated description, not appended.
+            execution: Optional ``Execution`` that called release.
+                Stored on the released row's ``Execution`` link.
+                Mutator authorship during the dev period is not
+                captured here — it's recoverable from the catalog's
+                audit trail (``RMT`` on changed rows + per-row
+                provenance).
+
+        Returns:
+            The new released ``DatasetVersion``.
+
+        Raises:
+            DerivaMLException: If this dataset has no dev row to
+                promote, or if a concurrent writer modified the dev
+                row between this call's read and write.
+
+        Example:
+            >>> dataset.add_dataset_members(["1-abc", "1-def"])  # doctest: +SKIP
+            >>> dataset.add_dataset_members(["1-ghi"])  # doctest: +SKIP
+            >>> # Now at e.g. 0.4.0.post1.dev2; cut a real release:
+            >>> v = dataset.release(  # doctest: +SKIP
+            ...     bump=VersionPart.minor,
+            ...     description="Added 3 new samples for v0.5.0",
+            ... )
+            >>> print(v)  # doctest: +SKIP
+            0.5.0
+        """
+        history = self.dataset_history()
+        dev_entries = [h for h in history if h.dataset_version.is_devrelease]
+        if not dev_entries:
+            raise DerivaMLException(
+                f"Dataset {self.dataset_rid} has no dev period to release "
+                f"(current_version={self.current_version}). To release a "
+                "no-op change, call mark_dev() first to declare a dev "
+                "period, then release() to promote it."
+            )
+        if len(dev_entries) > 1:
+            raise DerivaMLException(
+                f"Dataset {self.dataset_rid} has {len(dev_entries)} dev rows; expected at most one."
+            )
+        dev_row = dev_entries[0]
+
+        # Find the last released version to anchor the next-release bump.
+        released_entries = [h for h in history if not h.dataset_version.is_devrelease]
+        if not released_entries:
+            # Defensive: every dataset has at least one released row at
+            # creation time. If this fires, the catalog is in an
+            # inconsistent state.
+            raise DerivaMLException(
+                f"Dataset {self.dataset_rid} is in a dev period but has "
+                "no released version to anchor the next release against."
+            )
+        last_released = max(h.dataset_version for h in released_entries)
+        next_label = str(last_released.next_release(bump))
+
+        # Re-fetch the dev row to get its current RMT for the conditional update.
+        schema_path = self._ml_instance.pathBuilder().schemas[self._ml_instance.ml_schema]
+        version_table = schema_path.tables["Dataset_Version"]
+        current_rows = list(version_table.filter(version_table.RID == dev_row.version_rid).entities().fetch())
+        if not current_rows:
+            raise DerivaMLException(
+                f"Dev version row {dev_row.version_rid} disappeared between read and update — concurrent deletion?"
+            )
+        observed_rmt = current_rows[0]["RMT"]
+
+        # Stamp the catalog snapshot at release time.
+        snapshot = self._ml_instance.catalog.get("/").json()["snaptime"]
+
+        execution_rid = execution.execution_rid if execution is not None else None
+        updated = list(
+            version_table.update(
+                [
+                    {
+                        "RID": dev_row.version_rid,
+                        "RMT": observed_rmt,
+                        "Version": next_label,
+                        "Snapshot": snapshot,
+                        "Description": description,
+                        "Execution": execution_rid,
+                    }
+                ],
+                correlation={"RID", "RMT"},
+            )
+        )
+        if not updated:
+            raise DerivaMLException(
+                f"Concurrent modification of dev row {dev_row.version_rid} "
+                f"for dataset {self.dataset_rid}: another writer advanced "
+                "the row between this call's read and write. Re-read the "
+                "dataset and retry if the new state is still what you "
+                "intended."
+            )
+
+        return DatasetVersion.parse(next_label)
 
     def _create_or_advance_dev_row(
         self,
@@ -1097,10 +1224,11 @@ class Dataset:
                 row between this call's read and write.
 
         Example:
-            >>> # A separate execution recorded labels for some images  # doctest: +SKIP
+            >>> # A separate execution recorded labels for some images
             >>> # that are members of this dataset. Flag the drift:
-            >>> dataset.mark_dev("Picked up classifier output for the test split")
-            >>> str(dataset.current_version)  # e.g. "0.4.0.post1.dev1"
+            >>> dataset.mark_dev("Picked up classifier output for the test split")  # doctest: +SKIP
+            >>> str(dataset.current_version)  # doctest: +SKIP
+            '0.4.0.post1.dev1'
         """
         execution_rid = execution.execution_rid if execution is not None else None
         self._create_or_advance_dev_row(

--- a/src/deriva_ml/interfaces.py
+++ b/src/deriva_ml/interfaces.py
@@ -86,6 +86,7 @@ from deriva_ml.model.catalog import DerivaModel
 if TYPE_CHECKING:
     from deriva_ml.dataset.aux_classes import DatasetHistory, DatasetSpec, DatasetVersion, VersionPart
     from deriva_ml.dataset.dataset import Dataset
+    from deriva_ml.execution.execution import Execution
     from deriva_ml.execution.execution_record import ExecutionRecord
     from deriva_ml.execution.state_store import ExecutionStatus
     from deriva_ml.execution.workflow import Workflow
@@ -497,7 +498,7 @@ class WritableDataset(DatasetLike, Protocol):
     Example:
         >>> def add_samples(dataset: WritableDataset, sample_rids: list[str]):
         ...     dataset.add_dataset_members(sample_rids)
-        ...     dataset.increment_dataset_version(VersionPart.minor)
+        ...     dataset.release(VersionPart.minor, "Added samples")
     """
 
     def add_dataset_members(
@@ -537,21 +538,27 @@ class WritableDataset(DatasetLike, Protocol):
         """
         ...
 
-    def increment_dataset_version(
+    def release(
         self,
-        component: "VersionPart",
-        description: str | None = "",
-        execution_rid: RID | None = None,
+        bump: "VersionPart",
+        description: str,
+        execution: "Execution | None" = None,
     ) -> DatasetVersion:
-        """Increment the dataset version.
+        """Promote this dataset's dev period to a released version.
+
+        Per ADR-0003: ``release`` is the only operation that produces
+        a released ``Dataset_Version`` row. Errors if the dataset has
+        no dev period to release.
 
         Args:
-            component: Which version component to increment (VersionPart.major, .minor, or .patch).
-            description: Optional description of the changes in this version.
-            execution_rid: Optional execution RID to associate with this version.
+            bump: Which release-segment part to advance (``major``,
+                ``minor``, or ``patch``).
+            description: Release notes. Replaces the dev row's
+                accumulated description.
+            execution: Optional ``Execution`` that called release.
 
         Returns:
-            The new version after incrementing.
+            The new released version.
         """
         ...
 

--- a/tests/catalog/test_clone_catalog.py
+++ b/tests/catalog/test_clone_catalog.py
@@ -159,8 +159,10 @@ class TestCreateMlWorkspace:
             cloned_dataset = cloned_ml.lookup_dataset(source_dataset_rid)
             assert cloned_dataset is not None, "Dataset should exist in clone"
 
-            # Create a new version in the clone
-            new_version = cloned_dataset.increment_dataset_version(
+            # Create a new version in the clone via the private force-bump
+            # primitive — this test stamps a fresh snapshot, not exercises
+            # the dev → release lifecycle.
+            new_version = cloned_dataset._increment_dataset_version(
                 component=VersionPart.patch,
                 description="Version created in cloned catalog",
             )

--- a/tests/dataset/test_dataset_version.py
+++ b/tests/dataset/test_dataset_version.py
@@ -33,7 +33,10 @@ class TestDatasetVersion:
         )
         v0 = dataset.current_version
         assert "1.0.0" == str(v0)
-        v1 = dataset.increment_dataset_version(component=VersionPart.minor)
+        # Use the private force-bump primitive: this test verifies the
+        # release-segment arithmetic and graph propagation without
+        # going through the dev → release lifecycle.
+        v1 = dataset._increment_dataset_version(component=VersionPart.minor)
         assert "1.1.0" == str(v1)
         assert "1.1.0" == str(dataset.current_version)
 
@@ -58,7 +61,7 @@ class TestDatasetVersion:
             version=DatasetVersion(1, 0, 0),
         )
         assert 1 == len(dataset.dataset_history())
-        v1 = dataset.increment_dataset_version(component=VersionPart.minor)
+        v1 = dataset._increment_dataset_version(component=VersionPart.minor)
         assert 2 == len(dataset.dataset_history())
 
     def test_dataset_version(self, dataset_test, tmp_path):
@@ -76,7 +79,10 @@ class TestDatasetVersion:
             "d1": [ds.current_version for ds in nested_datasets],
             "d2": [ds.current_version for ds in datasets],
         }
-        nested_datasets[0].increment_dataset_version(VersionPart.major)
+        # Use the private force-bump primitive: this test verifies graph
+        # propagation, which is _increment_dataset_version's specialty.
+        # The public release() path operates on a single dataset only.
+        nested_datasets[0]._increment_dataset_version(VersionPart.major)
         new_versions = {
             "d0": dataset_description.dataset.current_version,
             "d1": [ds.current_version for ds in nested_datasets],
@@ -177,8 +183,8 @@ class TestMarkDev:
     def test_history_is_sorted_ascending(self, test_ml):
         dataset, _execution = self._setup_dataset(test_ml)
         # Make a few releases plus a dev row.
-        dataset.increment_dataset_version(VersionPart.minor, "first bump")
-        dataset.increment_dataset_version(VersionPart.minor, "second bump")
+        dataset._increment_dataset_version(VersionPart.minor, "first bump")
+        dataset._increment_dataset_version(VersionPart.minor, "second bump")
         dataset.mark_dev("then dev")
 
         history = dataset.dataset_history()
@@ -326,13 +332,187 @@ class TestMutationsLandOnDev:
         assert version_after == version_before
         assert not version_after.is_devrelease
 
-    def test_existing_release_path_still_works(self, test_ml):
-        """``increment_dataset_version`` (renamed in PR 5) still produces released rows."""
+    def test_force_bump_via_internal_helper(self, test_ml):
+        """``_increment_dataset_version`` (private, force-bump) still produces released rows.
+
+        After PR 5, the public release path is :meth:`Dataset.release`,
+        which requires a dev row. ``_increment_dataset_version`` is
+        kept as a private internal primitive for callers that need to
+        force-bump without a dev period (e.g., catalog clone).
+        """
         dataset, _test_rids = self._setup_dataset_with_table(test_ml)
 
-        # Direct release — bypasses the dev-versioning model entirely.
-        # Will be renamed to release() in PR 5.
-        new_version = dataset.increment_dataset_version(VersionPart.minor)
+        new_version = dataset._increment_dataset_version(VersionPart.minor)
 
         assert not new_version.is_devrelease
         assert str(new_version) == "0.5.0"
+
+
+class TestRelease:
+    """Integration tests for ``Dataset.release`` per ADR-0003 / PR 5.
+
+    Verifies:
+    - release() promotes the dev row in place (released label, stamped Snapshot,
+      replaced Description, overwritten Execution).
+    - release() errors when no dev row exists.
+    - release() honors the ``bump`` argument (major / minor / patch).
+    - release() returns the new released ``DatasetVersion``.
+    """
+
+    def _setup_dataset_with_dev(self, ml_instance):
+        """Helper: create a fresh dataset and flip it to dev via mark_dev.
+
+        Returns (dataset, execution, dev_row_rid).
+        """
+        ml_instance.add_term("Dataset_Type", "ReleaseTest", description="A test type")
+        ml_instance.add_term("Workflow_Type", "Manual Workflow", description="Manual workflow")
+        workflow = ml_instance.create_workflow(
+            name="Release Workflow",
+            workflow_type="Manual Workflow",
+            description="Workflow for release tests",
+        )
+        execution = ml_instance.create_execution(
+            ExecutionConfiguration(description="Release Execution", workflow=workflow)
+        )
+        dataset = execution.create_dataset(
+            dataset_types="ReleaseTest",
+            description="Dataset for release tests",
+            version=DatasetVersion(0, 4, 0),
+        )
+        dataset.mark_dev("initial drift")
+        # Find the dev row's RID for in-place promotion verification.
+        dev_row = next(h for h in dataset.dataset_history() if h.dataset_version.is_devrelease)
+        return dataset, execution, dev_row.version_rid
+
+    def test_release_minor_bump(self, test_ml):
+        dataset, _execution, _dev_rid = self._setup_dataset_with_dev(test_ml)
+        assert str(dataset.current_version) == "0.4.0.post1.dev1"
+
+        v = dataset.release(bump=VersionPart.minor, description="release notes")
+
+        assert str(v) == "0.5.0"
+        assert not v.is_devrelease
+        assert str(dataset.current_version) == "0.5.0"
+
+    def test_release_major_bump(self, test_ml):
+        dataset, _execution, _dev_rid = self._setup_dataset_with_dev(test_ml)
+
+        v = dataset.release(bump=VersionPart.major, description="major change")
+
+        assert str(v) == "1.0.0"
+
+    def test_release_patch_bump(self, test_ml):
+        dataset, _execution, _dev_rid = self._setup_dataset_with_dev(test_ml)
+
+        v = dataset.release(bump=VersionPart.patch, description="patch change")
+
+        assert str(v) == "0.4.1"
+
+    def test_release_promotes_in_place(self, test_ml):
+        """Per ADR-0003 / Q12: the dev row's RID is preserved across promotion."""
+        dataset, _execution, dev_rid = self._setup_dataset_with_dev(test_ml)
+
+        dataset.release(bump=VersionPart.minor, description="promoted")
+
+        # The released row should have the same RID as the dev row
+        # (UPDATE in place, not INSERT a new row + DELETE the old).
+        history = dataset.dataset_history()
+        released_at_05 = [h for h in history if str(h.dataset_version) == "0.5.0"]
+        assert len(released_at_05) == 1
+        assert released_at_05[0].version_rid == dev_rid
+
+    def test_release_stamps_snapshot(self, test_ml):
+        """Released rows have a non-NULL Snapshot; dev rows had NULL."""
+        dataset, _execution, _dev_rid = self._setup_dataset_with_dev(test_ml)
+
+        dataset.release(bump=VersionPart.minor, description="snap test")
+
+        released = next(h for h in dataset.dataset_history() if str(h.dataset_version) == "0.5.0")
+        assert released.snapshot is not None
+        assert released.snapshot != ""
+
+    def test_release_replaces_description(self, test_ml):
+        """Per Q12: release replaces the dev row's accumulated description."""
+        dataset, _execution, _dev_rid = self._setup_dataset_with_dev(test_ml)
+        # Add another mark_dev to accumulate description.
+        dataset.mark_dev("more drift")
+
+        dataset.release(bump=VersionPart.minor, description="release notes only")
+
+        released = next(h for h in dataset.dataset_history() if str(h.dataset_version) == "0.5.0")
+        assert released.description == "release notes only"
+        assert "drift" not in (released.description or "")
+
+    def test_release_overwrites_execution(self, test_ml):
+        """release()'s execution arg overwrites whatever the dev row had."""
+        dataset, original_execution, _dev_rid = self._setup_dataset_with_dev(test_ml)
+        # Create a different execution to attach at release time.
+        ml_instance = dataset._ml_instance
+        workflow = ml_instance.create_workflow(
+            name="Release Workflow 2",
+            workflow_type="Manual Workflow",
+            description="A second workflow",
+        )
+        release_execution = ml_instance.create_execution(
+            ExecutionConfiguration(description="Release-time execution", workflow=workflow)
+        )
+
+        dataset.release(
+            bump=VersionPart.minor,
+            description="with release execution",
+            execution=release_execution,
+        )
+
+        released = next(h for h in dataset.dataset_history() if str(h.dataset_version) == "0.5.0")
+        assert released.execution_rid == release_execution.execution_rid
+        # Not the original mark_dev execution.
+        assert released.execution_rid != original_execution.execution_rid
+
+    def test_release_without_execution_leaves_null(self, test_ml):
+        dataset, _execution, _dev_rid = self._setup_dataset_with_dev(test_ml)
+
+        dataset.release(bump=VersionPart.minor, description="no execution")
+
+        released = next(h for h in dataset.dataset_history() if str(h.dataset_version) == "0.5.0")
+        # DatasetHistory normalises empty/missing execution_rid to None.
+        assert released.execution_rid is None
+
+    def test_release_errors_on_no_dev_row(self, test_ml):
+        """release() with no dev period to promote raises a clear error."""
+        import pytest
+
+        # Use the mark_dev helper *without* mark_dev — fresh released-only dataset.
+        ml_instance = test_ml
+        ml_instance.add_term("Dataset_Type", "ReleaseTest", description="A test type")
+        ml_instance.add_term("Workflow_Type", "Manual Workflow", description="Manual workflow")
+        workflow = ml_instance.create_workflow(
+            name="Release Workflow",
+            workflow_type="Manual Workflow",
+            description="Workflow for release tests",
+        )
+        execution = ml_instance.create_execution(
+            ExecutionConfiguration(description="Release Execution", workflow=workflow)
+        )
+        dataset = execution.create_dataset(
+            dataset_types="ReleaseTest",
+            description="Dataset with no dev period",
+            version=DatasetVersion(0, 4, 0),
+        )
+        # Sanity: dataset is at a released version, no dev row.
+        assert not dataset.current_version.is_devrelease
+
+        with pytest.raises(Exception) as exc_info:
+            dataset.release(bump=VersionPart.minor, description="should fail")
+        # Error message points the user at mark_dev as the resolution.
+        assert "mark_dev" in str(exc_info.value)
+
+    def test_release_then_mark_dev_creates_new_dev_period(self, test_ml):
+        """After release, the next mark_dev creates a fresh .dev1 anchored at the new release."""
+        dataset, _execution, _dev_rid = self._setup_dataset_with_dev(test_ml)
+        dataset.release(bump=VersionPart.minor, description="0.5.0 release")
+        assert str(dataset.current_version) == "0.5.0"
+
+        dataset.mark_dev("new drift")
+
+        # Anchored at 0.5.0 (the new last-released), not 0.4.0.
+        assert str(dataset.current_version) == "0.5.0.post1.dev1"

--- a/tests/dataset/test_denormalize.py
+++ b/tests/dataset/test_denormalize.py
@@ -1358,9 +1358,7 @@ class TestNewFKPatterns:
         # Row count lower bound: one row per Image at minimum.
         members = bag.list_dataset_members(recurse=True)
         image_count = len(members.get("Image", []))
-        assert len(df) >= image_count, (
-            f"Row count ({len(df)}) should be at least Image member count ({image_count})."
-        )
+        assert len(df) >= image_count, f"Row count ({len(df)}) should be at least Image member count ({image_count})."
 
     # -------------------------------------------------------------------------
     # Association table as mandatory intermediate
@@ -1593,7 +1591,10 @@ class TestVersionPinnedDenormalize:
         v0_rids = set(df_v0["Subject.RID"].dropna())
 
         # Bump to v1 (creates a new snapshot) without changing members.
-        v1 = str(dataset.increment_dataset_version(component=VersionPart.patch))
+        # Uses the private force-bump primitive; this test stamps a fresh
+        # snapshot to test denormalization at multiple versions, not to
+        # exercise the dev → release lifecycle.
+        v1 = str(dataset._increment_dataset_version(component=VersionPart.patch))
         assert v0 != v1, "Version increment should produce a distinct version string"
 
         df_v1 = dataset.get_denormalized_as_dataframe(
@@ -1629,17 +1630,15 @@ class TestVersionPinnedDenormalize:
 
         v0 = str(dataset.current_version)
         bag_v0 = dataset.download_dataset_bag(v0, use_minid=False)
-        bag_v0_rids = {
-            m["RID"] for m in bag_v0.list_dataset_members(recurse=True).get("Subject", [])
-        }
+        bag_v0_rids = {m["RID"] for m in bag_v0.list_dataset_members(recurse=True).get("Subject", [])}
 
-        # Bump the live catalog to v1.
-        dataset.increment_dataset_version(component=VersionPart.patch)
+        # Bump the live catalog to v1 via the private force-bump primitive
+        # (this test stamps a snapshot, not exercises dev → release).
+        dataset._increment_dataset_version(component=VersionPart.patch)
 
         # The bag remains at v0 — bag's own SQLite is unchanged.
         df = bag_v0.get_denormalized_as_dataframe(include_tables=["Subject"])
         bag_denorm_rids = set(df["Subject.RID"].dropna())
         assert bag_denorm_rids == bag_v0_rids, (
-            "Bag denormalize should return exactly the Subjects in the bag "
-            "regardless of later live-catalog changes."
+            "Bag denormalize should return exactly the Subjects in the bag regardless of later live-catalog changes."
         )

--- a/tests/dataset/test_download.py
+++ b/tests/dataset/test_download.py
@@ -193,7 +193,9 @@ class TestDatasetDownload:
                 columns=[],
             )
         )
-        new_version = dataset_description.dataset.increment_dataset_version(component=VersionPart.minor)
+        # Use the private force-bump primitive: this test stamps a new
+        # snapshot to capture a schema change, not to release a dev period.
+        new_version = dataset_description.dataset._increment_dataset_version(component=VersionPart.minor)
 
         current_bag = dataset_description.dataset.download_dataset_bag(current_version, use_minid=False)
         new_bag = dataset_description.dataset.download_dataset_bag(new_version, use_minid=False)
@@ -431,8 +433,10 @@ class TestDatabasePathCaching:
         bag1 = dataset.download_dataset_bag(version=current_version, use_minid=False)
         dbase_path1 = bag1.model.database_dir
 
-        # Increment version (this creates a new version in the catalog)
-        new_version = dataset.increment_dataset_version(
+        # Force-bump to a new released version to test downloading two
+        # distinct snapshots. The private primitive is appropriate here —
+        # the test isn't exercising the dev → release lifecycle.
+        new_version = dataset._increment_dataset_version(
             component=VersionPart.minor, description="Test version increment"
         )
 

--- a/tests/feature/conftest.py
+++ b/tests/feature/conftest.py
@@ -3,6 +3,7 @@
 Provides fixtures that combine an online DerivaML instance with a downloaded
 + materialized bag so that online/offline symmetry can be tested.
 """
+
 from __future__ import annotations
 
 import dataclasses
@@ -174,9 +175,7 @@ def feature_symmetry_fixture(catalog_manager, tmp_path_factory):
     target_table = "Image"
 
     # All Image RIDs (feature values exist for all of them from demo catalog seeding)
-    all_image_rids = [
-        r["RID"] for r in ml._domain_path().tables[target_table].entities().fetch()
-    ]
+    all_image_rids = [r["RID"] for r in ml._domain_path().tables[target_table].entities().fetch()]
     assert all_image_rids, "Demo catalog must have Image rows"
 
     # Find a workflow that has executions for the Quality feature.
@@ -218,25 +217,22 @@ def feature_symmetry_fixture(catalog_manager, tmp_path_factory):
         )
         symmetry_dataset.add_dataset_members(members={target_table: all_image_rids})
 
-    symmetry_dataset.increment_dataset_version(
-        component=VersionPart.minor,
+    # add_dataset_members above lands on dev (PR 4); release the dev
+    # period to mint v1 as a stable reference for the test fixture.
+    symmetry_dataset.release(
+        bump=VersionPart.minor,
         description="v1 for symmetry test",
     )
 
     # Download and materialize a bag from the all-image dataset.
-    bag = symmetry_dataset.download_dataset_bag(
-        version=symmetry_dataset.current_version, use_minid=False
-    )
+    bag = symmetry_dataset.download_dataset_bag(version=symmetry_dataset.current_version, use_minid=False)
 
     # Compute expected records and workflow executions AFTER all catalog setup
     # (including the symmetry execution) so the baseline is complete.
     # The symmetry execution uses the same deduplicated workflow as the feature
     # creation execution, so expected_executions reflects the full catalog state.
     all_quality_records = sorted(
-        [
-            r.model_dump(exclude={"RCT", "RMT"})
-            for r in ml.feature_values(target_table, feature_name)
-        ],
+        [r.model_dump(exclude={"RCT", "RMT"}) for r in ml.feature_values(target_table, feature_name)],
         key=lambda d: d[target_table],
     )
     assert all_quality_records, "Must have at least one Quality feature record"

--- a/tests/feature/test_feature_values.py
+++ b/tests/feature/test_feature_values.py
@@ -4,6 +4,7 @@ This task (Task 4) covers DerivaML online reads. The parametrized symmetry
 suite across DerivaML / Dataset / DatasetBag is added in Task 8 once all
 three containers have the method.
 """
+
 from __future__ import annotations
 
 import dataclasses
@@ -108,9 +109,12 @@ def test_ml_with_feature_multi(populated_catalog):
 
 def test_feature_values_yields_feature_records(test_ml_with_feature) -> None:
     """feature_values yields FeatureRecord instances with the expected attrs."""
-    records = list(test_ml_with_feature.ml.feature_values(
-        "Image", test_ml_with_feature.feature_name,
-    ))
+    records = list(
+        test_ml_with_feature.ml.feature_values(
+            "Image",
+            test_ml_with_feature.feature_name,
+        )
+    )
     assert len(records) > 0
     rec = records[0]
     assert isinstance(rec, FeatureRecord)
@@ -128,19 +132,23 @@ def test_feature_values_unknown_feature_raises(test_ml) -> None:
 def test_feature_values_is_iterable_not_list(test_ml_with_feature) -> None:
     """Return type is an iterator (streaming), not a materialized list."""
     import collections.abc
+
     result = test_ml_with_feature.ml.feature_values(
-        "Image", test_ml_with_feature.feature_name,
+        "Image",
+        test_ml_with_feature.feature_name,
     )
     assert isinstance(result, collections.abc.Iterator)
 
 
 def test_feature_values_with_select_newest(test_ml_with_feature_multi) -> None:
     """Selector reduces multi-value groups to one record per target RID."""
-    records = list(test_ml_with_feature_multi.ml.feature_values(
-        "Image",
-        test_ml_with_feature_multi.feature_name,
-        selector=FeatureRecord.select_newest,
-    ))
+    records = list(
+        test_ml_with_feature_multi.ml.feature_values(
+            "Image",
+            test_ml_with_feature_multi.feature_name,
+            selector=FeatureRecord.select_newest,
+        )
+    )
     # After selector: one record per target Image
     rids = [r.Image for r in records]
     assert len(rids) == len(set(rids))
@@ -148,11 +156,17 @@ def test_feature_values_with_select_newest(test_ml_with_feature_multi) -> None:
 
 def test_feature_values_selector_returning_none_omits_target(test_ml_with_feature) -> None:
     """Selector returning None removes that target from the iterator."""
+
     def reject_all(records):
         return None
-    records = list(test_ml_with_feature.ml.feature_values(
-        "Image", test_ml_with_feature.feature_name, selector=reject_all,
-    ))
+
+    records = list(
+        test_ml_with_feature.ml.feature_values(
+            "Image",
+            test_ml_with_feature.feature_name,
+            selector=reject_all,
+        )
+    )
     assert records == []
 
 
@@ -227,7 +241,9 @@ def catalog_with_feature_and_dataset(populated_catalog):
             description="Dataset for Task 5 test",
         )
         dataset.add_dataset_members(members={"Image": member_rids})
-    dataset.increment_dataset_version(component=VersionPart.minor, description="v1")
+    # add_dataset_members lands on dev (PR 4); release the dev period
+    # to mint v1 as a stable reference for the test fixture.
+    dataset.release(bump=VersionPart.minor, description="v1")
 
     member_set = set(member_rids)
     non_member_set = set(all_image_rids) - member_set
@@ -250,17 +266,13 @@ def test_dataset_feature_values_filters_to_members(catalog_with_feature_and_data
     exclude them.
     """
     fx = catalog_with_feature_and_dataset
-    assert fx.non_member_rids, (
-        "fixture must have at least one image with a feature value that is NOT a dataset member"
-    )
+    assert fx.non_member_rids, "fixture must have at least one image with a feature value that is NOT a dataset member"
 
     records = list(fx.dataset.feature_values(fx.target_table, fx.feature_name))
     yielded_rids = {getattr(r, fx.target_table) for r in records}
 
     # Every yielded RID is a member
-    assert yielded_rids.issubset(fx.member_rids), (
-        f"non-member RIDs leaked through: {yielded_rids - fx.member_rids}"
-    )
+    assert yielded_rids.issubset(fx.member_rids), f"non-member RIDs leaked through: {yielded_rids - fx.member_rids}"
     # No non-member RID was yielded — filter actually applied
     assert not (yielded_rids & fx.non_member_rids), (
         f"non-member RIDs should have been excluded: {yielded_rids & fx.non_member_rids}"
@@ -421,9 +433,7 @@ class TestFeatureValuesSymmetry:
         if isinstance(feature_container.container, DatasetBag):
             # Verify the method is callable; skip if execution data not in bag.
             try:
-                rids = feature_container.container.list_workflow_executions(
-                    feature_container.workflow
-                )
+                rids = feature_container.container.list_workflow_executions(feature_container.workflow)
             except DerivaMLException:
                 pytest.skip(
                     "DatasetBag.list_workflow_executions requires Execution rows "
@@ -432,13 +442,9 @@ class TestFeatureValuesSymmetry:
                 )
 
             if not rids:
-                pytest.skip(
-                    "DatasetBag returned empty execution list — pre-existing bag-export limitation."
-                )
+                pytest.skip("DatasetBag returned empty execution list — pre-existing bag-export limitation.")
         else:
-            rids = feature_container.container.list_workflow_executions(
-                feature_container.workflow
-            )
+            rids = feature_container.container.list_workflow_executions(feature_container.workflow)
         # Order-independent comparison against the catalog-computed baseline
         assert set(rids) == feature_container.expected_workflow_executions
 
@@ -478,10 +484,7 @@ def test_offline_construct_records_online_stage(
     # Build records entirely offline — ImageQuality is the vocab column name (from
     # create_feature("Image", "Quality", terms=["ImageQuality"])).
     # "Good" is a valid ImageQuality term per demo_catalog.py.
-    records = [
-        RecordClass(**{fx.target_table: rid, "ImageQuality": "Good"})
-        for rid in target_rids
-    ]
+    records = [RecordClass(**{fx.target_table: rid, "ImageQuality": "Good"}) for rid in target_rids]
     # Confirm Execution is not set — exe.add_features must auto-fill it
     assert all(r.Execution is None for r in records), "Execution should be None before staging"
 
@@ -497,8 +500,7 @@ def test_offline_construct_records_online_stage(
     with execution.execute() as exe:
         count = exe.add_features(records)
         assert count == len(target_rids), (
-            f"add_features should return the number of staged records; "
-            f"got {count}, expected {len(target_rids)}"
+            f"add_features should return the number of staged records; got {count}, expected {len(target_rids)}"
         )
     # __exit__ does NOT auto-upload (Task 7 review) — explicit call required
     execution.upload_execution_outputs()
@@ -509,9 +511,6 @@ def test_offline_construct_records_online_stage(
     written = list(fx.ml.feature_values(fx.target_table, fx.feature_name))
     ours = [r for r in written if r.Execution == execution.execution_rid]
     assert len(ours) == len(target_rids), (
-        f"Expected {len(target_rids)} new records from execution "
-        f"{execution.execution_rid}; found {len(ours)}"
+        f"Expected {len(target_rids)} new records from execution {execution.execution_rid}; found {len(ours)}"
     )
-    assert all(r.ImageQuality == "Good" for r in ours), (
-        "All written records should have ImageQuality='Good'"
-    )
+    assert all(r.ImageQuality == "Good" for r in ours), "All written records should have ImageQuality='Good'"


### PR DESCRIPTION
## Summary

PR 5 of 7 in the dev-versioning delivery sequence (ADR-0005).
**The second breaking PR.** The public method
\`Dataset.increment_dataset_version\` is renamed to
\`Dataset._increment_dataset_version\` (private), and a new public
\`Dataset.release(bump, description, execution=None)\` method
implements the dev → release promotion per ADR-0003.

Per ADR-0003: \`release\` is the only operation that produces a
released \`Dataset_Version\` row. It errors if the dataset has no
dev period to promote.

This PR is based on PR 4 ([#85](https://github.com/informatics-isi-edu/deriva-ml/pull/85)) and should not merge until that
does.

## What's new

**\`Dataset.release(bump, description, execution=None)\`**

Promotes the existing dev row **in place** (per ADR-0003 / Q12):

- Rewrites \`Version\` to the released label (\`<last_release>.next_release(bump)\`).
- Stamps \`Snapshot\` with the catalog snapshot at release time.
- Replaces \`Description\` with the supplied release notes.
- Overwrites \`Execution\` with the supplied execution (or \`NULL\`).
- Returns the new released \`DatasetVersion\`.

The dev row's RID is preserved across promotion — the same row
becomes the released row. This was the design choice in Q12.

**Concurrency**: the UPDATE uses \`correlation={'RID', 'RMT'}\` so a
competing writer that landed between this method's read and write
is detected (zero rows match, raises \`DerivaMLException\` with a
retry message).

**No-dev-row precondition**: errors with a clear message pointing
at \`mark_dev()\` as the resolution.

## Why \`_increment_dataset_version\` is kept (private)

The catalog-clone path uses \`increment_dataset_version\` not as a
release-of-dev-period but as a structural \"reinitialise versions
after copying a snapshot\" operation. That's the use case Q14
explicitly removed from the new \`release()\` API. Rather than
either:

1. Force the clone code through a contrived \`mark_dev\` →
   \`release\` dance just to satisfy the dev-row precondition, or
2. Add a \`force=True\` flag to \`release()\` that defeats the
   precondition's whole point,

I kept the old behavior as a private \`_increment_dataset_version\`
primitive. Public callers use \`release()\`. Internal infrastructure
that needs force-bump semantics (clone, occasional test setup) uses
the underscore form. Documented in the new method's docstring.

## Test classification

For tests that previously called \`increment_dataset_version\`, I
classified each by intent:

| Test | Uses |
|---|---|
| Tests that genuinely exercise dev → release (feature fixtures) | \`release()\` |
| Tests that test bump arithmetic / graph propagation | \`_increment_dataset_version\` |
| Tests that stamp a fresh snapshot to test multi-version downloads | \`_increment_dataset_version\` |
| Tests that verify clone-reinitialisation | \`_increment_dataset_version\` |

Each callsite has a comment explaining the choice.

## New tests

\`TestRelease\` (10 integration tests):

| Test | Verifies |
|---|---|
| \`test_release_minor_bump\` | Minor bump from \`0.4.0.post1.dev1\` → \`0.5.0\` |
| \`test_release_major_bump\` | Major bump → \`1.0.0\` |
| \`test_release_patch_bump\` | Patch bump → \`0.4.1\` |
| \`test_release_promotes_in_place\` | Dev row's RID is preserved (UPDATE not INSERT+DELETE) |
| \`test_release_stamps_snapshot\` | Released rows have non-NULL \`Snapshot\` |
| \`test_release_replaces_description\` | Release notes replace dev-period description |
| \`test_release_overwrites_execution\` | release()'s \`execution\` arg overrides the dev row's value |
| \`test_release_without_execution_leaves_null\` | No execution → NULL |
| \`test_release_errors_on_no_dev_row\` | Errors with a mark_dev hint when no dev period |
| \`test_release_then_mark_dev_creates_new_dev_period\` | Post-release mark_dev anchors at the new release |

## Verification

| Check | Result |
|---|---|
| Unit tests | 270 / 270 pass |
| New \`TestRelease\` integration tests | 10 / 10 pass against \`localhost\` |
| Total dev-versioning integration tests | 27 / 27 (10 TestRelease + 8 TestMutationsLandOnDev + 9 TestMarkDev) |
| Doctest collection | All 27 doctests parse cleanly (catalog-dependent ones are SKIP) |
| \`ruff format\` | Applied to my edits |

## Pre-existing failures (unchanged from \`main\`)

- Workspace-resolution \`FileNotFoundError\` on several catalog
  integration tests.
- deriva-py URL parse bug in \`delete_dataset_members\`.

## Refs

- [#79](https://github.com/informatics-isi-edu/deriva-ml/issues/79) — design proposal
- [#80](https://github.com/informatics-isi-edu/deriva-ml/pull/80) — design docs (must merge first)
- [#81](https://github.com/informatics-isi-edu/deriva-ml/pull/81) — PR 1
- [#82](https://github.com/informatics-isi-edu/deriva-ml/pull/82) — PR 2
- [#84](https://github.com/informatics-isi-edu/deriva-ml/pull/84) — PR 3
- [#85](https://github.com/informatics-isi-edu/deriva-ml/pull/85) — PR 4 (this PR is based on it)
- ADR-0003 — dev versioning model
- ADR-0005 — full delivery sequence

🤖 Generated with [Claude Code](https://claude.com/claude-code)