### PR TITLE
test(feature): fixture must flush staged features via upload_execution_outputs

### DIFF
--- a/tests/feature/test_feature_values_limits.py
+++ b/tests/feature/test_feature_values_limits.py
@@ -50,6 +50,10 @@ def catalog_with_feature_values(populated_catalog):
         with execution.execute() as exe:
             for img_rid in image_rids:
                 exe.add_features([record_class(Image=img_rid, score=0.5 + i * 0.1)])
+        # ``add_features`` only stages records to SQLite; the flush to
+        # ermrest happens during upload. Without this call the feature
+        # rows never land at the catalog and the tests see 0 records.
+        execution.upload_execution_outputs()
 
     return ml
 


### PR DESCRIPTION
## Summary

\`catalog_with_feature_values\` calls \`exe.add_features(...)\` inside the with-block but never calls \`execution.upload_execution_outputs()\`. Per the \`add_features\` docstring:

> The records are not sent to ermrest immediately — they are flushed in a single batch, **after asset upload**, when the execution completes successfully.

The \"after asset upload\" step is \`upload_execution_outputs()\`. Without it, records stay staged in SQLite and never reach ermrest, so the test assertions (\"at least 6 records present in the live catalog\") all see 0 rows.

**4 tests failing on baseline:**

- \`test_feature_values_materialize_limit_not_exceeded\`
- \`test_feature_values_materialize_limit_exceeded_raises\`
- \`test_feature_values_execution_rids_filters_results\`
- \`test_feature_values_execution_rids_with_materialize_limit_combine\`

Every other working feature-test in the suite (\`test_feature_values.py\`, \`test_features.py\`) calls \`upload_execution_outputs()\` after \`add_features\`; this one was simply missing it.

## Test plan

- [x] \`DERIVA_HOST=localhost uv run pytest tests/feature/test_feature_values_limits.py\` → **5/5 passed** (was 4 failed, 1 passed)
- [x] One-line fixture change in tests/; no production-code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)