### PR TITLE
fix: VersionPart enum coercion + bag-builder nested-descendant scan (closes #89, #90)

### DIFF
--- a/src/deriva_ml/dataset/aux_classes.py
+++ b/src/deriva_ml/dataset/aux_classes.py
@@ -6,7 +6,7 @@ used throughout DerivaML to represent dataset versions, provenance
 records, and hydra-zen configuration entries.
 """
 
-from enum import Enum
+from enum import StrEnum
 from typing import Any, Optional, SupportsInt
 
 from hydra_zen import hydrated_dataclass
@@ -25,13 +25,20 @@ from deriva_ml.core.definitions import RID
 from deriva_ml.core.validation import VALIDATION_CONFIG
 
 
-class VersionPart(Enum):
+class VersionPart(StrEnum):
     """Names the component of a dataset version to advance on release.
 
     DerivaML uses a ``major.minor.patch`` release segment within the broader
     PEP 440 version space (see ADR-0004). Picking a ``VersionPart`` selects
     which component is incremented when a dev period is promoted to a
     released version.
+
+    Inherits from :class:`enum.StrEnum` so members compare equal to their
+    raw string values. This matters because ``VALIDATION_CONFIG`` has
+    ``use_enum_values=True``, so Pydantic's ``@validate_call`` coerces
+    members to their string values at the call boundary; the
+    ``match``/``case`` in :meth:`DatasetVersion.next_release` needs the
+    coerced string to still equal the enum member it's being compared to.
 
     Attributes:
         major: Schema-altering changes that break backward compatibility.

--- a/src/deriva_ml/dataset/bag_builder.py
+++ b/src/deriva_ml/dataset/bag_builder.py
@@ -758,12 +758,21 @@ class DatasetBagBuilder:
         """Return ``{(schema, table)}`` for associations with no members.
 
         For each ``Dataset_X`` association table, include it in
-        the walk only when the dataset has at least one member of
-        element type X (or when the association links to a
-        vocabulary table — those carry dataset metadata and must
-        always be included). Empty associations are added to the
+        the walk only when the dataset (or any of its nested
+        descendants) has at least one member of element type X
+        (or when the association links to a vocabulary table —
+        those carry dataset metadata and must always be included).
+        Empty associations are added to the
         :attr:`FKTraversalPolicy.exclude_tables` set so the
         generic walker prunes them.
+
+        Descendants matter because the walker anchors at every
+        descendant dataset RID (via :meth:`anchors_for`). An
+        association that's empty at the root but populated under
+        a nested child must stay in the walk so the child's
+        member rows are reachable. Limiting the member scan to
+        the root would silently drop all rows of element types
+        only owned by descendants.
 
         When ``dataset`` is ``None`` (catalog-wide annotation /
         aggregate path), the member-based filter doesn't apply —
@@ -778,11 +787,21 @@ class DatasetBagBuilder:
         ml_schema_name = self._ml_instance.ml_schema
         dataset_table = model.schemas[ml_schema_name].tables["Dataset"]
 
-        # Element types that have members in this dataset.
+        # Element types that have members anywhere in the dataset
+        # tree — root or any nested descendant. Excluding by root
+        # alone would prune Dataset_X for element types X that
+        # only appear under a nested child, dropping their rows
+        # from the bag (see #94: child Image members disappearing).
         dataset_obj = self._ml_instance.lookup_dataset(dataset.dataset_rid)
-        member_element_types: set[Table] = {
-            model.name_to_table(name) for name, members in dataset_obj.list_dataset_members().items() if members
-        }
+        rids_to_scan: list[RID] = [dataset.dataset_rid]
+        rids_to_scan.extend(self._iter_descendant_rids(dataset))
+
+        member_element_types: set[Table] = set()
+        for rid in rids_to_scan:
+            ds = self._ml_instance.lookup_dataset(rid) if rid != dataset.dataset_rid else dataset_obj
+            for name, members in ds.list_dataset_members().items():
+                if members:
+                    member_element_types.add(model.name_to_table(name))
 
         # Every vocabulary table in any schema — associations into
         # vocabularies always come along for the ride.


### PR DESCRIPTION
## Summary

Two narrow fixes that together drop 9 of 11 long-standing `test_download.py` + `test_dataset_version.py` failures, with no other code or test changes.

### Fix 1 — `VersionPart` becomes a `StrEnum`

`core/validation.py:VALIDATION_CONFIG` sets `use_enum_values=True`. With that config, Pydantic's `@validate_call` (decorating `_increment_dataset_version`) coerces the `VersionPart.minor` argument to its raw value `\"minor\"` before the function body runs. The body then does:

\`\`\`python
match bump:
    case VersionPart.major: ...
    case VersionPart.minor: ...
    case _: raise ValueError(f\"unknown VersionPart: {bump!r}\")
\`\`\`

For a plain `Enum`, `VersionPart.minor != \"minor\"`, so the `_` branch fires and every release-segment bump explodes with `ValueError: unknown VersionPart: 'minor'`.

Promoting `VersionPart` to `StrEnum` (Python 3.11+; project requires ≥3.12) makes `VersionPart.minor == \"minor\"` true, so the `match` keeps matching after the Pydantic round-trip.

### Fix 2 — `_exclude_empty_associations` scans the whole dataset tree

`DatasetBagBuilder._exclude_empty_associations` decided which `Dataset_X` association tables to walk based on **only the root dataset's** member element types. For nested-dataset trees that's wrong: the root may have only `Dataset` members (children) while the actual domain rows (`Image`, `Subject`, …) live under those children. The check pruned `Dataset_Image` (and `Dataset_Subject`, …) as \"empty\" and the walker never followed them — so the bag landed with all 7 dataset rows but **zero** `Image` / `Subject` rows.

Fix: extend the scan to the root **and** every descendant RID. `anchors_for` already enumerates every descendant via `RIDAnchor`; the exclusion check needs to consider the same set the walker actually starts from.

## Effect on the test suite

| State | Failures |
|---|---|
| Before any fix | 11 in `test_download.py` + `test_dataset_version.py` |
| After Fix 1 only (`StrEnum`) | 5 in `test_download.py` |
| After Fix 1 + Fix 2 | **2** in `test_download.py` |

The remaining 2 are pre-existing, separate bugs filed as follow-up issues:

- #113 — `test_dataset_download_versions` fails: ADR-0003 multi-dataset version semantics in `compare_datasets`
- #114 — `test_dataset_download_schemas` fails: bag schema reflects live catalog, not version snapshot

## Test plan

- [x] `uv run pytest tests/dataset/test_dataset_version_unit.py` — 24 / 24
- [x] `DERIVA_HOST=localhost uv run pytest tests/dataset/test_dataset_version.py tests/dataset/test_download.py` — **9 passed** (was 0), 2 failed (was 11)
- [x] Confirmed 2 remaining failures are pre-existing on `main` and tracked in #113, #114
- [ ] Re-run full suite after merge to confirm overall delta

Closes #89
Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)