### PR TITLE
docs(reference): backfill schema.md to match create_schema.py

### DIFF
--- a/docs/reference/schema.md
+++ b/docs/reference/schema.md
@@ -105,7 +105,11 @@ columns:
   type: text
 - name: Description
   type: markdown
-- name: Duration
+- name: Execution_Duration
+  type: text
+- name: Download_Duration
+  type: text
+- name: Upload_Duration
   type: text
 - name: Status
   type: text
@@ -181,11 +185,7 @@ terms:
 - name: Analysis
 - name: Ingest
 - name: Data_Cleaning
-- name: Embedding
 - name: Dataset_Management
-- name: VGG19
-- name: RETFound
-- name: Multimodal
 ```
 
 ## Feature_Name


### PR DESCRIPTION
## Summary

The schema validator CI check (\`schema.md ↔ create_schema.py\`) had been red on every PR for some time. This PR brings the doc back into sync with the code so the validator runs clean and future PRs see green CI.

## Two corrections (both in the doc — code is authoritative in both cases)

**1. Execution table columns** (caused by [#166](https://github.com/informatics-isi-edu/deriva-ml/pull/166)):
- Renamed \`Duration\` → \`Execution_Duration\` to match create_schema.py after the 2026-05-19 phase-duration split.
- Added \`Download_Duration\` and \`Upload_Duration\` columns.

**2. \`Workflow_Type\` vocabulary** (pre-existing drift since 2026-04-20):
- Removed \`Embedding\`, \`VGG19\`, \`RETFound\`, and \`Multimodal\` from the doc.
- create_schema.py's own [\`create_default_terms\` docstring](https://github.com/informatics-isi-edu/deriva-ml/blob/main/src/deriva_ml/schema/create_schema.py#L411) (lines 411–417) explicitly says these are *"domain-specific terms"* that *"must not appear"* in the platform vocab — they belong in user vocabularies added at the catalog level after schema creation, not seeded into \`Workflow_Type\`.
- The doc was over-eager when bootstrapped (commit \`8a8b3a07\`, 2026-04-20); aligning it with the code's stated policy.

## Verification

\`\`\`
$ uv run deriva-ml-validate-schema
deriva-ml-validate-schema: schema.md and create_schema.py agree.
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)