### PR TITLE
feat(catalog): nested-Dataset anchor expansion + vocab FULL default + schema-clone fixture

### DIFF
--- a/src/deriva_ml/catalog/clone_via_bag.py
+++ b/src/deriva_ml/catalog/clone_via_bag.py
@@ -63,6 +63,7 @@ from deriva.bag.catalog_loader import BagCatalogLoader, LoadReport
 from deriva.bag.traversal import (
     AssetMode,
     FKTraversalPolicy,
+    VocabExport,
 )
 from deriva.core import DerivaServer, get_credential
 
@@ -109,6 +110,93 @@ def _materialize_bag_dir(bag_path: Path) -> Path:
             f"Could not locate bag directory after unzipping {zip_candidate}; candidates: {[p.name for p in extracted]}"
         )
     return extracted[0]
+
+
+def _expand_nested_dataset_anchors(
+    anchors: list[Anchor], source_catalog: "ErmrestCatalog"
+) -> list[Anchor]:
+    """Expand ``Dataset`` ``RIDAnchor``s to include transitively-nested datasets.
+
+    deriva-ml's nested-dataset feature lets a parent Dataset
+    contain child Datasets via the ``Dataset_Dataset`` association
+    table (``Dataset → Nested_Dataset``). A bag rooted at the
+    parent is expected to carry every nested dataset's content as
+    if each child were anchored separately — that's the semantic
+    the legacy ``Dataset.download_dataset_bag`` path provided.
+
+    Without this expansion, the bag walker would include
+    ``Dataset_Dataset`` rows whose ``Nested_Dataset`` value points
+    at a Dataset RID outside the slice, producing dangling FKs at
+    load time.
+
+    The expansion walks the source catalog's ``Dataset_Dataset``
+    table transitively, starting from each ``RIDAnchor`` whose
+    table is ``Dataset``. Non-``Dataset`` anchors and non-``RIDAnchor``
+    types are returned unchanged.
+
+    Args:
+        anchors: The caller's anchor list.
+        source_catalog: Live catalog to query for nested children.
+
+    Returns:
+        A new anchor list with each ``Dataset`` ``RIDAnchor``'s
+        RID set expanded to include all transitively-nested RIDs.
+    """
+    expanded: list[Anchor] = []
+    for anchor in anchors:
+        if isinstance(anchor, RIDAnchor) and anchor.table == "Dataset":
+            full_rids = _collect_nested_dataset_rids(
+                anchor.rids, source_catalog
+            )
+            expanded.append(
+                RIDAnchor(table=anchor.table, rids=sorted(full_rids))
+            )
+        else:
+            expanded.append(anchor)
+    return expanded
+
+
+def _collect_nested_dataset_rids(
+    seed_rids: list[str], source_catalog: "ErmrestCatalog"
+) -> set[str]:
+    """BFS the ``Dataset_Dataset`` association from a seed RID set.
+
+    One GET per BFS frontier (each level fans out by the
+    frontier's RID list). Stops when no new children are found.
+    For the typical 1-3 levels of nesting in deriva-ml datasets
+    this is at most a handful of round trips.
+    """
+    from urllib.parse import quote as urlquote
+
+    collected: set[str] = set(seed_rids)
+    frontier: set[str] = set(seed_rids)
+    while frontier:
+        rid_list = ",".join(urlquote(r) for r in sorted(frontier))
+        path = (
+            f"/entity/deriva-ml:Dataset_Dataset"
+            f"/Dataset=any({rid_list})"
+        )
+        try:
+            response = source_catalog.get(path)
+            response.raise_for_status()
+            rows = response.json()
+        except Exception as e:
+            logger.warning(
+                "Could not expand nested datasets from %s: %s; "
+                "proceeding with the seed RID set only",
+                sorted(frontier), e,
+            )
+            return collected
+        new_children: set[str] = set()
+        for row in rows:
+            child = row.get("Nested_Dataset")
+            if child and child not in collected:
+                new_children.add(child)
+        if not new_children:
+            break
+        collected.update(new_children)
+        frontier = new_children
+    return collected
 
 
 def _materialize_bag_assets(bag_path: Path) -> None:
@@ -239,7 +327,13 @@ def clone_via_bag(
         assert root_rid is not None  # narrowed by the check above
         anchors = [RIDAnchor(table="Dataset", rids=[root_rid])]
 
-    policy = policy or FKTraversalPolicy()
+    # Clone semantics require every controlled-vocabulary term to
+    # exist on the destination — FK references from content tables
+    # may resolve through any term, not just the ones the
+    # BFS-shortest path happens to walk. Default to
+    # ``VocabExport.FULL`` here so the bag carries the complete
+    # vocabulary regardless of which path was discovered.
+    policy = policy or FKTraversalPolicy(vocab_export=VocabExport.FULL)
 
     if output_dir is None:
         output_dir = Path.cwd() / f"clone-{source_catalog_id}-to-{dest_catalog_id}"
@@ -249,6 +343,14 @@ def clone_via_bag(
     source_creds = source_credential or get_credential(source_hostname)
     source_server = DerivaServer("https", source_hostname, credentials=source_creds)
     source_catalog = source_server.connect_ermrest(source_catalog_id)
+
+    # Expand any ``Dataset`` RIDAnchors to include transitively
+    # nested datasets. A bag rooted at a parent dataset is expected
+    # to carry every nested dataset's content too — without this
+    # expansion the walker would include ``Dataset_Dataset`` rows
+    # whose ``Nested_Dataset`` value points outside the slice,
+    # producing dangling FKs at load time.
+    anchors = _expand_nested_dataset_anchors(anchors, source_catalog)
 
     # Build the bag. CatalogBagBuilder drives deriva-py's export
     # engine, which already handles paged ERMrest queries, MD5

--- a/tests/catalog/test_clone_via_bag.py
+++ b/tests/catalog/test_clone_via_bag.py
@@ -11,6 +11,7 @@ network connection.
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -138,7 +139,10 @@ def test_clone_via_bag_passes_through_explicit_anchors(
         )
 
         _, kwargs = MockBuilder.call_args
-        assert kwargs["anchors"] is custom_anchors
+        # ``clone_via_bag`` may rewrap the list (e.g., to expand
+        # nested-dataset anchors) — non-Dataset anchors should
+        # survive content-equivalent.
+        assert kwargs["anchors"] == custom_anchors
 
 
 def test_clone_via_bag_default_output_dir(tmp_path: Path) -> None:
@@ -301,3 +305,96 @@ def test_clone_via_bag_uses_explicit_credentials(tmp_path: Path) -> None:
         # When both credentials are explicit, get_credential is
         # never consulted.
         mock_creds.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Nested-dataset anchor expansion
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_catalog_with_dataset_dataset_rows(
+    rows_by_seed: dict[tuple[str, ...], list[dict[str, str]]],
+) -> MagicMock:
+    """Mock that returns predetermined Dataset_Dataset rows per query.
+
+    Args:
+        rows_by_seed: ``{frozenset(seed_rids): rows}`` mapping —
+            the helper looks up by the comma-sorted seed list as a
+            tuple. Each ``rows`` is a list of ``{"Nested_Dataset": rid}``.
+    """
+    catalog = MagicMock()
+
+    def _get(path: str, **_: Any):
+        # Path looks like:
+        # /entity/deriva-ml:Dataset_Dataset/Dataset=any(rid1,rid2,...)
+        match = path.split("any(")
+        if len(match) < 2:
+            seeds = ()
+        else:
+            inner = match[1].rstrip(")")
+            seeds = tuple(sorted(inner.split(",")))
+        rows = rows_by_seed.get(seeds, [])
+        resp = MagicMock()
+        resp.raise_for_status.return_value = None
+        resp.json.return_value = rows
+        return resp
+
+    catalog.get = _get
+    return catalog
+
+
+def test_expand_nested_dataset_anchors_collects_transitive_children() -> None:
+    """Anchored Dataset 'P' pulls in nested 'C1', 'C2', and 'C1's nested 'G1'."""
+    from deriva_ml.catalog.clone_via_bag import (
+        _expand_nested_dataset_anchors,
+    )
+
+    catalog = _make_mock_catalog_with_dataset_dataset_rows(
+        {
+            ("P",): [
+                {"Nested_Dataset": "C1"},
+                {"Nested_Dataset": "C2"},
+            ],
+            ("C1", "C2"): [
+                {"Nested_Dataset": "G1"},
+            ],
+            ("G1",): [],
+        }
+    )
+    anchors = [RIDAnchor(table="Dataset", rids=["P"])]
+    expanded = _expand_nested_dataset_anchors(anchors, catalog)
+    assert len(expanded) == 1
+    assert isinstance(expanded[0], RIDAnchor)
+    # All four datasets — root plus two children plus one grandchild.
+    assert set(expanded[0].rids) == {"P", "C1", "C2", "G1"}
+
+
+def test_expand_nested_dataset_anchors_leaves_non_dataset_unchanged() -> None:
+    """Non-Dataset anchors and non-RID anchor kinds are passed through."""
+    from deriva_ml.catalog.clone_via_bag import (
+        _expand_nested_dataset_anchors,
+    )
+
+    catalog = _make_mock_catalog_with_dataset_dataset_rows({})
+    anchors = [
+        TableAnchor(table="Subject"),
+        RIDAnchor(table="Image", rids=["I1"]),
+    ]
+    expanded = _expand_nested_dataset_anchors(anchors, catalog)
+    assert len(expanded) == 2
+    assert expanded[0] == anchors[0]
+    assert expanded[1] == anchors[1]
+
+
+def test_expand_nested_dataset_anchors_no_children() -> None:
+    """A leaf Dataset (no nested children) is returned with just its own RID."""
+    from deriva_ml.catalog.clone_via_bag import (
+        _expand_nested_dataset_anchors,
+    )
+
+    catalog = _make_mock_catalog_with_dataset_dataset_rows(
+        {("L",): []}
+    )
+    anchors = [RIDAnchor(table="Dataset", rids=["L"])]
+    expanded = _expand_nested_dataset_anchors(anchors, catalog)
+    assert set(expanded[0].rids) == {"L"}

--- a/tests/catalog/test_clone_via_bag_integration.py
+++ b/tests/catalog/test_clone_via_bag_integration.py
@@ -77,22 +77,30 @@ _AWAITING_LOADER_REWRITE = pytest.mark.xfail(
 
 
 @pytest.fixture
-def dest_catalog(catalog_host: str) -> "ErmrestCatalog":
-    """A freshly-created destination catalog, deleted at test end.
+def dest_catalog(
+    catalog_with_datasets: "tuple[DerivaML, DatasetDescription]",
+    catalog_host: str,
+) -> "ErmrestCatalog":
+    """Freshly-created destination catalog with the source's schema cloned in.
 
-    The destination is created with the deriva-ml schema already
-    populated (via :func:`create_ml_catalog`), matching what the bag
-    loader expects: schema-compatible catalog with no domain rows.
-
-    Yields:
-        ErmrestCatalog: empty destination catalog ready for the
-        loader to insert into.
+    Matches :class:`BagCatalogLoader`'s ADR-0001 precondition: the
+    destination is schema-ready. Uses ``clone_catalog(copy_data=False)``
+    so every dynamically-built table (feature association tables,
+    SubjectHealth/ImageQuality vocabs, etc.) lands at the destination.
     """
-    catalog = create_ml_catalog(catalog_host, project_name="clone-via-bag-dest")
+    source_ml, _ = catalog_with_datasets
+    dest = create_ml_catalog(catalog_host, project_name="clone-via-bag-dest")
     try:
-        yield catalog
+        source_ml.catalog.clone_catalog(
+            dst_catalog=dest,
+            copy_data=False,
+            copy_annotations=True,
+            copy_policy=False,
+            truncate_after=False,
+        )
+        yield dest
     finally:
-        catalog.delete_ermrest_catalog(really=True)
+        dest.delete_ermrest_catalog(really=True)
 
 
 # ----------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -789,7 +789,7 @@ wheels = [
 [[package]]
 name = "deriva"
 version = "2.0.0.dev0"
-source = { git = "https://github.com/informatics-isi-edu/deriva-py?branch=deriva-ml#5692db130eadebaa4b34117ffe26e7556ecf10dd" }
+source = { git = "https://github.com/informatics-isi-edu/deriva-py?branch=deriva-ml#004cf8707a567aac650a1d43113c66d57d410e6c" }
 dependencies = [
     { name = "bdbag" },
     { name = "fair-identifiers-client" },


### PR DESCRIPTION
## Summary

Three deriva-ml-side changes that complete the `clone_via_bag` integration with the bag-pipeline upstream work in deriva-py #220 + #222 + #223. Picks up the new deriva-py tip via `uv.lock` bump.

## Why now

The legacy `Dataset.download_dataset_bag` path recursed through nested Datasets, included full controlled vocabularies, and cloned schemas to a fresh destination — behaviors deriva-ml users depend on. The new `clone_via_bag` flow inherited from `CatalogBagBuilder` (which is generic across catalog shapes) didn't reproduce them by default. These three changes restore the deriva-ml-specific semantics.

## Changes

### 1. Nested-Dataset anchor expansion

`clone_via_bag` now expands any `Dataset` `RIDAnchor` by walking `Dataset_Dataset` on the source catalog transitively (BFS frontier per round), collecting every nested RID into the anchor's RID set. Non-Dataset anchors and non-RID anchor kinds pass through unchanged.

Without this, the bag walker reaches `Dataset_Dataset` from a single anchored parent Dataset RID but its `Nested_Dataset` rows point at child Datasets outside the slice — dangling FKs at load time. The legacy `Dataset.download_dataset_bag` already handled this; we just bring the equivalent into the bag-pipeline path.

### 2. `vocab_export=FULL` by default

Clone semantics require every controlled-vocabulary term to exist on the destination — FK references from content tables may resolve through any term, not just the ones the BFS-shortest path happens to walk.

Switch the default policy from `REFERENCED_ONLY` to `FULL`. Callers wanting tighter slice exports can still pass their own policy.

### 3. `dest_catalog` fixture uses `clone_catalog(copy_data=False)`

Integration tests need a destination that mirrors the source's full schema (including dynamically-built feature association tables and feature vocab tables). The previous fixture `create_ml_catalog`'d a fresh catalog with only the `deriva-ml` schema — domain tables were missing.

The new fixture uses `source_ml.catalog.clone_catalog(copy_data=False)` to project the full source schema. This is now possible thanks to [deriva-py#216](https://github.com/informatics-isi-edu/deriva-py/pull/216)'s `Column.sname` fix.

## Tests

- Three new unit tests in `test_clone_via_bag.py`:
  - `test_expand_nested_dataset_anchors_collects_transitive_children`
  - `test_expand_nested_dataset_anchors_leaves_non_dataset_unchanged`
  - `test_expand_nested_dataset_anchors_no_children`
- `tests/catalog/test_clone_via_bag.py` — **10 pass** (7 existing + 3 new)
- `tests/catalog/test_clone_via_bag_integration.py` — 3 xfail (live catalog; the loader still hits a separate multi-path emission gap on `Dataset_Image.Image`, tracked separately)

## Remaining upstream blocker for green integration tests

With deriva-py #215–#223 + this PR, the integration tests get past 7 of 8 distinct architectural issues. The last one is **multi-path emission** for content tables: `CatalogBagBuilder` records the BFS-shortest path from each anchor to each reached table, but the rows that need to land in the bag may be reachable only via *other* paths. The systematic fix is one CSV processor per FK path, with rows unioned in the bag. That's tracked as a producer-side redesign, not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)