### PR TITLE
docs: correct version label from 2.0 to 1.34 to match actual delivery

### DIFF
--- a/docs/adr/0003-dataset-dev-versioning-model.md
+++ b/docs/adr/0003-dataset-dev-versioning-model.md
@@ -170,9 +170,9 @@ notational-clarity goal was supposed to avoid.
   vocabulary. The `execution` argument changes type from `RID |
   None` to `Execution | None` to match the rest of the new API
   surface (typed objects, not bare RIDs). This is a breaking
-  change for callers of the previous public API and belongs in a
-  2.0 release. No deprecated alias is provided — CLAUDE.md's "no
-  backwards-compat shims" rule applies.
+  change for callers of the previous public API and ships in
+  1.34 with the migration guide. No deprecated alias is provided —
+  CLAUDE.md's "no backwards-compat shims" rule applies.
 - A new `Dataset.is_dirty()` / `Dataset.release_diff()` /
   `Dataset.compare_versions(v_a, v_b)` trio detects catalog drift
   by walking the same FK paths used to generate the dataset bag
@@ -280,7 +280,11 @@ that the conditional-update primitive handles cleanly.
 
 ## Migration impact
 
-This work is a 2.0 breaking change. There is no DDL change (the
+This work is a breaking change shipped in 1.34 (the renamed
+`release()` method, the dev-flip behavior change for
+`add_dataset_members` / `delete_dataset_members`, and the changed
+`Dataset.current_version` / `dataset_history()` semantics). There
+is no DDL change (the
 schema's `Snapshot` column is already nullable), but the
 *semantics* of several existing public methods change. The
 behavior-change inventory:
@@ -308,7 +312,7 @@ Downstream callers must:
 
 Out-of-repo blast radius (handled in dependent PRs, not this ADR):
 `deriva-ml-mcp`'s tool that exposes `increment_dataset_version`,
-the model-template workflows, and any user notebooks. The 2.0
+the model-template workflows, and any user notebooks. The 1.34
 changelog and migration guide are written at PR-ready time and
 point users at this ADR.
 

--- a/docs/adr/0005-dev-versioning-delivery-sequence.md
+++ b/docs/adr/0005-dev-versioning-delivery-sequence.md
@@ -1,7 +1,18 @@
 # ADR-0005: Dev-versioning delivery — seven sequenced PRs
 
 Date: 2026-05-09
-Status: Accepted
+Status: Accepted (with one deviation at delivery — see "Delivery outcome" below)
+
+## Delivery outcome (added 2026-05-10)
+
+The plan below described a **2.0 major-version bump**. At delivery
+time, the maintainer chose to ship the work as a **1.34.0 minor bump**
+instead. The breaking changes (renamed `release()` method, dev-flip
+behavior for member mutations, changed `current_version` semantics,
+etc.) are unchanged — what changed is the package version label
+attached to them. References to "2.0" in the ADR body below describe
+the plan at the time it was written. The release-notes and migration
+guide use the actual shipped version (1.34.0).
 
 ## Context
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,4 +1,4 @@
-Version 2.0.0
+Version 1.34.0
 
 - **Dataset dev versioning** (breaking). Datasets now use a two-state versioning model: released versions (citable, snapshot-pinned) and dev versions (mutable, between-release labels of the form `<release>.post1.devN`). Every mutation lands on a dev version; `Dataset.release()` is the only path to a released version. See `docs/adr/0003-dataset-dev-versioning-model.md` and `docs/user-guide/migration.md` for the full migration story.
 - **`increment_dataset_version` renamed to `release`** (breaking). New signature: `Dataset.release(bump, description, execution=None)`. The old method is preserved as a private `_increment_dataset_version` for system-internal use only (e.g., catalog clone reinitialization).

--- a/docs/user-guide/migration.md
+++ b/docs/user-guide/migration.md
@@ -375,15 +375,15 @@ For known downstream projects in the deriva-ml ecosystem, the sibling-repo grep 
 
 Template maintainers should update the `group_by=` to `targets=` in lockstep with upgrading.
 
-## Migrating to 2.0: dev versioning
+## Migrating to 1.34: dev versioning
 
-The 2.0 release introduces a two-state versioning model for datasets — see [ADR-0003](../adr/0003-dataset-dev-versioning-model.md) and the ["How to version a dataset"](datasets.md#how-to-version-a-dataset) chapter for the full picture. This is the largest semantic break in the 2.0 release.
+The 1.34 release introduces a two-state versioning model for datasets — see [ADR-0003](../adr/0003-dataset-dev-versioning-model.md) and the ["How to version a dataset"](datasets.md#how-to-version-a-dataset) chapter for the full picture. This is the largest semantic break in the 1.34 release.
 
 **Headline change:** `add_dataset_members`, `delete_dataset_members`, and the dataset-type mutation methods now flip the dataset to a *dev* version (a mutable label of the form `<last_release>.post1.devN`) instead of bumping to a released version. The new `Dataset.release()` method is the only operation that produces a released version.
 
 ### At-a-glance
 
-| Before (1.x) | After (2.0) |
+| Before (≤1.33) | After (1.34) |
 |---|---|
 | `dataset.increment_dataset_version(VersionPart.minor, "...")` | `dataset.release(bump=VersionPart.minor, description="...")` |
 | `add_dataset_members` → `0.4.0` → `0.5.0` (released bump) | `add_dataset_members` → `0.4.0` → `0.4.0.post1.dev1` (dev flip) |
@@ -397,14 +397,14 @@ The 2.0 release introduces a two-state versioning model for datasets — see [AD
 The most mechanical break. Every `increment_dataset_version` call site needs to switch to `release()`:
 
 ```python
-# Before (1.x)
+# Before (≤1.33)
 new_version = dataset.increment_dataset_version(
     component=VersionPart.minor,
     description="Stable for experiment 1",
     execution_rid=exe.execution_rid,
 )
 
-# After (2.0)
+# After (1.34)
 new_version = dataset.release(
     bump=VersionPart.minor,
     description="Stable for experiment 1",
@@ -427,11 +427,11 @@ A private `_increment_dataset_version` is preserved as an internal force-bump pr
 Code that calls `add_dataset_members` and assumes the result is a released version needs to call `release()` afterward to mint a stable reference:
 
 ```python
-# Before (1.x): one call, one released version
+# Before (≤1.33): one call, one released version
 dataset.add_dataset_members(members={"Image": image_rids})
 # dataset.current_version is now e.g. "0.5.0" (released)
 
-# After (2.0): one call → dev label; release explicitly
+# After (1.34): one call → dev label; release explicitly
 dataset.add_dataset_members(members={"Image": image_rids})
 # dataset.current_version is now "0.4.0.post1.dev1" (dev)
 dataset.release(bump=VersionPart.minor, description="Add training images")
@@ -449,7 +449,7 @@ Code that only consumes `current_version` for display works without changes; cod
 
 ### New methods (additive)
 
-Four methods are new in 2.0; you don't need to migrate to them but they're available:
+Four methods are new in 1.34; you don't need to migrate to them but they're available:
 
 - `Dataset.mark_dev(description, execution=None)` — explicitly flip the dataset to dev when the catalog drifted via a path that didn't go through the dataset API (a separate execution recorded a feature value, etc.).
 - `Dataset.is_dirty() -> bool` — fast predicate for "has anything reachable changed since the last release?"


### PR DESCRIPTION
## Summary

The dev-versioning stack ([#80](https://github.com/informatics-isi-edu/deriva-ml/pull/80) – [#87](https://github.com/informatics-isi-edu/deriva-ml/pull/87)) was planned as a 2.0 major-version bump, but was shipped as a 1.34 minor bump. The plan-stage \`v2.0.0\` tag has been deleted from origin (it never reached PyPI — the publish workflow has been failing). This PR updates the user-facing documentation to match what actually shipped.

## What changed

- **\`docs/release-notes.md\`** — \`Version 2.0.0\` → \`Version 1.34.0\`.
- **\`docs/user-guide/migration.md\`** — section heading and prose references to "2.0" updated to "1.34". Code-block \`Before/After\` annotations updated from \`(1.x)\` / \`(2.0)\` to \`(≤1.33)\` / \`(1.34)\`.
- **\`docs/adr/0003-dataset-dev-versioning-model.md\`** — two body references to "2.0 release" replaced with "1.34". The migration-impact section names the actual shipping version.
- **\`docs/adr/0005-dev-versioning-delivery-sequence.md\`** — adds a "Delivery outcome" section at the top noting the deviation between the plan (2.0 major) and what actually shipped (1.34 minor). The body of ADR-0005 is left intact as the historical record of the plan.

## What did **not** change

- No code changes. Behavior change inventory is identical.
- No semantic changes to the dev-versioning model.
- ADR-0003's body is largely intact; only the literal version references are updated. The decisions, mechanics, and rationale stand.
- ADR-0005's body is unchanged — the "Delivery outcome" header is the only addition. The plan documents the design intent at the time it was written; the deviation is captured as an addendum, not a rewrite.

## Why a doc-only PR

The dev-versioning stack is already on \`main\`. The version-label discrepancy is a documentation-correctness issue — users reading \`release-notes.md\` should see the version number that was actually tagged. The literal \`v2.0.0\` tag has been removed from origin.

After this merges, \`uv run bump-version minor\` on a clean \`main\` checkout produces \`v1.34.0\` — the actual release tag.

## Test plan

- [x] No code change; existing tests unaffected.
- [ ] Reviewer skim of the four touched files for prose accuracy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)