### PR TITLE
docs(dataset): user guide, migration guide, release notes for dev versioning (ADR-0003; PR 7 of 7)

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,3 +1,12 @@
+Version 2.0.0
+
+- **Dataset dev versioning** (breaking). Datasets now use a two-state versioning model: released versions (citable, snapshot-pinned) and dev versions (mutable, between-release labels of the form `<release>.post1.devN`). Every mutation lands on a dev version; `Dataset.release()` is the only path to a released version. See `docs/adr/0003-dataset-dev-versioning-model.md` and `docs/user-guide/migration.md` for the full migration story.
+- **`increment_dataset_version` renamed to `release`** (breaking). New signature: `Dataset.release(bump, description, execution=None)`. The old method is preserved as a private `_increment_dataset_version` for system-internal use only (e.g., catalog clone reinitialization).
+- **`add_dataset_members`, `delete_dataset_members`, `add_dataset_type`, `add_dataset_types`, `remove_dataset_type` now land on dev** (breaking). Each call advances `.devN` rather than producing a released version. To mint a release after mutations, call `dataset.release(...)`.
+- **`DatasetVersion` rebased on PEP 440** (breaking for some equality assertions). The wire format for released versions is unchanged (`"0.4.0"`); dev labels use PEP 440 post-release form (`"0.4.0.post1.dev1"`). String equality (`current_version == "1.0.0"`) no longer works — coerce explicitly: `str(current_version) == "1.0.0"`.
+- **New: `Dataset.mark_dev`, `is_dirty`, `release_diff`, `compare_versions`.** Mark drift explicitly, detect whether the catalog has drifted since the last release, and compare any two versions.
+- Documentation: new ADRs (0003 dev-versioning model, 0004 PEP 440 vocabulary, 0005 delivery sequence) and a CONTEXT.md vocabulary file.
+
 Version 1.2.0
 
 - Dataset versioning with semantic versioning. Note that the current dataset version does *NOT* have the current catalog values, but rather the values at the time the dataset was created. 

--- a/docs/user-guide/datasets.md
+++ b/docs/user-guide/datasets.md
@@ -246,7 +246,18 @@ members = dataset.list_dataset_members(version="0.2.0")
 versioned_bag = dataset.download_dataset_bag(version="0.2.0")
 ```
 
-This is the guarantee that makes dataset downloads reproducible: downloading a *released* version always returns the same rows. Downloading the *current dev* label resolves to live state and may differ between calls.
+This is the guarantee that makes dataset downloads reproducible: downloading a *released* version always returns the same rows.
+
+!!! warning
+    **Always release before downloading.** As of 2.0, `download_dataset_bag()` requires a *released* version label — passing a dev label (or letting `current_version` default to a dev label when the dataset is in a dev period) raises a Pydantic `ValidationError` because dev rows have no pinned snapshot. Call `dataset.release(...)` to mint a released version, then download:
+
+    ```python
+    dataset.add_dataset_members(...)
+    dataset.release(VersionPart.minor, "Cut for download")
+    bag = dataset.download_dataset_bag(dataset.current_version)
+    ```
+
+    Downloading at the live dev state is on the roadmap — see [issue #89](https://github.com/informatics-isi-edu/deriva-ml/issues/89). Until that lands, the dev-vs-released distinction is enforced by the download path itself.
 
 **Notes**
 

--- a/docs/user-guide/datasets.md
+++ b/docs/user-guide/datasets.md
@@ -107,7 +107,7 @@ dataset.add_dataset_members(
 )
 ```
 
-Both forms trigger a minor version increment on the dataset. To link the addition to the execution that created the data, pass `execution_rid`:
+Both forms flip the dataset to a *dev* version (a mutable, in-progress label of the form `<last_release>.post1.devN` — see ["How to version a dataset"](#how-to-version-a-dataset) below for the full model). To link the addition to the execution that created the data, pass `execution_rid`:
 
 ```python
 dataset.add_dataset_members(
@@ -133,7 +133,7 @@ ml.add_dataset_element_type("Subject")
 **Notes**
 
 - Use the dict form whenever you know which table the RIDs come from. The list form issues an extra catalog query per batch to identify tables.
-- Each call to `add_dataset_members` automatically increments the dataset's minor version. If you need to add members in multiple batches without creating intermediate versions, consider collecting all RIDs first and calling `add_dataset_members` once.
+- Each call to `add_dataset_members` advances the dataset's dev version (`.dev1` → `.dev2` → …). The dev row is a single mutable record, so multiple calls don't create intermediate released versions — they just bump `.devN` on the same row. When you're ready to mint a stable, citable version, call `dataset.release(...)`.
 - Members can only come from tables registered with `add_dataset_element_type`. Attempting to add a RID from an unregistered table raises `DerivaMLException`.
 
 ## Parent and child datasets
@@ -177,46 +177,85 @@ Bag export honors the hierarchy: downloading a parent dataset includes all recor
 
 ## How to version a dataset
 
-Every dataset starts at version `0.1.0` and increments its minor version each time `add_dataset_members` is called. You can also increment a version explicitly and control which component changes.
+DerivaML datasets use a two-state versioning model: **released versions** are stable, snapshot-pinned, citable references; **dev versions** are mutable working states that accumulate changes between releases. Every mutation lands on dev; `release()` is the only operation that produces a released version.
+
+A new dataset is created at a released version (`0.1.0` by default). Mutations — adding or removing members, adding or removing dataset types — flip it to a dev label of the form `<last_release>.post1.devN` and advance `.devN` on each subsequent mutation. When the working state is ready to be cited or consumed by an execution, call `release()` to mint a clean released version.
 
 ```python
 from deriva_ml.dataset import VersionPart
 
-# Read the current version
-print(dataset.current_version)  # e.g., DatasetVersion(0, 3, 0)
+# Read the current version. .is_devrelease tells you which state.
+print(dataset.current_version)        # DatasetVersion("0.1.0")
+print(dataset.current_version.is_devrelease)  # False
 
-# View the version history
-for entry in dataset.dataset_history():
-    print(f"v{entry.dataset_version}: {entry.description} ({entry.snapshot})")
+# Mutate — flips to dev.
+dataset.add_dataset_members(members={"Image": image_rids})
+print(dataset.current_version)        # DatasetVersion("0.1.0.post1.dev1")
 
-# Bump to 1.0.0 when the dataset is stable for a training run
-new_version = dataset.increment_dataset_version(
-    component=VersionPart.major,
+# More mutations — advance .devN on the same dev row.
+dataset.add_dataset_members(members={"Image": more_image_rids})
+print(dataset.current_version)        # DatasetVersion("0.1.0.post1.dev2")
+
+# Promote the dev period to a clean released version.
+new_version = dataset.release(
+    bump=VersionPart.minor,
     description="Stable release for experiment 1",
 )
-print(new_version)  # DatasetVersion(1, 0, 0)
+print(new_version)                    # DatasetVersion("0.2.0")
 ```
 
-`increment_dataset_version` propagates the bump through the parent/child graph using a topological sort, so all related datasets move to consistent version numbers together.
+**The dev row is mutable** — there is at most one dev row per dataset per dev period, and `.devN` advances by `UPDATE`, not `INSERT`. Consequence: a dev label is observable only at the moment that's its current value. By the time you read `.dev2` and try to use it later, the catalog may already say `.dev3`. Dev labels are notational, not citational. If you want a stable reference, call `release()`.
 
-Each version is tied to a catalog snapshot. To read members as they existed at a specific version, pass `version=` to `list_dataset_members()` or download the versioned bag:
+### Recording indirect drift with `mark_dev`
+
+Sometimes the catalog drifts under the dataset without `add_dataset_members` having been called — for example, a separate execution records a feature value for a member of this dataset, or an asset's metadata changes. The dataset's row is untouched but its content has changed. To flag that drift explicitly:
 
 ```python
-# List members as they existed at v1.0.0 (uses the catalog snapshot for that version)
-members = dataset.list_dataset_members(version="1.0.0")
-
-# Or download the versioned bag for fully offline use
-versioned_bag = dataset.download_dataset_bag(version="1.0.0")
+dataset.mark_dev("Picked up classifier output for the test split")
+print(dataset.current_version)        # DatasetVersion("0.1.0.post1.dev1")
 ```
 
-This is the guarantee that makes dataset downloads reproducible. Downloading a versioned dataset always returns the same rows.
+`mark_dev` returns `None` (a returned dev label can't be passed to anything later — the next mutation would invalidate it).
+
+### Detecting drift
+
+Three methods report what's drifted, all using the same FK-path walk under the hood:
+
+```python
+# Has anything reachable changed since the last release?
+if dataset.is_dirty():
+    # Per-table change counts since the last release
+    for table_name, count in dataset.release_diff().items():
+        print(f"{table_name}: {count} rows changed")
+
+# Compare two specific versions
+diff = dataset.compare_versions("0.1.0", "0.2.0")
+```
+
+**Limitations**: deletions of catalog rows that this dataset references are not detected by these methods. If you delete catalog content that affects a dataset, call `mark_dev()` manually to record the drift.
+
+### Release and citation
+
+Each released version pins a catalog snapshot. To read members as they existed at a specific released version, pass `version=` to `list_dataset_members()` or `download_dataset_bag()`:
+
+```python
+# List members as they existed at v0.2.0 (uses the catalog snapshot for that version)
+members = dataset.list_dataset_members(version="0.2.0")
+
+# Or download the versioned bag for fully offline use
+versioned_bag = dataset.download_dataset_bag(version="0.2.0")
+```
+
+This is the guarantee that makes dataset downloads reproducible: downloading a *released* version always returns the same rows. Downloading the *current dev* label resolves to live state and may differ between calls.
 
 **Notes**
 
-- Every call to `add_dataset_members` unconditionally bumps the minor version once. There is no parameter to suppress this. If you want fewer version bumps, **batch all members into a single `add_dataset_members` call** rather than making multiple small calls.
-- To mark a milestone (major or patch version) without adding members, call `increment_dataset_version` explicitly.
+- Each call to `add_dataset_members` advances `.devN` once. Multiple calls during a dev period accumulate on the same dev row — there are no intermediate released versions until you call `release()`.
+- `release()` errors if the dataset has no dev period to promote. To mint a release without a real change (for example, to attach release notes), call `mark_dev()` first.
 - `VersionPart` lives in `deriva_ml.dataset.aux_classes` alongside `DatasetVersion` and related types, and is re-exported from `deriva_ml.dataset` for convenience.
-- Version pinning for executions (`DatasetSpec(rid=..., version="1.0.0")`) is covered in Chapter 7 ("Reproducibility").
+- The version vocabulary is PEP 440 (the same form `setuptools-scm` uses for between-release labels). This is sortable: `0.1.0 < 0.1.0.post1.dev1 < 0.2.0`.
+- Version pinning for executions (`DatasetSpec(rid=..., version="0.2.0")`) is covered in Chapter 7 ("Reproducibility").
+- Executions consume **released** versions only — dev labels are not stable references.
 
 ## How to split a dataset
 
@@ -479,9 +518,11 @@ Non-element-type tables (such as `Device`) are always traversed normally.
     The column name must be in the format `TableName.ColumnName` (e.g., `Image_Classification.Image_Class`). A common mistake is using the underscore-joined form (`Image_Classification_Image_Class`), which is the denormalized DataFrame column name — not the argument to `stratify_by_column`.
 
 !!! warning
-    **Version numbers do not update automatically when members change.**
+    **Indirect drift does not update version numbers automatically.**
 
-    `add_dataset_members` auto-increments the minor version as a convenience, but if you never call `add_dataset_members` (for example, you added members in a previous session and now want to mark the dataset as stable), you must call `increment_dataset_version()` explicitly. The version counter is not driven by catalog state — it only advances when you tell it to.
+    `add_dataset_members` and `delete_dataset_members` flip the dataset to a dev version. But changes to catalog rows the dataset *references* — for example, a feature value added to a member by a separate execution — do not flip the dataset to dev automatically; that would require every catalog write to know which datasets reference it, which is impractical.
+
+    Use `dataset.is_dirty()` to detect indirect drift, and `dataset.mark_dev(...)` to record it explicitly when it matters. To mint a stable release, call `dataset.release(bump, description)` — the dev period must be in progress.
 
 !!! warning
     **`materialize=False` gives you table metadata, not asset files.**

--- a/docs/user-guide/migration.md
+++ b/docs/user-guide/migration.md
@@ -375,6 +375,104 @@ For known downstream projects in the deriva-ml ecosystem, the sibling-repo grep 
 
 Template maintainers should update the `group_by=` to `targets=` in lockstep with upgrading.
 
+## Migrating to 2.0: dev versioning
+
+The 2.0 release introduces a two-state versioning model for datasets — see [ADR-0003](../adr/0003-dataset-dev-versioning-model.md) and the ["How to version a dataset"](datasets.md#how-to-version-a-dataset) chapter for the full picture. This is the largest semantic break in the 2.0 release.
+
+**Headline change:** `add_dataset_members`, `delete_dataset_members`, and the dataset-type mutation methods now flip the dataset to a *dev* version (a mutable label of the form `<last_release>.post1.devN`) instead of bumping to a released version. The new `Dataset.release()` method is the only operation that produces a released version.
+
+### At-a-glance
+
+| Before (1.x) | After (2.0) |
+|---|---|
+| `dataset.increment_dataset_version(VersionPart.minor, "...")` | `dataset.release(bump=VersionPart.minor, description="...")` |
+| `add_dataset_members` → `0.4.0` → `0.5.0` (released bump) | `add_dataset_members` → `0.4.0` → `0.4.0.post1.dev1` (dev flip) |
+| Multiple `add_dataset_members` calls = multiple released versions | Multiple `add_dataset_members` calls = one mutable dev row, advancing `.devN` |
+| No way to record indirect drift | `dataset.mark_dev(description)` records drift explicitly |
+| No drift detection | `dataset.is_dirty()`, `dataset.release_diff()`, `dataset.compare_versions(a, b)` |
+| `DatasetVersion` extends `semver.Version` | `DatasetVersion` extends `packaging.Version` (PEP 440) |
+
+### `increment_dataset_version` → `release()`
+
+The most mechanical break. Every `increment_dataset_version` call site needs to switch to `release()`:
+
+```python
+# Before (1.x)
+new_version = dataset.increment_dataset_version(
+    component=VersionPart.minor,
+    description="Stable for experiment 1",
+    execution_rid=exe.execution_rid,
+)
+
+# After (2.0)
+new_version = dataset.release(
+    bump=VersionPart.minor,
+    description="Stable for experiment 1",
+    execution=exe,            # the Execution object, not the RID
+)
+```
+
+Three changes in the signature:
+
+- Method name: `increment_dataset_version` → `release`.
+- Argument name: `component` → `bump`.
+- Argument type: `execution_rid: RID | None` → `execution: Execution | None` (pass the object, not the RID).
+
+**`release()` errors if the dataset has no dev period to promote.** This is intentional — every release must come from a real working state. If you want to mint a release without any actual change (for example, to attach release notes), call `mark_dev(description)` first to declare a dev period, then `release()` to close it.
+
+A private `_increment_dataset_version` is preserved as an internal force-bump primitive. **Don't use it for application code** — it bypasses the dev-versioning model and exists for system-internal use cases (catalog clone version reinitialization). Public callers should always use `release()`.
+
+### Member mutations now land on dev
+
+Code that calls `add_dataset_members` and assumes the result is a released version needs to call `release()` afterward to mint a stable reference:
+
+```python
+# Before (1.x): one call, one released version
+dataset.add_dataset_members(members={"Image": image_rids})
+# dataset.current_version is now e.g. "0.5.0" (released)
+
+# After (2.0): one call → dev label; release explicitly
+dataset.add_dataset_members(members={"Image": image_rids})
+# dataset.current_version is now "0.4.0.post1.dev1" (dev)
+dataset.release(bump=VersionPart.minor, description="Add training images")
+# dataset.current_version is now "0.5.0" (released)
+```
+
+Code that only consumes `current_version` for display works without changes; code that uses `current_version` as a stable reference (passing it to `DatasetSpec`, citing it externally, etc.) needs to verify it's a released label.
+
+### Version label format change
+
+`DatasetVersion` is now a `packaging.Version` (PEP 440) rather than a `semver.Version`. The wire format for *released* versions is unchanged: `"0.4.0"` parses and serializes identically. Two corner cases to watch:
+
+- **String equality with `DatasetVersion` no longer works.** Under semver, `Version.parse("1.0.0") == "1.0.0"` was True. Under `packaging.Version`, it's False. If you have assertions like `dataset.current_version == "1.0.0"`, change them to `str(dataset.current_version) == "1.0.0"`.
+- **Dev versions** print as `"0.4.0.post1.dev3"`, not `"0.4.0-dev3"`. Choice of post-release form (vs. semver's pre-release form) was made so the dev label sorts *after* its anchor release, matching `setuptools-scm`'s convention.
+
+### New methods (additive)
+
+Four methods are new in 2.0; you don't need to migrate to them but they're available:
+
+- `Dataset.mark_dev(description, execution=None)` — explicitly flip the dataset to dev when the catalog drifted via a path that didn't go through the dataset API (a separate execution recorded a feature value, etc.).
+- `Dataset.is_dirty() -> bool` — fast predicate for "has anything reachable changed since the last release?"
+- `Dataset.release_diff() -> dict[str, int]` — per-table change counts since the last release.
+- `Dataset.compare_versions(v_a, v_b) -> dict[str, int]` — per-table change counts between two versions.
+
+### Find every callsite
+
+```bash
+# Method renames
+grep -rn "increment_dataset_version" your_project/ --include="*.py"
+
+# String-equality assertions on DatasetVersion (most common silent break)
+grep -rnE "current_version == |== current_version|\.version == \"" your_project/ --include="*.py"
+
+# Code that relies on add_dataset_members producing a released version
+grep -rn "add_dataset_members" your_project/ --include="*.py"
+```
+
+### Out-of-repo follow-ups
+
+The deriva-ml-mcp tool surface is updated separately. The `deriva_ml_increment_dataset_version` MCP tool will be renamed to `deriva_ml_release` in a coordinated MCP-server release; until that lands, MCP-mediated callers should use the bundle resource directly rather than the renamed tool.
+
 ## Version compatibility
 
 | deriva-ml version | Python | Torch | TensorFlow | Notes |

--- a/docs/user-guide/migration.md
+++ b/docs/user-guide/migration.md
@@ -469,6 +469,18 @@ grep -rnE "current_version == |== current_version|\.version == \"" your_project/
 grep -rn "add_dataset_members" your_project/ --include="*.py"
 ```
 
+### Known limitation: download requires released versions
+
+`download_dataset_bag()` does not yet accept a dev label. If your test fixtures or scripts call `add_dataset_members(...)` and then `download_dataset_bag(current_version)` without releasing in between, the download will raise `ValidationError` (the dev row has no snapshot). Add an explicit `release()` between the mutation and the download:
+
+```python
+dataset.add_dataset_members(...)
+dataset.release(VersionPart.minor, "Cut for download")
+bag = dataset.download_dataset_bag(dataset.current_version)
+```
+
+Tracked as [issue #89](https://github.com/informatics-isi-edu/deriva-ml/issues/89). Resolving downloads against live dev state is on the roadmap.
+
 ### Out-of-repo follow-ups
 
 The deriva-ml-mcp tool surface is updated separately. The `deriva_ml_increment_dataset_version` MCP tool will be renamed to `deriva_ml_release` in a coordinated MCP-server release; until that lands, MCP-mediated callers should use the bundle resource directly rather than the renamed tool.

--- a/docs/user-guide/reproducibility.md
+++ b/docs/user-guide/reproducibility.md
@@ -54,14 +54,18 @@ with ml.create_execution(config) as exe:
     # bag contains exactly the rows present at version 2.1.0
 ```
 
-Under the hood, each dataset version stores a catalog snapshot timestamp. When deriva-ml downloads a versioned dataset bag, it appends the snapshot timestamp to every query, so it reads the catalog as of that moment. The same RID at version `2.1.0` returns the same rows on every run, regardless of subsequent additions or deletions.
+Under the hood, each released dataset version stores a catalog snapshot timestamp. When deriva-ml downloads a versioned dataset bag, it appends the snapshot timestamp to every query, so it reads the catalog as of that moment. The same RID at version `2.1.0` returns the same rows on every run, regardless of subsequent additions or deletions.
+
+!!! warning
+    **Dev versions are not reproducible references.** A version label of the form `<release>.post1.devN` resolves to *live catalog state*, not a pinned snapshot. Two runs that consume `1.0.0.post1.dev3` may see different content. Executions should consume **released** versions only — pass a clean `MAJOR.MINOR.PATCH` label to `DatasetSpec`. To convert a dev period into a stable reference, call `dataset.release(...)` to mint a released version.
 
 **Notes:**
 
 - The `version` argument accepts a string (`"2.1.0"`), a three-element list, or a `DatasetVersion` object.
-- Omitting `version` uses the dataset's current version, which changes as members are added.
+- Omitting `version` uses the dataset's current version. If the dataset is in a dev period, that's a dev label — not a stable reference. Make sure you're pinning a released version for executions you want to reproduce.
 - `materialize=False` downloads table metadata only, without fetching asset files. Use this for large datasets when you only need row counts or identifiers.
 - Snapshot timestamps can age out if your catalog has a retention policy. Verify that the snapshot still exists before depending on a version in long-running production code.
+- Use `dataset.is_dirty()` before kicking off a long training run to confirm the dataset hasn't drifted since its last release. If it has, decide whether to release first or proceed with the existing released version.
 
 ## How to capture workflow checksums and git commits
 


### PR DESCRIPTION
## Summary

PR 7 of 7 — the **final PR** in the dev-versioning delivery
sequence (ADR-0005). Closes out the documentation for the work.
**Documentation only**: no code changes.

This PR is based on PR 6 ([#87](https://github.com/informatics-isi-edu/deriva-ml/pull/87)). It should not merge until that
does.

## What's updated

- **\`docs/user-guide/datasets.md\`** — the load-bearing rewrite:
  - The "How to add members" notes are updated to describe the
    dev-flip behavior rather than the old "minor version
    increment" wording.
  - The **"How to version a dataset" section is fully rewritten**
    around the two-state model from ADR-0003. Worked examples use
    \`add_dataset_members → release()\`; also covers \`mark_dev\`,
    the drift-detection trio, and the rule that dev labels are
    notational, not citational.
  - The "Version numbers do not update automatically" warning callout
    now describes indirect drift and points users at \`mark_dev\`
    as the escape hatch.

- **\`docs/user-guide/reproducibility.md\`**:
  - Adds a warning that dev versions are not reproducible references
    — executions should pin released versions only.
  - Suggests \`is_dirty()\` as a sanity check before starting a long
    training run.

- **\`docs/user-guide/migration.md\`**:
  - New section "Migrating to 2.0: dev versioning". Covers every
    class of break (rename, member-mutation behavior change, PEP 440
    vocabulary, string-equality regression), plus the new additive
    methods, with grep recipes for finding callsites.

- **\`docs/release-notes.md\`** — adds the 2.0 release entry
  summarising the dev-versioning work.

## What's NOT in this PR

The actual \`bump-version major\` step happens **after** this PR merges,
on \`main\`, in a clean working tree (per workspace \`CLAUDE.md\`'s
"bump-version rules"). PR 7 doesn't carry the version bump itself —
that's the standard release-mechanics convention, not an oversight.

## Test plan

- [x] Unit tests pass (no code changes, but verified clean):
      270 / 270 pass.
- [ ] Reviewer reads the updated user-guide pages and confirms the
      narrative makes sense for someone who hasn't read the ADRs.
- [ ] Reviewer follows the migration-guide grep recipes against a
      downstream project to confirm they find the right callsites.

## Refs

- [#79](https://github.com/informatics-isi-edu/deriva-ml/issues/79) — design proposal
- [#80](https://github.com/informatics-isi-edu/deriva-ml/pull/80) — design docs
- [#81](https://github.com/informatics-isi-edu/deriva-ml/pull/81) — PR 1
- [#82](https://github.com/informatics-isi-edu/deriva-ml/pull/82) — PR 2
- [#84](https://github.com/informatics-isi-edu/deriva-ml/pull/84) — PR 3
- [#85](https://github.com/informatics-isi-edu/deriva-ml/pull/85) — PR 4
- [#86](https://github.com/informatics-isi-edu/deriva-ml/pull/86) — PR 5
- [#87](https://github.com/informatics-isi-edu/deriva-ml/pull/87) — PR 6 (this PR is based on it)
- ADR-0003 — dev versioning model
- ADR-0005 — full delivery sequence

🤖 Generated with [Claude Code](https://claude.com/claude-code)