### PR TITLE
fix(dataset): adapters resolve asset paths against canonical BDBag layout; document RID opacity rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,6 +164,43 @@ surface uses a slightly different `find_*` rule (catalog-wide
 search by non-RID identifier — see the
 `deriva_ml_getting_started` prompt for the MCP-side definition).
 
+**RIDs are opaque: equality only.** A RID's only valid operation
+is equality comparison. The format (`<catalog-prefix>-<encoded-counter>`,
+e.g. `4CY`, `BR0`) is a server implementation detail. In particular:
+
+- **Never hard-code a RID as a literal** in tests, fixtures,
+  scripts, configs, or docstring examples. Obtain RIDs from a
+  fresh catalog lookup or fixture call — never from a string
+  written by a human. The failure mode is silent: a literal like
+  `"1-IMG1"` round-trips through a test that mocks the layer
+  where the RID matters, the test passes, and production breaks
+  the first time a real RID flows through the same code path
+  (see the 2026-05-19 torch-adapter bag-layout bug for an
+  illustrative case — every adapter test stubbed the path
+  argument so the wrong on-disk layout went undetected for
+  three weeks).
+- **Never parse, slice, regex, or `startswith`** on a RID. The
+  format is not stable contract.
+- **Never sort RIDs lexicographically and treat the order as
+  meaningful.** Catalog cursor pagination (`after_rid`) is a
+  server-supported equality boundary on the indexed RID column —
+  that's not a violation; client-side ordering by RID for
+  display purposes is.
+- **Never compare RIDs across catalogs.** RID `4CY` in catalog 46
+  has nothing to do with RID `4CY` in catalog 42. Cross-catalog
+  identity is `(host, catalog_id, RID)`.
+- **Never infer column values from a RID across snaptimes.** The
+  same RID at two snaptimes refers to the same row, but its
+  column values can differ — RID identity is constant; row data
+  is not.
+
+For tests specifically: every RID a test touches must come from
+a fixture-produced catalog row (e.g. via `CatalogManager`
+populated datasets, or a fresh `create_*` call inside the test).
+The test asserts shape and equality against values it pulled
+from the catalog — never against values it wrote into a string
+literal.
+
 ### Testing
 
 Tests require a running Deriva catalog. Set `DERIVA_HOST` environment variable to specify the test server (defaults to `localhost`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,11 +181,14 @@ e.g. `4CY`, `BR0`) is a server implementation detail. In particular:
   three weeks).
 - **Never parse, slice, regex, or `startswith`** on a RID. The
   format is not stable contract.
-- **Never sort RIDs lexicographically and treat the order as
-  meaningful.** Catalog cursor pagination (`after_rid`) is a
-  server-supported equality boundary on the indexed RID column —
-  that's not a violation; client-side ordering by RID for
-  display purposes is.
+- **RID ordering is server-internal mechanics, not semantics.**
+  The server sorts rows by RID to provide stable iteration order
+  for cursor pagination — `after_rid=X` returns rows with
+  `RID > X`, walking the table in the server's RID collation.
+  That ordering is what makes pagination work; **it carries no
+  semantic meaning**. Don't sort by RID client-side to surface
+  "newest" or "related" rows; use `RCT` for newest-first ordering
+  and follow the relevant FK / association table for relatedness.
 - **Never compare RIDs across catalogs.** RID `4CY` in catalog 46
   has nothing to do with RID `4CY` in catalog 42. Cross-catalog
   identity is `(host, catalog_id, RID)`.

--- a/src/deriva_ml/dataset/dataset_bag.py
+++ b/src/deriva_ml/dataset/dataset_bag.py
@@ -1171,9 +1171,9 @@ class DatasetBag:
                 once per ``__getitem__`` call. Receives:
 
                 - ``Path | None`` — absolute filesystem path under
-                  ``bag.path / "data/assets/<element_type>/<rid>/<filename>"``
-                  when ``element_type`` is an asset table; ``None``
-                  otherwise.
+                  ``bag.path / "data/asset/<rid>/<element_type>/<filename>"``
+                  (the canonical BDBag asset layout) when
+                  ``element_type`` is an asset table; ``None`` otherwise.
                 - ``dict[str, Any]`` — the raw row dict from the element
                   table (all columns, not just those the framework needs).
 
@@ -1332,9 +1332,9 @@ class DatasetBag:
                 once per generated element. Receives:
 
                 - ``Path | None`` — absolute filesystem path under
-                  ``bag.path / "data/assets/<element_type>/<rid>/<filename>"``
-                  when ``element_type`` is an asset table; ``None``
-                  otherwise.
+                  ``bag.path / "data/asset/<rid>/<element_type>/<filename>"``
+                  (the canonical BDBag asset layout) when
+                  ``element_type`` is an asset table; ``None`` otherwise.
                 - ``dict[str, Any]`` — the raw row dict from the element
                   table (all columns, not just those the framework needs).
 

--- a/src/deriva_ml/dataset/tf_adapter.py
+++ b/src/deriva_ml/dataset/tf_adapter.py
@@ -199,6 +199,13 @@ def _build_row_lookup(bag: "DatasetBag", element_type: str) -> dict:
 
 
 def _resolve_asset_path(bag: "DatasetBag", element_type: str, rid: str, row: dict) -> Path:
-    """Compute the on-disk path for an asset's file."""
+    """Compute the on-disk path for an asset's file.
+
+    Uses the canonical BDBag asset layout produced by the bag
+    materializer: ``data/asset/{RID}/{element_type}/{Filename}``
+    (singular ``asset/``; the RID comes before the element-type
+    segment). See ``deriva_ml.dataset.restructure`` for the matching
+    layout reference in the restructure path.
+    """
     filename = row.get("Filename") or f"{rid}.bin"
-    return bag.path / "data" / "assets" / element_type / rid / filename
+    return bag.path / "data" / "asset" / rid / element_type / filename

--- a/src/deriva_ml/dataset/torch_adapter.py
+++ b/src/deriva_ml/dataset/torch_adapter.py
@@ -174,6 +174,13 @@ def _build_row_lookup(bag: "DatasetBag", element_type: str) -> dict:
 
 
 def _resolve_asset_path(bag: "DatasetBag", element_type: str, rid: str, row: dict) -> Path:
-    """Compute the on-disk path for an asset's file."""
+    """Compute the on-disk path for an asset's file.
+
+    Uses the canonical BDBag asset layout produced by the bag
+    materializer: ``data/asset/{RID}/{element_type}/{Filename}``
+    (singular ``asset/``; the RID comes before the element-type
+    segment). See ``deriva_ml.dataset.restructure`` for the matching
+    layout reference in the restructure path.
+    """
     filename = row.get("Filename") or f"{rid}.bin"
-    return bag.path / "data" / "assets" / element_type / rid / filename
+    return bag.path / "data" / "asset" / rid / element_type / filename

--- a/tests/dataset/test_torch_adapter_logic.py
+++ b/tests/dataset/test_torch_adapter_logic.py
@@ -355,19 +355,37 @@ def test_resolve_asset_path_uses_bdbag_canonical_layout(tmp_path):
     ``data/assets/{element_type}/{RID}/{Filename}`` (plural, swapped),
     which never matched a real bag and was masked by canned
     sample_loaders in all other tests.
+
+    Per the RID opacity rule
+    (deriva-skills/skills/deriva-context/references/concepts.md
+    "RID opacity rule"), this test treats the asset's RID as an
+    opaque token: it's generated from secrets.token_hex once and
+    threaded through both the on-disk layout and the bag mock, so
+    the test author never writes a RID-shaped literal. The
+    assertion compares the path the sample_loader received against
+    the path the test built — RIDs are equality-compared only;
+    nothing parses them.
     """
+    import secrets
+
+    # Single opaque token shared between the mock bag and the on-disk
+    # layout — the test author never types a RID-shaped string.
+    asset_rid = secrets.token_hex(3).upper()
+    filename = "asset.bin"
+    asset_bytes = b"fake-asset-bytes"
+
     # Build a bag directory tree at the canonical layout. Put a real
     # file at the leaf so the test can verify the resolver hands back
     # a path that exists.
     bag_root = tmp_path / "Dataset_FAKE"
-    canonical_dir = bag_root / "data" / "asset" / "1-IMG1" / "Image"
+    canonical_dir = bag_root / "data" / "asset" / asset_rid / "Image"
     canonical_dir.mkdir(parents=True)
-    canonical_file = canonical_dir / "img1.jpg"
-    canonical_file.write_bytes(b"fake-image-bytes")
+    canonical_file = canonical_dir / filename
+    canonical_file.write_bytes(asset_bytes)
 
-    bag = _mock_bag_with_labeled_images({"1-IMG1": "Mild"})
+    bag = _mock_bag_with_labeled_images({asset_rid: "Mild"})
     bag.path = bag_root
-    bag.get_table_as_dict.return_value = iter([{"RID": "1-IMG1", "Filename": "img1.jpg"}])
+    bag.get_table_as_dict.return_value = iter([{"RID": asset_rid, "Filename": filename}])
 
     received_paths: list[Path] = []
 
@@ -386,4 +404,4 @@ def test_resolve_asset_path_uses_bdbag_canonical_layout(tmp_path):
     # to read it. Pre-fix, sample_loader received a non-existent path
     # and raised FileNotFoundError inside the read.
     assert received_paths == [canonical_file]
-    assert sample == b"fake-image-bytes"
+    assert sample == asset_bytes

--- a/tests/dataset/test_torch_adapter_logic.py
+++ b/tests/dataset/test_torch_adapter_logic.py
@@ -13,6 +13,7 @@ Coverage matrix (spec §6.2):
 - Multi-target returns dict[str, FeatureRecord] via target_transform
 - Asset-table element with no sample_loader raises at construction
 """
+
 from __future__ import annotations
 
 from pathlib import Path
@@ -47,9 +48,7 @@ def _mock_bag_with_labeled_images(rids_and_labels: dict[str, str]):
     """
     bag = MagicMock()
     bag.path = Path("/tmp/fake_bag")
-    bag.list_dataset_members = MagicMock(
-        return_value={"Image": [{"RID": rid} for rid in rids_and_labels]}
-    )
+    bag.list_dataset_members = MagicMock(return_value={"Image": [{"RID": rid} for rid in rids_and_labels]})
 
     def fake_feature_values(element_type, feature_name, selector=None):
         for rid, label in rids_and_labels.items():
@@ -86,9 +85,7 @@ def _mock_non_asset_bag(rids_and_labels: dict[str, str]):
     """Build a MagicMock bag for a non-asset element type (tabular)."""
     bag = MagicMock()
     bag.path = Path("/tmp/fake_bag")
-    bag.list_dataset_members = MagicMock(
-        return_value={"Subject": [{"RID": rid} for rid in rids_and_labels]}
-    )
+    bag.list_dataset_members = MagicMock(return_value={"Subject": [{"RID": rid} for rid in rids_and_labels]})
 
     def fake_feature_values(element_type, feature_name, selector=None):
         for rid, label in rids_and_labels.items():
@@ -148,12 +145,8 @@ def test_missing_error_raises_at_construction():
     """missing='error' raises DerivaMLException at construction listing RIDs."""
     bag = MagicMock()
     bag.path = Path("/tmp/fake_bag")
-    bag.list_dataset_members = MagicMock(
-        return_value={"Image": [{"RID": "1-IMG1"}, {"RID": "1-IMG2"}]}
-    )
-    bag.feature_values = MagicMock(
-        return_value=iter([_FakeRecord(Image="1-IMG1", Grade="Mild")])
-    )
+    bag.list_dataset_members = MagicMock(return_value={"Image": [{"RID": "1-IMG1"}, {"RID": "1-IMG2"}]})
+    bag.feature_values = MagicMock(return_value=iter([_FakeRecord(Image="1-IMG1", Grade="Mild")]))
     bag.model = MagicMock()
     bag.model.is_asset = MagicMock(return_value=True)
     bag.get_table_as_dict = MagicMock(return_value=iter([]))
@@ -186,10 +179,12 @@ def test_missing_unknown_keeps_all_elements_with_none_target():
     """missing='unknown' keeps all elements; target is None for unlabeled."""
     bag = _mock_bag_with_labeled_images({"1-IMG1": "Mild", "1-IMG2": ""})
     # Override get_table_as_dict to return both rows
-    bag.get_table_as_dict.return_value = iter([
-        {"RID": "1-IMG1", "Filename": "img1.jpg"},
-        {"RID": "1-IMG2", "Filename": "img2.jpg"},
-    ])
+    bag.get_table_as_dict.return_value = iter(
+        [
+            {"RID": "1-IMG1", "Filename": "img1.jpg"},
+            {"RID": "1-IMG2", "Filename": "img2.jpg"},
+        ]
+    )
     ds = build_torch_dataset(
         bag,
         "Image",
@@ -238,9 +233,7 @@ def test_multi_target_target_transform_receives_dict():
     """Multi-target: target_transform receives dict[str, FeatureRecord]."""
     bag = MagicMock()
     bag.path = Path("/tmp/fake_bag")
-    bag.list_dataset_members = MagicMock(
-        return_value={"Image": [{"RID": "1-IMG1"}]}
-    )
+    bag.list_dataset_members = MagicMock(return_value={"Image": [{"RID": "1-IMG1"}]})
 
     class _FakeGradeRecord(FeatureRecord):
         Image: str
@@ -340,3 +333,57 @@ def test_non_asset_table_no_sample_loader_returns_row_dict():
     )
     assert isinstance(ds, torch.utils.data.Dataset)
     assert len(ds) >= 0  # construction succeeded
+
+
+# ---------------------------------------------------------------------------
+# Asset path resolution against the canonical BDBag layout (regression test
+# for 2026-05-19: _resolve_asset_path computed data/assets/{table}/{rid}/...
+# but the BDBag materializer writes data/asset/{rid}/{table}/..., so
+# __getitem__ on a real bag raised FileNotFoundError. All prior asset-table
+# tests passed a canned sample_loader that ignored its `path` argument,
+# leaving the bug latent for ~3 weeks.)
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_asset_path_uses_bdbag_canonical_layout(tmp_path):
+    """``_resolve_asset_path`` must return a path matching the on-disk
+    BDBag layout produced by the bag materializer: ``data/asset/{RID}/
+    {element_type}/{Filename}``. Singular ``asset/``; RID before the
+    element-type segment.
+
+    Regression test: the original implementation used
+    ``data/assets/{element_type}/{RID}/{Filename}`` (plural, swapped),
+    which never matched a real bag and was masked by canned
+    sample_loaders in all other tests.
+    """
+    # Build a bag directory tree at the canonical layout. Put a real
+    # file at the leaf so the test can verify the resolver hands back
+    # a path that exists.
+    bag_root = tmp_path / "Dataset_FAKE"
+    canonical_dir = bag_root / "data" / "asset" / "1-IMG1" / "Image"
+    canonical_dir.mkdir(parents=True)
+    canonical_file = canonical_dir / "img1.jpg"
+    canonical_file.write_bytes(b"fake-image-bytes")
+
+    bag = _mock_bag_with_labeled_images({"1-IMG1": "Mild"})
+    bag.path = bag_root
+    bag.get_table_as_dict.return_value = iter([{"RID": "1-IMG1", "Filename": "img1.jpg"}])
+
+    received_paths: list[Path] = []
+
+    def capturing_loader(path, row):
+        received_paths.append(path)
+        return path.read_bytes()
+
+    ds = build_torch_dataset(
+        bag,
+        "Image",
+        sample_loader=capturing_loader,
+        targets=["Grade"],
+    )
+    sample, _ = ds[0]
+    # The sample_loader received the canonical-layout path and was able
+    # to read it. Pre-fix, sample_loader received a non-existent path
+    # and raised FileNotFoundError inside the read.
+    assert received_paths == [canonical_file]
+    assert sample == b"fake-image-bytes"


### PR DESCRIPTION
## Summary

Fixes a path-construction bug in the PyTorch and TensorFlow dataset adapters that has been latent since they shipped (commit 4faa5e8d, 2026-04-24), and documents the RID-opacity rule that the test suite needs to follow to catch this class of bug.

### The bug

[torch_adapter.py:179](https://github.com/informatics-isi-edu/deriva-ml/blob/fix/torch-adapter-resolve-asset-path/src/deriva_ml/dataset/torch_adapter.py#L179) and [tf_adapter.py:204](https://github.com/informatics-isi-edu/deriva-ml/blob/fix/torch-adapter-resolve-asset-path/src/deriva_ml/dataset/tf_adapter.py#L204) computed:

```python
bag.path / "data" / "assets" / element_type / rid / filename
```

The actual BDBag asset layout produced by the materializer — and documented in [`deriva_ml.dataset.restructure:609`](https://github.com/informatics-isi-edu/deriva-ml/blob/main/src/deriva_ml/dataset/restructure.py#L609) — is:

```python
bag.path / "data" / "asset" / rid / element_type / filename
```

Three differences: `assets` vs `asset` (plural vs singular), and the `rid` and `element_type` segments are swapped. Any DataLoader/Dataset that tried to read a real file through `sample_loader` raised `FileNotFoundError` as a result.

Surfaced today running `cifar10_quick` from `deriva-ml-model-template` end-to-end against a fresh catalog: dry-run succeeded (dry-run skips `run_model` so the adapter never reads files), real run crashed mid-training with `FileNotFoundError` on a path under `data/assets/Image/{rid}/...` that didn't exist.

### Why no test caught this

Every test in `tests/dataset/test_torch_adapter_*.py` and `test_tf_adapter_*.py` passes a canned `sample_loader` that returns synthetic bytes (`lambda p, row: b"fake"`) and ignores its `path` argument. No test exercised `_resolve_asset_path` against a real on-disk layout until this PR. The regression test added here lays a real file at the canonical layout and uses a `sample_loader` that actually calls `path.read_bytes()` — catching this entire class of bug going forward.

### Two commits

1. **`fix(dataset): adapters resolve asset paths against canonical BDBag layout`** — swap the path segments in both adapters; update two `dataset_bag.py` docstrings that documented the wrong layout.

2. **`docs: RID opacity rule; de-RID-literalize the regression test`** — adds the RID opacity rule to `deriva-ml/CLAUDE.md` under Key Patterns (five bullets: no literals, no parsing, no lex-ordering, no cross-catalog comparison, no cross-snaptime value inference) and rewrites the new regression test to thread a `secrets.token_hex(3)` opaque token through both the on-disk layout and the mock bag, so the test author never writes a RID-shaped literal anywhere. The companion deriva-skills doc edit lives at [informatics-isi-edu/deriva-skills#TBD](https://github.com/informatics-isi-edu/deriva-skills/pull/new/docs/rid-opacity-rule).

## Test plan

- [x] New regression test `test_resolve_asset_path_uses_bdbag_canonical_layout` lays out a real file at the canonical bag path and asserts the adapter resolves the path correctly.
- [x] `tests/execution/` full suite: 302 passed, 8 skipped, 2 deselected (one pre-existing failure in `test_bag_loader_path_builder_refresh` deselected — unrelated to this PR; reproduces on unmodified `main`).
- [x] `tests/dataset/test_torch_adapter_logic.py`: 11 passed (10 previously + 1 new).
- [ ] One pre-existing failure in `tests/dataset/test_torch_adapter_e2e.py::test_bag_to_dataloader_yields_tensors` (`assert 0 > 0` from the fixture producing no bag rows) reproduces on unmodified `main` — not caused by this PR; tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)