### PR TITLE
test(validate): persist Workflow via _add_workflow before validation

### DIFF
--- a/tests/dataset/test_validate_specs_live.py
+++ b/tests/dataset/test_validate_specs_live.py
@@ -86,11 +86,14 @@ def test_validate_dataset_specs_live_unknown_rid(test_ml):
 
 def test_validate_execution_configuration_live_full(test_ml):
     rid, version = _make_dataset(test_ml)
+    # create_workflow is a pure constructor; persist via _add_workflow
+    # so the Workflow has a real RID that the validator can resolve.
     wf = test_ml.create_workflow(
         name="Validate composite workflow",
         workflow_type="Validate Test",
         description="composite smoke",
     )
+    wf = wf.model_copy(update={"rid": test_ml._add_workflow(wf)})
     config = ExecutionConfiguration(
         workflow=wf,
         datasets=[DatasetSpec(rid=rid, version=version)],
@@ -146,12 +149,15 @@ def test_validate_execution_configuration_live_assets(test_ml):
 
     Skipped when no asset table can be enumerated."""
     # Use the workflow RID created above as the "wrong-shape" target so we
-    # always have a known non-asset RID.
+    # always have a known non-asset RID. create_workflow is a pure
+    # constructor; persist via _add_workflow so the Workflow has a real
+    # RID that the AssetSpec can reference.
     wf = test_ml.create_workflow(
         name="Validate asset workflow",
         workflow_type="Validate Test",
         description="asset smoke",
     )
+    wf = wf.model_copy(update={"rid": test_ml._add_workflow(wf)})
     config = ExecutionConfiguration(
         workflow=wf,
         assets=[AssetSpec(rid=wf.rid)],


### PR DESCRIPTION
## Summary

\`create_workflow\` is a pure constructor that returns a \`Workflow\` with \`rid=None\`; persisting to the catalog requires the explicit \`_add_workflow\` call. Two tests skipped this step and then passed the unpersisted \`Workflow\` to \`validate_execution_configuration\`:

- **\`test_validate_execution_configuration_live_full\`**: validator sees \`wf.rid is None\` and sets \`workflow_result=None\`, breaking the \`workflow_result is not None\` assertion.
- **\`test_validate_execution_configuration_live_assets\`**: \`AssetSpec\` construction with \`rid=None\` fails Pydantic string-type validation.

Other tests in the same file (e.g. \`test_validate_execution_configuration_live_workflow_rid_is_dataset\`) work around this by \`model_copy\`'ing the workflow with a synthetic RID. For these two we want a *real* persisted workflow, so call \`_add_workflow\` and stamp the returned RID back onto the model.

## Test plan

- [x] \`DERIVA_HOST=localhost uv run pytest tests/dataset/test_validate_specs_live.py\` → **7/7 passing** (was 5 passed, 2 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)