### PR TITLE
feat(dataset): adapters always surface element RID in return tuple

### DIFF
--- a/src/deriva_ml/dataset/dataset_bag.py
+++ b/src/deriva_ml/dataset/dataset_bag.py
@@ -1195,8 +1195,10 @@ class DatasetBag:
             targets: Source of label data. Three shapes are accepted:
 
                 - ``None`` (default) — unlabeled dataset. ``__getitem__``
-                  returns just the sample (not a tuple). Useful for
-                  inference loops and self-supervised pretext tasks.
+                  returns ``(sample, rid)``. Useful for inference loops
+                  and self-supervised pretext tasks (the RID is still
+                  surfaced so the inference loop can record predictions
+                  back to the catalog).
                 - ``list[str]`` — feature names read via
                   ``bag.feature_values(element_type, name)`` with no
                   selector. One ``FeatureRecord`` is resolved per element.
@@ -1239,10 +1241,18 @@ class DatasetBag:
         Returns:
             A ``torch.utils.data.Dataset`` whose ``__getitem__`` returns:
 
-            - ``sample`` when ``targets=None`` (unlabeled).
-            - ``(sample, target)`` when ``targets`` is set, where
+            - ``(sample, rid)`` when ``targets=None`` (unlabeled).
+            - ``(sample, target, rid)`` when ``targets`` is set, where
               ``sample = transform(sample_loader(path, row_dict))`` and
               ``target = target_transform(feature_record_shape)``.
+
+            The element's catalog RID is always the last positional
+            value. It's passed through raw — never touched by
+            ``transform`` or ``target_transform`` — because the RID
+            is the row's catalog identity, not a feature value. The
+            motivating use case is downstream code that records
+            per-element predictions back to the catalog (the RID is
+            the FK target for the feature row).
 
             ``__len__`` equals the count of labeled elements when
             ``missing="skip"``, the total element count otherwise.
@@ -1309,8 +1319,10 @@ class DatasetBag:
         ``DatasetBag``. TensorFlow is imported lazily inside the builder
         so the base library stays importable without TensorFlow installed.
 
-        Each call to the generator yields one element (sample, or
-        ``(sample, target)`` when ``targets`` is supplied). Callers are
+        Each call to the generator yields one element — either
+        ``(sample, rid)`` (unlabeled) or ``(sample, target, rid)``
+        (with ``targets`` set). The RID is always the last value;
+        see the Returns section for details. Callers are
         responsible for chaining ``.batch()`` and ``.prefetch()`` to get
         production throughput — the method does not apply batching itself.
 
@@ -1407,10 +1419,18 @@ class DatasetBag:
         Returns:
             A ``tf.data.Dataset`` whose elements are:
 
-            - ``sample`` when ``targets=None`` (unlabeled).
-            - ``(sample, target)`` when ``targets`` is set, where
+            - ``(sample, rid)`` when ``targets=None`` (unlabeled).
+            - ``(sample, target, rid)`` when ``targets`` is set, where
               ``sample = transform(sample_loader(path, row_dict))`` and
               ``target = target_transform(feature_record_shape)``.
+
+            The element's catalog RID is always the last positional
+            value. It's passed through raw — never touched by
+            ``transform`` or ``target_transform`` — because the RID
+            is the row's catalog identity, not a feature value. The
+            motivating use case is downstream code that records
+            per-element predictions back to the catalog (the RID is
+            the FK target for the feature row).
 
             Callers must chain ``.batch()`` / ``.prefetch()`` themselves —
             the returned dataset is unbatched.

--- a/src/deriva_ml/dataset/tf_adapter.py
+++ b/src/deriva_ml/dataset/tf_adapter.py
@@ -73,8 +73,17 @@ def build_tf_dataset(
             then the generator is re-wrapped so the first sample is not lost.
 
     Returns:
-        A ``tf.data.Dataset`` whose elements are ``sample`` when
-        ``targets=None``, or ``(sample, target)`` otherwise.
+        A ``tf.data.Dataset`` whose elements are:
+
+        - ``(sample, rid)`` when ``targets=None`` (unlabeled).
+        - ``(sample, target, rid)`` when ``targets`` is set (labeled).
+
+        The element's RID is always the last positional value. It's
+        passed through raw — never touched by ``transform`` or
+        ``target_transform`` — because the RID is the row's catalog
+        identity, not a feature value. The motivating use case is
+        downstream code that records per-element predictions back to
+        the catalog (the RID is the FK target for the feature row).
 
     Raises:
         ImportError: If TensorFlow is not installed.
@@ -141,12 +150,12 @@ def build_tf_dataset(
                 sample = transform(sample)
 
             if targets is None:
-                yield sample
+                yield (sample, rid)
             else:
                 target = target_map.get(rid)
                 if target_transform is not None:
                     target = target_transform(target)
-                yield (sample, target)
+                yield (sample, target, rid)
 
     # output_signature handling.
     if output_signature is None:

--- a/src/deriva_ml/dataset/torch_adapter.py
+++ b/src/deriva_ml/dataset/torch_adapter.py
@@ -64,8 +64,17 @@ def build_torch_dataset(
             ``"unknown"`` keeps them with target=None.
 
     Returns:
-        A ``torch.utils.data.Dataset`` whose ``__getitem__`` returns
-        ``sample`` when ``targets=None``, or ``(sample, target)`` otherwise.
+        A ``torch.utils.data.Dataset`` whose ``__getitem__`` returns:
+
+        - ``(sample, rid)`` when ``targets=None`` (unlabeled).
+        - ``(sample, target, rid)`` when ``targets`` is set (labeled).
+
+        The element's RID is always the last positional value. It's
+        passed through raw — never touched by ``transform`` or
+        ``target_transform`` — because the RID is the row's catalog
+        identity, not a feature value. The motivating use case is
+        downstream code that records per-element predictions back to
+        the catalog (the RID is the FK target for the feature row).
 
     Raises:
         ImportError: If torch is not installed.
@@ -138,12 +147,12 @@ def build_torch_dataset(
                 sample = transform(sample)
 
             if targets is None:
-                return sample
+                return sample, rid
 
             target = self._target_map.get(rid)
             if target_transform is not None:
                 target = target_transform(target)
-            return sample, target
+            return sample, target, rid
 
     return _TorchDataset()
 

--- a/tests/dataset/test_tf_adapter_logic.py
+++ b/tests/dataset/test_tf_adapter_logic.py
@@ -15,6 +15,7 @@ Coverage matrix (spec §6.2):
 - Non-asset-table element works without sample_loader
 - output_signature=None triggers first-sample inference
 """
+
 from __future__ import annotations
 
 from pathlib import Path
@@ -49,9 +50,7 @@ def _mock_bag_with_labeled_images(rids_and_labels: dict[str, str]):
     """
     bag = MagicMock()
     bag.path = Path("/tmp/fake_bag")
-    bag.list_dataset_members = MagicMock(
-        return_value={"Image": [{"RID": rid} for rid in rids_and_labels]}
-    )
+    bag.list_dataset_members = MagicMock(return_value={"Image": [{"RID": rid} for rid in rids_and_labels]})
 
     def fake_feature_values(element_type, feature_name, selector=None):
         for rid, label in rids_and_labels.items():
@@ -88,9 +87,7 @@ def _mock_non_asset_bag(rids_and_labels: dict[str, str]):
     """Build a MagicMock bag for a non-asset element type (tabular)."""
     bag = MagicMock()
     bag.path = Path("/tmp/fake_bag")
-    bag.list_dataset_members = MagicMock(
-        return_value={"Subject": [{"RID": rid} for rid in rids_and_labels]}
-    )
+    bag.list_dataset_members = MagicMock(return_value={"Subject": [{"RID": rid} for rid in rids_and_labels]})
 
     def fake_feature_values(element_type, feature_name, selector=None):
         for rid, label in rids_and_labels.items():
@@ -127,7 +124,8 @@ def test_as_tf_dataset_returns_tf_dataset():
         targets=["Grade"],
         output_signature=(
             tf.TensorSpec(shape=(3,), dtype=tf.float32),
-            tf.TensorSpec(shape=(), dtype=tf.string),
+            tf.TensorSpec(shape=(), dtype=tf.string),  # target
+            tf.TensorSpec(shape=(), dtype=tf.string),  # rid
         ),
     )
     assert isinstance(ds, tf.data.Dataset)
@@ -136,10 +134,12 @@ def test_as_tf_dataset_returns_tf_dataset():
 def test_element_count_reflects_all_when_no_skip():
     """Dataset element count equals total member count when missing != 'skip'."""
     bag = _mock_bag_with_labeled_images({"1-IMG1": "Mild", "1-IMG2": "Severe"})
-    bag.get_table_as_dict.return_value = iter([
-        {"RID": "1-IMG1", "Filename": "img1.jpg"},
-        {"RID": "1-IMG2", "Filename": "img2.jpg"},
-    ])
+    bag.get_table_as_dict.return_value = iter(
+        [
+            {"RID": "1-IMG1", "Filename": "img1.jpg"},
+            {"RID": "1-IMG2", "Filename": "img2.jpg"},
+        ]
+    )
     ds = build_tf_dataset(
         bag,
         "Image",
@@ -148,7 +148,8 @@ def test_element_count_reflects_all_when_no_skip():
         target_transform=lambda rec: tf.constant(rec.Grade if rec is not None else ""),
         output_signature=(
             tf.TensorSpec(shape=(1,), dtype=tf.float32),
-            tf.TensorSpec(shape=(), dtype=tf.string),
+            tf.TensorSpec(shape=(), dtype=tf.string),  # target
+            tf.TensorSpec(shape=(), dtype=tf.string),  # rid
         ),
     )
     count = sum(1 for _ in ds)
@@ -164,12 +165,8 @@ def test_missing_error_raises_at_construction():
     """missing='error' raises DerivaMLException at construction listing RIDs."""
     bag = MagicMock()
     bag.path = Path("/tmp/fake_bag")
-    bag.list_dataset_members = MagicMock(
-        return_value={"Image": [{"RID": "1-IMG1"}, {"RID": "1-IMG2"}]}
-    )
-    bag.feature_values = MagicMock(
-        return_value=iter([_FakeRecord(Image="1-IMG1", Grade="Mild")])
-    )
+    bag.list_dataset_members = MagicMock(return_value={"Image": [{"RID": "1-IMG1"}, {"RID": "1-IMG2"}]})
+    bag.feature_values = MagicMock(return_value=iter([_FakeRecord(Image="1-IMG1", Grade="Mild")]))
     bag.model = MagicMock()
     bag.model.is_asset = MagicMock(return_value=True)
     bag.get_table_as_dict = MagicMock(return_value=iter([]))
@@ -197,7 +194,8 @@ def test_missing_skip_drops_unlabeled_elements():
         missing="skip",
         output_signature=(
             tf.TensorSpec(shape=(1,), dtype=tf.float32),
-            tf.TensorSpec(shape=(), dtype=tf.string),
+            tf.TensorSpec(shape=(), dtype=tf.string),  # target
+            tf.TensorSpec(shape=(), dtype=tf.string),  # rid
         ),
     )
     count = sum(1 for _ in ds)
@@ -208,10 +206,12 @@ def test_missing_unknown_keeps_all_elements_with_none_target():
     """missing='unknown' keeps all elements; target is None for unlabeled."""
     bag = _mock_bag_with_labeled_images({"1-IMG1": "Mild", "1-IMG2": ""})
     # Override get_table_as_dict to return both rows
-    bag.get_table_as_dict.return_value = iter([
-        {"RID": "1-IMG1", "Filename": "img1.jpg"},
-        {"RID": "1-IMG2", "Filename": "img2.jpg"},
-    ])
+    bag.get_table_as_dict.return_value = iter(
+        [
+            {"RID": "1-IMG1", "Filename": "img1.jpg"},
+            {"RID": "1-IMG2", "Filename": "img2.jpg"},
+        ]
+    )
     # target_transform must handle None for the unlabeled element.
     targets_seen = []
 
@@ -228,7 +228,8 @@ def test_missing_unknown_keeps_all_elements_with_none_target():
         missing="unknown",
         output_signature=(
             tf.TensorSpec(shape=(1,), dtype=tf.float32),
-            tf.TensorSpec(shape=(), dtype=tf.string),
+            tf.TensorSpec(shape=(), dtype=tf.string),  # target
+            tf.TensorSpec(shape=(), dtype=tf.string),  # rid
         ),
     )
     count = sum(1 for _ in ds)
@@ -259,7 +260,8 @@ def test_single_target_target_transform_receives_featurerecord():
         target_transform=capture_target,
         output_signature=(
             tf.TensorSpec(shape=(1,), dtype=tf.float32),
-            tf.TensorSpec(shape=(), dtype=tf.int32),
+            tf.TensorSpec(shape=(), dtype=tf.int32),  # target
+            tf.TensorSpec(shape=(), dtype=tf.string),  # rid
         ),
     )
     list(ds)  # consume to trigger __call__
@@ -272,9 +274,7 @@ def test_multi_target_target_transform_receives_dict():
     """Multi-target: target_transform receives dict[str, FeatureRecord]."""
     bag = MagicMock()
     bag.path = Path("/tmp/fake_bag")
-    bag.list_dataset_members = MagicMock(
-        return_value={"Image": [{"RID": "1-IMG1"}]}
-    )
+    bag.list_dataset_members = MagicMock(return_value={"Image": [{"RID": "1-IMG1"}]})
 
     class _FakeGradeRecord(FeatureRecord):
         Image: str
@@ -315,7 +315,8 @@ def test_multi_target_target_transform_receives_dict():
         target_transform=capture_target,
         output_signature=(
             tf.TensorSpec(shape=(1,), dtype=tf.float32),
-            tf.TensorSpec(shape=(), dtype=tf.int32),
+            tf.TensorSpec(shape=(), dtype=tf.int32),  # target
+            tf.TensorSpec(shape=(), dtype=tf.string),  # rid
         ),
     )
     list(ds)
@@ -348,7 +349,8 @@ def test_selector_dict_form_passes_selector_to_feature_values():
         target_transform=lambda rec: tf.constant(rec.Grade if rec is not None else ""),
         output_signature=(
             tf.TensorSpec(shape=(1,), dtype=tf.float32),
-            tf.TensorSpec(shape=(), dtype=tf.string),
+            tf.TensorSpec(shape=(), dtype=tf.string),  # target
+            tf.TensorSpec(shape=(), dtype=tf.string),  # rid
         ),
     )
     list(ds)
@@ -393,7 +395,8 @@ def test_non_asset_table_no_sample_loader_returns_row_dict():
         target_transform=lambda rec: tf.constant(rec.Grade if rec is not None else ""),
         output_signature=(
             tf.TensorSpec(shape=None, dtype=tf.string),
-            tf.TensorSpec(shape=(), dtype=tf.string),
+            tf.TensorSpec(shape=(), dtype=tf.string),  # target
+            tf.TensorSpec(shape=(), dtype=tf.string),  # rid
         ),
     )
     assert isinstance(ds_no_loader, tf.data.Dataset)
@@ -409,7 +412,8 @@ def test_non_asset_table_no_sample_loader_returns_row_dict():
         target_transform=lambda rec: tf.constant(rec.Grade if rec is not None else ""),
         output_signature=(
             tf.TensorSpec(shape=(), dtype=tf.string),
-            tf.TensorSpec(shape=(), dtype=tf.string),
+            tf.TensorSpec(shape=(), dtype=tf.string),  # target
+            tf.TensorSpec(shape=(), dtype=tf.string),  # rid
         ),
     )
     assert isinstance(ds, tf.data.Dataset)
@@ -425,10 +429,12 @@ def test_non_asset_table_no_sample_loader_returns_row_dict():
 def test_output_signature_none_infers_from_first_sample():
     """output_signature=None: element_spec is inferred from the first yielded sample."""
     bag = _mock_bag_with_labeled_images({"1-IMG1": "Mild", "1-IMG2": "Severe"})
-    bag.get_table_as_dict.return_value = iter([
-        {"RID": "1-IMG1", "Filename": "img1.jpg"},
-        {"RID": "1-IMG2", "Filename": "img2.jpg"},
-    ])
+    bag.get_table_as_dict.return_value = iter(
+        [
+            {"RID": "1-IMG1", "Filename": "img1.jpg"},
+            {"RID": "1-IMG2", "Filename": "img2.jpg"},
+        ]
+    )
 
     ds = build_tf_dataset(
         bag,
@@ -439,10 +445,12 @@ def test_output_signature_none_infers_from_first_sample():
     )
 
     assert isinstance(ds, tf.data.Dataset)
-    # element_spec should reflect a float32 tensor of shape (3,)
-    spec = ds.element_spec
-    assert spec.dtype == tf.float32
-    assert spec.shape == (3,)
+    # element_spec is now (sample_spec, rid_spec) — the rid is always
+    # the last positional value in the yielded tuple.
+    sample_spec, rid_spec = ds.element_spec
+    assert sample_spec.dtype == tf.float32
+    assert sample_spec.shape == (3,)
+    assert rid_spec.dtype == tf.string
 
     # All elements should be present (inference must not drop the first sample)
     count = sum(1 for _ in ds)

--- a/tests/dataset/test_torch_adapter_logic.py
+++ b/tests/dataset/test_torch_adapter_logic.py
@@ -193,10 +193,11 @@ def test_missing_unknown_keeps_all_elements_with_none_target():
         missing="unknown",
     )
     assert len(ds) == 2
-    # Find the unlabeled item — target should be None
+    # Find the unlabeled item — target should be None.
+    # Return shape with targets set is (sample, target, rid).
     targets_seen = []
     for i in range(len(ds)):
-        sample, target = ds[i]
+        sample, target, _rid = ds[i]
         targets_seen.append(target)
     assert None in targets_seen
 
@@ -399,9 +400,93 @@ def test_resolve_asset_path_uses_bdbag_canonical_layout(tmp_path):
         sample_loader=capturing_loader,
         targets=["Grade"],
     )
-    sample, _ = ds[0]
+    # Return shape with targets set is (sample, target, rid).
+    sample, _target, returned_rid = ds[0]
     # The sample_loader received the canonical-layout path and was able
     # to read it. Pre-fix, sample_loader received a non-existent path
     # and raised FileNotFoundError inside the read.
     assert received_paths == [canonical_file]
     assert sample == asset_bytes
+    # The RID surfaced as the last positional value is the same opaque
+    # token threaded through the bag mock and the on-disk layout.
+    assert returned_rid == asset_rid
+
+
+# ---------------------------------------------------------------------------
+# Return-shape contract (RID always last positional value, per spec §3)
+# ---------------------------------------------------------------------------
+
+
+def test_return_shape_targets_none_is_sample_rid_tuple(tmp_path):
+    """``targets=None`` → ``__getitem__`` returns ``(sample, rid)``.
+
+    The RID is the catalog identity of the row. It's always surfaced
+    so downstream code can record per-element predictions / outputs
+    back to the catalog without re-iterating the bag's row table.
+    """
+    import secrets
+
+    # Set up a single asset on disk so sample_loader can succeed.
+    asset_rid = secrets.token_hex(3).upper()
+    filename = "asset.bin"
+    asset_bytes = b"opaque-bytes"
+
+    bag_root = tmp_path / "Dataset_FAKE"
+    leaf_dir = bag_root / "data" / "asset" / asset_rid / "Image"
+    leaf_dir.mkdir(parents=True)
+    (leaf_dir / filename).write_bytes(asset_bytes)
+
+    bag = _mock_bag_with_labeled_images({asset_rid: "Mild"})
+    bag.path = bag_root
+    bag.get_table_as_dict.return_value = iter([{"RID": asset_rid, "Filename": filename}])
+
+    ds = build_torch_dataset(
+        bag,
+        "Image",
+        sample_loader=lambda path, row: path.read_bytes(),
+        # No targets → unlabeled shape.
+    )
+    item = ds[0]
+    assert isinstance(item, tuple), f"expected tuple, got {type(item).__name__}"
+    assert len(item) == 2, f"expected 2-tuple (sample, rid), got len={len(item)}"
+    sample, returned_rid = item
+    assert sample == asset_bytes
+    assert returned_rid == asset_rid
+
+
+def test_return_shape_with_targets_is_sample_target_rid_tuple(tmp_path):
+    """``targets`` set → ``__getitem__`` returns ``(sample, target, rid)``.
+
+    RID is the last positional value regardless of targets shape. It's
+    passed through raw (never touched by ``transform`` or
+    ``target_transform``).
+    """
+    import secrets
+
+    asset_rid = secrets.token_hex(3).upper()
+    filename = "asset.bin"
+    asset_bytes = b"opaque-bytes"
+
+    bag_root = tmp_path / "Dataset_FAKE"
+    leaf_dir = bag_root / "data" / "asset" / asset_rid / "Image"
+    leaf_dir.mkdir(parents=True)
+    (leaf_dir / filename).write_bytes(asset_bytes)
+
+    bag = _mock_bag_with_labeled_images({asset_rid: "Mild"})
+    bag.path = bag_root
+    bag.get_table_as_dict.return_value = iter([{"RID": asset_rid, "Filename": filename}])
+
+    ds = build_torch_dataset(
+        bag,
+        "Image",
+        sample_loader=lambda path, row: path.read_bytes(),
+        targets=["Grade"],
+    )
+    item = ds[0]
+    assert isinstance(item, tuple)
+    assert len(item) == 3, f"expected 3-tuple (sample, target, rid), got len={len(item)}"
+    sample, target, returned_rid = item
+    assert sample == asset_bytes
+    assert getattr(target, "Grade", None) == "Mild"
+    # RID is the SAME opaque token the bag mock produced — last positional.
+    assert returned_rid == asset_rid


### PR DESCRIPTION
## Summary

\`bag.as_torch_dataset()\` and \`bag.as_tf_dataset()\` now always include the element's catalog RID as the last positional value of each yielded item:

| Targets | Return shape |
|---|---|
| \`None\` (unlabeled) | \`(sample, rid)\` |
| set (labeled) | \`(sample, target, rid)\` |

The RID is passed through raw — never touched by \`transform\` or \`target_transform\` — because it's the row's catalog identity, not a feature value.

## Why

The 2026-05-19 e2e platform test session surfaced a duplication that the previous adapter shape made unavoidable: every downstream consumer that needs the RID (e.g. to record per-element predictions back to the catalog) had to hand-roll a parallel \`Dataset\` subclass that re-implements bag iteration, label resolution, and asset-path construction. The template's \`_RidAwareImageDataset\` (in \`models/cifar10_cnn.py:89-135\`) is exactly that workaround. The duplication had a real cost: both the deriva-ml adapter AND the template's hand-rolled copy contained the same path-layout bug (fixed in [#167](https://github.com/informatics-isi-edu/deriva-ml/pull/167) and template [#11](https://github.com/informatics-isi-edu/deriva-ml-model-template/pull/11)).

Surfacing the RID directly from the adapter eliminates the need for that workaround. The companion follow-up PR on the template removes \`_RidAwareImageDataset\` entirely.

## Wire-shape change (no shim)

This is a breaking change to the adapter's wire shape. Callers that wrote \`for sample, target in dataloader:\` need to update to \`for sample, target, rid in dataloader:\` (or \`for sample, target, _ in dataloader:\` to discard).

- The break is explicit: Python raises \`ValueError: too many values to unpack\` at unpack time. Silent semantic shifts are not possible.
- The adapter shipped 2026-04-24 and the only known callers are this workspace's template and a sandbox clone (both rewritten in the follow-up).
- No PyPI release has carried the old shape.

The maintainer asked for the simplification rather than a compatibility flag, on the grounds that no external consumers exist yet.

## Files changed

- \`src/deriva_ml/dataset/torch_adapter.py\` — \`_TorchDataset.__getitem__\` always includes rid.
- \`src/deriva_ml/dataset/tf_adapter.py\` — generator always yields rid as last positional value.
- \`src/deriva_ml/dataset/dataset_bag.py\` — \`as_torch_dataset\` / \`as_tf_dataset\` docstrings updated.
- \`tests/dataset/test_torch_adapter_logic.py\` — 2 existing tests updated to unpack the new shape; 2 new shape-contract tests added.
- \`tests/dataset/test_tf_adapter_logic.py\` — \`output_signature\` tuples and inference test updated for the new shape.

## Test plan

- [x] \`tests/dataset/test_torch_adapter_logic.py\`: 13 passed (11 existing + 2 new shape-contract tests).
- [x] \`tests/dataset/test_tf_adapter_logic.py\`: 11 passed (all existing, updated for new shape).
- [x] \`tests/dataset/test_torch_adapter_no_torch.py\` and \`test_tf_adapter_no_tf.py\` (import-guard tests): both passed (4 total).
- [x] Pre-existing failures in \`tests/dataset/test_torch_adapter_e2e.py\` and \`tests/dataset/test_tf_adapter_e2e.py\` (\"empty bag fixtures\" — produces no rows for the dataset → adapter pipeline) reproduce on unmodified \`main\` HEAD; **not caused by this PR**.

## Follow-up

deriva-ml-model-template PR (separate): rewrite \`_RidAwareImageDataset\` site to use \`bag.as_torch_dataset(..., targets=...)\` directly. Delete \`_RidAwareImageDataset\` and \`_rid_collate\`. Verify cifar10_quick produces equivalent predictions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)