### PR TITLE
refactor(feature): Phase 3 audit cleanup — 12 commits, 16 actions

### DIFF
--- a/src/deriva_ml/__init__.py
+++ b/src/deriva_ml/__init__.py
@@ -106,7 +106,11 @@ __all__ = [
     "AssetFilePath",
     "AssetSpec",
     "AssetSpecConfig",
-    # Feature record for feature values and restructure_assets selectors
+    # FeatureRecord — base class for dynamically-generated feature
+    # rows. Used in user code for typing (FeatureRecord subclasses
+    # returned by Feature.feature_record_class()) and as the type
+    # for selector functions passed to feature_values() and
+    # restructure_assets().
     "FeatureRecord",
     # Catalog provenance (lazy-loaded)
     "CatalogProvenance",

--- a/src/deriva_ml/core/exceptions.py
+++ b/src/deriva_ml/core/exceptions.py
@@ -60,6 +60,7 @@ __all__ = [
     "DerivaMLNotFoundError",
     "DerivaMLDatasetNotFound",
     "DerivaMLTableNotFound",
+    "DerivaMLFeatureNotFound",
     "DerivaMLInvalidTerm",
     "DerivaMLTableTypeError",
     "DerivaMLValidationError",
@@ -269,6 +270,36 @@ class DerivaMLTableNotFound(DerivaMLNotFoundError):
     def __init__(self, table_name: str, msg: str = "Table not found") -> None:
         super().__init__(f"{msg}: {table_name}")
         self.table_name = table_name
+
+
+class DerivaMLFeatureNotFound(DerivaMLNotFoundError):
+    """Exception raised when a feature cannot be found on a table.
+
+    Raised by ``DerivaML.lookup_feature`` when the requested feature
+    is not defined on the target table. Carries the table and
+    feature name so callers can construct precise error messages
+    or do programmatic recovery (e.g., create the feature on the
+    fly).
+
+    Args:
+        table_name: Name of the table the feature was looked up on.
+        feature_name: Name of the feature that was not found.
+        msg: Additional context. Defaults to "Feature not found".
+
+    Example:
+        >>> raise DerivaMLFeatureNotFound("Image", "Glaucoma")  # doctest: +SKIP
+        DerivaMLFeatureNotFound: Feature not found: Glaucoma on Image
+    """
+
+    def __init__(
+        self,
+        table_name: str,
+        feature_name: str,
+        msg: str = "Feature not found",
+    ) -> None:
+        super().__init__(f"{msg}: {feature_name} on {table_name}")
+        self.table_name = table_name
+        self.feature_name = feature_name
 
 
 class DerivaMLInvalidTerm(DerivaMLNotFoundError):

--- a/src/deriva_ml/core/mixins/feature.py
+++ b/src/deriva_ml/core/mixins/feature.py
@@ -312,8 +312,9 @@ class FeatureMixin:
             A Feature schema descriptor.
 
         Raises:
-            DerivaMLException: If the feature doesn't exist on the specified
-                table.
+            DerivaMLFeatureNotFound: If the feature doesn't exist on the
+                specified table. Subclass of DerivaMLException — existing
+                ``except DerivaMLException`` callers still catch it.
 
         Example:
             >>> feature = ml.lookup_feature("Image", "Classification")  # doctest: +SKIP

--- a/src/deriva_ml/core/mixins/feature.py
+++ b/src/deriva_ml/core/mixins/feature.py
@@ -46,6 +46,7 @@ class FeatureMixin:
         lookup_feature: Retrieve a Feature object
         find_features: Find all features in the catalog, optionally filtered by table
         feature_values: Get all values for a feature
+        list_workflow_executions: Resolve a Workflow → list of Execution RIDs
     """
 
     # Type hints for IDE support - actual attributes/methods from host class
@@ -445,24 +446,25 @@ class FeatureMixin:
         Example:
             Get the newest Glaucoma label per image::
 
-                >>> from deriva_ml.feature import FeatureRecord
-                >>> for rec in ml.feature_values(
+                >>> from deriva_ml import DerivaML  # doctest: +SKIP
+                >>> from deriva_ml.feature import FeatureRecord  # doctest: +SKIP
+                >>> for rec in ml.feature_values(  # doctest: +SKIP
                 ...     "Image", "Glaucoma", selector=FeatureRecord.select_newest,
                 ... ):
                 ...     print(f"{rec.Image}: {rec.Glaucoma} (by {rec.Execution})")
 
             Filter by a specific workflow — works identically on a downloaded bag::
 
-                >>> workflow = ml.lookup_workflow("Glaucoma_Training_v2")
-                >>> sel = FeatureRecord.select_by_workflow(workflow, container=ml)
-                >>> labels = [r.Glaucoma for r in ml.feature_values(
+                >>> workflow = ml.lookup_workflow("Glaucoma_Training_v2")  # doctest: +SKIP
+                >>> sel = FeatureRecord.select_by_workflow(workflow, container=ml)  # doctest: +SKIP
+                >>> labels = [r.Glaucoma for r in ml.feature_values(  # doctest: +SKIP
                 ...     "Image", "Glaucoma", selector=sel,
                 ... )]
 
             Convert to a pandas DataFrame when needed::
 
-                >>> import pandas as pd
-                >>> df = pd.DataFrame(
+                >>> import pandas as pd  # doctest: +SKIP
+                >>> df = pd.DataFrame(  # doctest: +SKIP
                 ...     r.model_dump()
                 ...     for r in ml.feature_values("Image", "Glaucoma")
                 ... )
@@ -592,13 +594,13 @@ class FeatureMixin:
         Example:
             List all executions of a workflow and count them::
 
-                >>> rids = ml.list_workflow_executions("Glaucoma_Training_v2")
-                >>> print(f"{len(rids)} executions of this workflow")
+                >>> rids = ml.list_workflow_executions("Glaucoma_Training_v2")  # doctest: +SKIP
+                >>> print(f"{len(rids)} executions of this workflow")  # doctest: +SKIP
 
             Use as the catalog-backed resolver for the selector factory::
 
-                >>> from deriva_ml.feature import FeatureRecord
-                >>> sel = FeatureRecord.select_by_workflow(
+                >>> from deriva_ml.feature import FeatureRecord  # doctest: +SKIP
+                >>> sel = FeatureRecord.select_by_workflow(  # doctest: +SKIP
                 ...     "Glaucoma_Training_v2", container=ml,
                 ... )
         """

--- a/src/deriva_ml/core/mixins/feature.py
+++ b/src/deriva_ml/core/mixins/feature.py
@@ -7,25 +7,19 @@ and listing feature values.
 
 from __future__ import annotations
 
-# Deriva imports - use importlib to avoid shadowing by local 'deriva.py' files
-import importlib
 from collections import defaultdict
 from functools import reduce
 from itertools import chain
 from operator import or_
 from typing import TYPE_CHECKING, Any, Callable, Iterable
 
-datapath = importlib.import_module("deriva.core.datapath")
-_ermrest_model = importlib.import_module("deriva.core.ermrest_model")
-Key = _ermrest_model.Key
-Table = _ermrest_model.Table
-
+from deriva.core.ermrest_model import Key, Table
 from pydantic import validate_call
 
 from deriva_ml.core.definitions import ColumnDefinition, VocabularyTerm
 from deriva_ml.core.exceptions import DerivaMLException, DerivaMLMaterializeLimitExceeded
-from deriva_ml.feature import Feature, FeatureRecord
 from deriva_ml.core.validation import VALIDATION_CONFIG
+from deriva_ml.feature import Feature, FeatureRecord
 
 if TYPE_CHECKING:
     from deriva_ml.model.catalog import DerivaModel

--- a/src/deriva_ml/core/mixins/feature.py
+++ b/src/deriva_ml/core/mixins/feature.py
@@ -154,11 +154,22 @@ class FeatureMixin:
             else:
                 return m
 
-        # Validate asset and term tables
-        if not all(map(self.model.is_asset, assets)):
-            raise DerivaMLException("Invalid create_feature asset table.")
-        if not all(map(self.model.is_vocabulary, terms)):
-            raise DerivaMLException("Invalid create_feature asset table.")
+        # Validate asset and term tables. Surface the offending
+        # table names in the error so a user passing the wrong
+        # parameter doesn't have to bisect a list to find the
+        # bad entry.
+        bad_assets = [a for a in assets if not self.model.is_asset(a)]
+        if bad_assets:
+            raise DerivaMLException(
+                f"Invalid create_feature asset table(s): {bad_assets}. "
+                "Each entry of `assets` must be a registered asset table."
+            )
+        bad_terms = [t for t in terms if not self.model.is_vocabulary(t)]
+        if bad_terms:
+            raise DerivaMLException(
+                f"Invalid create_feature vocabulary table(s): {bad_terms}. "
+                "Each entry of `terms` must be a controlled vocabulary table."
+            )
 
         # Get references to required tables
         target_table = self.model.name_to_table(target_table)

--- a/src/deriva_ml/dataset/dataset.py
+++ b/src/deriva_ml/dataset/dataset.py
@@ -623,20 +623,28 @@ class Dataset:
         return self._ml_instance.lookup_feature(table, feature_name)
 
     def list_workflow_executions(self, workflow: str) -> list[str]:
-        """Dataset-scoped list_workflow_executions — see DerivaML.list_workflow_executions.
+        """Pass-through to ``DerivaML.list_workflow_executions`` (dataset scoping deferred).
 
-        Current implementation returns the full workflow execution list from the
-        catalog. Target-RID filtering at selection time (via ``feature_values``)
-        ensures that records from executions outside the dataset's member set
-        are excluded. A stricter scope (executions whose outputs touch dataset
-        members) is a performance optimization deferred to a later change.
+        Despite the name, the live ``Dataset`` implementation does **not**
+        filter the returned execution list to executions whose outputs touch
+        the dataset's member set — it returns every execution of the
+        workflow. The intended dataset-level scoping is provided downstream
+        by ``feature_values``, which filters feature rows by target RID
+        membership and therefore excludes contributions from out-of-set
+        executions at read time.
+
+        For symmetry: ``DatasetBag.list_workflow_executions`` *is* scoped,
+        because a bag only contains the slice of executions reachable from
+        its member set. A caller relying on dataset-scoped behavior should
+        either use a bag or apply RID-set filtering themselves.
 
         Args:
             workflow: Workflow RID or Workflow_Type name. See
-                ``DerivaML.list_workflow_executions`` for the resolution rules.
+                ``DerivaML.list_workflow_executions`` for resolution rules.
 
         Returns:
-            List of execution RIDs. May be empty.
+            List of execution RIDs for the workflow, **not** filtered to the
+            dataset.
 
         Raises:
             DerivaMLException: If the catalog query fails.

--- a/src/deriva_ml/dataset/dataset_bag.py
+++ b/src/deriva_ml/dataset/dataset_bag.py
@@ -486,7 +486,7 @@ class DatasetBag:
                         members[k].extend(v)
         return dict(members)
 
-    def find_features(self, table: str | Table) -> Iterable[Feature]:
+    def find_features(self, table: str | Table | None = None) -> Iterable[Feature]:
         """Find all features defined on a table within this dataset bag.
 
         Features are measurable properties associated with records in a table,
@@ -503,18 +503,31 @@ class DatasetBag:
         - ``feature_record_class()``: A Pydantic model for reading/writing values
 
         Args:
-            table: The table to find features for (name or Table object).
+            table: The table to find features for (name or Table object). When
+                ``None``, returns every feature in the bag's slice.
 
         Returns:
             An iterable of Feature instances describing each feature
-            defined on the table.
+            defined on the table (or every feature when ``table`` is ``None``).
 
         Example:
             >>> for f in bag.find_features("Image"):  # doctest: +SKIP
             ...     print(f"{f.feature_name}: {len(f.term_columns)} terms, "
             ...           f"{len(f.value_columns)} value columns")
+
+            >>> # Every feature in the bag:
+            >>> for f in bag.find_features():  # doctest: +SKIP
+            ...     print(f"{f.target_table.name}: {f.feature_name}")
         """
-        return self.model.find_features(table)
+        if table is None:
+            # Walk every table in the bag and collect each table's features.
+            # The model's find_features takes a table; iterate to get the
+            # global view. Order is by schema-then-table for determinism.
+            for schema in sorted(self.model.schemas):
+                for t in sorted(self.model.schemas[schema].tables):
+                    yield from self.model.find_features(t)
+            return
+        yield from self.model.find_features(table)
 
     def feature_values(
         self,

--- a/src/deriva_ml/feature.py
+++ b/src/deriva_ml/feature.py
@@ -577,8 +577,8 @@ class Feature:
                     - str for all other types
 
             Example:
-                >>> col = Column(name="score", type="float4")
-                >>> typ = map_type(col)  # Returns float
+                >>> col = Column(name="score", type="float4")  # doctest: +SKIP
+                >>> typ = map_type(col)  # Returns float  # doctest: +SKIP
             """
             if c.name in {c.name for c in self.asset_columns}:
                 return str | Path

--- a/src/deriva_ml/feature.py
+++ b/src/deriva_ml/feature.py
@@ -366,6 +366,28 @@ class FeatureRecord(BaseModel):
         return _selector
 
     @classmethod
+    def _require_feature(cls) -> "Feature":
+        """Return ``cls.feature``, raising a helpful error if unset.
+
+        The four column-accessor classmethods below all need
+        ``cls.feature`` to be populated, which only happens on
+        subclasses returned by ``Feature.feature_record_class()``.
+        Calling them on the ``FeatureRecord`` base class would
+        otherwise crash with ``AttributeError: 'NoneType' object
+        has no attribute 'feature_columns'`` — this guard
+        substitutes a useful message naming the actual problem.
+        """
+        if cls.feature is None:
+            raise DerivaMLException(
+                f"{cls.__name__}.feature is None — the column-accessor "
+                "classmethods (feature_columns, asset_columns, "
+                "term_columns, value_columns) are only valid on "
+                "subclasses returned by Feature.feature_record_class(), "
+                "not on the FeatureRecord base class."
+            )
+        return cls.feature
+
+    @classmethod
     def feature_columns(cls) -> set[Column]:
         """Return all columns specific to this feature.
 
@@ -379,12 +401,12 @@ class FeatureRecord(BaseModel):
             set[Column]: Feature-specific ERMrest ``Column`` objects. Equivalent
             to ``cls.feature.feature_columns``.
 
-        Note:
-            Only available on a class returned by ``Feature.feature_record_class()``.
-            Calling this on the ``FeatureRecord`` base class (where ``feature``
-            is ``None``) raises ``AttributeError``.
+        Raises:
+            DerivaMLException: Called on the ``FeatureRecord`` base class
+                rather than a subclass returned by
+                ``Feature.feature_record_class()``.
         """
-        return cls.feature.feature_columns
+        return cls._require_feature().feature_columns
 
     @classmethod
     def asset_columns(cls) -> set[Column]:
@@ -398,12 +420,12 @@ class FeatureRecord(BaseModel):
             set[Column]: ERMrest ``Column`` objects that are FK references to
             asset tables. A subset of ``feature_columns()``.
 
-        Note:
-            Only available on a class returned by ``Feature.feature_record_class()``.
-            Calling this on the ``FeatureRecord`` base class (where ``feature``
-            is ``None``) raises ``AttributeError``.
+        Raises:
+            DerivaMLException: Called on the ``FeatureRecord`` base class
+                rather than a subclass returned by
+                ``Feature.feature_record_class()``.
         """
-        return cls.feature.asset_columns
+        return cls._require_feature().asset_columns
 
     @classmethod
     def term_columns(cls) -> set[Column]:
@@ -417,12 +439,12 @@ class FeatureRecord(BaseModel):
             set[Column]: ERMrest ``Column`` objects that are FK references to
             vocabulary tables. A subset of ``feature_columns()``.
 
-        Note:
-            Only available on a class returned by ``Feature.feature_record_class()``.
-            Calling this on the ``FeatureRecord`` base class (where ``feature``
-            is ``None``) raises ``AttributeError``.
+        Raises:
+            DerivaMLException: Called on the ``FeatureRecord`` base class
+                rather than a subclass returned by
+                ``Feature.feature_record_class()``.
         """
-        return cls.feature.term_columns
+        return cls._require_feature().term_columns
 
     @classmethod
     def value_columns(cls) -> set[Column]:
@@ -438,12 +460,12 @@ class FeatureRecord(BaseModel):
             values. Computed as ``feature_columns() - asset_columns() -
             term_columns()``.
 
-        Note:
-            Only available on a class returned by ``Feature.feature_record_class()``.
-            Calling this on the ``FeatureRecord`` base class (where ``feature``
-            is ``None``) raises ``AttributeError``.
+        Raises:
+            DerivaMLException: Called on the ``FeatureRecord`` base class
+                rather than a subclass returned by
+                ``Feature.feature_record_class()``.
         """
-        return cls.feature.value_columns
+        return cls._require_feature().value_columns
 
 
 class Feature:
@@ -558,6 +580,11 @@ class Feature:
             >>> DiagnosisRecord = feature.feature_record_class()  # doctest: +SKIP
             >>> rec = DiagnosisRecord(Diagnosis="benign")  # doctest: +SKIP
         """
+        # Compute the asset-column-name set once; map_type is called
+        # for every column on the feature, and re-computing this
+        # comprehension on each call is N² for a feature with N
+        # columns.
+        asset_col_names = {c.name for c in self.asset_columns}
 
         def map_type(c: Column) -> UnionType | Type[str] | Type[int] | Type[float]:
             """Maps a Deriva column type to a Python/pydantic type.
@@ -580,7 +607,7 @@ class Feature:
                 >>> col = Column(name="score", type="float4")  # doctest: +SKIP
                 >>> typ = map_type(col)  # Returns float  # doctest: +SKIP
             """
-            if c.name in {c.name for c in self.asset_columns}:
+            if c.name in asset_col_names:
                 return str | Path
 
             match c.type.typename:

--- a/src/deriva_ml/feature.py
+++ b/src/deriva_ml/feature.py
@@ -32,12 +32,15 @@ Typical usage:
     >>> record = DiagnosisRecord(Diagnosis="benign", Confidence=0.97)  # doctest: +SKIP
 """
 
+from collections import Counter
 from pathlib import Path
 from types import UnionType
 from typing import TYPE_CHECKING, Callable, ClassVar, Optional, Type
 
 from deriva.core.ermrest_model import Column, FindAssociationResult
 from pydantic import BaseModel, create_model
+
+from deriva_ml.core.exceptions import DerivaMLException
 
 if TYPE_CHECKING:
     from deriva_ml.model.catalog import DerivaModel
@@ -171,8 +174,6 @@ class FeatureRecord(BaseModel):
         def _selector(records: list["FeatureRecord"]) -> "FeatureRecord":
             filtered = [r for r in records if r.Execution == execution_rid]
             if not filtered:
-                from deriva_ml.core.exceptions import DerivaMLException
-
                 raise DerivaMLException(f"No feature records match execution '{execution_rid}'.")
             return FeatureRecord.select_newest(filtered)
 
@@ -345,25 +346,16 @@ class FeatureRecord(BaseModel):
                     if len(record_cls.feature.term_columns) == 1:
                         col = record_cls.feature.term_columns[0].name
                     else:
-                        from deriva_ml.core.exceptions import (
-                            DerivaMLException,
-                        )
-
                         raise DerivaMLException(
                             "select_majority_vote requires a column name for "
                             "features with multiple term columns. "
                             f"Available: {[c.name for c in record_cls.feature.term_columns]}"
                         )
                 else:
-                    from deriva_ml.core.exceptions import (
-                        DerivaMLException,
-                    )
-
                     raise DerivaMLException(
                         "select_majority_vote requires a column name — could not auto-detect from feature metadata."
                     )
 
-            from collections import Counter
 
             counts = Counter(getattr(r, col, None) for r in records)
             max_count = max(counts.values())

--- a/src/deriva_ml/feature.py
+++ b/src/deriva_ml/feature.py
@@ -45,7 +45,7 @@ FindAssociationResult = _ermrest_model.FindAssociationResult
 from pydantic import BaseModel, create_model
 
 if TYPE_CHECKING:
-    from model.catalog import DerivaModel
+    from deriva_ml.model.catalog import DerivaModel
 
 
 class FeatureRecord(BaseModel):

--- a/src/deriva_ml/feature.py
+++ b/src/deriva_ml/feature.py
@@ -32,16 +32,11 @@ Typical usage:
     >>> record = DiagnosisRecord(Diagnosis="benign", Confidence=0.97)  # doctest: +SKIP
 """
 
-# Deriva imports - use importlib to avoid shadowing by local 'deriva.py' files
-import importlib
 from pathlib import Path
 from types import UnionType
 from typing import TYPE_CHECKING, Callable, ClassVar, Optional, Type
 
-_ermrest_model = importlib.import_module("deriva.core.ermrest_model")
-Column = _ermrest_model.Column
-FindAssociationResult = _ermrest_model.FindAssociationResult
-
+from deriva.core.ermrest_model import Column, FindAssociationResult
 from pydantic import BaseModel, create_model
 
 if TYPE_CHECKING:

--- a/src/deriva_ml/interfaces.py
+++ b/src/deriva_ml/interfaces.py
@@ -212,11 +212,13 @@ class DatasetLike(Protocol):
         """
         ...
 
-    def find_features(self, table: str | Table) -> Iterable[Feature]:
-        """Find features associated with a table.
+    def find_features(self, table: str | Table | None = None) -> Iterable[Feature]:
+        """Find features associated with a table, or all features when ``None``.
 
         Args:
-            table: Table to find features for.
+            table: Table to find features for. When ``None``, return every
+                feature defined on the catalog (or every feature in the
+                bag's slice, for ``DatasetBag``).
 
         Returns:
             Iterable of Feature objects.
@@ -758,11 +760,12 @@ class DerivaMLCatalogReader(Protocol):
         """
         ...
 
-    def find_features(self, table: str | Table) -> Iterable[Feature]:
-        """Find features associated with a table.
+    def find_features(self, table: str | Table | None = None) -> Iterable[Feature]:
+        """Find features associated with a table, or all features when ``None``.
 
         Args:
-            table: Table to find features for.
+            table: Table to find features for. When ``None``, return every
+                feature defined on the catalog.
 
         Returns:
             Iterable of Feature objects.

--- a/src/deriva_ml/model/catalog.py
+++ b/src/deriva_ml/model/catalog.py
@@ -37,7 +37,12 @@ from deriva_ml.core.definitions import (
     _get_domain_schemas,
     _is_system_schema,
 )
-from deriva_ml.core.exceptions import DerivaMLException, DerivaMLReadOnlyError, DerivaMLTableTypeError
+from deriva_ml.core.exceptions import (
+    DerivaMLException,
+    DerivaMLFeatureNotFound,
+    DerivaMLReadOnlyError,
+    DerivaMLTableTypeError,
+)
 from deriva_ml.core.logging_config import get_logger
 from deriva_ml.core.validation import VALIDATION_CONFIG
 
@@ -615,14 +620,15 @@ class DerivaModel:
             The :class:`Feature` wrapper for the matching association.
 
         Raises:
-            DerivaMLException: If ``table`` doesn't exist, or if no
-                feature with ``feature_name`` is defined on it.
+            DerivaMLTableNotFound: If ``table`` doesn't exist.
+            DerivaMLFeatureNotFound: If no feature with
+                ``feature_name`` is defined on ``table``.
         """
         table = self.name_to_table(table)
         try:
             return [f for f in self.find_features(table) if f.feature_name == feature_name][0]
         except IndexError:
-            raise DerivaMLException(f"Feature {table.name}:{feature_name} doesn't exist.")
+            raise DerivaMLFeatureNotFound(table.name, feature_name) from None
 
     def asset_metadata(self, table: TableInput) -> set[str]:
         """Return the non-asset columns of an asset table.

--- a/tests/feature/conftest.py
+++ b/tests/feature/conftest.py
@@ -11,10 +11,8 @@ from typing import Any
 
 import pytest
 
-from deriva_ml import BuiltinTypes, ColumnDefinition
 from deriva_ml.dataset.aux_classes import VersionPart
 from deriva_ml.execution import ExecutionConfiguration
-
 
 # ---------------------------------------------------------------------------
 # Bag fixture for retired-API tests

--- a/tests/feature/test_features.py
+++ b/tests/feature/test_features.py
@@ -128,6 +128,43 @@ class TestFeatures:
         assert len(image_quality_feature.term_columns()) == 1
         assert len(image_quality_feature.feature_columns()) == 1
 
+    def test_create_feature_with_non_asset_table_raises(self, test_ml):
+        """create_feature surfaces the bad table name in the error.
+
+        Closes audit Phase 3 feature/ §3.5 — pairs with the §1.4
+        error-message fix in fix(feature): correct duplicated/wrong
+        validation message in create_feature. A user passing a
+        regular domain table as `assets=[...]` should see the
+        offending table name in the exception message.
+        """
+        # Subject is a domain table, not an asset table.
+        with pytest.raises(DerivaMLException, match="asset table"):
+            test_ml.create_feature(
+                target_table="Subject",
+                feature_name="BadAssetFeature",
+                assets=["Subject"],  # ← not an asset table
+                terms=[],
+                metadata=[ColumnDefinition(name="value", type=BuiltinTypes.text)],
+            )
+
+    def test_create_feature_with_non_vocabulary_table_raises(self, test_ml):
+        """create_feature names the right parameter when `terms` is wrong.
+
+        Closes audit Phase 3 feature/ §3.5 — pre-fix, the error
+        said "asset table" even though the failure was on
+        `terms`. Post-fix, the message correctly identifies the
+        vocabulary-table check.
+        """
+        # Subject is a domain table, not a vocabulary table.
+        with pytest.raises(DerivaMLException, match="vocabulary table"):
+            test_ml.create_feature(
+                target_table="Image",
+                feature_name="BadVocabFeature",
+                assets=[],
+                terms=["Subject"],  # ← not a vocabulary
+                metadata=[ColumnDefinition(name="value", type=BuiltinTypes.text)],
+            )
+
     def test_lookup_feature(self, dataset_test, tmp_path):
         ml_instance = DerivaML(
             dataset_test.catalog.hostname, dataset_test.catalog.catalog_id, working_dir=tmp_path, use_minid=False
@@ -344,8 +381,41 @@ class TestFeatures:
                 bag_features.sort(key=lambda x: x[t])
                 assert catalog_features == bag_features
 
-    def test_delete_feature(self, test_ml):
-        pass
+    def test_delete_feature_success(self, test_ml):
+        """delete_feature returns True after a successful drop.
+
+        Closes audit Phase 3 feature/ §1.5 — the placeholder
+        `def test_delete_feature: pass` left both real branches
+        of delete_feature() unexercised. Verify the success
+        path: create a feature, delete it, observe True + the
+        feature is gone from find_features.
+        """
+        self.create_features(test_ml)
+        # Sanity: feature exists before delete
+        assert "Health" in [
+            f.feature_name for f in test_ml.model.find_features("Subject")
+        ]
+
+        result = test_ml.delete_feature("Subject", "Health")
+        assert result is True
+
+        # And it's actually gone
+        assert "Health" not in [
+            f.feature_name for f in test_ml.model.find_features("Subject")
+        ]
+
+    def test_delete_feature_missing_returns_false(self, test_ml):
+        """delete_feature returns False when the feature doesn't exist.
+
+        Closes audit Phase 3 feature/ §1.5 — the StopIteration
+        branch in delete_feature() (line 276) was previously
+        untested.
+        """
+        # The Subject table exists (test_ml fixture provides it)
+        # but a feature named 'NonexistentFeature' has never been
+        # created. delete_feature should return False, not raise.
+        result = test_ml.delete_feature("Subject", "NonexistentFeature")
+        assert result is False
 
     def create_features(self, ml_instance: DerivaML):
         ml_instance.create_vocabulary("SubjectHealth", "A vocab")

--- a/tests/feature/test_retired_apis.py
+++ b/tests/feature/test_retired_apis.py
@@ -6,8 +6,6 @@ Silent fallthrough or generic errors are not acceptable.
 """
 from __future__ import annotations
 
-import dataclasses
-
 import pytest
 
 from deriva_ml.core.exceptions import DerivaMLException

--- a/tests/feature/test_select_by_execution.py
+++ b/tests/feature/test_select_by_execution.py
@@ -1,0 +1,59 @@
+"""Tests for FeatureRecord.select_by_execution selector factory.
+
+Unit tests; no live catalog required.
+
+Closes audit Phase 3 feature/ §3.2.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from deriva_ml.core.exceptions import DerivaMLException
+from deriva_ml.feature import FeatureRecord
+
+
+def _make_record(
+    execution: str, rct: str, feature_name: str = "Label"
+) -> FeatureRecord:
+    """Create a minimal FeatureRecord with the given execution and RCT."""
+    return FeatureRecord(Execution=execution, Feature_Name=feature_name, RCT=rct)
+
+
+def test_select_by_execution_picks_matching_record() -> None:
+    """The selector returns the record whose Execution matches."""
+    selector = FeatureRecord.select_by_execution("exec-target")
+    records = [
+        _make_record("exec-other", "2024-01-01T00:00:00"),
+        _make_record("exec-target", "2024-01-02T00:00:00"),
+    ]
+    result = selector(records)
+    assert result.Execution == "exec-target"
+
+
+def test_select_by_execution_picks_newest_among_matches() -> None:
+    """When multiple records share the execution RID, newest by RCT wins.
+
+    Mirrors the contract documented in the docstring: ties broken
+    by select_newest semantics.
+    """
+    selector = FeatureRecord.select_by_execution("exec-multi")
+    records = [
+        _make_record("exec-multi", "2024-01-01T00:00:00"),
+        _make_record("exec-multi", "2024-06-15T12:00:00"),  # newer
+        _make_record("exec-other", "2025-01-01T00:00:00"),  # newer but wrong exec
+    ]
+    result = selector(records)
+    assert result.Execution == "exec-multi"
+    assert result.RCT == "2024-06-15T12:00:00"
+
+
+def test_select_by_execution_raises_when_no_match() -> None:
+    """No record with the requested Execution → DerivaMLException."""
+    selector = FeatureRecord.select_by_execution("exec-missing")
+    records = [
+        _make_record("exec-a", "2024-01-01T00:00:00"),
+        _make_record("exec-b", "2024-01-02T00:00:00"),
+    ]
+    with pytest.raises(DerivaMLException, match="No feature records match execution"):
+        selector(records)

--- a/tests/feature/test_select_by_workflow.py
+++ b/tests/feature/test_select_by_workflow.py
@@ -3,13 +3,11 @@
 Unit tests using a stub container (no live catalog required).
 """
 
-from dataclasses import dataclass, field
 
 import pytest
 
 from deriva_ml.core.exceptions import DerivaMLException
 from deriva_ml.feature import FeatureRecord
-
 
 # ---------------------------------------------------------------------------
 # Stub infrastructure

--- a/tests/feature/test_select_majority_vote.py
+++ b/tests/feature/test_select_majority_vote.py
@@ -1,0 +1,103 @@
+"""Tests for FeatureRecord.select_majority_vote selector factory.
+
+Unit tests; no live catalog required.
+
+Closes audit Phase 3 feature/ §3.1.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from deriva_ml.core.exceptions import DerivaMLException
+from deriva_ml.feature import FeatureRecord
+
+
+def _make_record(
+    execution: str, rct: str, label: str, feature_name: str = "Diagnosis"
+) -> FeatureRecord:
+    """Create a minimal FeatureRecord with a `Diagnosis` term-style column.
+
+    We attach the label as a dynamic attribute since the base
+    FeatureRecord doesn't have a Diagnosis field; the selector
+    reads via getattr(r, col, None).
+    """
+    rec = FeatureRecord(Execution=execution, Feature_Name=feature_name, RCT=rct)
+    # The selector reads via getattr; setting via Pydantic's
+    # __dict__ is the simplest way without a real subclass.
+    object.__setattr__(rec, "Diagnosis", label)
+    return rec
+
+
+def test_select_majority_vote_picks_most_frequent_value() -> None:
+    """The most-frequent label wins the vote."""
+    selector = FeatureRecord.select_majority_vote(column="Diagnosis")
+    records = [
+        _make_record("e1", "2024-01-01T00:00:00", "benign"),
+        _make_record("e2", "2024-01-02T00:00:00", "benign"),
+        _make_record("e3", "2024-01-03T00:00:00", "benign"),
+        _make_record("e4", "2024-01-04T00:00:00", "malignant"),
+        _make_record("e5", "2024-01-05T00:00:00", "malignant"),
+    ]
+    result = selector(records)
+    assert result.Diagnosis == "benign"
+
+
+def test_select_majority_vote_breaks_ties_by_newest_rct() -> None:
+    """When two values tie, pick the candidate record with the newest RCT.
+
+    Three votes each for 'benign' and 'malignant'. The newest
+    record overall is malignant — tie-break by RCT puts that
+    record in the result.
+    """
+    selector = FeatureRecord.select_majority_vote(column="Diagnosis")
+    records = [
+        _make_record("e1", "2024-01-01T00:00:00", "benign"),
+        _make_record("e2", "2024-01-02T00:00:00", "benign"),
+        _make_record("e3", "2024-01-03T00:00:00", "benign"),
+        _make_record("e4", "2024-06-04T00:00:00", "malignant"),
+        _make_record("e5", "2024-06-05T00:00:00", "malignant"),
+        _make_record("e6", "2024-12-15T00:00:00", "malignant"),  # newest overall
+    ]
+    result = selector(records)
+    # Tie at 3-3; both label groups are majority candidates.
+    # Among the 6 candidate records, the newest is e6 (malignant).
+    assert result.Diagnosis == "malignant"
+    assert result.Execution == "e6"
+
+
+def test_select_majority_vote_picks_when_single_dominant() -> None:
+    """One value with clear plurality wins regardless of RCT order."""
+    selector = FeatureRecord.select_majority_vote(column="Diagnosis")
+    records = [
+        _make_record("e1", "2025-12-31T23:59:59", "benign"),  # newest, but minority
+        _make_record("e2", "2024-01-01T00:00:00", "malignant"),
+        _make_record("e3", "2024-01-02T00:00:00", "malignant"),
+        _make_record("e4", "2024-01-03T00:00:00", "malignant"),
+    ]
+    result = selector(records)
+    assert result.Diagnosis == "malignant"
+
+
+def test_select_majority_vote_raises_without_column_when_no_metadata() -> None:
+    """Calling with column=None and no feature metadata → useful error.
+
+    The base FeatureRecord doesn't have a feature ClassVar
+    populated, so the auto-detect branch fails with a clear
+    message rather than crashing on attribute access.
+    """
+    selector = FeatureRecord.select_majority_vote()  # column=None
+    records = [_make_record("e1", "2024-01-01T00:00:00", "x")]
+    with pytest.raises(DerivaMLException, match="could not auto-detect"):
+        selector(records)
+
+
+def test_select_majority_vote_with_explicit_column_overrides_auto_detect() -> None:
+    """Explicit column kwarg is used regardless of metadata state."""
+    selector = FeatureRecord.select_majority_vote(column="Diagnosis")
+    records = [
+        _make_record("e1", "2024-01-01T00:00:00", "benign"),
+        _make_record("e2", "2024-01-02T00:00:00", "benign"),
+    ]
+    result = selector(records)
+    assert result.Diagnosis == "benign"

--- a/tests/feature/test_select_newest_first_latest.py
+++ b/tests/feature/test_select_newest_first_latest.py
@@ -1,0 +1,107 @@
+"""Tests for the pure-Python ``select_newest`` / ``select_first`` /
+``select_latest`` selectors on FeatureRecord.
+
+Unit tests; no live catalog required.
+
+Closes audit Phase 3 feature/ §3.3.
+"""
+
+from __future__ import annotations
+
+from deriva_ml.feature import FeatureRecord
+
+
+def _make_record(execution: str, rct: str) -> FeatureRecord:
+    """Create a minimal FeatureRecord with the given execution and RCT."""
+    return FeatureRecord(Execution=execution, Feature_Name="Label", RCT=rct)
+
+
+# ---------------------------------------------------------------------------
+# select_newest
+# ---------------------------------------------------------------------------
+
+
+def test_select_newest_picks_max_rct() -> None:
+    """``select_newest`` returns the record with the lexicographically max RCT."""
+    records = [
+        _make_record("e1", "2024-01-01T00:00:00"),
+        _make_record("e2", "2024-06-15T12:00:00"),  # newest
+        _make_record("e3", "2024-03-01T00:00:00"),
+    ]
+    result = FeatureRecord.select_newest(records)
+    assert result.Execution == "e2"
+
+
+def test_select_newest_treats_none_rct_as_oldest() -> None:
+    """A record with ``RCT=None`` is treated as older than any timestamped one.
+
+    The selector uses ``r.RCT or ""`` for the comparison key,
+    so None coerces to the empty string which sorts before any
+    ISO 8601 timestamp.
+    """
+    records = [
+        _make_record("e1", "2024-01-01T00:00:00"),
+        FeatureRecord(Execution="e2", Feature_Name="Label", RCT=None),
+    ]
+    result = FeatureRecord.select_newest(records)
+    assert result.Execution == "e1"
+
+
+def test_select_newest_single_record() -> None:
+    """One-record input → that record."""
+    records = [_make_record("e1", "2024-01-01T00:00:00")]
+    assert FeatureRecord.select_newest(records).Execution == "e1"
+
+
+# ---------------------------------------------------------------------------
+# select_first
+# ---------------------------------------------------------------------------
+
+
+def test_select_first_picks_min_rct() -> None:
+    """``select_first`` returns the record with the lexicographically min RCT."""
+    records = [
+        _make_record("e1", "2024-06-15T12:00:00"),
+        _make_record("e2", "2024-01-01T00:00:00"),  # oldest
+        _make_record("e3", "2024-03-01T00:00:00"),
+    ]
+    result = FeatureRecord.select_first(records)
+    assert result.Execution == "e2"
+
+
+def test_select_first_treats_none_rct_as_oldest() -> None:
+    """A record with ``RCT=None`` wins ``select_first`` over any timestamp.
+
+    Same coercion as select_newest, just on the other end of the sort.
+    """
+    records = [
+        _make_record("e1", "2024-01-01T00:00:00"),
+        FeatureRecord(Execution="e2", Feature_Name="Label", RCT=None),
+    ]
+    result = FeatureRecord.select_first(records)
+    assert result.Execution == "e2"
+
+
+# ---------------------------------------------------------------------------
+# select_latest — alias for select_newest
+# ---------------------------------------------------------------------------
+
+
+def test_select_latest_is_alias_of_select_newest() -> None:
+    """``select_latest`` delegates to ``select_newest`` (documented contract)."""
+    records = [
+        _make_record("e1", "2024-01-01T00:00:00"),
+        _make_record("e2", "2024-06-15T12:00:00"),
+    ]
+    assert FeatureRecord.select_latest(records) is FeatureRecord.select_newest(records)
+
+
+def test_selectors_are_callable_factories() -> None:
+    """All three selectors are usable directly as ``selector=`` arguments.
+
+    Verifies the bare-function (no factory call) shape that
+    ``feature_values(selector=FeatureRecord.select_newest)`` relies on.
+    """
+    assert callable(FeatureRecord.select_newest)
+    assert callable(FeatureRecord.select_first)
+    assert callable(FeatureRecord.select_latest)


### PR DESCRIPTION
## Summary

Acts on the Phase 3 `feature/` audit (PR #159, `docs/design/deriva-ml-audit-2026-05-phase3-feature.md`). **12 commits covering 16 audit items.** This closes the last Phase 3 cleanup PR — after this lands, every deriva-ml subsystem has been through the Phase 2/3 deep-dive process.

## Per-commit summary

| # | Commit | Audit § | Notes |
|---|---|---|---|
| 1 | `fix(feature): correct duplicated/wrong validation message in create_feature` | §1.4 | Highest impact-per-effort: was sending users to the wrong parameter |
| 2 | `fix(feature): repair broken TYPE_CHECKING import path for DerivaModel` | §1.3 | `from model.catalog` → `from deriva_ml.model.catalog` |
| 3 | `refactor(feature): drop importlib.import_module workarounds` | §1.1, §1.2 | Anti-shadowing pattern no longer needed |
| 4 | `refactor(feature): move inline exception imports to module level` | §6.4 | 3 inline imports → 1 module-level |
| 5 | `docs(feature): doctest +SKIP markers + class docstring updates` | §4.2, §4.3, §4.4, §4.6, §2.4 | 5 audit items bundled |
| 6 | `refactor(feature): guard column-accessor base-class calls + lift asset_col_names` | §2.1, §2.3 | Useful error message + N² → N perf |
| 7 | `test(feature): pure-Python selector coverage` | §3.1, §3.2, §3.3 | +15 new tests across 3 new files |
| 8 | `test(feature): real test_delete_feature + create_feature validation tests` | §1.5, §3.5 | Replaces `pass` placeholder; pairs with §1.4 fix |
| 9 | `docs(dataset): honest docstring for Dataset.list_workflow_executions` | §3.7 (option a) | "Dataset-scoped" → "pass-through (scoping deferred)" |
| 10 | `feat(feature): DatasetLike.find_features accepts table=None for "all features"` | §11 | Protocol + DatasetBag implementation widened |
| 11 | `feat(feature): add DerivaMLFeatureNotFound exception subclass` | §12 | Specific subclass under DerivaMLNotFoundError |
| 12 | `style(feature): ruff import-sort cleanup in feature tests` | — | Auto-fix bycatch |

## Strategic decisions (from audit Q&A)

- **§3.7 — `list_workflow_executions` honesty:** Picked option (a) — honest docstring. The actual scoping work is its own task.
- **§11 — `table=None` support on `DatasetBag.find_features`:** Yes, wired through both the protocol and the bag implementation.
- **§12 — `DerivaMLFeatureNotFound`:** Yes, sibling of `DerivaMLDatasetNotFound`/`DerivaMLTableNotFound`, carries `table_name` + `feature_name` attributes for programmatic recovery.

## Cleanup totals

- **Source LoC removed:** ~−25 (importlib workarounds + inline imports + duplicate validation)
- **Source LoC added:** ~+90 (guard helper, error-message detail, `find_features(table=None)` branch, new exception class)
- **Test LoC added:** ~+340 (15 new selector tests + 2 delete_feature + 2 create_feature validation)
- **Docstring/comment LoC:** ~+30 (audit §4.2 SKIP markers, §3.7 honesty rewrite, etc.)

**Modest absolute scope** — `feature/` was the healthiest of the four Phase 3 subsystems audited, and most ranked actions are docstring/test gaps rather than structural problems.

## Items NOT in this PR (deferred)

Audit §3.7 option (b) — actually implement `Dataset.list_workflow_executions` scoping by filtering through execution → dataset member membership. ~15 LoC, but it's a behavior change that should ship with its own test, not in a cleanup.

## Verification

- ✅ Offline sanity sweep: **314 passed, 3 skipped** (5.25s)
- ✅ New selector tests pass standalone: **15 tests / ~0.03s**
- ✅ Lint clean on touched files
- ✅ Imports verified post-refactor: `Feature`, `FeatureRecord`, `FeatureMixin`, `DerivaMLFeatureNotFound`
- ✅ Backward-compat verified: `DerivaMLFeatureNotFound` is a `DerivaMLException` subclass

## After this lands

**The per-subsystem Phase 3 audit arc is complete.** All seven subsystems (`model/`, `dataset/`, `execution/`, `core/`, `catalog/`, `schema/`, `feature/`) have shipped audit + cleanup arcs.

## Test plan

- [x] Audit doc PR #159 already opened
- [x] Offline sweep green
- [x] Lint clean
- [x] Imports verified
- [ ] Live-catalog integration tests pass on CI after merge (delete_feature + create_feature validation use the `test_ml` fixture; pre-existing fixture flakiness applies)

🤖 Generated with [Claude Code](https://claude.com/claude-code)