### PR TITLE
fix(feature): select_by_execution returns None on no match (not raise)

### DIFF
--- a/src/deriva_ml/feature.py
+++ b/src/deriva_ml/feature.py
@@ -153,12 +153,14 @@ class FeatureRecord(BaseModel):
             execution_rid: RID of the execution to filter by.
 
         Returns:
-            A selector function ``(list[FeatureRecord]) -> FeatureRecord``
-            suitable for use as the ``selector=`` argument to ``feature_values``.
-
-        Raises:
-            DerivaMLException: If no records in the group match the
-                given execution RID.
+            A selector function ``(list[FeatureRecord]) -> FeatureRecord | None``
+            suitable for use as the ``selector=`` argument to
+            ``feature_values``. Returns ``None`` when no record in the group
+            matches the execution; returns the newest matching record (by RCT)
+            otherwise. Mirrors ``select_by_workflow``'s no-match semantics:
+            ``feature_values`` invokes the selector once per target row, so
+            targets whose record group lacks a match are silently omitted
+            from the output rather than aborting the whole query.
 
         Examples:
             Select values from a specific execution::
@@ -171,10 +173,16 @@ class FeatureRecord(BaseModel):
                 ...     print(rec)
         """
 
-        def _selector(records: list["FeatureRecord"]) -> "FeatureRecord":
+        def _selector(records: list["FeatureRecord"]) -> "FeatureRecord | None":
             filtered = [r for r in records if r.Execution == execution_rid]
             if not filtered:
-                raise DerivaMLException(f"No feature records match execution '{execution_rid}'.")
+                # Return None so feature_values omits this target RID silently.
+                # Parallel to select_by_workflow's behavior; raising used to
+                # abort the whole query when any target row lacked a record
+                # from the target execution, which made the selector
+                # unusable in any catalog where the feature is sparsely
+                # annotated by execution (the common case).
+                return None
             return FeatureRecord.select_newest(filtered)
 
         return _selector
@@ -201,8 +209,8 @@ class FeatureRecord(BaseModel):
         **None return semantics:** when no record in a group matches the
         workflow, the selector returns ``None``. ``feature_values`` treats
         ``None`` as "feature absent for this target RID" and omits the target
-        from the iterator. This is distinct from ``select_by_execution``, which
-        raises on no-match.
+        from the iterator. ``select_by_execution`` follows the same
+        convention.
 
         Args:
             workflow: Name (or RID) of the workflow to filter by. Must be a
@@ -355,7 +363,6 @@ class FeatureRecord(BaseModel):
                     raise DerivaMLException(
                         "select_majority_vote requires a column name — could not auto-detect from feature metadata."
                     )
-
 
             counts = Counter(getattr(r, col, None) for r in records)
             max_count = max(counts.values())

--- a/tests/feature/test_select_by_execution.py
+++ b/tests/feature/test_select_by_execution.py
@@ -7,15 +7,10 @@ Closes audit Phase 3 feature/ §3.2.
 
 from __future__ import annotations
 
-import pytest
-
-from deriva_ml.core.exceptions import DerivaMLException
 from deriva_ml.feature import FeatureRecord
 
 
-def _make_record(
-    execution: str, rct: str, feature_name: str = "Label"
-) -> FeatureRecord:
+def _make_record(execution: str, rct: str, feature_name: str = "Label") -> FeatureRecord:
     """Create a minimal FeatureRecord with the given execution and RCT."""
     return FeatureRecord(Execution=execution, Feature_Name=feature_name, RCT=rct)
 
@@ -28,6 +23,7 @@ def test_select_by_execution_picks_matching_record() -> None:
         _make_record("exec-target", "2024-01-02T00:00:00"),
     ]
     result = selector(records)
+    assert result is not None
     assert result.Execution == "exec-target"
 
 
@@ -44,16 +40,60 @@ def test_select_by_execution_picks_newest_among_matches() -> None:
         _make_record("exec-other", "2025-01-01T00:00:00"),  # newer but wrong exec
     ]
     result = selector(records)
+    assert result is not None
     assert result.Execution == "exec-multi"
     assert result.RCT == "2024-06-15T12:00:00"
 
 
-def test_select_by_execution_raises_when_no_match() -> None:
-    """No record with the requested Execution → DerivaMLException."""
+def test_select_by_execution_returns_none_when_no_match() -> None:
+    """No record with the requested Execution → returns None.
+
+    Mirrors ``select_by_workflow``'s behavior. ``feature_values``
+    calls the selector once per target row; targets whose record
+    group lacks a match should be silently omitted from the
+    output, not abort the whole query. The earlier contract
+    (raise ``DerivaMLException``) was retired in 2026-05 because
+    it made the selector unusable in any catalog where a feature
+    is sparsely annotated by execution — the common case.
+    """
     selector = FeatureRecord.select_by_execution("exec-missing")
     records = [
         _make_record("exec-a", "2024-01-01T00:00:00"),
         _make_record("exec-b", "2024-01-02T00:00:00"),
     ]
-    with pytest.raises(DerivaMLException, match="No feature records match execution"):
-        selector(records)
+    assert selector(records) is None
+
+
+def test_select_by_execution_returns_none_on_empty_records() -> None:
+    """selector([]) returns None — no record group can satisfy an execution filter.
+
+    Parallel to ``select_by_workflow``'s empty-records test.
+    """
+    selector = FeatureRecord.select_by_execution("exec-anything")
+    assert selector([]) is None
+
+
+def test_select_by_execution_skips_unrelated_targets_in_mixed_groups() -> None:
+    """Simulates the feature_values per-target loop with mixed groups.
+
+    feature_values calls the selector once per target. Groups that
+    happen to contain a matching record return that record;
+    groups that don't return None and are silently skipped by the
+    caller. This is the e2e shape that surfaced B12.
+    """
+    selector = FeatureRecord.select_by_execution("exec-target")
+    # Group A: has the target execution + others (yields the target).
+    group_a = [
+        _make_record("exec-other-1", "2024-01-01T00:00:00"),
+        _make_record("exec-target", "2024-02-01T00:00:00"),
+        _make_record("exec-other-2", "2024-03-01T00:00:00"),
+    ]
+    # Group B: only other executions (yields None — skipped).
+    group_b = [
+        _make_record("exec-other-1", "2024-01-01T00:00:00"),
+        _make_record("exec-other-2", "2024-02-01T00:00:00"),
+    ]
+    a = selector(group_a)
+    b = selector(group_b)
+    assert a is not None and a.Execution == "exec-target"
+    assert b is None


### PR DESCRIPTION
## Summary

`FeatureRecord.select_by_execution` previously raised `DerivaMLException` whenever a per-target record group lacked a record from the target execution. Since `feature_values` calls the selector **once per target row**, a single no-match group aborted the entire query. This made the selector unusable in any catalog where the feature is sparsely annotated by execution — the common case: a training execution writes labels only for its test split, but `feature_values` iterates over every target row.

The parallel selector `select_by_workflow` (same file) already handles the same case correctly by returning `None`, letting `feature_values` silently omit the target from the output. This PR aligns `select_by_execution` with that contract.

**This is a behavior change.** Callers that depended on the exception to detect "no records for this execution at all" need to handle the new `None` return shape — but in practice, no such caller exists in the deriva-ml / deriva-ml-mcp / deriva-ml-model-template tree (verified via grep). The exception was an accident of the old single-target API that didn't survive the move to per-target invocation in `feature_values`.

## How surfaced

E2E Phase 3 against catalog 46:
- 500 `Image_Classification` ground-truth records (load-cifar10 exec)
- 50 predictions each from two training execs (`CDG`, `CMY`)

MCP call `deriva_ml_list_feature_values(selector="by_execution", selector_execution_rid="CDG")` returned `\"No feature records match execution 'CDG'.\"` even though direct ermrest showed CDG had 50 rows. The `execution_rids=[\"CDG\"]` filter param worked because it filters **before** grouping.

## Test plan

- [x] `tests/feature/test_select_by_execution.py` — 5 unit tests pass (3 existing + 2 new):
  - existing matching-record + newest-among-matches tests unchanged
  - `test_select_by_execution_raises_when_no_match` flipped to `test_select_by_execution_returns_none_when_no_match`
  - new `test_select_by_execution_returns_none_on_empty_records` (parallel to `select_by_workflow`'s empty-records test)
  - new `test_select_by_execution_skips_unrelated_targets_in_mixed_groups` mirrors the `feature_values` per-target loop shape that surfaced B12 in the e2e run
- [x] `tests/feature/test_select_by_workflow.py` — 7 tests still pass (no behavior change)
- [x] `ruff check` + `ruff format` clean
- [ ] E2E re-verification on catalog 46 after this lands — selector="by_execution" should return the same 50-row count as the `execution_rids=` filter path

🤖 Generated with [Claude Code](https://claude.com/claude-code)