### PR TITLE
fix(dataset): URL parse error in delete_dataset_members + test fixture (closes #122)

### DIFF
--- a/src/deriva_ml/dataset/dataset.py
+++ b/src/deriva_ml/dataset/dataset.py
@@ -2105,9 +2105,13 @@ class Dataset:
             fk_column = "Nested_Dataset" if table == "Dataset" else table
 
             atable_path = schema_path.tables[association_map[table]]
+            # Chain two .filter() calls rather than ``& (a == AnyQuantifier(*xs))``
+            # — the compound-and form generates an URL the server rejects with
+            # "URL parse error at token: None" for the Any-quantified clause.
             atable_path.filter(
-                (atable_path.Dataset == self.dataset_rid)
-                & (atable_path.columns[fk_column] == AnyQuantifier(*elements)),
+                atable_path.Dataset == self.dataset_rid,
+            ).filter(
+                atable_path.columns[fk_column] == AnyQuantifier(*elements),
             ).delete()
 
         # Per ADR-0003: every mutation lands on dev. The caller passed a

--- a/tests/dataset/test_datasets.py
+++ b/tests/dataset/test_datasets.py
@@ -247,9 +247,17 @@ class TestDataset:
 
         dataset = execution.create_dataset(dataset_types=["TestSet"], description="Test dataset")
         dataset.add_dataset_members({"TestTableDelete": test_rids})
+        # add_dataset_members above lands on a dev row; release so the
+        # subsequent delete_dataset_members exercises the "starting from
+        # a released version" path. Without this, the test would
+        # observe dev2 (1 from add, 1 from delete) — see ADR-0003 on
+        # per-call dev increments.
+        from deriva_ml.dataset.aux_classes import VersionPart
+        dataset.release(bump=VersionPart.minor, description="Released after seed")
 
-        # Get initial version
+        # Get initial version (now a released label).
         initial_version = dataset.current_version
+        assert not initial_version.is_devrelease
         initial_members = dataset.list_dataset_members()
         assert len(initial_members.get("TestTableDelete", [])) == 5
 


### PR DESCRIPTION
## Summary

Two changes:

### 1. \`delete_dataset_members\` URL fix (\`src/deriva_ml/dataset/dataset.py\`)

The compound filter

\`\`\`python
atable_path.filter(
    (atable_path.Dataset == self.dataset_rid)
    & (atable_path.columns[fk_column] == AnyQuantifier(*elements)),
)
\`\`\`

produced a URL the ERMrest server rejected with:

\`\`\`
400 Bad Request: URL parse error at token: None
\`\`\`

for tables where \`fk_column\` is a dynamically-created table's name (e.g. \`TestTableDelete\`). Every other \`AnyQuantifier\` usage in the codebase passes a *single* filter (no \`&\` compound) — the compound form is the trigger.

Fix: chain two \`.filter()\` calls instead. Same semantics, generates a URL the server accepts.

### 2. Test fixture (\`tests/dataset/test_datasets.py\`)

\`test_delete_dataset_members_lands_on_dev\` expected \`dev == 1\` after a single \`delete_dataset_members\` call, but the test setup already bumps to dev1 via \`add_dataset_members\`. Per ADR-0003 per-call dev counter semantics, the assertion-as-written was inconsistent with the setup.

Fix: call \`dataset.release()\` between the seed-load and the delete so the delete starts from a released version, matching the docstring intent (\"delete_dataset_members lands on dev — anchored at the previous released version\").

## Test plan

- [x] \`DERIVA_HOST=localhost uv run pytest tests/dataset/test_datasets.py\` → 11/11 pass
- [x] Production-code change: 1 file (\`dataset.py\`), 1 method (\`delete_dataset_members\`)

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)