### PR TITLE
docs(api): document find_*/list_* method naming convention on DerivaML (E2)

### DIFF
--- a/src/deriva_ml/core/base.py
+++ b/src/deriva_ml/core/base.py
@@ -99,6 +99,23 @@ class DerivaML(
     This class provides core functionality for managing ML workflows, features, and datasets in a Deriva catalog.
     It handles data versioning, feature management, vocabulary control, and execution tracking.
 
+    Method naming convention:
+        - ``find_*`` methods search the catalog for entities of a kind, optionally filtered.
+          Examples: ``find_features(table=None)``, ``find_datasets()``, ``find_workflows()``,
+          ``find_executions()``, ``find_experiments()``, ``find_assets()``. ``find_*`` returns
+          everything that matches; pass arguments to narrow the search.
+        - ``list_*`` methods enumerate things scoped to a specific entity passed as the first
+          argument. Examples: ``list_assets(asset_table)``, ``list_dataset_members(dataset)``,
+          ``list_dataset_children(dataset)``, ``list_workflow_executions(workflow)``,
+          ``list_vocabulary_terms(table)``. ``list_*`` always has a "scope" argument; there is
+          no scope-less ``list_*`` flavor for entities of a given kind — use ``find_*`` for that.
+
+        So: "all features on the catalog" → ``find_features()``; "all features on table T" →
+        ``find_features(T)`` (scoping is a filter); "all members of dataset D" →
+        ``list_dataset_members(D)`` (scoping is the parent entity itself). There is no
+        ``list_features()`` because features aren't scoped to a parent entity in the way
+        dataset members are scoped to a dataset.
+
     Attributes:
         host_name (str): Hostname of the Deriva server (e.g., 'deriva.example.org').
         catalog_id (Union[str, int]): Catalog identifier or name.
@@ -112,9 +129,9 @@ class DerivaML(
         start_time (datetime): Timestamp when this instance was created.
 
     Example:
-        >>> ml = DerivaML('deriva.example.org', 'my_catalog')
-        >>> ml.create_feature('my_table', 'new_feature')
-        >>> ml.add_term('vocabulary_table', 'new_term', description='Description of term')
+        >>> ml = DerivaML('deriva.example.org', 'my_catalog')  # doctest: +SKIP
+        >>> ml.create_feature('my_table', 'new_feature')  # doctest: +SKIP
+        >>> ml.add_term('vocabulary_table', 'new_term', description='Description of term')  # doctest: +SKIP
     """
 
     # Class-level type annotations for DerivaMLCatalog protocol compliance


### PR DESCRIPTION
## Summary

Closes **E2** from the e2e findings doc (`deriva-ml-model-template/docs/findings/2026-05-16-phase-1-improvements.md`):

> "Inconsistent verb: find_features vs list_*"

**The finding was incorrect.** The two prefixes denote different scoping patterns and are used consistently throughout the library — the muscle-memory miss reported is a discoverability issue, not an inconsistency.

## The actual convention (now documented)

| Prefix | Purpose | Examples |
|---|---|---|
| `find_*` | Catalog-wide search for entities of a kind, optionally filtered | `find_features(table=None)`, `find_datasets()`, `find_workflows()`, `find_executions()`, `find_experiments()`, `find_assets()`, `find_incomplete_executions()` |
| `list_*` | Enumerate things scoped to a specific entity (the scope is the first argument) | `list_assets(asset_table)`, `list_dataset_members(dataset)`, `list_dataset_children(dataset)`, `list_workflow_executions(workflow)`, `list_vocabulary_terms(table)`, `list_files(...)`, `list_asset_executions(asset_rid)` |

So:
- "all features on the catalog" → `find_features()`
- "all features on table T" → `find_features(T)` (scoping is a filter)
- "all members of dataset D" → `list_dataset_members(D)` (scoping is the parent entity itself)

There is no `list_features()` because features aren't scoped to a parent entity in the way dataset members are scoped to a dataset.

## Where this is documented

This PR adds the convention to the `DerivaML` class docstring in `core/base.py` — visible in `help(DerivaML)`, in auto-generated API documentation, and to anyone reading the source.

## Companion changes (separate PRs)

- **`deriva-ml-skills`** — add the same convention to the `deriva-ml-context` always-on skill, so an LLM coming through the skill plugin sees it before reaching for `ml.list_*`.
- **`deriva-ml-model-template` findings doc** — close E2 as "convention is intentional; documented in DerivaML class docstring + deriva-ml-context skill".

## What's NOT changed

- No method signatures changed. Nothing renamed. No alias added.
- The MCP layer is unaffected — MCP tools all use `deriva_ml_list_*` and don't expose a `find_*` flavor at all (the confusion in the e2e journal was specifically about the Python API, not the MCP).

## Drive-by

Added `# doctest: +SKIP` markers to the three existing example lines on the class docstring — they call into a live catalog and should have been marked SKIP per the project's doctest convention.

## Verification

- ✅ Imports clean
- ✅ Offline sanity sweep: 293 passed, 3 skipped, 13s (`tests/local_db/`, `tests/catalog/test_*`, `tests/core/test_refresh_schema_warning.py`)
- ✅ Lint clean on touched file (3 pre-existing F821s in other doctest blocks unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)