### PR TITLE
test: rewrite lease-validator mock for datapath API

### DIFF
--- a/tests/execution/test_pending_asset_lease_validator.py
+++ b/tests/execution/test_pending_asset_lease_validator.py
@@ -7,28 +7,63 @@ import pytest
 
 
 def _fake_catalog(found_rids: set[str]):
-    """Build a fake ErmrestCatalog whose .get() returns rows with
-    RIDs from ``found_rids`` that match the query's filter."""
+    """Build a fake ErmrestCatalog whose datapath fetch returns rows
+    with RIDs from ``found_rids`` that match ``RID.in_(<chunk>)``.
+
+    Mirrors the implementation's call shape:
+
+        pb = catalog.getPathBuilder()
+        t = pb.schemas["public"].tables["ERMrest_RID_Lease"]
+        rows = t.filter(t.RID.in_(chunk)).attributes(t.RID).fetch()
+
+    The mock records every chunk passed to ``RID.in_(...)`` so call-count
+    assertions still work; access via ``catalog._lease_fetch_calls``.
+    """
     catalog = MagicMock()
+    catalog._lease_fetch_calls = []  # list of chunks seen
 
-    def fake_get(path: str):
-        # Parse "/entity/public:ERMrest_RID_Lease/RID=r1;RID=r2;..."
-        response = MagicMock()
-        assert path.startswith("/entity/public:ERMrest_RID_Lease/")
-        filter_part = path.split("/entity/public:ERMrest_RID_Lease/", 1)[1]
-        queried = []
-        for clause in filter_part.split(";"):
-            key, _, value = clause.partition("=")
-            if key == "RID":
-                queried.append(value)
-        response.json.return_value = [
-            {"RID": rid, "ID": f"token-{rid}"}
-            for rid in queried
-            if rid in found_rids
-        ]
-        return response
+    # The end of the datapath chain — .fetch() — needs to return
+    # only the rows whose RID is in the chunk that was filtered.
+    # We build a chain mock per fetch() so each call sees the right
+    # chunk; using side_effect on .fetch makes that lookup work.
 
-    catalog.get.side_effect = fake_get
+    def fetch_side_effect():
+        # ``_current_chunk`` is set by filter() below before the chain
+        # reaches .attributes().fetch().
+        chunk = catalog._current_chunk
+        return [{"RID": rid} for rid in chunk if rid in found_rids]
+
+    def filter_side_effect(predicate):
+        # predicate is t.RID.in_(<chunk>); MagicMock has recorded the
+        # in_ call's args on the predicate object's parent. Extract
+        # the chunk by re-running the path through call_args.
+        # Simpler: have the test seed the chunk via the predicate's
+        # MagicMock _mock_self closure — but that's brittle. Instead,
+        # bind the chunk through a side_effect on RID.in_ itself.
+        return catalog._chain
+
+    def in_side_effect(chunk):
+        catalog._current_chunk = list(chunk)
+        catalog._lease_fetch_calls.append(list(chunk))
+        return MagicMock()  # the in_(...) predicate object itself
+
+    pb = MagicMock()
+    catalog.getPathBuilder.return_value = pb
+
+    lease_table = MagicMock()
+    pb.schemas = {"public": MagicMock()}
+    pb.schemas["public"].tables = {"ERMrest_RID_Lease": lease_table}
+
+    # Chain: filter(pred).attributes(col).fetch() → rows
+    chain = MagicMock()
+    catalog._chain = chain
+    lease_table.filter.side_effect = filter_side_effect
+    chain.attributes.return_value = chain  # attributes() returns self
+    chain.fetch.side_effect = fetch_side_effect
+
+    # RID.in_(chunk) records the chunk and returns a predicate sentinel
+    lease_table.RID.in_.side_effect = in_side_effect
+
     return catalog
 
 
@@ -36,7 +71,8 @@ def test_empty_entries_returns_none():
     from deriva_ml.execution.rid_lease import _validate_pending_asset_leases
     catalog = MagicMock()
     assert _validate_pending_asset_leases(catalog, []) is None
-    catalog.get.assert_not_called()
+    # Empty entries should short-circuit before touching the datapath API.
+    catalog.getPathBuilder.assert_not_called()
 
 
 def test_all_leases_valid_passes():
@@ -86,5 +122,7 @@ def test_batched_queries_use_chunk_size(monkeypatch):
     catalog = _fake_catalog({"1-A", "1-B", "1-C"})
     entries = [("k1", "1-A"), ("k2", "1-B"), ("k3", "1-C")]
     _validate_pending_asset_leases(catalog, entries)
-    # Expect 2 calls: first batch of 2, second batch of 1.
-    assert catalog.get.call_count == 2
+    # Expect 2 chunks: first batch of 2, second batch of 1.
+    assert len(catalog._lease_fetch_calls) == 2
+    assert len(catalog._lease_fetch_calls[0]) == 2
+    assert len(catalog._lease_fetch_calls[1]) == 1


### PR DESCRIPTION
## Summary

\`_validate_pending_asset_leases\` was refactored to use the deriva-py datapath fluent API (per \`CLAUDE.md\` API Priority rule: \"prefer datapath API over raw ERMrest URLs\"). The unit tests still mocked the old raw-HTTP shape (\`catalog.get(path)\`) so the validator always saw \"no rows found\" and raised \`DerivaMLValidationError\` for every entry. **3 tests failing on baseline.**

## Implementation

\`\`\`python
pb = catalog.getPathBuilder()
t = pb.schemas[\"public\"].tables[\"ERMrest_RID_Lease\"]
rows = t.filter(t.RID.in_(chunk)).attributes(t.RID).fetch()
\`\`\`

## Fix

Replace the mock with a datapath-shaped one that:

- routes \`catalog.getPathBuilder()\` → \`schemas\` → \`tables\` to a per-table MagicMock chain
- captures the chunk passed to \`t.RID.in_(chunk)\` via a side_effect
- returns rows whose RID is both in the requested chunk AND in the test-configured \`found_rids\` set

The mock records chunks on \`catalog._lease_fetch_calls\` so \`test_batched_queries_use_chunk_size\` can still assert call count + per-chunk sizing.

## Test plan

- [x] \`uv run pytest tests/execution/test_pending_asset_lease_validator.py\` → 5/5 passed (was 2/5)
- [x] No source-code changes; mock-only fix in tests/

🤖 Generated with [Claude Code](https://claude.com/claude-code)