### PR TITLE
fix(execution): drop unsupported upload_timeout / upload_chunk_size from run_model

### DIFF
--- a/src/deriva_ml/execution/runner.py
+++ b/src/deriva_ml/execution/runner.py
@@ -358,8 +358,6 @@ def run_model(
     model_config: Any,
     dry_run: bool = False,
     ml_class: type["DerivaML"] | None = None,
-    upload_timeout: int = 600,
-    upload_chunk_size: int = 50_000_000,
     script_config: Any = None,
 ) -> None:
     """
@@ -413,16 +411,6 @@ def run_model(
         The DerivaML class (or subclass) to instantiate. If None, uses the
         base DerivaML class. Use this to instantiate domain-specific classes
         like EyeAI or GUDMAP.
-
-    upload_timeout : int, optional
-        Timeout in seconds for each chunk upload. Default is 600 (10 min).
-        This value is used as both the connect and read timeout. Since urllib3
-        uses the connect timeout for socket writes, it must be large enough
-        to send a full chunk over the network.
-
-    upload_chunk_size : int, optional
-        Chunk size in bytes for hatrac uploads. Default is 50000000 (50 MB).
-        Larger chunks reduce overhead but require more memory.
 
     Returns
     -------
@@ -593,11 +581,28 @@ def run_model(
     # ---------------------------------------------------------------------------
     # After the model completes, upload any output files (metrics, predictions,
     # model checkpoints) to the Deriva catalog for permanent storage.
+    #
+    # NOTE(2026-05-19): previously this call passed timeout=... and
+    # chunk_size=... kwargs. Both were unsupported by
+    # Execution.upload_execution_outputs's signature (which only accepts
+    # clean_folder and progress_callback) and the @validate_call decorator
+    # made the mismatch fatal at runtime. The kwargs have been removed from
+    # this call AND from run_model's signature because:
+    #
+    #   * chunk_size: had a defined home at DerivaUpload._hatracUpload's
+    #     chunk_size parameter (deriva-py), but the call site at
+    #     deriva.bag.catalog_loader._hatracUpload doesn't pass it through.
+    #     Filed as a follow-up on deriva-py.
+    #
+    #   * timeout: has no home anywhere in the deriva-py upload chain.
+    #     HatracStore.put_loc, _hatracUpload, and the underlying requests
+    #     calls do not accept a per-call timeout. Adding it requires a
+    #     deriva-py feature, not a deriva-ml plumbing change.
+    #
+    # Once deriva-py grows the matching support, re-introduce both
+    # parameters here AND in run_model's signature.
     if not dry_run:
-        uploaded_assets = execution.upload_execution_outputs(
-            timeout=(upload_timeout, upload_timeout),
-            chunk_size=upload_chunk_size,
-        )
+        uploaded_assets = execution.upload_execution_outputs()
 
         # Print summary of uploaded assets
         total_files = sum(len(files) for files in uploaded_assets.values())

--- a/tests/execution/test_runner.py
+++ b/tests/execution/test_runner.py
@@ -308,3 +308,88 @@ class TestRunModelWithMocks:
 
         # Verify custom class was used for instantiation
         mock_custom_class.instantiate.assert_called_once_with(mock_config)
+
+
+class TestRunModelUploadCallContract:
+    """Regression tests for runner.run_model's call to upload_execution_outputs.
+
+    Surfaced 2026-05-19: ``runner.run_model`` was calling
+    ``execution.upload_execution_outputs(timeout=..., chunk_size=...)`` but
+    the method's signature only accepts ``clean_folder`` and
+    ``progress_callback``. The ``@validate_call`` decorator on the method
+    made the mismatch fatal at runtime. Every other runner test in this
+    file uses bare ``MagicMock()`` for the execution, which accepts any
+    kwargs without complaint — so the bug went undetected until the
+    e2e platform test exercised the real method.
+
+    These tests use ``MagicMock(spec=Execution)`` so the mock validates
+    kwargs against the real method signature.
+    """
+
+    @pytest.fixture(autouse=True)
+    def reset_state(self):
+        """Reset multirun state before each test."""
+        reset_multirun_state()
+        yield
+        reset_multirun_state()
+
+    @patch("deriva_ml.execution.runner._is_multirun")
+    def test_run_model_call_matches_upload_execution_outputs_signature(self, mock_is_multirun):
+        """run_model must only pass kwargs that upload_execution_outputs accepts.
+
+        Before the 2026-05-19 fix, run_model passed timeout= and chunk_size=
+        kwargs that the upload method's signature did not accept. The fix
+        strips those (deferred until deriva-py adds per-call timeout and
+        plumbed-through chunk_size support). This test pins the contract.
+        """
+        from deriva_ml.execution.execution import Execution
+
+        mock_is_multirun.return_value = False
+
+        mock_ml_class = MagicMock()
+        mock_ml_instance = MagicMock()
+        mock_ml_class.instantiate.return_value = mock_ml_instance
+
+        # spec=Execution enforces that method calls match the real
+        # Execution surface — passing unknown kwargs raises AttributeError
+        # / TypeError at the mock layer, which is what we want.
+        mock_execution = MagicMock(spec=Execution)
+        mock_execution.execute.return_value.__enter__ = Mock(return_value=mock_execution)
+        mock_execution.execute.return_value.__exit__ = Mock(return_value=False)
+        mock_execution.upload_execution_outputs.return_value = {}
+        mock_ml_instance.create_execution.return_value = mock_execution
+
+        mock_model_config = Mock()
+        mock_config = MagicMock()
+        mock_workflow = MagicMock()
+
+        # Call should complete without raising. Pre-fix, this raised
+        # because the upload_execution_outputs MagicMock(spec=...) rejected
+        # the timeout=/chunk_size= kwargs the runner passed.
+        run_model(
+            deriva_ml=mock_config,
+            datasets=[],
+            assets=[],
+            description="Test",
+            workflow=mock_workflow,
+            model_config=mock_model_config,
+            dry_run=False,
+            ml_class=mock_ml_class,
+        )
+
+        # Verify the actual kwargs the runner passed are a subset of the
+        # real method's signature.
+        import inspect
+
+        real_sig = inspect.signature(Execution.upload_execution_outputs)
+        real_params = set(real_sig.parameters.keys())
+
+        call_args = mock_execution.upload_execution_outputs.call_args
+        passed_kwargs = set(call_args.kwargs.keys()) if call_args else set()
+
+        unsupported = passed_kwargs - real_params
+        assert not unsupported, (
+            f"run_model passed kwargs not accepted by "
+            f"Execution.upload_execution_outputs: {unsupported}. "
+            f"Real method accepts: {real_params - {'self'}}."
+        )


### PR DESCRIPTION
## Summary

\`run_model\` in [src/deriva_ml/execution/runner.py](https://github.com/informatics-isi-edu/deriva-ml/blob/main/src/deriva_ml/execution/runner.py) declared two parameters — \`upload_timeout\` and \`upload_chunk_size\` — and passed them as kwargs to \`Execution.upload_execution_outputs\`. The method's signature only accepts \`clean_folder\` and \`progress_callback\`; \`@validate_call\` made the kwargs mismatch fatal at runtime.

Surfaced today by the e2e platform test running \`cifar10_quick\`: training completed (model trained, weights saved, predictions recorded) and then crashed at the upload step with \`ValidationError: Unexpected keyword argument\`. Independent of and stacked on top of [#167](https://github.com/informatics-isi-edu/deriva-ml/pull/167) (the torch-adapter path fix that lets training reach the upload step).

## Investigation

Both parameters turned out to have no destination in the underlying upload chain:

- **\`chunk_size\`** has a defined home at \`DerivaUpload._hatracUpload\`'s \`chunk_size\` parameter, but \`deriva.bag.catalog_loader.BagCatalogLoader\` doesn't pass it through — \`_hatracUpload\` falls back to \`DEFAULT_CHUNK_SIZE\`. Plumbing requires a deriva-py change. Filed as [deriva-py#261](https://github.com/informatics-isi-edu/deriva-py/issues/261).
- **\`timeout\`** has no home anywhere in the deriva-py upload chain. \`HatracStore.put_loc\`, \`DerivaUpload._hatracUpload\`, and the underlying \`requests\` calls accept no per-call timeout. Adding it requires a deriva-py feature. Filed as [deriva-py#262](https://github.com/informatics-isi-edu/deriva-py/issues/262).

Since neither parameter can flow to the leaf today, this PR strips them rather than ship a half-built API. They can be re-introduced once the two deriva-py issues land.

## Why no test caught this

Every existing \`run_model\` test in \`tests/execution/test_runner.py\` uses a bare \`MagicMock()\` for the execution mock, which accepts any kwargs without complaint — the real method's \`@validate_call\` is what enforced the contract in production. The new regression test added here uses \`MagicMock(spec=Execution)\` plus \`inspect.signature(Execution.upload_execution_outputs)\` to validate the runner's call against the method's real signature, so future signature drift gets caught at the unit level.

## Test plan

- [x] New regression test \`TestRunModelUploadCallContract.test_run_model_call_matches_upload_execution_outputs_signature\` fails on unmodified main with \`run_model passed kwargs not accepted by Execution.upload_execution_outputs: {'chunk_size', 'timeout'}\`. Passes after the fix.
- [x] Full \`tests/execution/test_runner.py\` suite: 16 passed (15 existing + 1 new).
- [ ] End-to-end verification against catalog 46 (cifar10_quick training + upload) pending after this PR lands and the e2e worktree picks it up.

## Notes for reviewers

- The parameters were aspirational from the start. The original docstring described \`upload_timeout\` as *"the connect and read timeout… large enough to send a full chunk over the network"* — sensible, but unimplementable until the deriva-py issues land.
- The call site keeps a detailed inline comment explaining the deferral so a future contributor sees the context without having to dig through PR history.
- This PR's branch is **independent** of [#167](https://github.com/informatics-isi-edu/deriva-ml/pull/167) — neither stacks on the other, both branch from \`main\`. Phase 2 of the e2e platform test needs both to land before training-and-upload completes end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)