### PR TITLE
fix(bag): snapshot-aware bag-builder + multi-version compare_datasets (closes #113, #114)

### DIFF
--- a/src/deriva_ml/dataset/bag_builder.py
+++ b/src/deriva_ml/dataset/bag_builder.py
@@ -68,6 +68,57 @@ from deriva_ml.core.logging_config import get_logger
 logger = get_logger(__name__)
 
 
+class _SnapshotAwareCatalogBagBuilder(CatalogBagBuilder):
+    """``CatalogBagBuilder`` that honors the catalog's snapshot in exports.
+
+    Upstream's :class:`CatalogBagBuilder._run_export` passes
+    ``str(self.catalog.catalog_id)`` to the export engine — the bare
+    catalog ID, dropping any snapshot suffix. For an
+    :class:`ErmrestSnapshot` (a snapshot-bound catalog with
+    ``snaptime`` set), this causes the export to query the *live*
+    catalog instead of the snapshot, and the bag's ``schema.json``
+    reflects the live schema rather than the snapshot's. See issue
+    #114.
+
+    This subclass overrides ``_run_export`` to re-attach the snapshot
+    suffix when the catalog has one.
+    """
+
+    def _run_export(self, spec: dict) -> Path:  # type: ignore[override]
+        # Local import — see upstream's note on transitive deps.
+        from deriva.transfer.download.deriva_download import (
+            GenericDownloader,
+        )
+
+        # Restore the snapshot suffix dropped by upstream's
+        # ``str(self.catalog.catalog_id)`` round-trip.
+        catalog_id_str = str(self.catalog.catalog_id)
+        snaptime = getattr(self.catalog, "snaptime", None)
+        if snaptime:
+            catalog_id_str = f"{catalog_id_str}@{snaptime}"
+
+        deriva_server = self.catalog.deriva_server
+        downloader = GenericDownloader(
+            server={
+                "host": deriva_server.server,
+                "protocol": deriva_server.scheme,
+                "catalog_id": catalog_id_str,
+            },
+            config=spec,
+            output_dir=str(self.output_dir),
+            credentials=self.catalog._credentials,
+        )
+        downloader.download()
+
+        bag_path = self.output_dir / self.output_dir.name
+        if not bag_path.exists():
+            # Fall back to scanning for a single sub-directory.
+            children = [p for p in self.output_dir.iterdir() if p.is_dir()]
+            if len(children) == 1:
+                bag_path = children[0]
+        return bag_path
+
+
 class DatasetBagBuilder:
     """Build a download spec for a deriva-ml dataset.
 
@@ -249,7 +300,12 @@ class DatasetBagBuilder:
             new_config["timeout"] = timeout
             catalog._session_config = new_config  # type: ignore[attr-defined]
         try:
-            builder = CatalogBagBuilder(
+            # Use the snapshot-aware subclass so the spec's catalog_id
+            # carries the ``@snaptime`` suffix when applicable. The
+            # upstream CatalogBagBuilder drops it (see #114) and the
+            # bag would otherwise reflect the live catalog's schema
+            # rather than the version-snapshot's.
+            builder = _SnapshotAwareCatalogBagBuilder(
                 catalog=catalog,
                 anchors=anchors,
                 output_dir=cb_output_dir,

--- a/tests/dataset/test_download.py
+++ b/tests/dataset/test_download.py
@@ -46,7 +46,18 @@ class TestDatasetDownload:
         for ds in sorted(reference_datasets, key=lambda d: d.dataset_rid):
             dataset_bag = db_catalog.lookup_dataset(ds.dataset_rid)  # Get nested bag from the dataset.
             snapshot_ds = ml_instance.lookup_dataset(dataset=ds.dataset_rid)
-            catalog_elements = snapshot_ds.list_dataset_members(version=dataset_spec.version, recurse=recurse)
+            # Query each dataset at *its own* current version. Per
+            # ADR-0003, dev rows are mutable and a single dataset's
+            # version doesn't translate across siblings — passing the
+            # outer dataset_spec.version to a nested dataset raises
+            # DerivaMLException ("Version X not found for dataset Y")
+            # whenever the outer was released and the nested wasn't.
+            # The intent of this helper is "what the catalog says now
+            # vs what the bag has", so each ds is queried at its own
+            # latest version.
+            catalog_elements = snapshot_ds.list_dataset_members(
+                version=snapshot_ds.current_version, recurse=recurse,
+            )
             del catalog_elements["File"]  # Files is not in the bag.
             bag_elements = dataset_bag.list_dataset_members(recurse=recurse)
 
@@ -147,13 +158,29 @@ class TestDatasetDownload:
             assert reference_members == member_rids
 
     def test_dataset_download_versions(self, dataset_test, tmp_path):
+        """Two bags taken across an add-members mutation differ by the added rows.
+
+        Per ADR-0003 dev rows are mutable: only released versions
+        pin to a stable snapshot. The demo fixture leaves the
+        dataset on a dev row, so we promote to a release before
+        snapping v1 — that gives a stable, downloadable v1 bag that
+        the subsequent ``add_dataset_members`` won't overwrite.
+        """
         hostname = dataset_test.catalog.hostname
         catalog_id = dataset_test.catalog.catalog_id
         ml_instance = DerivaML(hostname, catalog_id, working_dir=tmp_path, use_minid=False)
         dataset_description = dataset_test.dataset_description
         dataset = dataset_description.dataset
 
+        # Promote the fixture's initial dev row to a release so v1
+        # has a stable snapshot — a captured dev label would be
+        # overwritten by the next mutation (ADR-0003 lazy-mutable
+        # dev row).
+        if dataset.current_version.is_devrelease:
+            dataset.release(bump=VersionPart.minor, description="v1 baseline for versions test")
         current_version = dataset.current_version
+        assert not current_version.is_devrelease
+
         current_spec = DatasetSpec(rid=dataset_description.dataset.dataset_rid, version=current_version)
         self.compare_datasets(ml_instance, dataset_test, current_spec)
 
@@ -162,9 +189,8 @@ class TestDatasetDownload:
 
         dataset_description.dataset.add_dataset_members(subjects[-2:])
         new_version = dataset_description.dataset.current_version
-        # Per ADR-0003: add_dataset_members lands on a dev version, not a
-        # released minor bump. The dev label is anchored at the previous
-        # release (`current_version`).
+        # Per ADR-0003: add_dataset_members lands on a dev version,
+        # anchored at the previous release.
         assert new_version.is_devrelease
         assert new_version.release == current_version.release
         assert new_version.dev == 1

--- a/tests/dataset/test_download.py
+++ b/tests/dataset/test_download.py
@@ -180,12 +180,30 @@ class TestDatasetDownload:
         assert len(subjects_new) == len(subjects_current) + 2
 
     def test_dataset_download_schemas(self, dataset_test, tmp_path):
+        """Schema changes between two released versions are reflected in
+        their respective bags.
+
+        Per ADR-0003 dev rows have ``Snapshot=NULL`` and resolve to the
+        *live* catalog state, not a fixed point in time. To compare
+        schemas at two points the dataset must be at released versions
+        on both sides — dev labels can't pin a schema snapshot.
+
+        Setup releases the demo fixture's initial dev row to anchor v1
+        on a stable snapshot, then creates the new table and force-bumps
+        to v2 so v2's snapshot captures the schema change.
+        """
         hostname = dataset_test.catalog.hostname
         catalog_id = dataset_test.catalog.catalog_id
         ml_instance = DerivaML(hostname, catalog_id, working_dir=tmp_path, use_minid=False)
         dataset_description = dataset_test.dataset_description
+        dataset = dataset_description.dataset
 
-        current_version = dataset_description.dataset.current_version
+        # Promote the fixture's dev row to a release so v1's snapshot
+        # is pinned before the schema mutation below.
+        if dataset.current_version.is_devrelease:
+            dataset.release(bump=VersionPart.minor, description="Schema-test v1 baseline")
+        current_version = dataset.current_version
+        assert not current_version.is_devrelease
 
         ml_instance.create_table(
             TableDefinition(
@@ -195,10 +213,10 @@ class TestDatasetDownload:
         )
         # Use the private force-bump primitive: this test stamps a new
         # snapshot to capture a schema change, not to release a dev period.
-        new_version = dataset_description.dataset._increment_dataset_version(component=VersionPart.minor)
+        new_version = dataset._increment_dataset_version(component=VersionPart.minor)
 
-        current_bag = dataset_description.dataset.download_dataset_bag(current_version, use_minid=False)
-        new_bag = dataset_description.dataset.download_dataset_bag(new_version, use_minid=False)
+        current_bag = dataset.download_dataset_bag(current_version, use_minid=False)
+        new_bag = dataset.download_dataset_bag(new_version, use_minid=False)
 
         assert "NewTable" in new_bag.model.model.schemas[ml_instance.default_schema].tables
         assert "NewTable" not in current_bag.model.model.schemas[ml_instance.default_schema].tables


### PR DESCRIPTION
## Summary

Three changes that together resolve **#113 and #114** — the last two \`test_dataset_download.py\` failures.

### 1. Snapshot-aware bag-builder (\`src/deriva_ml/dataset/bag_builder.py\`)

Upstream \`CatalogBagBuilder._run_export\` passes \`str(self.catalog.catalog_id)\` to \`GenericDownloader\` — the bare catalog ID, dropping any snapshot suffix. For \`ErmrestSnapshot\` (a snapshot-bound catalog with \`snaptime\` set) the resulting export targets the *live* catalog instead of the snapshot, so the bag's \`schema.json\` reflects the live model rather than the snapshot's pinned schema.

Workaround in deriva-ml: \`_SnapshotAwareCatalogBagBuilder\` subclass that overrides \`_run_export\` to re-attach the \`@<snaptime>\` suffix when the catalog has one. \`build_bag\` uses the subclass instead of upstream's \`CatalogBagBuilder\` directly.

The real fix belongs upstream — filed as [deriva-py#253](https://github.com/informatics-isi-edu/deriva-py/issues/253). The workaround can be removed when that lands.

### 2. \`compare_datasets\` helper uses each ds's own current version

The helper passed the outer \`dataset_spec.version\` to every nested ds's \`list_dataset_members(...)\`. That worked when datasets shared a global version, but per ADR-0003 dev rows are mutable and a single dataset's version doesn't translate across siblings — the outer can be released to 1.1.0 while nested children are still on 1.0.0.post1.dev1. Passing the outer's version into the nested ds raised:

\`\`\`
DerivaMLException: Version 1.1.0 not found for dataset 5G8
\`\`\`

The helper's intent is \"what the catalog currently says vs what the bag has\", so each ds is now queried at its own \`current_version\`.

### 3. Test fixtures release before snapshotting

Both \`test_dataset_download_schemas\` and \`test_dataset_download_versions\` captured a dataset version while the fixture left the dataset on a dev row. Per ADR-0003 dev labels can't pin a snapshot — they always resolve to the live catalog state. Promote the dev row to a release before snapshotting v1 so the test's \"compare before/after\" semantics actually hold.

## Test plan

- [x] \`DERIVA_HOST=localhost uv run pytest tests/dataset/test_download.py\` → **11/11 pass** (was 9/11)
- [x] No source-code change affects non-snapshot code paths (\`_SnapshotAwareCatalogBagBuilder\` only re-attaches the suffix when the catalog has one)

Closes #113
Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)