### PR TITLE
test(catalog): live-catalog integration tests for clone_via_bag (xfail-marked)

### DIFF
--- a/src/deriva_ml/catalog/clone_via_bag.py
+++ b/src/deriva_ml/catalog/clone_via_bag.py
@@ -53,21 +53,89 @@ Legacy parameter            Bag-path mapping   Notes
 from __future__ import annotations
 
 import logging
+import zipfile
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
 
-from deriva.bag.anchors import Anchor, RIDAnchor, TableAnchor
+from deriva.bag.anchors import Anchor, RIDAnchor
 from deriva.bag.catalog_builder import CatalogBagBuilder
 from deriva.bag.catalog_loader import BagCatalogLoader, LoadReport
 from deriva.bag.traversal import (
     AssetMode,
-    DanglingFKStrategy,
     FKTraversalPolicy,
 )
-from deriva.core import DerivaServer, ErmrestCatalog, get_credential
+from deriva.core import DerivaServer, get_credential
 
 logger = logging.getLogger(__name__)
+
+
+def _materialize_bag_dir(bag_path: Path) -> Path:
+    """Return an on-disk unpacked bag directory, extracting a zip if needed.
+
+    Upstream ``CatalogBagBuilder._run_export`` hard-codes
+    ``bag_archiver=zip`` and removes the unpacked directory after
+    archiving, but returns the unpacked path as if it still existed.
+    Recover the bag by extracting ``{bag_path}.zip`` into
+    ``bag_path.parent`` when the directory is missing.
+
+    Args:
+        bag_path: Path the builder claimed it produced.
+
+    Returns:
+        Path to an extracted bag directory. ``bag_path`` itself when
+        the builder already left it on disk; otherwise the directory
+        produced by unzipping ``{bag_path}.zip``.
+
+    Raises:
+        FileNotFoundError: When neither the directory nor the zip is
+            present — the build genuinely failed.
+    """
+    if bag_path.is_dir():
+        return bag_path
+    zip_candidate = bag_path.with_suffix(".zip")
+    if not zip_candidate.exists():
+        raise FileNotFoundError(f"Bag missing at {bag_path}; no {zip_candidate} fallback")
+    extract_root = bag_path.parent
+    with zipfile.ZipFile(zip_candidate) as zf:
+        zf.extractall(extract_root)
+    # bdbag produces a single top-level directory inside the zip;
+    # use the builder's expected name when it landed, otherwise
+    # take the lone extracted directory.
+    if bag_path.is_dir():
+        return bag_path
+    extracted = [p for p in extract_root.iterdir() if p.is_dir() and p.name != ".bag-db"]
+    if len(extracted) != 1:
+        raise FileNotFoundError(
+            f"Could not locate bag directory after unzipping {zip_candidate}; candidates: {[p.name for p in extracted]}"
+        )
+    return extracted[0]
+
+
+def _materialize_bag_assets(bag_path: Path) -> None:
+    """Fetch any unresolved ``fetch.txt`` entries into the bag.
+
+    Asset uploads (``AssetMode.UPLOAD_IF_MISSING`` /
+    ``UPLOAD_FORCE``) require the bytes to be present locally —
+    the loader pushes them to the destination Hatrac. When the
+    source bag was produced with the deriva-bag profile, asset
+    payloads live as URL references in ``fetch.txt`` until a
+    materialize step copies them in. Skipping this step would
+    surface as ``ValueError: asset_mode=... is incompatible with
+    a holey bag`` from
+    :meth:`FKTraversalPolicy.validate_with_bag_state`.
+
+    Args:
+        bag_path: Path to the bag directory to materialize.
+    """
+    fetch_file = bag_path / "fetch.txt"
+    if not fetch_file.exists() or fetch_file.stat().st_size == 0:
+        return
+    # Local import — bdbag drags in heavy network deps; keep it
+    # lazy so callers who never hit an asset-upload path don't pay.
+    from bdbag import bdbag_api as bdb
+
+    logger.info("clone_via_bag: materializing bag assets at %s", bag_path)
+    bdb.materialize(str(bag_path))
 
 
 @dataclass
@@ -162,9 +230,7 @@ def clone_via_bag(
             12345
     """
     if anchors is None and root_rid is None:
-        raise ValueError(
-            "clone_via_bag requires either ``anchors`` or ``root_rid``"
-        )
+        raise ValueError("clone_via_bag requires either ``anchors`` or ``root_rid``")
 
     if anchors is None:
         # Convenience path: caller provided a single Dataset RID.
@@ -176,17 +242,12 @@ def clone_via_bag(
     policy = policy or FKTraversalPolicy()
 
     if output_dir is None:
-        output_dir = (
-            Path.cwd()
-            / f"clone-{source_catalog_id}-to-{dest_catalog_id}"
-        )
+        output_dir = Path.cwd() / f"clone-{source_catalog_id}-to-{dest_catalog_id}"
     output_dir = Path(output_dir)
 
     # Connect to the source catalog.
     source_creds = source_credential or get_credential(source_hostname)
-    source_server = DerivaServer(
-        "https", source_hostname, credentials=source_creds
-    )
+    source_server = DerivaServer("https", source_hostname, credentials=source_creds)
     source_catalog = source_server.connect_ermrest(source_catalog_id)
 
     # Build the bag. CatalogBagBuilder drives deriva-py's export
@@ -206,12 +267,25 @@ def clone_via_bag(
         source_catalog_id,
     )
     bag_path = builder.build()
+    # CatalogBagBuilder archives the bag as ``{bag_path}.zip`` and
+    # leaves only the zip on disk; materialize back into a directory
+    # the loader can open.
+    bag_path = _materialize_bag_dir(bag_path)
+
+    # Materialize asset payloads when the policy will upload them.
+    # An asset-uploading mode (``UPLOAD_IF_MISSING`` / ``UPLOAD_FORCE``)
+    # requires the bytes to already be local; the loader's
+    # ``validate_with_bag_state`` rejects the combination up front.
+    # ``ROWS_ONLY`` skips this — the bag's row data alone is enough.
+    if policy.asset_mode in (
+        AssetMode.UPLOAD_IF_MISSING,
+        AssetMode.UPLOAD_FORCE,
+    ):
+        _materialize_bag_assets(bag_path)
 
     # Connect to the destination catalog.
     dest_creds = dest_credential or get_credential(dest_hostname)
-    dest_server = DerivaServer(
-        "https", dest_hostname, credentials=dest_creds
-    )
+    dest_server = DerivaServer("https", dest_hostname, credentials=dest_creds)
     dest_catalog = dest_server.connect_ermrest(dest_catalog_id)
 
     # Load the bag into the destination. BagCatalogLoader walks

--- a/tests/catalog/test_clone_via_bag_integration.py
+++ b/tests/catalog/test_clone_via_bag_integration.py
@@ -1,0 +1,254 @@
+"""Live-catalog integration tests for :func:`clone_via_bag`.
+
+These tests stand up a real source catalog (populated by the demo
+fixtures), build a bag, load it into a freshly-created destination
+catalog, and verify that the destination's row counts match the
+source. They cover the bag pipeline end-to-end — the network round
+trips, the export-engine driver, the bag's on-disk artifact, the
+loader's FK-safe insert ordering, and (where applicable) the policy
+parameters that route asset bytes.
+
+Each test creates and destroys its own destination catalog so that
+runs are isolated. Source catalogs come from the session-scoped
+``catalog_manager`` fixture.
+
+These tests are slow (multiple minutes each) and require ``DERIVA_HOST``.
+Select them with ``-m integration`` and expect to run them rarely.
+
+**Currently xfailed**: each test is marked
+``pytest.mark.xfail(strict=False)`` pending the
+:class:`~deriva.bag.catalog_loader.BagCatalogLoader` conflict-policy
+rewrite tracked by `deriva-py#214
+<https://github.com/informatics-isi-edu/deriva-py/issues/214>`_ (per
+`deriva-py ADR-0001
+<https://github.com/informatics-isi-edu/deriva-py/blob/deriva-ml/docs/adr/0001-bag-catalog-loader-conflict-and-system-content.md>`_).
+The loader currently fails on RID conflicts when the destination
+catalog has pre-populated system vocabulary (which every catalog
+created via ``create_ml_catalog`` does). When the rewrite lands and
+the loader does vocabulary-by-name reconciliation, these tests will
+flip to PASS automatically.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+from deriva.bag.anchors import RIDAnchor
+from deriva.bag.traversal import (
+    AssetMode,
+    DanglingFKStrategy,
+    FKTraversalPolicy,
+)
+
+from deriva_ml.catalog.clone_via_bag import (
+    CloneViaBagResult,
+    clone_via_bag,
+)
+from deriva_ml.schema import create_ml_catalog
+
+if TYPE_CHECKING:
+    from deriva.core import ErmrestCatalog
+
+    from deriva_ml import DerivaML
+    from deriva_ml.demo_catalog import DatasetDescription
+
+
+# ----------------------------------------------------------------------
+# Shared markers
+# ----------------------------------------------------------------------
+
+
+#: Each end-to-end test is xfailed pending the
+#: :class:`BagCatalogLoader` conflict-policy rewrite tracked by
+#: deriva-py#214 (per deriva-py ADR-0001). ``strict=False`` so the
+#: tests flip to ``XPASS`` and surface a green diff the moment the
+#: upstream rewrite lands. The reason is in module docstring.
+_AWAITING_LOADER_REWRITE = pytest.mark.xfail(
+    reason="awaits BagCatalogLoader rewrite per deriva-py ADR-0001 (issue #214)",
+    strict=False,
+)
+
+
+# ----------------------------------------------------------------------
+# Fixtures
+# ----------------------------------------------------------------------
+
+
+@pytest.fixture
+def dest_catalog(catalog_host: str) -> "ErmrestCatalog":
+    """A freshly-created destination catalog, deleted at test end.
+
+    The destination is created with the deriva-ml schema already
+    populated (via :func:`create_ml_catalog`), matching what the bag
+    loader expects: schema-compatible catalog with no domain rows.
+
+    Yields:
+        ErmrestCatalog: empty destination catalog ready for the
+        loader to insert into.
+    """
+    catalog = create_ml_catalog(catalog_host, project_name="clone-via-bag-dest")
+    try:
+        yield catalog
+    finally:
+        catalog.delete_ermrest_catalog(really=True)
+
+
+# ----------------------------------------------------------------------
+# Helpers
+# ----------------------------------------------------------------------
+
+
+def _row_count(catalog: "ErmrestCatalog", schema: str, table: str) -> int:
+    """Return the row count of ``schema.table`` via path builder."""
+    pb = catalog.getPathBuilder()
+    return len(list(pb.schemas[schema].tables[table].path.entities().fetch()))
+
+
+def _count_by_table(catalog: "ErmrestCatalog", schema: str, tables: list[str]) -> dict[str, int]:
+    """Return ``{table: row_count}`` for each table in ``tables``."""
+    return {t: _row_count(catalog, schema, t) for t in tables}
+
+
+# ----------------------------------------------------------------------
+# Tests
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.integration
+@_AWAITING_LOADER_REWRITE
+def test_clone_via_bag_end_to_end_default_policy(
+    catalog_with_datasets: "tuple[DerivaML, DatasetDescription]",
+    dest_catalog: "ErmrestCatalog",
+    tmp_path: Path,
+    catalog_host: str,
+) -> None:
+    """Default policy clones a Dataset-anchored slice end-to-end.
+
+    Builds a bag rooted at the top-level Dataset RID from a source
+    catalog populated by the demo fixture, then loads it into a
+    fresh destination catalog. The destination must contain the
+    same number of rows in the reachable tables as the source.
+    """
+    source_ml, dataset_desc = catalog_with_datasets
+    root_rid = dataset_desc.dataset.dataset_rid
+
+    # Snapshot source row counts for tables we expect the walk to
+    # reach from the Dataset anchor.
+    domain_tables = ["Subject", "Image", "Observation"]
+    src_domain = _count_by_table(source_ml.catalog, source_ml.default_schema, domain_tables)
+    src_dataset = _row_count(source_ml.catalog, "deriva-ml", "Dataset")
+    assert src_dataset > 0, "demo fixture should have created datasets"
+    assert src_domain["Subject"] > 0
+    assert src_domain["Image"] > 0
+
+    output_dir = tmp_path / "bag"
+
+    result = clone_via_bag(
+        source_hostname=source_ml.catalog.deriva_server.server,
+        source_catalog_id=str(source_ml.catalog.catalog_id),
+        dest_hostname=catalog_host,
+        dest_catalog_id=str(dest_catalog.catalog_id),
+        root_rid=root_rid,
+        output_dir=output_dir,
+    )
+
+    # Smoke checks on the result object.
+    assert isinstance(result, CloneViaBagResult)
+    assert result.source_catalog_id == str(source_ml.catalog.catalog_id)
+    assert result.dest_catalog_id == str(dest_catalog.catalog_id)
+    assert result.bag_path.exists()
+    assert result.bag_path.is_dir()
+    assert result.load_report.total_rows_inserted > 0
+
+    # Destination row counts match what the source had for the
+    # reachable tables.
+    dst_domain = _count_by_table(dest_catalog, source_ml.default_schema, domain_tables)
+    assert dst_domain == src_domain
+    assert _row_count(dest_catalog, "deriva-ml", "Dataset") == src_dataset
+
+
+@pytest.mark.integration
+@_AWAITING_LOADER_REWRITE
+def test_clone_via_bag_rows_only_skips_asset_uploads(
+    catalog_with_datasets: "tuple[DerivaML, DatasetDescription]",
+    dest_catalog: "ErmrestCatalog",
+    tmp_path: Path,
+    catalog_host: str,
+) -> None:
+    """``AssetMode.ROWS_ONLY`` inserts rows but uploads zero asset bytes.
+
+    The ROWS_ONLY policy is the cheap path: the bag still records
+    the Image rows but the loader doesn't push their byte contents
+    into the destination Hatrac. We verify both: row counts match,
+    and the load report shows ``assets_uploaded == 0``.
+    """
+    source_ml, dataset_desc = catalog_with_datasets
+    root_rid = dataset_desc.dataset.dataset_rid
+
+    policy = FKTraversalPolicy(
+        asset_mode=AssetMode.ROWS_ONLY,
+        dangling_fk_strategy=DanglingFKStrategy.FAIL,
+    )
+
+    result = clone_via_bag(
+        source_hostname=source_ml.catalog.deriva_server.server,
+        source_catalog_id=str(source_ml.catalog.catalog_id),
+        dest_hostname=catalog_host,
+        dest_catalog_id=str(dest_catalog.catalog_id),
+        root_rid=root_rid,
+        output_dir=tmp_path / "bag",
+        policy=policy,
+    )
+
+    # No asset uploads happened.
+    total_assets_uploaded = sum(s.assets_uploaded for s in result.load_report.table_stats.values())
+    assert total_assets_uploaded == 0, f"ROWS_ONLY must not upload asset bytes, got {total_assets_uploaded} uploads"
+
+    # Image rows still landed.
+    src_images = _row_count(source_ml.catalog, source_ml.default_schema, "Image")
+    dst_images = _row_count(dest_catalog, source_ml.default_schema, "Image")
+    assert dst_images == src_images
+
+
+@pytest.mark.integration
+@_AWAITING_LOADER_REWRITE
+def test_clone_via_bag_rid_anchor_scopes_walk(
+    catalog_with_datasets: "tuple[DerivaML, DatasetDescription]",
+    dest_catalog: "ErmrestCatalog",
+    tmp_path: Path,
+    catalog_host: str,
+) -> None:
+    """A single-RID anchor walks only the reachable slice, not the full catalog.
+
+    Anchored at one Subject RID, the destination should land **one**
+    Subject (not the full source population). Verifies the bag walker
+    is honoring anchor scope rather than dumping the whole table.
+    """
+    source_ml, _ = catalog_with_datasets
+
+    # Pick one Subject RID to anchor at.
+    pb = source_ml.catalog.getPathBuilder()
+    subjects = list(pb.schemas[source_ml.default_schema].tables["Subject"].path.entities().fetch())
+    src_total_subjects = len(subjects)
+    assert src_total_subjects > 1, (
+        "demo fixture should have multiple subjects so the scoped walk has something to exclude"
+    )
+    one_subject_rid = subjects[0]["RID"]
+
+    result = clone_via_bag(
+        source_hostname=source_ml.catalog.deriva_server.server,
+        source_catalog_id=str(source_ml.catalog.catalog_id),
+        dest_hostname=catalog_host,
+        dest_catalog_id=str(dest_catalog.catalog_id),
+        anchors=[RIDAnchor(table="Subject", rids=[one_subject_rid])],
+        output_dir=tmp_path / "bag",
+    )
+
+    assert result.load_report.total_rows_inserted > 0
+
+    dst_subjects = _row_count(dest_catalog, source_ml.default_schema, "Subject")
+    assert dst_subjects == 1, (
+        f"expected exactly the anchored Subject, got {dst_subjects} (source had {src_total_subjects})"
+    )


### PR DESCRIPTION
## Summary

Adds three live-catalog end-to-end integration tests for [\`clone_via_bag\`](src/deriva_ml/catalog/clone_via_bag.py). They stand up a real source catalog (populated by the demo fixtures), build a bag, and load it into a freshly-created destination catalog. The tests cover:

- the default policy end-to-end (rows + asset uploads)
- \`AssetMode.ROWS_ONLY\` skipping asset bytes
- a single-RID anchor scoping the walk to one slice

## Why xfail

All three are \`@pytest.mark.xfail(strict=False)\` pending the \`BagCatalogLoader\` rewrite tracked by [deriva-py#214](https://github.com/informatics-isi-edu/deriva-py/issues/214) (per [deriva-py ADR-0001](https://github.com/informatics-isi-edu/deriva-py/blob/deriva-ml/docs/adr/0001-bag-catalog-loader-conflict-and-system-content.md)). The loader currently fails on RID conflicts when the destination catalog has pre-populated system vocabulary (which every catalog created via \`create_ml_catalog\` does).

The tests will flip to PASS automatically once the upstream rewrite lands and does vocabulary-by-name reconciliation. \`strict=False\` means an XPASS is surfaced as a diff in the CI output but doesn't fail the run.

## Companion work

Getting these tests to *fail at the conflict-policy level* (rather than the seven earlier bugs that hid it) needed seven upstream fixes. Those landed in [deriva-py#213](https://github.com/informatics-isi-edu/deriva-py/pull/213). Once that PR merges, deriva-ml's pinned deriva-py rev will pick up the fixes.

## Two small workaround helpers in \`clone_via_bag.py\`

These are defensive against upstream gaps that aren't worth fixing in deriva-py right now:

- \`_materialize_bag_dir\` — \`CatalogBagBuilder._run_export\` archives the bag as a zip and removes the unpacked directory, but returns the (deleted) unpacked path. We recover by extracting the zip when the dir is missing.
- \`_materialize_bag_assets\` — call \`bdb.materialize\` before the loader runs when the policy will upload assets, so the holey-bag validation doesn't reject the load up front.

Both are no-ops once the upstream gaps are closed.

## Test plan

- [x] \`tests/catalog/test_clone_via_bag.py\` — 7 pass (existing mocked unit tests, unchanged)
- [x] \`tests/catalog/test_clone_via_bag_integration.py\` — 3 xfail (live catalog, hit the conflict-policy gap)
- [ ] Once [deriva-py#213](https://github.com/informatics-isi-edu/deriva-py/pull/213) and the [#214](https://github.com/informatics-isi-edu/deriva-py/issues/214) rewrite both ship, re-run the integration suite and verify XPASS
- [ ] Reviewer self-check: confirm the xfail reason + the link to [deriva-py#214](https://github.com/informatics-isi-edu/deriva-py/issues/214) make the deferred work findable

🤖 Generated with [Claude Code](https://claude.com/claude-code)