### PR TITLE
test: update two tests for datapath/Pydantic boundary changes

### DIFF
--- a/tests/catalog/test_clone_via_bag.py
+++ b/tests/catalog/test_clone_via_bag.py
@@ -389,29 +389,48 @@ def _make_mock_catalog_with_dataset_dataset_rows(
 ) -> MagicMock:
     """Mock that returns predetermined Dataset_Dataset rows per query.
 
+    Mirrors the implementation's datapath call shape:
+
+        pb = catalog.getPathBuilder()
+        dd = pb.schemas["deriva-ml"].tables["Dataset_Dataset"]
+        rows = dd.filter(dd.Dataset.in_(sorted(frontier))).entities().fetch()
+
     Args:
-        rows_by_seed: ``{frozenset(seed_rids): rows}`` mapping —
+        rows_by_seed: ``{tuple(sorted(seed_rids)): rows}`` mapping —
             the helper looks up by the comma-sorted seed list as a
             tuple. Each ``rows`` is a list of ``{"Nested_Dataset": rid}``.
     """
     catalog = MagicMock()
 
-    def _get(path: str, **_: Any):
-        # Path looks like:
-        # /entity/deriva-ml:Dataset_Dataset/Dataset=any(rid1,rid2,...)
-        match = path.split("any(")
-        if len(match) < 2:
-            seeds = ()
-        else:
-            inner = match[1].rstrip(")")
-            seeds = tuple(sorted(inner.split(",")))
-        rows = rows_by_seed.get(seeds, [])
-        resp = MagicMock()
-        resp.raise_for_status.return_value = None
-        resp.json.return_value = rows
-        return resp
+    # The end of the chain — .fetch() — returns rows keyed off the
+    # last seen seed list. We capture the seeds during the .in_(...)
+    # call so .fetch() can look them up.
+    def fetch_side_effect():
+        seeds = tuple(sorted(catalog._current_seeds))
+        return rows_by_seed.get(seeds, [])
 
-    catalog.get = _get
+    def in_side_effect(seeds):
+        catalog._current_seeds = list(seeds)
+        return MagicMock()  # the in_(...) predicate object
+
+    def filter_side_effect(_predicate):
+        return catalog._chain
+
+    pb = MagicMock()
+    catalog.getPathBuilder.return_value = pb
+
+    dd_table = MagicMock()
+    pb.schemas = {"deriva-ml": MagicMock()}
+    pb.schemas["deriva-ml"].tables = {"Dataset_Dataset": dd_table}
+
+    chain = MagicMock()
+    catalog._chain = chain
+    dd_table.filter.side_effect = filter_side_effect
+    chain.entities.return_value = chain  # entities() returns self
+    chain.fetch.side_effect = fetch_side_effect
+
+    dd_table.Dataset.in_.side_effect = in_side_effect
+
     return catalog
 
 

--- a/tests/dataset/test_catalog_dataset_functions.py
+++ b/tests/dataset/test_catalog_dataset_functions.py
@@ -93,10 +93,13 @@ class TestCatalogDatasetFunctions:
 
     def test_dataset_spec(self):
         """Test DatasetSpec creation and validation."""
-        # Create with required fields
+        # Create with required fields. DatasetSpec coerces the version
+        # string through DatasetVersion.parse so spec.version is a
+        # DatasetVersion (a PEP 440 Version subclass), not a bare
+        # string — compare on the rendered form.
         spec = DatasetSpec(rid="1234", version="1.0.0")
         assert spec.rid == "1234"
-        assert spec.version == "1.0.0"
+        assert str(spec.version) == "1.0.0"
         assert spec.materialize  # Default value
 
         # Create with all fields


### PR DESCRIPTION
## Summary

Two unrelated baseline failures, both purely test-side updates against the existing source contract:

### 1. \`tests/catalog/test_clone_via_bag.py::test_expand_nested_dataset_anchors_collects_transitive_children\`

\`_expand_nested_dataset_anchors\` was refactored to use the deriva-py datapath API (per \`CLAUDE.md\` API Priority); the test still mocked raw HTTP \`catalog.get(path)\`. Same bug shape as PR #117's lease-validator mock — replace with a datapath-shaped MagicMock chain that captures \`.Dataset.in_(...)\` seed lists via side_effect.

The companion test \`test_expand_nested_dataset_anchors_leaves_non_dataset_unchanged\` continues to pass (doesn't touch the datapath chain).

### 2. \`tests/dataset/test_catalog_dataset_functions.py::TestCatalogDatasetFunctions::test_dataset_spec\`

\`DatasetSpec\` coerces the version string through \`DatasetVersion.parse\` so \`spec.version\` is a \`DatasetVersion\` (a \`packaging.Version\` subclass), not a bare string. Compare on the rendered form (\`str(spec.version)\`) instead.

## Test plan

- [x] \`uv run pytest tests/catalog/test_clone_via_bag.py\` — 11/11 passing
- [x] \`uv run pytest tests/dataset/test_catalog_dataset_functions.py::TestCatalogDatasetFunctions::test_dataset_spec\` — passes
- [x] No production-code changes; tests-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)