### PR TITLE
fix(execution): __exit__ writes Duration; split into three phase columns

### DIFF
--- a/src/deriva_ml/core/mixins/execution.py
+++ b/src/deriva_ml/core/mixins/execution.py
@@ -289,7 +289,10 @@ class ExecutionMixin:
         workflow_rid = execution_data.get("Workflow")
         workflow = self.lookup_workflow(workflow_rid) if workflow_rid else None
 
-        # Create ExecutionRecord bound to this catalog
+        # Create ExecutionRecord bound to this catalog. Reads the three
+        # per-phase duration columns added 2026-05-19; old catalogs that
+        # predate the schema bump report None for all three (forward-only
+        # migration — see docs/bugs/2026-05-19-execution-phase-durations-design.md).
         record = ExecutionRecord(
             execution_rid=execution_rid,
             workflow=workflow,
@@ -297,7 +300,9 @@ class ExecutionMixin:
             description=execution_data.get("Description"),
             start_time=start_time,
             stop_time=stop_time,
-            duration=execution_data.get("Duration"),
+            duration=execution_data.get("Execution_Duration"),
+            download_duration=execution_data.get("Download_Duration"),
+            upload_duration=execution_data.get("Upload_Duration"),
             _ml_instance=self,
             _logger=getattr(self, "_logger", None),
         )

--- a/src/deriva_ml/execution/execution.py
+++ b/src/deriva_ml/execution/execution.py
@@ -1625,11 +1625,7 @@ class Execution:
         # "give me every asset that's ever served as input" queryable
         # through Asset_Type alone, regardless of which execution
         # it was input to.
-        direction_tag = (
-            ExecAssetType.input_file.value
-            if asset_role == "Input"
-            else ExecAssetType.output_file.value
-        )
+        direction_tag = ExecAssetType.input_file.value if asset_role == "Input" else ExecAssetType.output_file.value
 
         pb = self._ml_object.pathBuilder()
         for asset_table, asset_list in uploaded_assets.items():
@@ -2343,21 +2339,23 @@ class Execution:
             return False
 
         if exc_value is None:
-            target = ExecutionStatus.Stopped
-            extra = {"stop_time": now}
+            # Clean exit: delegate Running → Stopped to execution_stop() so
+            # the duration computation + single-atomic-transition contract
+            # (audit §4.5) is honored. The inline transition this replaced
+            # wrote stop_time but not duration, leaving the catalog
+            # Duration column null for every with-block exit — see
+            # docs/bugs/2026-05-19-execution-exit-omits-duration.md.
+            self.execution_stop()
         else:
-            target = ExecutionStatus.Failed
-            extra = {"stop_time": now, "error": f"{exc_type.__name__}: {exc_value}"}
-
-        transition(
-            store=self._ml_object.workspace.execution_state_store(),
-            catalog=(self._ml_object.catalog if self._ml_object._mode is ConnectionMode.online else None),
-            execution_rid=self.execution_rid,
-            current=current,
-            target=target,
-            mode=self._ml_object._mode,
-            extra_fields=extra,
-        )
+            transition(
+                store=self._ml_object.workspace.execution_state_store(),
+                catalog=(self._ml_object.catalog if self._ml_object._mode is ConnectionMode.online else None),
+                execution_rid=self.execution_rid,
+                current=current,
+                target=ExecutionStatus.Failed,
+                mode=self._ml_object._mode,
+                extra_fields={"stop_time": now, "error": f"{exc_type.__name__}: {exc_value}"},
+            )
 
         # Emit the pending-summary INFO log per §2.12 / R6.3. Full
         # PendingSummary object lands in Group G; this is a placeholder.

--- a/src/deriva_ml/execution/execution.py
+++ b/src/deriva_ml/execution/execution.py
@@ -106,6 +106,37 @@ _METADATA_DESCRIPTIONS: dict[str, str] = {
 _ENV_SNAPSHOT_DESCRIPTION = "Runtime environment snapshot: installed packages, OS, platform, and Python configuration"
 
 
+def _format_duration(start: "datetime | None", end: "datetime | None") -> str:
+    """Format a wall-clock interval as ``"<H>H <M>min <S>sec"``.
+
+    Used by every per-phase duration measurement (algorithm, download,
+    upload, and the failed-path algorithm computation in ``__exit__``).
+    Centralizes the rounding and string format so all four sites stay
+    in sync.
+
+    Args:
+        start: Phase start timestamp. If None or tz-naive, falls back
+            to UTC interpretation. None yields ``"0H 0min 0.0sec"``.
+        end: Phase end timestamp. None yields ``"0H 0min 0.0sec"``.
+
+    Returns:
+        Pre-formatted string suitable for the catalog ``*_Duration``
+        columns and the SQLite ``*_duration`` columns.
+    """
+    from datetime import timezone
+
+    if start is None or end is None:
+        return "0H 0min 0.0sec"
+    if start.tzinfo is None:
+        start = start.replace(tzinfo=timezone.utc)
+    if end.tzinfo is None:
+        end = end.replace(tzinfo=timezone.utc)
+    delta = end - start
+    hours, remainder = divmod(delta.total_seconds(), 3600)
+    minutes, seconds = divmod(remainder, 60)
+    return f"{round(hours, 0)}H {round(minutes, 0)}min {round(seconds, 4)}sec"
+
+
 class Execution:
     """Manages the lifecycle and context of a DerivaML execution.
 
@@ -300,7 +331,18 @@ class Execution:
                 _logger=self._logger,
             )
 
+        # Bracket _initialize_execution with timestamps so the
+        # download/materialize phase contributes a Download_Duration to
+        # the catalog row. The SQLite registry row doesn't exist yet at
+        # this point (insert_execution runs below), so we stash the
+        # formatted string on self and write it through after the row
+        # is created. See docs/bugs/2026-05-19-execution-phase-durations-design.md.
+        from datetime import timezone
+
+        _download_start = datetime.now(timezone.utc)
         self._initialize_execution(reload)
+        _download_end = datetime.now(timezone.utc)
+        self._download_duration_str = _format_duration(_download_start, _download_end)
 
         # Guard SQLite registry insertion: skip when (a) this is a dry-run
         # (we never want to persist dry-run state) or (b) we are resuming an
@@ -308,8 +350,6 @@ class Execution:
         # entry was written by the original run and should not be overwritten.
         # Writing twice would corrupt the start-time and initial-status fields.
         if not self._dry_run and reload is None:
-            from datetime import datetime, timezone
-
             store = self._ml_object.workspace.execution_state_store()
             now = datetime.now(timezone.utc)
 
@@ -330,6 +370,14 @@ class Execution:
                     working_dir_rel=f"execution/{self.execution_rid}",
                     created_at=now,
                     last_activity=now,
+                )
+                # Persist the just-measured download duration through
+                # update_execution. Done as a follow-up write rather
+                # than baked into insert_execution so the insert
+                # signature stays focused on identity / config fields.
+                store.update_execution(
+                    self.execution_rid,
+                    download_duration=self._download_duration_str,
                 )
             except Exception as exc:
                 # The catalog row is already created at this point —
@@ -1169,22 +1217,11 @@ class Execution:
 
         now = datetime.now(timezone.utc)
 
-        # Compute duration against the start_time read-through property.
-        # Falls back to "0H 0min 0.0sec" if start_time is missing
-        # (shouldn't happen in practice — Running → Stopped requires
-        # __enter__/execution_start to have set start_time).
-        start = self.start_time
-        if start is not None:
-            # Coerce any naive datetime from SQLite to UTC so arithmetic
-            # with `now` (aware) doesn't raise.
-            if start.tzinfo is None:
-                start = start.replace(tzinfo=timezone.utc)
-            duration = now - start
-            hours, remainder = divmod(duration.total_seconds(), 3600)
-            minutes, seconds = divmod(remainder, 60)
-            duration_str = f"{round(hours, 0)}H {round(minutes, 0)}min {round(seconds, 4)}sec"
-        else:
-            duration_str = "0H 0min 0.0sec"
+        # Compute algorithm duration against start_time. Falls back to
+        # "0H 0min 0.0sec" if start_time is missing (shouldn't happen
+        # in practice — Running → Stopped requires __enter__ /
+        # execution_start to have set start_time).
+        duration_str = _format_duration(self.start_time, now)
 
         if self._dry_run:
             return
@@ -1389,6 +1426,15 @@ class Execution:
         if self.status is ExecutionStatus.Stopped:
             self.update_status(ExecutionStatus.Pending_Upload)
 
+        # Bracket the upload work with timestamps so Upload_Duration
+        # gets populated regardless of whether the call succeeds or
+        # raises. The write goes to SQLite *before* the terminal status
+        # transition so the state-machine PUT that follows carries the
+        # measurement to the catalog. See
+        # docs/bugs/2026-05-19-execution-phase-durations-design.md.
+        from datetime import timezone
+
+        _upload_start = datetime.now(timezone.utc)
         try:
             # ``_bag_commit_upload`` returns the per-call subset of
             # uploaded assets (see ``report_to_asset_map``). External
@@ -1399,6 +1445,14 @@ class Execution:
                 progress_callback=progress_callback,
             )
             self._set_asset_descriptions(uploaded)
+            # Record Upload_Duration just before the terminal transition
+            # so the catalog PUT for Pending_Upload → Uploaded carries
+            # the new value (state machine reads the full SQLite row
+            # via _catalog_body_for_execution).
+            self._ml_object.workspace.execution_state_store().update_execution(
+                self.execution_rid,
+                upload_duration=_format_duration(_upload_start, datetime.now(timezone.utc)),
+            )
             # Successful end of upload: Pending_Upload → Uploaded.
             if self.status is ExecutionStatus.Pending_Upload:
                 self.update_status(ExecutionStatus.Uploaded)
@@ -1406,6 +1460,13 @@ class Execution:
                 self._clean_folder_contents(self._execution_root)
             return uploaded
         except Exception as e:
+            # Capture partial upload duration before transitioning to
+            # Failed — same write-then-transition order so the failure
+            # PUT carries the partial measurement.
+            self._ml_object.workspace.execution_state_store().update_execution(
+                self.execution_rid,
+                upload_duration=_format_duration(_upload_start, datetime.now(timezone.utc)),
+            )
             error = format_exception(e)
             self.update_status(ExecutionStatus.Failed, error=error)
             raise e
@@ -2343,10 +2404,15 @@ class Execution:
             # the duration computation + single-atomic-transition contract
             # (audit §4.5) is honored. The inline transition this replaced
             # wrote stop_time but not duration, leaving the catalog
-            # Duration column null for every with-block exit — see
-            # docs/bugs/2026-05-19-execution-exit-omits-duration.md.
+            # Execution_Duration column null for every with-block exit —
+            # see docs/bugs/2026-05-19-execution-exit-omits-duration.md.
             self.execution_stop()
         else:
+            # Failed exit: write stop_time, error, AND duration so the
+            # Execution_Duration column reflects how long the run got
+            # before it crashed. Useful diagnostic when comparing failed
+            # vs successful runs of the same workflow.
+            duration_str = _format_duration(self.start_time, now)
             transition(
                 store=self._ml_object.workspace.execution_state_store(),
                 catalog=(self._ml_object.catalog if self._ml_object._mode is ConnectionMode.online else None),
@@ -2354,7 +2420,11 @@ class Execution:
                 current=current,
                 target=ExecutionStatus.Failed,
                 mode=self._ml_object._mode,
-                extra_fields={"stop_time": now, "error": f"{exc_type.__name__}: {exc_value}"},
+                extra_fields={
+                    "stop_time": now,
+                    "duration": duration_str,
+                    "error": f"{exc_type.__name__}: {exc_value}",
+                },
             )
 
         # Emit the pending-summary INFO log per §2.12 / R6.3. Full

--- a/src/deriva_ml/execution/execution_record.py
+++ b/src/deriva_ml/execution/execution_record.py
@@ -85,7 +85,16 @@ class ExecutionRecord(BaseModel):
             property updates the catalog.
         start_time (datetime | None): When the execution started (read-only).
         stop_time (datetime | None): When the execution completed (read-only).
-        duration (str | None): Duration string from catalog (read-only).
+        duration (str | None): Algorithm-phase duration string from the
+            catalog ``Execution_Duration`` column (read-only). Renamed
+            from "Duration" 2026-05-19; old catalogs that predate the
+            schema bump report None.
+        download_duration (str | None): Init/download-phase duration
+            string from the catalog ``Download_Duration`` column
+            (read-only). None for old catalogs.
+        upload_duration (str | None): Upload-phase duration string from
+            the catalog ``Upload_Duration`` column (read-only). None for
+            old catalogs.
 
     Example:
         Look up an execution and query its state::
@@ -125,6 +134,8 @@ class ExecutionRecord(BaseModel):
     start_time: datetime | None = None
     stop_time: datetime | None = None
     duration: str | None = None
+    download_duration: str | None = None
+    upload_duration: str | None = None
 
     _ml_instance: "DerivaMLCatalog | None" = PrivateAttr(default=None)
     _logger: logging.Logger = PrivateAttr(default_factory=lambda: get_logger(__name__))
@@ -138,6 +149,8 @@ class ExecutionRecord(BaseModel):
         start_time: datetime | None = None,
         stop_time: datetime | None = None,
         duration: str | None = None,
+        download_duration: str | None = None,
+        upload_duration: str | None = None,
         **kwargs: Any,
     ) -> None:
         """Initialize an ExecutionRecord.
@@ -149,7 +162,9 @@ class ExecutionRecord(BaseModel):
             description: Description of the execution.
             start_time: When the execution started.
             stop_time: When the execution completed.
-            duration: Duration string.
+            duration: Algorithm-phase duration string (Execution_Duration).
+            download_duration: Init/download-phase duration string.
+            upload_duration: Upload-phase duration string.
             **kwargs: Additional arguments (including _ml_instance for internal use).
         """
         super().__init__(
@@ -157,6 +172,8 @@ class ExecutionRecord(BaseModel):
             start_time=start_time,
             stop_time=stop_time,
             duration=duration,
+            download_duration=download_duration,
+            upload_duration=upload_duration,
         )
         self._workflow = workflow
         self._status = status
@@ -641,7 +658,11 @@ class ExecutionRecord(BaseModel):
         if self.stop_time:
             lines.append(f"  stop_time: {self.stop_time}")
         if self.duration:
-            lines.append(f"  duration: {self.duration}")
+            lines.append(f"  execution_duration: {self.duration}")
+        if self.download_duration:
+            lines.append(f"  download_duration: {self.download_duration}")
+        if self.upload_duration:
+            lines.append(f"  upload_duration: {self.upload_duration}")
         return "\n".join(lines)
 
     def __repr__(self) -> str:

--- a/src/deriva_ml/execution/state_machine.py
+++ b/src/deriva_ml/execution/state_machine.py
@@ -332,13 +332,14 @@ def _catalog_body_for_execution(
         # concurrent delete. Surface clearly rather than putting a
         # partial body to the catalog.
         raise DerivaMLStateInconsistency(f"executions row {execution_rid} vanished between write and PUT")
-    # Catalog Execution schema has: Workflow, Description, Duration,
-    # Status, Status_Detail (see src/deriva_ml/schema/create_schema.py).
+    # Catalog Execution schema has: Workflow, Description,
+    # Execution_Duration, Download_Duration, Upload_Duration, Status,
+    # Status_Detail (see src/deriva_ml/schema/create_schema.py).
     # Start/stop times are NOT catalog columns — they live in SQLite
-    # only. Duration IS a catalog column; we project it when SQLite
-    # has it set (execution_stop writes it during the Running →
-    # Stopped transition; pre-Stopped rows have duration=NULL and
-    # leave the catalog column unchanged via the body's omission).
+    # only. The three duration columns ARE catalog columns; we project
+    # each when SQLite has the matching value set. SQLite stores them
+    # as "duration", "download_duration", "upload_duration" — the
+    # catalog uses the title-case "<Phase>_Duration" naming.
     body: dict = {
         "RID": row["rid"],
         "Status": row["status"],
@@ -346,7 +347,11 @@ def _catalog_body_for_execution(
         "Status_Detail": row["error"] or row["description"],
     }
     if row.get("duration") is not None:
-        body["Duration"] = row["duration"]
+        body["Execution_Duration"] = row["duration"]
+    if row.get("download_duration") is not None:
+        body["Download_Duration"] = row["download_duration"]
+    if row.get("upload_duration") is not None:
+        body["Upload_Duration"] = row["upload_duration"]
     return [body]
 
 

--- a/src/deriva_ml/execution/state_store.py
+++ b/src/deriva_ml/execution/state_store.py
@@ -115,9 +115,17 @@ class ExecutionStateStore:
         # executions — see spec §2.5.1 for column purposes.
         # status values: created|running|stopped|failed|pending_upload|uploaded|aborted
         # mode values: online|offline
-        # duration: pre-formatted "Hh Mmin Ssec" string set during the
-        #     Running → Stopped transition; mirrored to the catalog's
-        #     Execution.Duration column via the state machine.
+        # Three pre-formatted "Hh Mmin Ssec" duration strings:
+        #   duration          — algorithm phase (Running → Stopped).
+        #                       Mirrored to catalog Execution.Execution_Duration.
+        #                       Internal SQLite name remains "duration"
+        #                       (avoiding a schema migration for existing
+        #                       workspaces); catalog-side rename is in
+        #                       _catalog_body_for_execution.
+        #   download_duration — init/download phase (_initialize_execution).
+        #                       Mirrored to catalog Execution.Download_Duration.
+        #   upload_duration   — upload phase (upload_execution_outputs).
+        #                       Mirrored to catalog Execution.Upload_Duration.
         self.executions = Table(
             EXECUTIONS_TABLE,
             self.metadata,
@@ -131,6 +139,8 @@ class ExecutionStateStore:
             Column("start_time", DateTime(timezone=True), nullable=True),
             Column("stop_time", DateTime(timezone=True), nullable=True),
             Column("duration", String, nullable=True),
+            Column("download_duration", String, nullable=True),
+            Column("upload_duration", String, nullable=True),
             Column("last_activity", DateTime(timezone=True), nullable=False),
             Column("error", Text, nullable=True),
             Column("sync_pending", Boolean, nullable=False, default=False),

--- a/src/deriva_ml/schema/annotations.py
+++ b/src/deriva_ml/schema/annotations.py
@@ -12,7 +12,6 @@ Public entry points:
   (used by ``create_ml_schema``).
 """
 
-
 from deriva.core.ermrest_model import Model, Table
 from deriva.core.utils.core_utils import tag as deriva_tags
 
@@ -432,7 +431,9 @@ def generate_annotation(model: Model, schema: str) -> dict:
                 "RCT",
                 "Description",
                 {"source": [{"outbound": [schema, "Execution_Workflow_fkey"]}, "RID"]},
-                "Duration",
+                "Execution_Duration",
+                "Download_Duration",
+                "Upload_Duration",
                 "Status",
                 "Status_Detail",
             ]

--- a/src/deriva_ml/schema/create_schema.py
+++ b/src/deriva_ml/schema/create_schema.py
@@ -167,7 +167,18 @@ def create_execution_table(schema: Schema, annotation: Optional[dict] = None) ->
             columns=[
                 ColumnDef("Workflow", BuiltinType.text),
                 ColumnDef("Description", BuiltinType.markdown),
-                ColumnDef("Duration", BuiltinType.text),
+                # Three duration columns, each measuring a distinct phase:
+                #   Execution_Duration — algorithm time inside the `with`
+                #     block (start of __enter__ → end of __exit__).
+                #     Renamed from "Duration" 2026-05-19 so all three
+                #     columns share the <Phase>_Duration pattern.
+                #   Download_Duration — init / dataset+asset download
+                #     time (_initialize_execution).
+                #   Upload_Duration   — upload_execution_outputs time
+                #     (bag commit + Hatrac PUTs).
+                ColumnDef("Execution_Duration", BuiltinType.text),
+                ColumnDef("Download_Duration", BuiltinType.text),
+                ColumnDef("Upload_Duration", BuiltinType.text),
                 ColumnDef("Status", BuiltinType.text),
                 ColumnDef("Status_Detail", BuiltinType.text),
             ],

--- a/tests/execution/test_execution.py
+++ b/tests/execution/test_execution.py
@@ -387,10 +387,19 @@ class TestExecutionLifecycle:
         vocabulary (Created, Running, Stopped, Pending_Upload, Uploaded,
         Failed, Aborted) — SQLite remains authoritative; the catalog is a
         synced mirror.
+
+        Regression guard (2026-05-19): __exit__'s clean-exit branch must
+        delegate to execution_stop() so that duration is written alongside
+        stop_time. Prior to the fix in commit "fix(execution): __exit__
+        writes Duration via execution_stop()", __exit__ used an inline
+        transition that wrote stop_time but not duration, leaving the
+        catalog Duration column null for every with-block exit. See
+        docs/bugs/2026-05-19-execution-exit-omits-duration.md.
         """
         from deriva_ml.execution.state_store import ExecutionStatus
 
         execution = basic_execution
+        ml = execution._ml_object
 
         with execution.execute() as exe:
             assert exe.execution_rid is not None
@@ -399,6 +408,16 @@ class TestExecutionLifecycle:
 
         # After context exit, the authoritative SQLite status is Stopped.
         assert execution.status is ExecutionStatus.Stopped
+
+        # Duration is populated on the SQLite registry row AND projected
+        # into the catalog row — both must be set by the clean-exit path.
+        assert execution.stop_time is not None, "stop_time must be set after __exit__"
+        catalog_row = ml._retrieve_rid(execution.execution_rid)
+        assert catalog_row["Duration"] is not None, (
+            "catalog Duration column must be populated after __exit__ "
+            "(regression: previously stayed null because __exit__ wrote "
+            "stop_time but not duration)"
+        )
 
         # Upload finalizes the catalog-visible lifecycle; after upload we
         # expect the SQLite status to have advanced (pending_upload or

--- a/tests/execution/test_execution.py
+++ b/tests/execution/test_execution.py
@@ -390,11 +390,16 @@ class TestExecutionLifecycle:
 
         Regression guard (2026-05-19): __exit__'s clean-exit branch must
         delegate to execution_stop() so that duration is written alongside
-        stop_time. Prior to the fix in commit "fix(execution): __exit__
-        writes Duration via execution_stop()", __exit__ used an inline
-        transition that wrote stop_time but not duration, leaving the
-        catalog Duration column null for every with-block exit. See
+        stop_time. Prior to the fix, __exit__ used an inline transition
+        that wrote stop_time but not duration, leaving the catalog
+        Duration column null for every with-block exit. See
         docs/bugs/2026-05-19-execution-exit-omits-duration.md.
+
+        Companion PR 2 (same date) renamed catalog column Duration →
+        Execution_Duration and added Download_Duration + Upload_Duration
+        for init/download and upload phases respectively. Assertions
+        below cover all three columns. See
+        docs/bugs/2026-05-19-execution-phase-durations-design.md.
         """
         from deriva_ml.execution.state_store import ExecutionStatus
 
@@ -409,14 +414,19 @@ class TestExecutionLifecycle:
         # After context exit, the authoritative SQLite status is Stopped.
         assert execution.status is ExecutionStatus.Stopped
 
-        # Duration is populated on the SQLite registry row AND projected
-        # into the catalog row — both must be set by the clean-exit path.
+        # Execution_Duration (algorithm phase) is populated on the SQLite
+        # registry row AND projected into the catalog row — both must be
+        # set by the clean-exit path. Download_Duration is also set
+        # because _initialize_execution ran during create_execution.
         assert execution.stop_time is not None, "stop_time must be set after __exit__"
         catalog_row = ml._retrieve_rid(execution.execution_rid)
-        assert catalog_row["Duration"] is not None, (
-            "catalog Duration column must be populated after __exit__ "
-            "(regression: previously stayed null because __exit__ wrote "
-            "stop_time but not duration)"
+        assert catalog_row["Execution_Duration"] is not None, (
+            "catalog Execution_Duration column must be populated after "
+            "__exit__ (regression: previously stayed null because "
+            "__exit__ wrote stop_time but not duration)"
+        )
+        assert catalog_row["Download_Duration"] is not None, (
+            "catalog Download_Duration must be populated by _initialize_execution timing (PR 2 download phase)"
         )
 
         # Upload finalizes the catalog-visible lifecycle; after upload we
@@ -425,6 +435,12 @@ class TestExecutionLifecycle:
         # relative to this task). We don't assert a specific terminal
         # state here — later tasks (E5/G-series) will refine.
         execution.upload_execution_outputs()
+
+        # After upload, Upload_Duration is populated.
+        catalog_row = ml._retrieve_rid(execution.execution_rid)
+        assert catalog_row["Upload_Duration"] is not None, (
+            "catalog Upload_Duration must be populated by upload_execution_outputs timing (PR 2 upload phase)"
+        )
 
     def test_execution_manual_start_stop(self, basic_execution):
         """``execution_start()`` / ``execution_stop()`` cycle status correctly.


### PR DESCRIPTION
## Summary

Two stacked commits that close a Duration regression and split execution timing into three phase-specific columns:

- **PR 1 commit `7960c101`** — `fix(execution): __exit__ writes Duration via execution_stop()`. `Execution.__exit__`'s clean-exit branch issued a `Running → Stopped` transition with `extra_fields={"stop_time": now}` only — no `duration`. The parallel `execution_stop()` writes both. Result: every execution that used the recommended `with` block ended up with `Duration=null` in the catalog. The fix delegates `__exit__`'s clean-exit branch to `execution_stop()`. Full diagnosis: [docs/bugs/2026-05-19-execution-exit-omits-duration.md](https://github.com/informatics-isi-edu/deriva-ml-model-template/blob/main/docs/bugs/2026-05-19-execution-exit-omits-duration.md) (in the workspace docs dir).

- **PR 2 commit `4727d6a1`** — `feat(execution): split Duration into three phase-specific columns`. Renames the catalog column `Duration` → `Execution_Duration`, adds `Download_Duration` (init/download phase, `_initialize_execution`) and `Upload_Duration` (upload phase, `upload_execution_outputs`). Failed-path duration now also recorded. Single `_format_duration()` helper centralizes the format string. Design: [docs/bugs/2026-05-19-execution-phase-durations-design.md](https://github.com/informatics-isi-edu/deriva-ml-model-template/blob/main/docs/bugs/2026-05-19-execution-phase-durations-design.md).

Forward-only migration: new catalogs get all three columns under the new names. Old catalogs keep their existing `Duration` column physically unchanged; deriva-ml client reads only the new names and reports `None` for the new fields against old catalogs (which is correct — Duration was empty anyway via the with-block path).

## Test plan

- [x] `tests/execution/test_execution.py::TestExecutionLifecycle::test_execution_context_manager` strengthened to assert all three catalog columns (`Execution_Duration` after `__exit__`, `Download_Duration` after `create_execution`, `Upload_Duration` after `upload_execution_outputs`).
- [x] Full execution test suite: 302 passed, 8 skipped. One pre-existing failure in `test_bag_loader_path_builder_refresh.py` deselected — confirmed it fails on the unmodified branch HEAD too, unrelated to this PR.
- [x] End-to-end verification against a live localhost catalog: created catalog 46 via `load-cifar10`, queried Execution rows. All 5 rows have all three columns populated. The bulk-asset-upload execution shows `Upload_Duration=10.6s` vs `Execution_Duration=0.83s` — the kind of phase-specific diagnostic that was invisible under the old single `Duration` column.

## Companion PR

`deriva-ml-mcp` PR — [feat/execution-phase-durations](https://github.com/informatics-isi-edu/deriva-ml-mcp/tree/feat/execution-phase-durations) — surfaces the two new fields through `ExecutionSummary`, the RAG serializer, and every read tool/resource. Should land after this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)