### PR TITLE
test(fixtures): existence guards on ensure_features + ensure_datasets

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,7 +144,7 @@ Tests require a running Deriva catalog. Set `DERIVA_HOST` environment variable t
 - `catalog_with_datasets`: Provides a catalog with populated demo data (datasets, splits)
 - `deriva_catalog`: Legacy session-scoped fixture (uses `catalog_manager` internally)
 
-**Gotcha**: `CatalogManager.ensure_populated()` validates data actually exists before trusting its state flag. Other test modules (function-scoped fixtures) may empty tables during teardown, making the state flag stale.
+**Gotcha**: All three `CatalogManager.ensure_*` methods (`ensure_populated`, `ensure_features`, `ensure_datasets`) validate data actually exists before trusting their state flag. Function-scoped fixtures may empty tables during teardown without resetting the manager's state, leaving the flag stale; the existence guards catch that and re-populate the necessary level.
 
 ### Docstring Examples (Doctest)
 

--- a/tests/catalog_manager.py
+++ b/tests/catalog_manager.py
@@ -387,7 +387,21 @@ class CatalogManager:
         ml = self.ensure_populated(working_dir)
 
         if self.state.value >= CatalogState.WITH_FEATURES.value:
-            return ml
+            # Verify data actually exists — state flag can be stale if
+            # a previous fixture's teardown emptied feature tables
+            # without resetting the manager's state. Same guard
+            # pattern as ``ensure_populated``.
+            pb = self.catalog.getPathBuilder()
+            try:
+                feature_names = list(
+                    pb.schemas["deriva-ml"].tables["Feature_Name"].path.entities().fetch()
+                )
+                if len(feature_names) > 0:
+                    return ml
+                self._logger.info("State is WITH_FEATURES but Feature_Name is empty — recreating features")
+                self.state = CatalogState.POPULATED
+            except Exception:
+                self.state = CatalogState.POPULATED
 
         workflow = ml.create_workflow(name="Feature Creation", workflow_type="Test Workflow")
         execution = ml.create_execution(workflow=workflow, configuration=ExecutionConfiguration())
@@ -410,7 +424,24 @@ class CatalogManager:
         ml = self.ensure_features(working_dir)
 
         if self.state == CatalogState.WITH_DATASETS and self._dataset_description:
-            return ml, self._dataset_description
+            # Verify the cached DatasetDescription still maps to a
+            # live Dataset row — state flag and cached description
+            # can both be stale if a previous fixture's teardown
+            # deleted dataset rows. Same guard pattern as
+            # ``ensure_populated``.
+            pb = self.catalog.getPathBuilder()
+            try:
+                datasets = list(
+                    pb.schemas["deriva-ml"].tables["Dataset"].path.entities().fetch()
+                )
+                if len(datasets) > 0:
+                    return ml, self._dataset_description
+                self._logger.info("State is WITH_DATASETS but Dataset table is empty — recreating datasets")
+                self.state = CatalogState.WITH_FEATURES
+                self._dataset_description = None
+            except Exception:
+                self.state = CatalogState.WITH_FEATURES
+                self._dataset_description = None
 
         workflow = ml.create_workflow(name="Dataset Creation", workflow_type="Test Workflow")
         execution = ml.create_execution(workflow=workflow, configuration=ExecutionConfiguration())


### PR DESCRIPTION
## Summary

``CatalogManager.ensure_populated()`` already validates that the ``Subject`` table actually has rows before trusting its state flag — function-scoped fixtures can empty tables during teardown without resetting the session-scoped manager's state, leaving the flag stale.

This PR applies the same guard pattern to ``ensure_features`` (checks ``deriva-ml.Feature_Name`` is non-empty) and ``ensure_datasets`` (checks ``deriva-ml.Dataset`` is non-empty and also clears the cached ``DatasetDescription`` on guard miss). On guard miss, both methods drop back one state level so the re-population path runs.

No symptom in the current test suite drove this — it's a prophylactic alignment so all three state-tracker methods behave consistently. Future test additions that empty those tables in teardown won't silently get stale fixture state.

## Test plan

- [x] Quick sanity: ``DERIVA_HOST=localhost uv run pytest tests/catalog/test_clone_via_bag_integration.py::test_clone_via_bag_rid_anchor_scopes_walk`` — passes (this test exercises ``ensure_datasets`` via the ``catalog_with_datasets`` fixture)
- [ ] Reviewer: spot-check a longer integration run if you want — guards are no-ops on the common path (state flag matches reality)

🤖 Generated with [Claude Code](https://claude.com/claude-code)