### PR TITLE
fix(execution): exclude produced datasets from list_input_datasets (closes #125)

### DIFF
--- a/src/deriva_ml/execution/execution.py
+++ b/src/deriva_ml/execution/execution.py
@@ -2004,6 +2004,11 @@ class Execution:
     def list_input_datasets(self) -> list[Dataset]:
         """List all datasets that were inputs to this execution.
 
+        Excludes any dataset this execution itself *produced* — the
+        ``Dataset_Execution`` association table has no role column to
+        distinguish inputs from outputs, so we infer authorship from
+        each dataset's ``Dataset_Version.Execution`` link.
+
         Returns:
             List of Dataset objects that were used as inputs.
 
@@ -2014,13 +2019,20 @@ class Execution:
         if self._execution_record is not None:
             return self._execution_record.list_input_datasets()
 
-        # Fallback for dry_run mode
+        # Fallback for dry_run mode — apply the same producer filter so
+        # dry-run lineage queries agree with the persistent path.
         pb = self._ml_object.pathBuilder()
         dataset_exec = pb.schemas[self._ml_object.ml_schema].Dataset_Execution
 
         records = list(dataset_exec.filter(dataset_exec.Execution == self.execution_rid).entities().fetch())
 
-        return [self._ml_object.lookup_dataset(r["Dataset"]) for r in records]
+        datasets: list[Dataset] = []
+        for r in records:
+            rid = r["Dataset"]
+            if self._ml_object._producer_of_dataset(rid) == self.execution_rid:
+                continue
+            datasets.append(self._ml_object.lookup_dataset(rid))
+        return datasets
 
     def list_assets(self, asset_role: str | None = None) -> list["Asset"]:
         """List all assets that were inputs or outputs of this execution.

--- a/src/deriva_ml/execution/execution_record.py
+++ b/src/deriva_ml/execution/execution_record.py
@@ -530,6 +530,12 @@ class ExecutionRecord(BaseModel):
     def list_input_datasets(self) -> list["Dataset"]:
         """List datasets that were input to this execution.
 
+        Filters out datasets that this execution *produced* (their
+        ``Dataset_Version.Execution`` row points back at this execution).
+        The catalog's ``Dataset_Execution`` table carries no role
+        column, so it can't natively distinguish inputs from outputs;
+        we use the version row's authorship as the source of truth.
+
         Returns:
             List of Dataset objects that were used as inputs to this execution.
 
@@ -548,12 +554,18 @@ class ExecutionRecord(BaseModel):
 
         records = list(dataset_exec_path.filter(dataset_exec_path.Execution == self.execution_rid).entities().fetch())
 
-        # Look up each dataset and return Dataset objects
+        # Look up each dataset and return Dataset objects, excluding
+        # any that this execution itself produced (those go on the
+        # output side; the Dataset_Execution table conflates both).
         datasets = []
         for record in records:
             dataset_rid = record.get("Dataset")
-            if dataset_rid:
-                datasets.append(self._ml_instance.lookup_dataset(dataset_rid))
+            if not dataset_rid:
+                continue
+            producer = self._ml_instance._producer_of_dataset(dataset_rid)
+            if producer == self.execution_rid:
+                continue
+            datasets.append(self._ml_instance.lookup_dataset(dataset_rid))
         return datasets
 
     def list_assets(self, asset_role: str | None = None) -> list["Asset"]:


### PR DESCRIPTION
## Summary

\`Dataset_Execution\` carries no role column to distinguish inputs from outputs — \`create_dataset\` writes a row when an execution *produces* a dataset, and execution-init writes a row when it *consumes* one. \`list_input_datasets\` read every row and returned both, conflating the two roles.

For the \`lookup_lineage\` walker this surfaces as a spurious cycle:

\`\`\`
exe2 produces ds2
  → list_input_datasets() returns [ds1, ds2]   ← ds2 wrongly included
    → _producer_of_dataset(ds2) is exe2
      → in_progress.add(exe2) hit on recursion
        → cycle_detected=True
\`\`\`

## Fix

In two places (the live path and the dry-run fallback): filter out any dataset whose \`Dataset_Version.Execution\` points back at the current execution. We use \`_producer_of_dataset\` (already shared with the lineage walker) so both surfaces agree on authorship.

## Test plan

- [x] \`DERIVA_HOST=localhost uv run pytest tests/execution/test_lookup_lineage_live.py\` → 1 passed, 1 skipped (was 1 failed)
- [x] \`DERIVA_HOST=localhost uv run pytest tests/execution/\` → 313 passed, 5 unrelated #124 (Bug C/E2 smoke) failures (no regressions from this PR)
- [x] No schema change; both surfaces (\`Execution\` and \`ExecutionRecord\`) updated for consistency

Closes #125.

🤖 Generated with [Claude Code](https://claude.com/claude-code)