### PR TITLE
refactor(interfaces): harmonize DatasetLike signatures across Dataset/DatasetBag (audit §3.C)

### DIFF
--- a/src/deriva_ml/dataset/dataset.py
+++ b/src/deriva_ml/dataset/dataset.py
@@ -452,10 +452,7 @@ class Dataset:
         Returns:
             ``{element_type_name -> Dataset_ElementType_name}`` map.
         """
-        return {
-            a.other_fkeys.pop().pk_table.name: a.table.name
-            for a in self._dataset_table.find_associations()
-        }
+        return {a.other_fkeys.pop().pk_table.name: a.table.name for a in self._dataset_table.find_associations()}
 
     # ==================== Read Interface Methods ====================
     # These methods implement the DatasetLike protocol for read operations.
@@ -1469,6 +1466,7 @@ class Dataset:
         recurse: bool = False,
         limit: int | None = None,
         _visited: set[RID] | None = None,
+        *,
         version: DatasetVersion | str | None = None,
         **kwargs: Any,
     ) -> dict[str, list[dict[str, Any]]]:
@@ -2090,6 +2088,7 @@ class Dataset:
         self,
         recurse: bool = False,
         _visited: set[RID] | None = None,
+        *,
         version: DatasetVersion | str | None = None,
         **kwargs: Any,
     ) -> list[Self]:
@@ -2155,6 +2154,7 @@ class Dataset:
         self,
         recurse: bool = False,
         _visited: set[RID] | None = None,
+        *,
         version: DatasetVersion | str | None = None,
         **kwargs: Any,
     ) -> list[Self]:
@@ -2790,4 +2790,3 @@ class Dataset:
             if version_record.snapshot
             else self._ml_instance.catalog.catalog_id
         )
-

--- a/src/deriva_ml/dataset/dataset_bag.py
+++ b/src/deriva_ml/dataset/dataset_bag.py
@@ -62,7 +62,6 @@ if TYPE_CHECKING:
     from deriva_ml.model.deriva_ml_bag_view import DerivaMLBagView
 
 
-
 class DatasetBag:
     """Read-only interface to a downloaded dataset bag.
 
@@ -396,7 +395,6 @@ class DatasetBag:
         recurse: bool = False,
         limit: int | None = None,
         _visited: set[RID] | None = None,
-        version: Any = None,
         **kwargs: Any,
     ) -> dict[str, list[dict[str, Any]]]:
         """Return all members of this dataset bag grouped by table name.
@@ -412,13 +410,10 @@ class DatasetBag:
                 (default) returns all rows.
             _visited: Internal parameter to track visited datasets and prevent
                 infinite recursion. Callers should not pass this.
-            version: Dataset version string (e.g. ``"1.2.0"``) to query.
-                When ``None`` (default), uses the latest materialized version
-                in the bag. This parameter exists for API symmetry with the
-                live-catalog ``Dataset.list_dataset_members``; bag contents
-                are immutable so changing ``version`` only filters which
-                version's membership snapshot is read.
-            **kwargs: Additional arguments (ignored, for protocol compatibility).
+            **kwargs: Accepted for ``DatasetLike`` protocol compatibility.
+                ``Dataset`` honours a ``version=`` keyword to pin the
+                catalog snapshot; bags are immutable, so any extras
+                (including ``version=``) are silently ignored.
 
         Returns:
             Dict mapping table name to list of row dicts. Empty dict if
@@ -597,20 +592,14 @@ class DatasetBag:
         # target row isn't in the bag is dangling: drop it so the bag's
         # feature_values matches what the bag actually contains.
         try:
-            target_rids = {
-                r["RID"] for r in self.model.get_table_contents(target_col)
-            }
+            target_rids = {r["RID"] for r in self.model.get_table_contents(target_col)}
         except Exception:
             # If the target table is missing from the bag entirely,
             # fall through with the unfiltered set — the cache fetch
             # would have raised anyway. Defensive only.
             target_rids = None
         if target_rids is not None:
-            records = [
-                r
-                for r in records
-                if getattr(r, target_col, None) in target_rids
-            ]
+            records = [r for r in records if getattr(r, target_col, None) in target_rids]
 
         # Apply execution_rids filter (Python-side; the bag cache doesn't
         # have a server-side query layer to push this into). Empty list
@@ -687,7 +676,7 @@ class DatasetBag:
             "Use feature_values(table, feature_name, selector=...) instead."
         )
 
-    def lookup_feature(self, table: str | Table, feature_name: str) -> "Feature":
+    def lookup_feature(self, table: str | Table, feature_name: str) -> Feature:
         """Look up a feature definition from bag metadata — works fully offline.
 
         Returns a ``Feature`` object with the same shape as the one returned by
@@ -798,7 +787,6 @@ class DatasetBag:
         self,
         recurse: bool = False,
         _visited: set[RID] | None = None,
-        version: Any = None,
         **kwargs: Any,
     ) -> list[Self]:
         """Return directly nested (child) datasets of this bag.
@@ -811,9 +799,10 @@ class DatasetBag:
                 Default is ``False``.
             _visited: Internal parameter tracking visited RIDs to guard
                 against circular references. Callers should not pass this.
-            version: Ignored (bags are immutable snapshots; present for
-                API symmetry with ``Dataset.list_dataset_children``).
-            **kwargs: Additional arguments (ignored, for protocol compatibility).
+            **kwargs: Accepted for ``DatasetLike`` protocol compatibility.
+                ``Dataset`` honours a ``version=`` keyword to pin the
+                catalog snapshot; bags are immutable, so any extras
+                (including ``version=``) are silently ignored.
 
         Returns:
             List of ``DatasetBag`` instances for each direct child dataset,
@@ -859,7 +848,6 @@ class DatasetBag:
         self,
         recurse: bool = False,
         _visited: set[RID] | None = None,
-        version: Any = None,
         **kwargs: Any,
     ) -> list[Self]:
         """Return the parent datasets that contain this dataset as a nested member.
@@ -872,9 +860,10 @@ class DatasetBag:
                 to the root. Default is ``False``.
             _visited: Internal parameter tracking visited RIDs to guard against
                 circular references. Callers should not pass this.
-            version: Ignored (bags are immutable snapshots; present for
-                API symmetry with ``Dataset.list_dataset_parents``).
-            **kwargs: Additional arguments (ignored, for protocol compatibility).
+            **kwargs: Accepted for ``DatasetLike`` protocol compatibility.
+                ``Dataset`` honours a ``version=`` keyword to pin the
+                catalog snapshot; bags are immutable, so any extras
+                (including ``version=``) are silently ignored.
 
         Returns:
             List of ``DatasetBag`` instances for each direct parent dataset.
@@ -1124,7 +1113,6 @@ class DatasetBag:
     # =========================================================================
     # Asset Restructuring Methods
     # =========================================================================
-
 
     def as_torch_dataset(
         self,
@@ -1460,7 +1448,6 @@ class DatasetBag:
             missing=missing,
             output_signature=output_signature,
         )
-
 
     def restructure_assets(
         self,

--- a/src/deriva_ml/interfaces.py
+++ b/src/deriva_ml/interfaces.py
@@ -62,7 +62,7 @@ from __future__ import annotations
 # Deriva imports - use importlib to avoid shadowing by local 'deriva.py' files
 import importlib
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Generator, Iterable, Protocol, Self, runtime_checkable
+from typing import TYPE_CHECKING, Any, Callable, Generator, Iterable, Protocol, Self, runtime_checkable
 
 import pandas as pd
 
@@ -135,31 +135,24 @@ class DatasetLike(Protocol):
         self,
         recurse: bool = False,
         _visited: set[RID] | None = None,
-        version: Any = None,
-        sort: SortSpec = None,
         **kwargs: Any,
     ) -> list[Self]:
         """Get nested child datasets.
 
         Args:
             recurse: Whether to recursively include children of children.
-            _visited: Internal parameter to track visited datasets and prevent infinite recursion.
-            version: Dataset version to list children from (Dataset only, ignored by DatasetBag).
-            sort: Optional sort spec — see :class:`deriva_ml.core.sort.SortSpec`.
-                ``None`` (default) preserves backend order. ``True`` applies
-                the method's default. A callable receives the path-builder
-                context and returns sort keys. Currently reserved for
-                forward-compat — concrete ``Dataset`` and ``DatasetBag``
-                implementations may ignore this parameter (it is accepted
-                via ``**kwargs``).
-            **kwargs: Additional implementation-specific arguments.
+            _visited: Internal parameter to track visited datasets and
+                prevent infinite recursion.
+            **kwargs: Implementation-specific arguments. ``Dataset``
+                accepts ``version: DatasetVersion | str | None`` to
+                query a historical catalog snapshot; ``DatasetBag``
+                ignores any extras since bags are immutable snapshots
+                of a fixed version. Code polymorphic over
+                ``DatasetLike`` should not rely on those extras.
 
         Returns:
-            List of child datasets (Dataset or DatasetBag depending on implementation).
-
-        Note:
-            Both Dataset and DatasetBag have `recurse` as the first parameter.
-            Dataset uses the `version` parameter to query historical versions.
+            List of child datasets — concrete type matches ``self``
+            (``Dataset`` or ``DatasetBag``).
         """
         ...
 
@@ -167,31 +160,22 @@ class DatasetLike(Protocol):
         self,
         recurse: bool = False,
         _visited: set[RID] | None = None,
-        version: Any = None,
-        sort: SortSpec = None,
         **kwargs: Any,
     ) -> list[Self]:
         """Get parent datasets that contain this dataset.
 
         Args:
             recurse: Whether to recursively include parents of parents.
-            _visited: Internal parameter to track visited datasets and prevent infinite recursion.
-            version: Dataset version to list parents from (Dataset only, ignored by DatasetBag).
-            sort: Optional sort spec — see :class:`deriva_ml.core.sort.SortSpec`.
-                ``None`` (default) preserves backend order. ``True`` applies
-                the method's default. A callable receives the path-builder
-                context and returns sort keys. Currently reserved for
-                forward-compat — concrete ``Dataset`` and ``DatasetBag``
-                implementations may ignore this parameter (it is accepted
-                via ``**kwargs``).
-            **kwargs: Additional implementation-specific arguments.
+            _visited: Internal parameter to track visited datasets and
+                prevent infinite recursion.
+            **kwargs: Implementation-specific arguments. ``Dataset``
+                accepts ``version: DatasetVersion | str | None`` to
+                query a historical catalog snapshot; ``DatasetBag``
+                ignores any extras.
 
         Returns:
-            List of parent datasets (Dataset or DatasetBag depending on implementation).
-
-        Note:
-            Both Dataset and DatasetBag have `recurse` as the first parameter.
-            Dataset uses the `version` parameter to query historical versions.
+            List of parent datasets — concrete type matches ``self``
+            (``Dataset`` or ``DatasetBag``).
         """
         ...
 
@@ -200,32 +184,23 @@ class DatasetLike(Protocol):
         recurse: bool = False,
         limit: int | None = None,
         _visited: set[RID] | None = None,
-        version: Any = None,
-        sort: SortSpec = None,
         **kwargs: Any,
     ) -> dict[str, list[dict[str, Any]]]:
         """List members of the dataset.
 
         Args:
             recurse: Whether to include members of nested datasets.
-            limit: Maximum number of members per type. None for no limit.
-            _visited: Internal parameter to track visited datasets and prevent infinite recursion.
-            version: Dataset version to list members from (Dataset only, ignored by DatasetBag).
-            sort: Optional sort spec — see :class:`deriva_ml.core.sort.SortSpec`.
-                ``None`` (default) preserves backend order. ``True`` applies
-                the method's default. A callable receives the path-builder
-                context and returns sort keys. Currently reserved for
-                forward-compat — concrete ``Dataset`` and ``DatasetBag``
-                implementations may ignore this parameter (it is accepted
-                via ``**kwargs``).
-            **kwargs: Additional implementation-specific arguments.
+            limit: Maximum number of members per type. ``None`` (the
+                default) means no limit.
+            _visited: Internal parameter to track visited datasets and
+                prevent infinite recursion.
+            **kwargs: Implementation-specific arguments. ``Dataset``
+                accepts ``version: DatasetVersion | str | None`` to
+                query a historical catalog snapshot; ``DatasetBag``
+                ignores any extras.
 
         Returns:
             Dictionary mapping member types to lists of member records.
-
-        Note:
-            Both Dataset and DatasetBag have `recurse` as the first parameter.
-            Dataset uses the `version` parameter to query historical versions.
         """
         ...
 
@@ -265,9 +240,9 @@ class DatasetLike(Protocol):
 
     def feature_values(
         self,
-        table: Table | str,
+        table: str | Table,
         feature_name: str,
-        selector: Any = None,
+        selector: Callable[[list[FeatureRecord]], FeatureRecord | None] | None = None,
         materialize_limit: int | None = None,
         execution_rids: list[str] | None = None,
     ) -> Iterable[FeatureRecord]:

--- a/tests/test_dataset_like_signature_parity.py
+++ b/tests/test_dataset_like_signature_parity.py
@@ -1,0 +1,272 @@
+"""Signature parity check for the ``DatasetLike`` protocol (audit §3.C).
+
+The audit
+(``docs/design/deriva-ml-audit-2026-05-phase2-dataset.md`` §3.C)
+flagged that the two concrete implementations of
+:class:`~deriva_ml.interfaces.DatasetLike` — :class:`Dataset` (live
+catalog) and :class:`DatasetBag` (downloaded bag) — had drifted to
+the point where the protocol was "more aspirational than
+load-bearing". The recommendation was to enforce method-signature
+parity in a CI check.
+
+This module is that CI check. It uses :mod:`inspect` to compare each
+protocol method's signature against the implementation in both
+concrete classes and fails the build if drift sneaks back in.
+
+Contract enforced
+-----------------
+
+For every callable defined on :class:`DatasetLike` and every concrete
+implementation in (``Dataset``, ``DatasetBag``):
+
+1. **All protocol parameters must be present in the implementation**,
+   in the same order and with the same kind (positional-or-keyword
+   vs. keyword-only, etc.).
+2. **Annotations must match exactly** (string-compared). The
+   protocol declares the contract; if an impl needs to narrow a
+   type, narrow it on the protocol too.
+3. **Default values must match** for every protocol parameter
+   (``None`` ↔ ``None``, ``False`` ↔ ``False``, …).
+4. **Return annotations must match.**
+5. **Implementations may declare additional optional keyword-only
+   parameters** beyond the protocol (e.g. ``Dataset.list_dataset_*``
+   accept a ``version=`` kwarg that's meaningless on bags). These
+   are *additive*; code polymorphic over ``DatasetLike`` cannot
+   rely on them.
+6. **Instance attributes declared on the protocol must appear on
+   both impls** (as class attributes, descriptors, or properties).
+
+What gets caught
+----------------
+
+- Adding a new method to ``DatasetLike`` without implementing it on
+  both ``Dataset`` and ``DatasetBag``.
+- Renaming or retyping a protocol parameter on only one side.
+- Drift between concrete signatures and the protocol declaration —
+  e.g. the protocol declaring ``selector: Any`` while both impls use
+  ``Callable[..., FeatureRecord | None] | None``.
+- An impl losing a protocol-required parameter.
+
+What is *not* enforced
+----------------------
+
+- Type-erased polymorphism over generic args (``list[str]``
+  vs. ``list[T]``). The string-compare check is strict; soften it
+  only if a refactor genuinely improves polymorphism.
+- Default-value identity for objects (the test compares
+  ``inspect.Parameter.default`` directly; for objects that don't
+  implement ``__eq__`` this can spuriously fail — flag it on the
+  protocol side then).
+"""
+
+from __future__ import annotations
+
+import inspect
+from typing import Any
+
+import pytest
+
+from deriva_ml.dataset.dataset import Dataset
+from deriva_ml.dataset.dataset_bag import DatasetBag
+from deriva_ml.interfaces import DatasetLike
+
+# ---------------------------------------------------------------------------
+# Discovery helpers
+# ---------------------------------------------------------------------------
+
+
+def _protocol_callables(proto: type) -> dict[str, Any]:
+    """Return ``{name: callable}`` for protocol methods.
+
+    Protocol methods land in ``proto.__dict__`` as plain functions
+    (because the ``...`` body is desugared to ``pass``). We filter out
+    underscore-prefixed names and the protocol bookkeeping attributes.
+    """
+    skip = {"__module__", "__qualname__", "__doc__", "__dict__"}
+    return {
+        name: obj
+        for name, obj in proto.__dict__.items()
+        if not name.startswith("_") and name not in skip and callable(obj)
+    }
+
+
+def _protocol_attributes(proto: type) -> dict[str, Any]:
+    """Return ``{name: annotation}`` for protocol *instance* attributes.
+
+    Excludes anything that's also a callable (those are methods, not
+    attributes) and anything underscore-prefixed.
+    """
+    callable_names = set(_protocol_callables(proto))
+    annotations = getattr(proto, "__annotations__", {})
+    return {name: ann for name, ann in annotations.items() if not name.startswith("_") and name not in callable_names}
+
+
+def _sig(fn: Any) -> inspect.Signature:
+    return inspect.signature(fn)
+
+
+# ---------------------------------------------------------------------------
+# DatasetLike parity tests
+# ---------------------------------------------------------------------------
+
+
+PROTOCOL_METHODS = sorted(_protocol_callables(DatasetLike))
+IMPLS: tuple[tuple[str, type], ...] = (("Dataset", Dataset), ("DatasetBag", DatasetBag))
+
+
+@pytest.fixture(scope="module")
+def protocol_sigs() -> dict[str, inspect.Signature]:
+    """Cache the protocol's :class:`inspect.Signature` per method."""
+    return {name: _sig(getattr(DatasetLike, name)) for name in PROTOCOL_METHODS}
+
+
+@pytest.mark.parametrize("impl_name,impl_cls", IMPLS, ids=[i[0] for i in IMPLS])
+@pytest.mark.parametrize("method", PROTOCOL_METHODS)
+def test_protocol_method_signature_parity(
+    method: str,
+    impl_name: str,
+    impl_cls: type,
+    protocol_sigs: dict[str, inspect.Signature],
+) -> None:
+    """Every parameter on the protocol must be matched verbatim on each impl.
+
+    Implementations may add additional optional kwargs, but cannot
+    drop, rename, retype, or relocate a protocol-required parameter.
+    """
+    proto_sig = protocol_sigs[method]
+    impl_method = getattr(impl_cls, method, None)
+    assert impl_method is not None, (
+        f"{impl_name} is missing protocol method {method!r}; the protocol says every DatasetLike supports it."
+    )
+    impl_sig = _sig(impl_method)
+
+    proto_params = proto_sig.parameters
+    impl_params = impl_sig.parameters
+    impl_param_names = list(impl_params)
+
+    # Walk protocol parameters in order. Each must appear on the impl
+    # with the same kind, default, and annotation. (We allow the impl
+    # to interleave additional optional kwargs between protocol
+    # params; this is uncommon but legal in Python.)
+    for pname, pparam in proto_params.items():
+        assert pname in impl_params, (
+            f"{impl_name}.{method} is missing the protocol parameter {pname!r}.\n"
+            f"  protocol: {proto_sig}\n"
+            f"  impl    : {impl_sig}"
+        )
+        iparam = impl_params[pname]
+        assert iparam.kind == pparam.kind, (
+            f"{impl_name}.{method}({pname}=...) kind differs.\n"
+            f"  protocol: {pparam.kind.name}\n"
+            f"  impl    : {iparam.kind.name}"
+        )
+        assert iparam.default == pparam.default, (
+            f"{impl_name}.{method}({pname}=...) default differs.\n"
+            f"  protocol: {pparam.default!r}\n"
+            f"  impl    : {iparam.default!r}"
+        )
+        # Annotation comparison is string-based to dodge generics
+        # equality quirks. ``inspect`` stringifies ``list[str]`` and
+        # ``'list[str]'`` differently in some Python versions, so
+        # we normalise to plain str.
+        proto_ann = str(pparam.annotation)
+        impl_ann = str(iparam.annotation)
+        assert proto_ann == impl_ann, (
+            f"{impl_name}.{method}({pname}=...) annotation differs.\n  protocol: {proto_ann}\n  impl    : {impl_ann}"
+        )
+
+    # Return annotation must match exactly.
+    proto_ret = str(proto_sig.return_annotation)
+    impl_ret = str(impl_sig.return_annotation)
+    assert proto_ret == impl_ret, (
+        f"{impl_name}.{method} return annotation differs.\n  protocol: {proto_ret}\n  impl    : {impl_ret}"
+    )
+
+    # Any impl-only parameters beyond the protocol must be keyword-only
+    # or VAR_KEYWORD. A positional impl-extra would break callers using
+    # positional args against the protocol signature.
+    extras = [n for n in impl_param_names if n not in proto_params]
+    for extra in extras:
+        eparam = impl_params[extra]
+        assert eparam.kind in (
+            inspect.Parameter.KEYWORD_ONLY,
+            inspect.Parameter.VAR_KEYWORD,
+            inspect.Parameter.VAR_POSITIONAL,
+        ), (
+            f"{impl_name}.{method} has impl-only parameter {extra!r} that is "
+            f"{eparam.kind.name}; impl-extras beyond the protocol must be "
+            f"KEYWORD_ONLY, VAR_KEYWORD, or VAR_POSITIONAL so positional "
+            f"calls against the protocol don't get hijacked."
+        )
+
+
+# ---------------------------------------------------------------------------
+# DatasetLike instance-attribute coverage
+# ---------------------------------------------------------------------------
+
+
+PROTOCOL_ATTRS = sorted(_protocol_attributes(DatasetLike))
+
+
+def _impl_exposes_attribute(impl_cls: type, attr: str) -> bool:
+    """Detect a protocol attribute on an impl without constructing one.
+
+    Constructing a real ``Dataset`` or ``DatasetBag`` requires a live
+    catalog / downloaded bag, so this test runs statically. We accept
+    any of:
+
+    - A class attribute (e.g. a class-level default or a typed slot).
+    - A ``@property`` or descriptor on the class.
+    - A ``self.<attr> = ...`` assignment in ``__init__`` source.
+    """
+    import re
+
+    if hasattr(impl_cls, attr):
+        return True
+    try:
+        init_src = inspect.getsource(impl_cls.__init__)
+    except (TypeError, OSError):
+        return False
+    # Look for ``self.<attr> = ...`` or ``self.<attr>: <type> = ...``
+    pattern = rf"\bself\.{re.escape(attr)}\s*(?::[^=]+)?\s*="
+    return re.search(pattern, init_src) is not None
+
+
+@pytest.mark.parametrize("impl_name,impl_cls", IMPLS, ids=[i[0] for i in IMPLS])
+@pytest.mark.parametrize("attr", PROTOCOL_ATTRS)
+def test_protocol_attribute_present_on_impl(attr: str, impl_name: str, impl_cls: type) -> None:
+    """Every instance attribute declared on the protocol must exist on the impl.
+
+    Accepted forms: class attribute, ``@property`` / descriptor on
+    the class, or ``self.<attr> = ...`` set in ``__init__``.
+    """
+    assert _impl_exposes_attribute(impl_cls, attr), (
+        f"{impl_name} is missing the protocol attribute {attr!r}. "
+        f"DatasetLike declares it as an instance attribute; expose it "
+        f"via a class attribute, a property, or a ``self.<attr> = ...`` "
+        f"assignment in ``__init__``."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Method-set coverage
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("impl_name,impl_cls", IMPLS, ids=[i[0] for i in IMPLS])
+def test_impl_covers_every_protocol_method(impl_name: str, impl_cls: type) -> None:
+    """Each impl must define every method the protocol declares.
+
+    Symmetric counterpart to the per-method tests above — catches the
+    case where someone adds a new ``DatasetLike`` method and forgets
+    to implement it on one side. The per-method tests already cover
+    this implicitly (they assert ``getattr is not None``), but a
+    dedicated symbol-level check produces a single readable failure
+    listing every missing method at once.
+    """
+    missing = [name for name in PROTOCOL_METHODS if not hasattr(impl_cls, name)]
+    assert not missing, (
+        f"{impl_name} is missing protocol methods: {missing}. "
+        f"DatasetLike declares them; both Dataset and DatasetBag must "
+        f"implement them."
+    )


### PR DESCRIPTION
## Summary

The Phase 2 dataset audit (§3.C) flagged that the two concrete
implementations of `DatasetLike` had drifted enough that the
protocol was "more aspirational than load-bearing". This PR
tightens the protocol contract and adds a CI regression test that
fails if drift sneaks back in.

## Changes

### Protocol (`src/deriva_ml/interfaces.py`)

- `list_dataset_{children,parents,members}`: dropped `version: Any`
  and `sort: SortSpec` from the protocol. Neither belongs in the
  minimum contract:
  - `version` is meaningful only on `Dataset` (snapshot-pinned
    queries); on `DatasetBag` it was accepted-but-never-read.
  - `sort: SortSpec` was forward-compat-only; neither concrete
    method honoured it.
- `feature_values.selector`: tightened from `Any` to the precise
  `Callable[[list[FeatureRecord]], FeatureRecord | None] | None`
  both impls already use.

### `DatasetBag` (`src/deriva_ml/dataset/dataset_bag.py`)

- Removed dead `version: Any = None` from
  `list_dataset_{children,parents,members}` (bodies never
  referenced it; bags are immutable, so the param was always a
  no-op). Any caller still passing `version=` hits the `**kwargs`
  catch-all and gets silently absorbed — same observable behaviour.
- Fixed `lookup_feature` return annotation: dropped string
  forward-reference (`-> "Feature"`); `Feature` is unconditionally
  imported at module top.

### `Dataset` (`src/deriva_ml/dataset/dataset.py`)

- Marked `version=` keyword-only on
  `list_dataset_{children,parents,members}` by inserting `*,` before
  it. Polymorphism safety fix: when `Dataset` is exposed via
  `DatasetLike`, a positional call like
  `ds.list_dataset_children(False, None, "1.0")` must not silently
  set the impl-only `version` parameter. All in-tree callers already
  use `version=` kwarg; verified by grep.

### CI check (`tests/test_dataset_like_signature_parity.py`, new)

Uses `inspect.signature` to compare the protocol against both
impls. Enforces:
- Every protocol parameter present on each impl with the same kind,
  default, and annotation (string-compared).
- Return annotations match exactly.
- Impl-only extras must be keyword-only / VAR_KEYWORD /
  VAR_POSITIONAL (catches the polymorphism hazard fixed above).
- Every protocol instance attribute present on each impl (via class
  attribute, property, or `self.<attr> =` in `__init__`).

38 parametrized cases (14 methods × 2 impls + 4 attrs × 2 impls + 2
coverage). Pure-local, ~50ms; no `DERIVA_HOST` needed.

## Test plan

- [x] `DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/test_dataset_like_signature_parity.py -v` → 38 passed
- [x] `DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/local_db/ tests/asset/ tests/model/ -q` → 434 passed, 3 skipped (no regressions)
- [x] `uv run ruff check` clean across all four files
- [x] `uv run ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)