### PR TITLE
refactor(dataset): rewire callers from CatalogGraph to DatasetBagBuilder

### DIFF
--- a/src/deriva_ml/core/mixins/dataset.py
+++ b/src/deriva_ml/core/mixins/dataset.py
@@ -253,8 +253,8 @@ class DatasetMixin:
         Example:
             >>> ml.add_dataset_element_type("Image")  # doctest: +SKIP
         """
-        # Import here to avoid circular imports
-        from deriva_ml.dataset.catalog_graph import CatalogGraph
+        # Import here to avoid circular imports.
+        from deriva_ml.dataset.bag_builder import DatasetBagBuilder
 
         # Add table to map.
         element_table = self.model.name_to_table(element)
@@ -287,8 +287,10 @@ class DatasetMixin:
                 )
 
         # self.model = self.catalog.getCatalogModel()
-        annotations = CatalogGraph(
-            self, s3_bucket=self.s3_bucket, use_minid=self.use_minid
+        annotations = DatasetBagBuilder(
+            ml_instance=self,
+            s3_bucket=self.s3_bucket,
+            use_minid=self.use_minid,
         ).generate_dataset_download_annotations()  # type: ignore[arg-type]
         self._dataset_table.annotations.update(annotations)
         self.model.model.apply()

--- a/src/deriva_ml/dataset/bag_builder.py
+++ b/src/deriva_ml/dataset/bag_builder.py
@@ -157,6 +157,40 @@ class DatasetBagBuilder:
         """
         return self._catalog_graph.generate_dataset_download_annotations()
 
+    def aggregate_queries(
+        self,
+        dataset: DatasetLike | None = None,
+    ) -> dict[str, list[Any]]:
+        """Return per-target-table datapaths for size estimation.
+
+        Byte-equivalent to
+        :meth:`CatalogGraph._aggregate_queries`. Returns a dict
+        keyed by terminal table name; each value is a list of
+        ``(datapath, target_pb_table, is_asset)`` tuples — one
+        per FK path that reaches the target table from the
+        dataset. Used by :meth:`Dataset.estimate_bag_size` to
+        compute row counts via RID-union semantics before
+        deciding whether to materialize.
+
+        Args:
+            dataset: Optional dataset to filter paths to. ``None``
+                aggregates across every dataset reachable in the
+                catalog.
+
+        Returns:
+            ``{target_table_name: [(datapath, pb_table, is_asset),
+            ...]}``.
+        """
+        # ``_aggregate_queries`` is a private CatalogGraph method;
+        # using it through the wrapper preserves byte equivalence
+        # while moving callers off the CatalogGraph import. When
+        # CatalogGraph is eventually retired in favor of a fully
+        # CatalogBagBuilder-backed implementation, this method
+        # will route through the same downstream as today's
+        # CatalogGraph (the export engine has the same datapath
+        # surface).
+        return self._catalog_graph._aggregate_queries(dataset)
+
     # ------------------------------------------------------------------
     # ADR-0006 bag-pipeline-shaped helpers
     # ------------------------------------------------------------------

--- a/src/deriva_ml/dataset/dataset.py
+++ b/src/deriva_ml/dataset/dataset.py
@@ -97,7 +97,7 @@ from deriva_ml.dataset.aux_classes import (
     DatasetVersion,
     VersionPart,
 )
-from deriva_ml.dataset.catalog_graph import CatalogGraph
+from deriva_ml.dataset.bag_builder import DatasetBagBuilder
 from deriva_ml.dataset.dataset_bag import DatasetBag
 from deriva_ml.feature import Feature
 from deriva_ml.interfaces import DerivaMLCatalog
@@ -115,7 +115,7 @@ def _hash_spec(spec: Any) -> str:
     Args:
         spec: The download spec (any JSON-serializable Python object,
             typically the dict returned by
-            ``CatalogGraph.generate_dataset_download_spec``).
+            ``DatasetBagBuilder.generate_dataset_download_spec``).
 
     Returns:
         Lowercase hex-digest string (64 chars).
@@ -1288,7 +1288,8 @@ class Dataset:
     ) -> "Iterator[tuple[str, int]]":
         """Yield ``(table_name, count)`` for rows reachable from this dataset with ``t_lower < RMT <= t_upper``.
 
-        Walks ``CatalogGraph._aggregate_queries`` paths and counts rows
+        Walks the dataset's FK paths via
+        :meth:`DatasetBagBuilder.aggregate_queries` and counts rows
         in each terminal table that fall within the given RMT window.
         ``t_upper=None`` means "no upper bound" — i.e., live state.
 
@@ -1298,10 +1299,8 @@ class Dataset:
         """
         from deriva.core.datapath import Cnt
 
-        from deriva_ml.dataset.catalog_graph import CatalogGraph
-
-        graph = CatalogGraph(self._ml_instance)
-        table_queries = graph._aggregate_queries(self)
+        builder = DatasetBagBuilder(ml_instance=self._ml_instance)
+        table_queries = builder.aggregate_queries(self)
 
         for table_name, path_entries in table_queries.items():
             for dp, target_pb_table, _is_asset in path_entries:
@@ -2455,9 +2454,10 @@ class Dataset:
     ) -> dict[str, Any]:
         """Estimate the size of a dataset bag before downloading.
 
-        Uses ``CatalogGraph._aggregate_queries`` to build datapath objects for
-        every FK path that reaches each table, then fetches RID lists from the
-        snapshot catalog and computes the exact union across all paths.
+        Uses :meth:`DatasetBagBuilder.aggregate_queries` to build datapath
+        objects for every FK path that reaches each table, then fetches RID
+        lists from the snapshot catalog and computes the exact union across
+        all paths.
 
         When the same table is reachable via multiple FK paths, **all** paths
         are queried and the RID sets are unioned to get the exact row count.
@@ -2489,14 +2489,14 @@ class Dataset:
         if isinstance(version, str):
             version = DatasetVersion.parse(version)
 
-        # Build a CatalogGraph on the version snapshot and collect aggregate
-        # datapath objects grouped by target table.
+        # Build a DatasetBagBuilder on the version snapshot and collect
+        # aggregate datapath objects grouped by target table.
         version_snapshot_catalog = self._version_snapshot_catalog(version)
-        graph = CatalogGraph(
-            version_snapshot_catalog,
+        builder = DatasetBagBuilder(
+            ml_instance=version_snapshot_catalog,
             exclude_tables=exclude_tables,
         )
-        table_queries = graph._aggregate_queries(self)
+        table_queries = builder.aggregate_queries(self)
 
         # Connect to the snapshot catalog for queries using the async catalog,
         # which uses httpx.AsyncClient with connection pooling and is safe for
@@ -2982,8 +2982,8 @@ class Dataset:
             # Generate spec if not supplied (allows callers to reuse a spec they already computed).
             if spec is None:
                 version_snapshot_catalog = self._version_snapshot_catalog(version)
-                downloader = CatalogGraph(
-                    version_snapshot_catalog,
+                downloader = DatasetBagBuilder(
+                    ml_instance=version_snapshot_catalog,
                     s3_bucket=self._ml_instance.s3_bucket,
                     use_minid=use_minid,
                     exclude_tables=exclude_tables,
@@ -3361,8 +3361,8 @@ class Dataset:
         # cheap and necessary for correctness.
         # =====================================================================
         version_snapshot_catalog = self._version_snapshot_catalog(version)
-        downloader = CatalogGraph(
-            version_snapshot_catalog,
+        downloader = DatasetBagBuilder(
+            ml_instance=version_snapshot_catalog,
             s3_bucket=self._ml_instance.s3_bucket,
             use_minid=use_minid,
             exclude_tables=exclude_tables,

--- a/tests/dataset/test_estimate_bag_size.py
+++ b/tests/dataset/test_estimate_bag_size.py
@@ -120,7 +120,7 @@ def _run_estimate(
     """Run estimate_bag_size with mocked internals.
 
     Args:
-        aggregate_queries: Return value for CatalogGraph._aggregate_queries.
+        aggregate_queries: Return value for DatasetBagBuilder.aggregate_queries.
             Maps table name to list of (mock_datapath, target_table, is_asset) tuples.
         catalog_responses: Mapping from query path substring to response JSON.
             For csv queries, responses should be RID arrays: [{"RID": "X"}, ...].
@@ -143,13 +143,13 @@ def _run_estimate(
     mock_catalog = _make_mock_async_catalog(catalog_responses)
 
     with (
-        patch("deriva_ml.dataset.dataset.CatalogGraph") as mock_graph_cls,
+        patch("deriva_ml.dataset.dataset.DatasetBagBuilder") as mock_builder_cls,
         patch("deriva.core.get_credential", return_value={}),
         patch("deriva_ml.dataset.dataset.AsyncErmrestSnapshot", return_value=mock_catalog),
     ):
-        mock_graph = MagicMock()
-        mock_graph._aggregate_queries.return_value = aggregate_queries
-        mock_graph_cls.return_value = mock_graph
+        mock_builder = MagicMock()
+        mock_builder.aggregate_queries.return_value = aggregate_queries
+        mock_builder_cls.return_value = mock_builder
 
         return Dataset.estimate_bag_size(dataset, "1.0.0")
 
@@ -187,13 +187,13 @@ def _run_estimate_counting(
     mock_catalog.close = AsyncMock()
 
     with (
-        patch("deriva_ml.dataset.dataset.CatalogGraph") as mock_graph_cls,
+        patch("deriva_ml.dataset.dataset.DatasetBagBuilder") as mock_builder_cls,
         patch("deriva.core.get_credential", return_value={}),
         patch("deriva_ml.dataset.dataset.AsyncErmrestSnapshot", return_value=mock_catalog),
     ):
-        mock_graph = MagicMock()
-        mock_graph._aggregate_queries.return_value = aggregate_queries
-        mock_graph_cls.return_value = mock_graph
+        mock_builder = MagicMock()
+        mock_builder.aggregate_queries.return_value = aggregate_queries
+        mock_builder_cls.return_value = mock_builder
 
         Dataset.estimate_bag_size(dataset, "1.0.0")
 


### PR DESCRIPTION
## Summary

Consumer-side follow-up to [deriva-ml#96](https://github.com/informatics-isi-edu/deriva-ml/pull/96). Moves every live `CatalogGraph` caller in deriva-ml onto the `DatasetBagBuilder` domain wrapper that landed in that PR. `DatasetBagBuilder` already composes a `CatalogGraph` internally for byte-equivalent output (verified by [tests/dataset/test_bag_builder.py](tests/dataset/test_bag_builder.py) against a live catalog), so this is a pure rename — no behavioral change.

### Call sites rewired

| File | Function | Was | Now |
| --- | --- | --- | --- |
| [src/deriva_ml/core/mixins/dataset.py:289](src/deriva_ml/core/mixins/dataset.py) | `add_dataset_element_type` | `CatalogGraph(...).generate_dataset_download_annotations()` | `DatasetBagBuilder(...).generate_dataset_download_annotations()` |
| [src/deriva_ml/dataset/dataset.py:1302](src/deriva_ml/dataset/dataset.py) | `_iter_drift_counts` | `CatalogGraph(...)._aggregate_queries(self)` | `DatasetBagBuilder(...).aggregate_queries(self)` |
| [src/deriva_ml/dataset/dataset.py:2492](src/deriva_ml/dataset/dataset.py) | `estimate_bag_size` | `CatalogGraph(...)._aggregate_queries(self)` | `DatasetBagBuilder(...).aggregate_queries(self)` |
| [src/deriva_ml/dataset/dataset.py:2985](src/deriva_ml/dataset/dataset.py) | `_create_dataset_minid` | `CatalogGraph(...).generate_dataset_download_spec(self)` | `DatasetBagBuilder(...).generate_dataset_download_spec(self)` |
| [src/deriva_ml/dataset/dataset.py:3364](src/deriva_ml/dataset/dataset.py) | `_create_dataset_bag_client` | `CatalogGraph(...).generate_dataset_download_spec(self)` | `DatasetBagBuilder(...).generate_dataset_download_spec(self)` |

Adds one new public method on `DatasetBagBuilder`:

- `aggregate_queries(dataset=None)` — passthrough to the underlying `CatalogGraph._aggregate_queries`, so `estimate_bag_size` callers don't reach into a private API.

### What this does NOT do

- `CatalogGraph` itself stays in place as the implementation behind `DatasetBagBuilder` and is still exported for `tests/dataset/test_bag_builder.py` spec-equivalence checks. Retiring it in favor of a fully `CatalogBagBuilder`-backed implementation is a follow-up once `clone_via_bag` live-catalog tests confirm deriva.bag output matches.

## Test plan

- [x] Unit tests: 475 pass, 3 skipped, 1 xfailed
- [x] `tests/dataset/test_estimate_bag_size.py` — patches updated to target `DatasetBagBuilder`; all 13 pass
- [x] `tests/dataset/test_bag_builder.py` — spec-equivalence vs `CatalogGraph` (live catalog) still green
- [x] 4 pre-existing failures in `tests/model/test_database.py` reproduced on `main` before this change — not caused by this PR (tracked separately)
- [ ] Reviewer self-check on a live catalog (optional): `download_dataset_bag` produces the same bag content as `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)