### PR TITLE
fix(dataset): DatasetMinid stops constructing rid@None when snapshot absent

### DIFF
--- a/src/deriva_ml/dataset/aux_classes.py
+++ b/src/deriva_ml/dataset/aux_classes.py
@@ -271,8 +271,13 @@ class DatasetMinid(BaseModel):
 
     @computed_field
     @property
-    def dataset_snapshot(self) -> str:
-        return self.version_rid.split("@")[1]
+    def dataset_snapshot(self) -> str | None:
+        # ``version_rid`` is ``{rid}`` or ``{rid}@{snapshot}`` per
+        # the validation pattern. The unsnapped form has no
+        # ``@`` segment; surface that as ``None`` rather than
+        # IndexError-ing on the missing split component.
+        parts = self.version_rid.split("@", 1)
+        return parts[1] if len(parts) == 2 else None
 
     @model_validator(mode="before")
     @classmethod

--- a/src/deriva_ml/dataset/dataset.py
+++ b/src/deriva_ml/dataset/dataset.py
@@ -3382,9 +3382,19 @@ class Dataset:
                 version,
                 cache_dir_name,
             )
+            # ``DatasetVersion.snapshot`` is ``str | None`` — a
+            # version without an associated snapshot is legitimate
+            # (e.g. an in-progress dataset that hasn't been
+            # snapshotted yet). The ``DatasetMinid.RID`` pattern
+            # accepts both ``{rid}`` and ``{rid}@{snap}``; only
+            # append the snapshot segment when there's a real
+            # snapshot to point at. Without this guard the
+            # f-string produces ``{rid}@None`` which fails the
+            # pattern validator with a cryptic regex error.
+            version_rid = f"{self.dataset_rid}@{snapshot}" if snapshot is not None else self.dataset_rid
             return DatasetMinid(
                 dataset_version=version,
-                RID=f"{self.dataset_rid}@{snapshot}",
+                RID=version_rid,
                 location=cached_bag_path.parent.as_uri(),
                 checksums=[{"function": "sha256", "value": cache_suffix}],
             )
@@ -3443,9 +3453,14 @@ class Dataset:
             spec_hash=spec_hash,
             timeout=timeout,
         )
+        # See the cache-hit branch above for why this guard is
+        # needed — ``snapshot`` is ``str | None`` and the
+        # ``DatasetMinid.RID`` pattern requires either ``{rid}`` or
+        # ``{rid}@{snap}``, not ``{rid}@None``.
+        version_rid = f"{self.dataset_rid}@{snapshot}" if snapshot is not None else self.dataset_rid
         return DatasetMinid(
             dataset_version=version,
-            RID=f"{self.dataset_rid}@{snapshot}",
+            RID=version_rid,
             location=minid_url,
             checksums=[{"function": "sha256", "value": cache_suffix}],
         )


### PR DESCRIPTION
## Summary

``DatasetVersion.snapshot`` is ``str | None`` — a version without an associated catalog snapshot is legitimate. Two construction sites in ``Dataset._get_dataset_minid`` built ``DatasetMinid.RID`` as ``f"{self.dataset_rid}@{snapshot}"``; when ``snapshot`` was ``None`` the f-string produced ``"5FW@None"``, which fails the ``RID`` field's pattern validator (the pattern correctly admits both ``{rid}`` and ``{rid}@{snap}`` forms; ``rid@None`` is neither).

Three changes:

1. **``dataset.py:_get_dataset_minid`` cache-hit branch** — guard the ``@snapshot`` segment, build the bare ``rid`` form when ``snapshot is None``.
2. **``dataset.py:_get_dataset_minid`` MINID-create branch** — same guard, same shape.
3. **``aux_classes.py:DatasetMinid.dataset_snapshot``** — the ``@property`` did ``version_rid.split("@")[1]`` which would IndexError on the unsnapped form. Now returns ``None`` for that case; type changes to ``str | None``.

## Impact

Dataset sweep on ``main`` with this fix: **165 → 9** failures (452 pass, 5 skip).

All 9 remaining failures are pre-existing and unrelated to ``DatasetMinid``:

- ``test_dataset_spec`` — unit test, ``Version`` vs ``str`` comparison.
- ``test_delete_dataset_members_lands_on_dev`` — pre-existing.
- ``test_catalog_direct_fk_preferred`` — denormalization.
- ``test_snapshot_only_dir_not_matched`` — ``StopIteration`` in test fixture.
- ``test_dataset_download_versions`` / ``_schemas`` — download path.
- ``test_versions_returned`` — split-dataset.
- 2× ``test_validate_specs_live`` — validate-specs API.

Spot-checked two of them on the fix branch: both fail in isolation in <1 minute with errors completely unrelated to snapshot stringification.

## Test plan

- [x] Single-test verification: ``test_restructure_missing_values_unknown``, ``test_total_path_count`` both went from failing (rid@None) to passing.
- [x] Full dataset sweep: 452 pass, 9 pre-existing failures, no new regressions.
- [ ] Other test directories (execution, asset, catalog, etc.) — not run; fix is localized to ``dataset.py`` + ``aux_classes.py`` and exercises only code reached from ``Dataset._get_dataset_minid`` callsites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)