### PR TITLE
docs(adr): record estimate_bag_size opt-out from bag pipeline (audit §3.D)

### DIFF
--- a/docs/adr/0008-estimate-bag-size-bypasses-bag-pipeline.md
+++ b/docs/adr/0008-estimate-bag-size-bypasses-bag-pipeline.md
@@ -1,0 +1,167 @@
+# ADR-0008: `Dataset.estimate_bag_size` deliberately bypasses `CatalogBagBuilder`
+
+Date: 2026-05-15
+Status: Accepted
+
+## Context
+
+ADR-0006 made `deriva.bag.catalog_builder.CatalogBagBuilder` the
+canonical "catalog → BDBag" producer for DerivaML. Every code path
+that materialises a bag (download, drift check, clone-via-bag,
+upload staging) now routes through it.
+
+`Dataset.estimate_bag_size` is the **one place** in
+`src/deriva_ml/dataset/` that does not. The function predicts the
+on-disk size of a bag *before* downloading it — used by the MCP
+plugin to gate large downloads, by `bag_info` to give users a
+heads-up, and by tooling that decides between materialised vs.
+metadata-only fetches.
+
+Its implementation
+(`src/deriva_ml/dataset/dataset.py::Dataset.estimate_bag_size`):
+
+1. Builds per-table aggregate datapaths via
+   `DatasetBagBuilder.aggregate_queries(self)` — the same walker
+   `CatalogBagBuilder` uses internally, so the **path computation**
+   is shared.
+2. Then bypasses `CatalogBagBuilder.build()` entirely and runs the
+   queries through `AsyncErmrestCatalog` + `asyncio.gather` to fetch
+   RID lists, asset-size pairs, and sample rows concurrently.
+
+The Phase 2 dataset audit
+(`docs/design/deriva-ml-audit-2026-05-phase2-dataset.md` §2.6 and
+§3.D) flagged this as architectural drift:
+
+> The async-query loop in `estimate_bag_size` (action 8) is the only
+> piece of `dataset/` that bypasses `CatalogBagBuilder` for
+> performance. Decision point: lift the optimisation upstream to
+> `CatalogBagBuilder` (giving every consumer free parallelism), or
+> formalise `estimate_bag_size` as an opt-out path. The current
+> "opportunistic copy-paste" is the worst of both worlds.
+
+The audit's framing — *"the worst of both worlds"* — is precise:
+neither alternative is strictly chosen, so a casual reader sees code
+that looks like copy-paste from `CatalogBagBuilder` without any
+signal that the bypass is deliberate.
+
+## Decision
+
+**Formalise `estimate_bag_size` as an opt-out path from the bag
+pipeline.** Keep the parallel async implementation; document the
+bypass as a deliberate architectural choice, not an oversight.
+
+Specifically:
+
+1. The function continues to use `AsyncErmrestCatalog` +
+   `asyncio.gather` directly. The perf headroom (~30–100× on
+   datasets with many tables) is real and load-bearing for the MCP
+   gate.
+2. `Dataset.estimate_bag_size`'s docstring carries a `Note:` block
+   pointing at this ADR so future maintainers understand the bypass
+   is deliberate.
+3. Path resolution is **not** duplicated: `aggregate_queries`
+   continues to drive a `CatalogBagBuilder` for the walk, so any
+   change to the walker semantics propagates to the estimator
+   automatically.
+4. The URI-parsing trick in `_extract_path` (audit §2.5) is
+   recorded as a known technical-debt point but **not fixed in this
+   ADR's scope**. It's a follow-up: either deriva-py exposes a
+   "give me the catalog-relative path" API on its datapath
+   objects, or `estimate_bag_size` keeps the trick. See "Open
+   questions" below.
+
+## Consequences
+
+### Accepted
+
+- The estimator and the bag builder share the **walk** but not the
+  **execution**. Walker changes propagate; transport-layer changes
+  don't.
+- One module in `dataset/` legitimately uses `AsyncErmrestCatalog`
+  directly. New async-catalog uses outside `estimate_bag_size`
+  should still go through `CatalogBagBuilder` unless a future ADR
+  amends this.
+- A future "lift parallelism upstream" project (see "Open
+  questions") would deprecate this ADR. The opt-out is a stable
+  position, not a permanent one.
+
+### Rejected alternatives
+
+#### Alternative A: Lift parallelism into `CatalogBagBuilder`
+
+Add an `async` execution mode to `CatalogBagBuilder.build()`. Every
+consumer (download, drift, clone, estimate) would get parallelism
+for free. Both estimator and builder would share both the walk and
+the execution.
+
+Rejected for now because:
+
+- Cross-repo coordination. `CatalogBagBuilder` lives in
+  `deriva-py`; the design discussion needs that repo's maintainers
+  to weigh in on async-catalog churn, connection-pool tuning, and
+  shared-catalog rate-limit risk.
+- Behavioural breadth. `CatalogBagBuilder.build()` does more than
+  parallelisable reads — it writes to disk, applies the BagIt
+  profile, manages temp directories. Parallelising the read phase
+  without breaking the write phase is non-trivial.
+- The estimator uses a different query shape than the builder. The
+  builder's queries hydrate full table contents; the estimator's
+  queries fetch only RID lists, RID+Length pairs, and 100-row
+  samples. Sharing the transport layer is harder than sharing the
+  walker.
+
+If/when the upstream project lands, this ADR is superseded and the
+estimator collapses back into the builder. The opt-out is a
+stable-but-not-permanent position.
+
+#### Alternative B: Leave the bypass undocumented
+
+Was the status quo before this ADR. The audit's critique is exactly
+that no signal distinguishes a deliberate opt-out from accidental
+divergence. Future contributors will keep "fixing" the duplication
+without realising the perf consequences.
+
+### Practical guidance for contributors
+
+- **Adding a new estimator-like operation** (e.g. "estimate dataset
+  cost before commit"): go through `CatalogBagBuilder.build()`
+  first. Only fall back to direct async-catalog usage if the same
+  measurement shows the bag-pipeline path is significantly slower
+  *and* the optimisation is load-bearing.
+- **Changing the walker** (`DatasetBagBuilder.aggregate_queries`,
+  `CatalogBagBuilder.iter_table_datapaths`, table-anchor policy):
+  the estimator picks the change up automatically. No special
+  handling needed.
+- **Refactoring `Dataset.estimate_bag_size`**: feel free to break
+  out helpers, but preserve the async transport — this ADR is the
+  signal that the perf path is deliberate.
+
+## Open questions (tracked as follow-up)
+
+1. **URI parsing in `_extract_path`** (audit §2.5). The function
+   parses datapath URIs back into ERMrest paths because the
+   datapath API doesn't expose a "give me the catalog-relative
+   path" accessor. Should we:
+   - File an upstream issue against `deriva-py` asking for a
+     `datapath.relative_path` property?
+   - Keep the string-parse trick (small, contained, fast)?
+   - Build a thin helper in deriva-ml and live with it?
+
+   No decision yet. The audit raised it; this ADR records it as a
+   known sharp edge but does not resolve it.
+
+2. **Long-term: lift parallelism upstream** (Alternative A). A
+   future ADR may revisit if/when the deriva-py async-catalog
+   surface stabilises and the cross-repo discussion is ready.
+
+## References
+
+- ADR-0006 — bag-oriented data movement (the producer/consumer
+  model this ADR opts out of).
+- `docs/design/deriva-ml-audit-2026-05-phase2-dataset.md` §2.6,
+  §3.D — the audit findings that motivated this ADR.
+- `src/deriva_ml/dataset/dataset.py::Dataset.estimate_bag_size` —
+  the function whose design is captured here.
+- `src/deriva_ml/dataset/bag_builder.py::DatasetBagBuilder.aggregate_queries` —
+  the shared walker that both the estimator and the bag builder
+  drive off.

--- a/docs/design/deriva-ml-audit-2026-05-phase2-dataset.md
+++ b/docs/design/deriva-ml-audit-2026-05-phase2-dataset.md
@@ -1023,6 +1023,17 @@ performance. Decision point: lift the optimisation upstream to
 formalise `estimate_bag_size` as an opt-out path. The current
 "opportunistic copy-paste" is the worst of both worlds.
 
+**Update (Phase 3 follow-up):** decision recorded in
+[ADR-0008](../adr/0008-estimate-bag-size-bypasses-bag-pipeline.md):
+the bypass is **formalised as a deliberate opt-out**, not lifted
+upstream. The estimator continues to share the *walker* via
+`DatasetBagBuilder.aggregate_queries` and bypasses
+`CatalogBagBuilder` only for *execution* (the async parallel
+queries). The docstring on `Dataset.estimate_bag_size` now points
+at the ADR. The "lift upstream" alternative remains open as future
+work; ADR-0008 documents what it would entail and why we haven't
+done it yet.
+
 ### 3.E `BagCacheIndex` semantics for multi-anchor bags
 
 The cutover doc (D1) noted that pre-cutover MINIDs may become

--- a/src/deriva_ml/dataset/dataset.py
+++ b/src/deriva_ml/dataset/dataset.py
@@ -2417,6 +2417,18 @@ class Dataset:
         For asset tables, ``(RID, Length)`` pairs are fetched and deduplicated
         by RID so that ``asset_bytes`` reflects the true total.
 
+        Note:
+            This is the one place in ``dataset/`` that bypasses
+            :class:`~deriva.bag.catalog_builder.CatalogBagBuilder` for
+            execution (it still shares the walker via
+            :meth:`~DatasetBagBuilder.aggregate_queries`). The bypass
+            is **deliberate** — see
+            :doc:`docs/adr/0008-estimate-bag-size-bypasses-bag-pipeline`
+            for the design decision, the rejected alternatives
+            (lifting parallelism upstream vs. leaving the divergence
+            undocumented), and practical contributor guidance. Do
+            not "fix" the duplication without reading the ADR first.
+
         Note: this fetches complete RID lists rather than using server-side
         aggregates, which gives exact union counts but uses O(N) memory where
         N is the total rows across all paths.  This is suitable for datasets


### PR DESCRIPTION
## Summary

Audit §3.D framed `Dataset.estimate_bag_size`'s bypass of
`CatalogBagBuilder` as a decision point. This PR takes the
**opt-out** path:

- Adds **ADR-0008** explaining why the estimator shares the
  walker (`aggregate_queries`) but bypasses `CatalogBagBuilder`
  for the execution layer (async-parallel `AsyncErmrestCatalog`
  queries). The performance headroom (~30–100× on datasets with
  many tables) is real and load-bearing for the MCP gate.
- Adds a `Note:` block to `Dataset.estimate_bag_size`'s docstring
  pointing at the ADR — this is the audit's actual ask: make the
  deliberate choice visible at the code site.
- Annotates the audit doc §3.D with a pointer to ADR-0008.

No code is touched. The ADR records the rejected alternative
("lift parallelism upstream"), the practical contributor
guidance, and the open follow-ups (URI-parsing in `_extract_path`,
the future upstream-lift project).

## Why opt-out and not lift-upstream?

The audit framed both paths as legitimate. The ADR explains why
lifting upstream is not the right *immediate* action:

- Cross-repo coordination needed (CatalogBagBuilder lives in
  `deriva-py`; design discussion with that repo's maintainers
  required for async-catalog churn, connection-pool tuning,
  rate-limit risk in shared catalogs).
- Behavioural breadth (`CatalogBagBuilder.build()` does more than
  parallelisable reads; parallelising without breaking write-phase
  semantics is non-trivial).
- Different query shapes (estimator fetches RID lists / sample
  rows; builder hydrates full tables).

The opt-out is a **stable-but-not-permanent** position. If/when
the upstream project lands, this ADR is superseded.

## Test plan

- [x] `uv run ruff check src/deriva_ml/dataset/dataset.py` clean
- [x] Doctest collection still passes
- [x] No code touched; behaviour unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)