### PR TITLE
fix(bag): drop feature values whose target row isn't in the bag (closes #126)

### DIFF
--- a/src/deriva_ml/dataset/dataset_bag.py
+++ b/src/deriva_ml/dataset/dataset_bag.py
@@ -639,6 +639,28 @@ class DatasetBag:
         target_col = table if isinstance(table, str) else table.name
         records = list(self._feature_cache.fetch_feature_records(target_col, feature_name))
 
+        # Filter to target rows that actually live in the bag. The bag
+        # walker can over-reach association tables (e.g. include
+        # Execution_Subject_Health rows whose Subject FK points at a
+        # Subject outside the dataset slice — see #126). A value whose
+        # target row isn't in the bag is dangling: drop it so the bag's
+        # feature_values matches what the bag actually contains.
+        try:
+            target_rids = {
+                r["RID"] for r in self.model.get_table_contents(target_col)
+            }
+        except Exception:
+            # If the target table is missing from the bag entirely,
+            # fall through with the unfiltered set — the cache fetch
+            # would have raised anyway. Defensive only.
+            target_rids = None
+        if target_rids is not None:
+            records = [
+                r
+                for r in records
+                if getattr(r, target_col, None) in target_rids
+            ]
+
         # Apply execution_rids filter (Python-side; the bag cache doesn't
         # have a server-side query layer to push this into). Empty list
         # short-circuits to an empty result.


### PR DESCRIPTION
## Summary

\`DatasetBag.feature_values\` was returning feature rows whose target FK points at a row that isn't in the bag's target table. The bag walker can over-reach an association feature table (e.g. include \`Execution_Subject_Health\` rows whose \`Subject\` FK targets a Subject outside the dataset slice — happens when the table is reached via the \`Execution\` side without cross-checking the \`Subject\` side).

A feature value whose target row isn't in the bag is **dangling** — it references rows the bag user has no way to look up. Drop those before yielding so \`bag.feature_values(\"Subject\", ...)\` only returns values for Subjects that are actually in the bag.

## Implementation

In \`DatasetBag.feature_values\`, after fetching from \`BagFeatureCache\` and before applying the \`execution_rids\` filter:

\`\`\`python
target_rids = {r[\"RID\"] for r in self.model.get_table_contents(target_col)}
records = [r for r in records if getattr(r, target_col, None) in target_rids]
\`\`\`

## Test plan

- [x] \`DERIVA_HOST=localhost uv run pytest tests/feature/test_features.py::TestFeatures::test_download_feature\` → passes (was failing)
- [x] \`DERIVA_HOST=localhost uv run pytest tests/feature/\` → 57 passed, 1 failed (the unchanged #116 failure)
- [x] Defensive filter at the deriva-ml layer; the deeper bag-walker over-reach in upstream \`CatalogBagBuilder\` is separate territory

Closes #126.

🤖 Generated with [Claude Code](https://claude.com/claude-code)