### PR TITLE
fix(denormalize): feature-assoc tables are transparent (#174)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,55 @@
 
 All notable changes to this project are documented here.
 
+## Unreleased — Issue #174: split_dataset stratify works for feature-target columns
+
+### Fixed
+
+- **Denormalization planner recognizes feature-association tables as
+  transparent intermediates.** Previously, a 3-FK feature-assoc table
+  (e.g. `Execution_Image_Image_Classification`) failed the 2-FK
+  topological-association predicate, which made `_outbound_reachable`
+  fail to bridge through it and surfaced two confusing errors from
+  `split_dataset(stratify_by_column=...)` when the stratification
+  column lived behind the bridge:
+
+  - `Anchors of table(s) ['Image'] have no FK path to ...` (variant A).
+  - `Multiple candidates for row_per: ['Image', 'Image_Classification']`
+    with no kwarg exposed to disambiguate (variant B).
+
+  The planner now treats both pure 2-FK association tables AND
+  3-FK feature-association tables (one FK to the ML schema's
+  `Execution` table) as transparent intermediates. See the
+  "Transparency model" section in
+  `src/deriva_ml/model/denormalize_planner.py` for the conceptual
+  contract. The sibling predicate `_is_feature_association` and the
+  union helper `_is_transparent_intermediate` are now consulted by
+  `_outbound_reachable`, `_enumerate_paths`, `_find_path_ambiguities`,
+  and `_build_join_tree`.
+
+- **Rule 5 (downstream-leaf rejection) uses strict downstream.**
+  A new helper `_outbound_reachable_strict` walks only direct FK
+  chains (no bidirectional bridge hop). Rule 5 and Rule 2
+  (sink-finding) consult it, so picking either endpoint of a
+  transparent bridge as `row_per=` is no longer rejected as a
+  "downstream leaf." Side effect: when both endpoints of a bridge
+  appear in `include_tables` with no explicit `row_per`, the
+  planner now raises `DerivaMLDenormalizeMultiLeaf` (with both
+  candidates listed) instead of the older `DerivaMLDenormalizeNoSink`
+  — strictly a better error message.
+
+### Added
+
+- **`split_dataset(row_per=..., via=..., ignore_unrelated_anchors=...)`**
+  pass-through parameters reach the underlying
+  `Denormalizer.as_dataframe` call. When `stratify_by_column` is set
+  and `row_per` is None, `split_dataset` defaults
+  `row_per=element_table` automatically — the natural anchor when
+  partitioning element rows through a feature-association bridge.
+
+- **CLI flags** `--row-per`, `--via`, `--ignore-unrelated-anchors` on
+  `deriva-ml-split-dataset` matching the new Python kwargs.
+
 ## Unreleased — Sort + materialize_limit + execution_rids on find_*/feature_values
 
 ### Added

--- a/src/deriva_ml/dataset/split.py
+++ b/src/deriva_ml/dataset/split.py
@@ -501,6 +501,10 @@ def split_dataset(
     selection_fn: SelectionFunction | None = None,
     workflow_type: str = "Dataset_Split",
     dry_run: bool = False,
+    # Denormalization-control parameters (issue #174)
+    row_per: str | None = None,
+    via: list[str] | None = None,
+    ignore_unrelated_anchors: bool = False,
 ) -> SplitResult:
     """Split a DerivaML dataset into training, testing, and optionally validation subsets.
 
@@ -561,6 +565,23 @@ def split_dataset(
             ``stratify_by_column``.
         workflow_type: Workflow type vocabulary term. Default: "Dataset_Split".
         dry_run: If True, return what would happen without modifying catalog.
+        row_per: Explicit leaf table for denormalization (passed
+            through to :meth:`Dataset.get_denormalized_as_dataframe`).
+            When ``stratify_by_column`` or ``selection_fn`` is set and
+            ``row_per`` is None, defaults to ``element_table`` — the
+            natural anchor when partitioning element rows. Set
+            explicitly to override (e.g., when projecting a feature
+            value table's columns through a feature-association
+            bridge and you want one row per feature value).
+        via: Tables forced into the join chain without contributing
+            columns (denormalizer ``via=`` parameter). Useful to
+            disambiguate path ambiguity (Rule 6) without polluting
+            the output column list.
+        ignore_unrelated_anchors: If True, silently drop dataset
+            anchors whose table has no FK path to any requested
+            table. Pass-through to the denormalizer (Rule 8) — useful
+            when the source dataset has heterogeneous member tables
+            and only a subset participates in the split.
 
     Returns:
         SplitResult with partition info for split, training, testing,
@@ -609,6 +630,33 @@ def split_dataset(
                 test_size=0.2,
                 stratify_by_column="Image_Classification.Image_Class",
                 include_tables=["Image", "Image_Classification"],
+            )
+
+        Stratified split on a feature-target column (one row per
+        Image, projecting the Image_Classification vocab term)::
+
+            # Image and Image_Classification are linked by the feature-
+            # association table Execution_Image_Image_Classification.
+            # ``split_dataset`` auto-defaults ``row_per=element_table``
+            # when stratifying, so the join produces one row per Image
+            # with the classification label projected as a column.
+            result = split_dataset(
+                ml, "28D0",
+                test_size=0.2,
+                stratify_by_column="Image_Classification.Image_Class",
+                include_tables=["Image", "Image_Classification"],
+                element_table="Image",
+            )
+
+        Override ``row_per`` to project one row per feature value
+        instead (e.g., when computing per-annotation statistics)::
+
+            result = split_dataset(
+                ml, "28D0",
+                test_size=0.2,
+                stratify_by_column="Image_Classification.Image_Class",
+                include_tables=["Image", "Execution_Image_Image_Classification"],
+                row_per="Execution_Image_Image_Classification",
             )
 
         Stratified split dropping rows with missing labels::
@@ -758,8 +806,23 @@ def split_dataset(
     use_denormalization = stratify_by_column is not None or selection_fn is not None
 
     if use_denormalization:
-        logger.info(f"Denormalizing dataset with tables: {include_tables}")
-        df = source_ds.get_denormalized_as_dataframe(include_tables)
+        # Default row_per to the element table when stratifying, so
+        # the natural "one row per element" cardinality lines up with
+        # how the partitions are built downstream (RID lookups happen
+        # via the {element_table}.RID column). Callers who want a
+        # different row_per (e.g., one row per feature value when the
+        # feature-assoc table is in include_tables) can pass it
+        # explicitly. See issue #174 for the motivating case.
+        effective_row_per = row_per if row_per is not None else element_table
+        logger.info(
+            f"Denormalizing dataset with tables: {include_tables} (row_per={effective_row_per}, via={via or []})"
+        )
+        df = source_ds.get_denormalized_as_dataframe(
+            include_tables,
+            row_per=effective_row_per,
+            via=via,
+            ignore_unrelated_anchors=ignore_unrelated_anchors,
+        )
         logger.info(f"Denormalized DataFrame: {len(df)} rows, {len(df.columns)} columns")
 
         if stratify_by_column:
@@ -885,6 +948,9 @@ def split_dataset(
             "stratify_missing": stratify_missing,
             "element_table": element_table,
             "include_tables": include_tables,
+            "row_per": row_per,
+            "via": via,
+            "ignore_unrelated_anchors": ignore_unrelated_anchors,
             "training_types": train_types,
             "testing_types": test_types,
             "validation_types": val_types if val_types else None,
@@ -1131,6 +1197,21 @@ def main() -> int:
         "(e.g., Image,Image_Classification). Required for stratified splitting.",
     )
     parser.add_argument(
+        "--row-per",
+        help="Explicit leaf table for denormalization. Defaults to --element-table when stratifying (issue #174).",
+    )
+    parser.add_argument(
+        "--via",
+        help="Comma-separated tables forced into the join chain without "
+        "contributing columns (denormalizer via= parameter). Use to "
+        "disambiguate path ambiguity (Rule 6) without polluting output.",
+    )
+    parser.add_argument(
+        "--ignore-unrelated-anchors",
+        action="store_true",
+        help="Silently drop dataset anchors with no FK path to any requested table (denormalizer Rule 8 escape hatch).",
+    )
+    parser.add_argument(
         "--training-types",
         default="Labeled",
         help="Comma-separated additional dataset types for training set (default: Labeled)",
@@ -1196,6 +1277,7 @@ def main() -> int:
         training_types = [t.strip() for t in args.training_types.split(",")] if args.training_types else None
         testing_types = [t.strip() for t in args.testing_types.split(",")] if args.testing_types else None
         validation_types = [t.strip() for t in args.validation_types.split(",")] if args.validation_types else None
+        via = [t.strip() for t in args.via.split(",")] if args.via else None
 
         # Run the split
         result = split_dataset(
@@ -1214,6 +1296,9 @@ def main() -> int:
             validation_types=validation_types,
             element_table=args.element_table,
             include_tables=include_tables,
+            row_per=args.row_per,
+            via=via,
+            ignore_unrelated_anchors=args.ignore_unrelated_anchors,
             workflow_type=args.workflow_type,
             dry_run=args.dry_run,
         )

--- a/src/deriva_ml/model/denormalize_planner.py
+++ b/src/deriva_ml/model/denormalize_planner.py
@@ -9,6 +9,59 @@ columns. It does **not** issue any SQL. The plan is consumed by
 ``core/mixins/dataset.py:list_denormalized_columns`` (which only needs
 the column list).
 
+------------------------------------------------------------------
+Transparency model
+------------------------------------------------------------------
+
+A *transparent* table is one the planner walks **through** without
+asking the caller to name it in ``include_tables`` or ``via``. The
+planner treats two kinds of tables as transparent:
+
+1. **Topological association tables** (M:N link tables):
+   :meth:`DenormalizePlanner._is_topological_association`. Exactly two
+   domain FKs (system FKs to ``ERMrest_Client`` / ``ERMrest_Group`` are
+   ignored). Examples: ``Dataset_Image``, ``Subject_Sample``. These
+   exist purely to link two domain tables — the planner hops through
+   them in both directions so ``A → assoc → B`` discovers B from A.
+
+2. **Feature association tables** (DerivaML feature value tables):
+   :meth:`DenormalizePlanner._is_feature_association`. Three domain
+   FKs, exactly one of which targets the ML schema's ``Execution``
+   table; the other two are the feature's target domain table and a
+   vocabulary / value table. Examples:
+   ``Execution_Image_Image_Classification``,
+   ``Execution_Subject_Diagnosis``. These exist to record one
+   feature value per (target, execution) — the Execution FK is an
+   audit / provenance edge, *not* a domain edge that callers ever
+   want to filter on. From the planner's denormalization perspective
+   they behave like a pure 2-FK bridge between the target and the
+   value table.
+
+In both cases, transparency means:
+
+- the planner walks **through** the table in both directions when
+  determining reachability (:meth:`_outbound_reachable`);
+- the table does **not** count as an interior table for the
+  diamond-disambiguation rule (Rule 6 in :meth:`_find_path_ambiguities`);
+- the table's own columns are excluded from the output **unless** the
+  caller explicitly names it in ``include_tables``, at which point
+  its non-FK metadata columns (``Feature_Name`` / ``Confidence`` /
+  etc.) become regular projected columns and the table behaves like
+  any requested table (it still routes the join, but it's no longer
+  "transparent" for *that* call).
+
+What is intentionally **not** transparent:
+
+- 4+ FK tables (multi-way associations the caller has to disambiguate
+  by hand).
+- 3-FK domain-only tables that don't reference ``Execution`` (these
+  are genuine 3-way associations whose third FK is a domain
+  semantic, not provenance, and the caller should signal intent).
+- Tables that satisfy neither predicate. The planner treats anything
+  not in ``include_tables`` / ``via`` and not transparent as a dead
+  end during reachability — that's how it stops itself from sliding
+  off the requested star into the rest of the schema.
+
 **This module is internal.** The user-facing API for denormalization
 is :class:`local_db.denormalize.Denormalizer` — see
 ``docs/superpowers/specs/2026-04-17-denormalization-semantics-design.md``
@@ -66,8 +119,13 @@ The methods compose in three layers, lowest first:
   with transparent association hops.
 - :meth:`DenormalizePlanner._schema_to_paths` — DFS path enumeration
   with cycle detection and vocab termination.
-- :meth:`DenormalizePlanner._is_topological_association` — predicate
-  for the "transparent intermediate" rule.
+- :meth:`DenormalizePlanner._is_topological_association` — 2-FK
+  predicate (pure M:N bridges).
+- :meth:`DenormalizePlanner._is_feature_association` — 3-FK predicate
+  (one FK targets the ML schema's ``Execution`` table; the other two
+  are domain/value edges).
+- :meth:`DenormalizePlanner._is_transparent_intermediate` — union of
+  the two predicates; this is what the reachability primitives consult.
 - :meth:`DenormalizePlanner._table_relationship` — column-pair
   extraction for a specific (table1, table2) FK.
 
@@ -308,11 +366,7 @@ class DenormalizePlanner:
             planner._is_topological_association("Observation")         # False (has 1 FK)
         """
         try:
-            tbl = (
-                name_or_table
-                if hasattr(name_or_table, "foreign_keys")
-                else self.model.name_to_table(name_or_table)
-            )
+            tbl = name_or_table if hasattr(name_or_table, "foreign_keys") else self.model.name_to_table(name_or_table)
             fks = list(tbl.foreign_keys)
             # Domain FKs exclude the system FKs to ERMrest_Client /
             # ERMrest_Group that every table carries (for RCB/RMB).
@@ -320,6 +374,106 @@ class DenormalizePlanner:
             return len(domain_fks) == 2
         except Exception:
             return False
+
+    def _is_feature_association(self, name_or_table: str | Table) -> bool:
+        """Predicate for DerivaML feature-association transparency.
+
+        A feature-association table is a 3-FK association whose third
+        FK is the DerivaML ``Execution`` provenance edge — the other
+        two FKs are the feature's *target* domain table (the entity
+        the feature is attached to) and a *value* table (a vocabulary
+        term, an asset, or a metadata table). Concrete example::
+
+            Execution_Image_Image_Classification
+                -> Image                    (feature target)
+                -> Image_Classification     (value: vocab term)
+                -> Execution                (provenance / audit)
+
+        The Execution FK is structurally an audit edge, not a domain
+        edge — it records *which run* asserted the value, not a
+        semantic relationship a caller would ever join through. The
+        denormalization planner therefore treats feature-association
+        tables as transparent in the same sense as topological 2-FK
+        associations: the planner hops through them in both directions
+        during reachability, and they don't count as interior tables
+        when checking for diamond ambiguity.
+
+        **Why we don't widen** :meth:`_is_topological_association` **instead**:
+        the 2-FK predicate is intentionally strict because the diamond
+        rule (Rule 6) uses it. Conflating "transparent bridge" with
+        "feature with audit edge" inside a single predicate makes the
+        rule docs harder to read and risks accidentally treating other
+        3-FK shapes as transparent in the future. The two predicates
+        compose at the call sites (mostly
+        :meth:`_outbound_reachable`) where transparency is consulted.
+
+        **Structural, not naming.** The predicate ignores the table
+        name (``Execution_*`` is a convention, not a contract) and
+        keys off the FK shape. Domain FKs exclude the system FKs to
+        ``ERMrest_Client`` / ``ERMrest_Group``.
+
+        Args:
+            name_or_table: table name (looked up via
+                ``self.model.name_to_table``) or a :class:`Table`
+                instance.
+
+        Returns:
+            ``True`` if the table has exactly 3 domain FKs and exactly
+            one of them targets the ML schema's ``Execution`` table.
+
+        Example::
+
+            planner._is_feature_association(
+                "Execution_Image_Image_Classification"
+            )                                                          # True
+            planner._is_feature_association("Dataset_Image")           # False (2 FKs)
+            planner._is_feature_association("Image")                   # False (no Execution FK)
+            planner._is_feature_association("Three_Way_Domain_Assoc")  # False (no FK to Execution)
+        """
+        try:
+            tbl = name_or_table if hasattr(name_or_table, "foreign_keys") else self.model.name_to_table(name_or_table)
+            fks = list(tbl.foreign_keys)
+            # Domain FKs exclude the system FKs to ERMrest_Client /
+            # ERMrest_Group that every table carries (for RCB/RMB).
+            domain_fks = [fk for fk in fks if fk.pk_table.name not in ("ERMrest_Client", "ERMrest_Group")]
+            if len(domain_fks) != 3:
+                return False
+            ml_schema = self.model.ml_schema
+            execution_fks = [
+                fk for fk in domain_fks if fk.pk_table.name == "Execution" and fk.pk_table.schema.name == ml_schema
+            ]
+            return len(execution_fks) == 1
+        except Exception:
+            return False
+
+    def _is_transparent_intermediate(self, name_or_table: str | Table) -> bool:
+        """Return ``True`` if the table is transparent (assoc or feature-assoc).
+
+        Convenience predicate that ORs
+        :meth:`_is_topological_association` and
+        :meth:`_is_feature_association`. See the module-level
+        "Transparency model" section for the conceptual contract.
+
+        Args:
+            name_or_table: table name or :class:`Table` instance.
+
+        Returns:
+            ``True`` if either transparency predicate matches.
+
+        Example::
+
+            planner._is_transparent_intermediate("Dataset_Image")
+            # True — 2-FK topological association.
+
+            planner._is_transparent_intermediate(
+                "Execution_Image_Image_Classification"
+            )
+            # True — 3-FK feature association.
+
+            planner._is_transparent_intermediate("Image")
+            # False — domain table, not a bridge.
+        """
+        return self._is_topological_association(name_or_table) or self._is_feature_association(name_or_table)
 
     def _fk_neighbors(self, table: str | Table) -> set[Table]:
         """Return FK-neighbor tables of *table* (outbound + inbound, deduplicated).
@@ -435,15 +589,23 @@ class DenormalizePlanner:
         Composes :meth:`_downstream_fk_sources` plus association-
         transparency logic — does NOT walk FKs directly.
 
-        **Transparent association hops**: when the walker hits an
-        association table (per :meth:`is_topological_association`) that isn't
-        in ``tables_in_set``, it hops through it in BOTH directions —
-        both the tables that point at the association (inbound) AND the
-        tables the association's FKs point at (outbound). This lets
-        ``A → assoc → B`` discover B from A even when A → assoc is an
-        inbound FK and assoc → B is an outbound FK. Without this
-        bidirectional hop, many-to-many relationships (Dataset ↔ Image
-        via Dataset_Image) wouldn't be traversable.
+        **Transparent hops**: when the walker hits a *transparent
+        intermediate* (per :meth:`_is_transparent_intermediate`) that
+        isn't in ``tables_in_set``, it hops through it in BOTH
+        directions — both the tables that point at the intermediate
+        (inbound) AND the tables the intermediate's FKs point at
+        (outbound). This lets ``A → bridge → B`` discover B from A
+        even when ``A → bridge`` is an inbound FK and ``bridge → B``
+        is an outbound FK. Without this bidirectional hop, many-to-many
+        relationships (Dataset ↔ Image via Dataset_Image) and feature
+        targets (Image ↔ Image_Classification via the feature-assoc
+        table) wouldn't be traversable.
+
+        Both topological 2-FK associations (e.g. ``Dataset_Image``)
+        and 3-FK feature associations (e.g.
+        ``Execution_Image_Image_Classification``, where the third FK
+        is the audit edge to ``Execution``) count as transparent —
+        see the module docstring's "Transparency model" section.
 
         **Direction matters**: with ``Image.Subject → Subject.RID``:
 
@@ -487,19 +649,24 @@ class DenormalizePlanner:
             except Exception:
                 continue
 
-            # When the current node is itself an association table AND it's
-            # not the starting point, hop through both directions: both the
-            # tables that point at it (referenced_by) AND the tables it
-            # points to (foreign_keys). This is the "transparent bridge"
-            # semantics — M:N link tables should be traversable in both
-            # directions so that A→assoc→B discovers B from A.
-            hopping_through_association = t != from_table and self._is_topological_association(tbl)
+            # When the current node is itself a transparent intermediate
+            # AND it's not the starting point, hop through both directions:
+            # both the tables that point at it (referenced_by) AND the
+            # tables it points to (foreign_keys). This is the "transparent
+            # bridge" semantics — M:N link tables and feature-assoc tables
+            # should be traversable in both directions so that
+            # A → bridge → B discovers B from A.
+            hopping_through_bridge = t != from_table and self._is_transparent_intermediate(tbl)
 
             valid_schemas = self.model.domain_schemas | {self.model.ml_schema}
             neighbors: list[Table] = list(self._downstream_fk_sources(t))
-            if hopping_through_association:
-                # Add the association's outbound FK targets (the "other
-                # side" of the M:N link) so we can see past the bridge.
+            if hopping_through_bridge:
+                # Add the bridge's outbound FK targets (the "other side"
+                # of the link) so we can see past the bridge. For feature-
+                # assoc tables this also exposes the Execution target,
+                # but that's fine — Execution is in _DEFAULT_SKIP_TABLES
+                # for path enumeration and the reachability set only
+                # cares about whether requested tables are reachable.
                 for fk in tbl.foreign_keys:
                     nxt = fk.pk_table
                     if nxt.schema.name in valid_schemas:
@@ -511,14 +678,99 @@ class DenormalizePlanner:
                     continue
                 if target_name in tables_in_set:
                     seen_names.add(target_name)
-                    # Continue only if this is itself an association (transparent)
-                    if self._is_topological_association(neighbor):
+                    # Continue only if this neighbor is itself transparent
+                    # (so we can chain bridges).
+                    if self._is_transparent_intermediate(neighbor):
                         stack.append(target_name)
-                elif self._is_topological_association(neighbor):
-                    # Transparent hop: continue through the association
+                elif self._is_transparent_intermediate(neighbor):
+                    # Transparent hop: continue through the bridge.
                     stack.append(target_name)
-                # else: non-requested, non-association — dead end
+                # else: non-requested, non-transparent — dead end
         return {t for t in seen_names if t in tables_in_set and t != from_table}
+
+    def _outbound_reachable_strict(
+        self,
+        from_table: str,
+        tables_in_set: set[str],
+    ) -> set[str]:
+        """Strict-direction variant of :meth:`_outbound_reachable`.
+
+        Walks downstream from ``from_table`` following only
+        :meth:`_downstream_fk_sources` (direct ``referenced_by``
+        edges). Does **NOT** perform the bidirectional transparent-
+        bridge hop that :meth:`_outbound_reachable` uses. This means
+        ``A ↔ assoc ↔ B`` (where both A and B are upstream of the
+        bridge) does **not** treat B as downstream of A — neither
+        side fans out into the other through the bridge.
+
+        Used by **Rule 5** (downstream-leaf rejection in
+        :meth:`_determine_row_per`) and **Rule 2** (sink-finding in
+        :meth:`_find_sinks`).
+
+        **Why a separate primitive.** :meth:`_outbound_reachable` is
+        used by :meth:`Denormalizer._classify_anchors` to answer the
+        connectivity question "is anchor X related to row_per via
+        *any* FK chain?" — there, the bidirectional bridge hop is the
+        right behavior (an Image-anchored set IS related to a
+        Dataset-anchored set, even though the bridge sits in between
+        and points at both). For Rules 2 and 5 we need the strict
+        directional notion: "if I pick X as row_per, will the rows
+        fan out into Y?" A bridge whose two endpoints are both
+        upstream of it does not fan out — it produces at most a
+        1:1:1 join, so neither endpoint should be considered
+        downstream of the other.
+
+        Args:
+            from_table: starting table (the candidate row_per).
+            tables_in_set: subgraph — only tables in this set count
+                as destinations in the result.
+
+        Returns:
+            Set of names in ``tables_in_set`` strictly downstream of
+            ``from_table`` (excluding ``from_table`` itself).
+
+        Example::
+
+            # Direct FK Image -> Subject:
+            planner._outbound_reachable_strict("Subject", {"Subject", "Image"})
+            # {"Image"}    — Image references Subject (Image is fan-out)
+            planner._outbound_reachable_strict("Image", {"Subject", "Image"})
+            # set()        — Subject is upstream of Image, not downstream
+
+            # Bridge case (Image <- feature-assoc -> Image_Classification):
+            planner._outbound_reachable_strict(
+                "Image", {"Image", "Image_Classification"}
+            )
+            # set()        — neither side is strictly downstream of the
+            #               other; the bridge does not fan out.
+        """
+        seen: set[str] = set()
+        visited: set[str] = set()
+        stack: list[str] = [from_table]
+        while stack:
+            t = stack.pop()
+            if t in visited:
+                continue
+            visited.add(t)
+            try:
+                tbl = self.model.name_to_table(t)
+            except Exception:
+                continue
+            for neighbor in self._downstream_fk_sources(tbl):
+                target_name = neighbor.name
+                if target_name == from_table:
+                    continue
+                if target_name in tables_in_set:
+                    seen.add(target_name)
+                # Recurse into downstream tables regardless of set
+                # membership — a chain like Subject ← Observation ←
+                # Image must surface Image when only {Subject, Image}
+                # are in the set. We never bridge through assoc tables
+                # bidirectionally here; only follow further
+                # `referenced_by` edges.
+                if target_name not in visited:
+                    stack.append(target_name)
+        return {t for t in seen if t in tables_in_set and t != from_table}
 
     def _schema_to_paths(
         self,
@@ -708,7 +960,11 @@ class DenormalizePlanner:
         the natural ``row_per`` — one output row per sink row, with
         upstream columns hoisted.
 
-        Composes :meth:`_outbound_reachable`; does not traverse FKs
+        Composes :meth:`_outbound_reachable_strict` — strict downstream
+        only (no bidirectional bridge hop). Two tables linked only by
+        a transparent bridge (M:N association or feature-assoc) are
+        therefore both sink candidates and the caller must
+        disambiguate with explicit ``row_per=``. Does not traverse FKs
         itself.
 
         Args:
@@ -735,11 +991,11 @@ class DenormalizePlanner:
         """
         via = via or []
         all_tables = set(include_tables) | set(via)
-        # A sink is a requested table whose outbound-reach set, minus
-        # itself, is empty — i.e., nothing else in the subgraph is
-        # downstream of it.
+        # A sink is a requested table whose strict-downstream set,
+        # minus itself, is empty — i.e., nothing else in the subgraph
+        # is strictly downstream of it via direct FK chain.
         return sorted(
-            t for t in all_tables if t in include_tables and not (self._outbound_reachable(t, all_tables) - {t})
+            t for t in all_tables if t in include_tables and not (self._outbound_reachable_strict(t, all_tables) - {t})
         )
 
     def _determine_row_per(
@@ -803,7 +1059,11 @@ class DenormalizePlanner:
         if row_per is not None:
             if row_per not in include_tables:
                 raise ValueError(f"row_per={row_per!r} must be in include_tables={include_tables}")
-            downstream = self._outbound_reachable(row_per, all_tables)
+            # Rule 5 uses strict downstream (no bidirectional bridge
+            # hop) — picking either side of a transparent bridge as
+            # row_per is legitimate, since the bridge produces at
+            # most a 1:1:1 join, not a fan-out.
+            downstream = self._outbound_reachable_strict(row_per, all_tables)
             downstream_in_inc = [t for t in include_tables if t in downstream and t != row_per]
             if downstream_in_inc:
                 raise DerivaMLDenormalizeDownstreamLeaf(
@@ -884,8 +1144,10 @@ class DenormalizePlanner:
         for path in paths:
             names = [t.name for t in path]
             # Transparency filter: every intermediate must be either
-            # requested (in tables_in_set) or a pure association.
-            if all(mid in tables_in_set or self._is_topological_association(mid) for mid in names[1:-1]):
+            # requested (in tables_in_set) or a transparent intermediate
+            # (a pure association table OR a feature-association table —
+            # see the module-level "Transparency model" section).
+            if all(mid in tables_in_set or self._is_transparent_intermediate(mid) for mid in names[1:-1]):
                 result.append(names)
         return result
 
@@ -1025,20 +1287,21 @@ class DenormalizePlanner:
                 return None
 
             def _is_downstream_chain(p: list[str]) -> bool:
-                """Check that the path is all-downstream, treating pure
-                association tables as transparent bridges. A transparent
-                bridge Image ← assoc → Subject counts as a single
-                downstream step (the assoc's referenced_by connects the
-                two sides). Association tables at interior positions
-                don't count as direction changes."""
+                """Check that the path is all-downstream, treating
+                transparent intermediates (pure 2-FK associations AND
+                feature-assoc tables) as transparent bridges. A
+                transparent bridge Image ← assoc → Subject counts as a
+                single downstream step (the assoc's referenced_by
+                connects the two sides). Transparent intermediates at
+                interior positions don't count as direction changes."""
                 i = 0
                 while i < len(p) - 1:
                     a, b = p[i], p[i + 1]
-                    # If b is an interior association table, hop across
-                    # it: count the A → assoc → C edge as a single
-                    # transparent bridge and move two steps forward.
-                    if i + 2 < len(p) and self._is_topological_association(b):
-                        # A → assoc → C: the bridge is legitimate
+                    # If b is an interior transparent intermediate, hop
+                    # across it: count the A → bridge → C edge as a
+                    # single transparent step and move two steps forward.
+                    if i + 2 < len(p) and self._is_transparent_intermediate(b):
+                        # A → bridge → C: the bridge is legitimate
                         # regardless of internal direction; advance past.
                         i += 2
                         continue
@@ -1059,8 +1322,9 @@ class DenormalizePlanner:
             # Disambiguation rule:
             # - A path is "signaled" if at least one of its non-endpoint
             #   intermediates is in ``include_tables ∪ via`` (user explicitly
-            #   routed through it). Association tables don't count — they're
-            #   transparent and the user shouldn't need to name them.
+            #   routed through it). Transparent intermediates (pure
+            #   associations and feature-assoc tables) don't count —
+            #   they're transparent and the user shouldn't need to name them.
             # - If exactly one path is signaled, the user has picked it → no
             #   ambiguity.
             # - Otherwise (0 or >1 signaled), we cannot silently choose →
@@ -1068,7 +1332,7 @@ class DenormalizePlanner:
             def _is_signaled(p: list[str]) -> bool:
                 intermediates = p[1:-1]
                 for mid in intermediates:
-                    if mid in all_tables and not self._is_topological_association(mid):
+                    if mid in all_tables and not self._is_transparent_intermediate(mid):
                         return True
                 return False
 
@@ -1082,7 +1346,7 @@ class DenormalizePlanner:
             all_intermediates: set[str] = set()
             for p in reportable:
                 for node in p[1:-1]:
-                    if node not in include_tables and not self._is_topological_association(node):
+                    if node not in include_tables and not self._is_transparent_intermediate(node):
                         all_intermediates.add(node)
             ambiguities.append(
                 {
@@ -1192,13 +1456,16 @@ class DenormalizePlanner:
                 selected_subpaths[target] = unique[0]
                 continue
 
-            # A path is "selected" if all its non-association intermediates are
-            # in include_tables.  Association tables (M:N link tables) are
-            # infrastructure that the user shouldn't need to name explicitly —
-            # they are transparently included in the join chain.
+            # A path is "selected" if all its non-transparent intermediates
+            # are in include_tables. Transparent intermediates (M:N link
+            # tables and feature-assoc tables) are infrastructure that
+            # the user shouldn't need to name explicitly — they are
+            # transparently included in the join chain.
             #
-            # We detect association tables via ``self._is_topological_association``
-            # (module-level method that ignores ERMrest system FKs).
+            # We detect transparent intermediates via
+            # ``self._is_transparent_intermediate`` (the union of the
+            # 2-FK topological-association predicate and the 3-FK
+            # feature-association predicate; both ignore ERMrest system FKs).
 
             def _intermediates_covered(sp: list[Table], ints: tuple[str, ...]) -> bool:
                 sp_tables = {t.name: t for t in sp}
@@ -1207,7 +1474,7 @@ class DenormalizePlanner:
                         # In include_tables OR in via= — explicitly routed.
                         continue
                     tbl = sp_tables.get(t)
-                    if tbl is not None and self._is_topological_association(tbl):
+                    if tbl is not None and self._is_transparent_intermediate(tbl):
                         continue  # transparent — doesn't need to be in include_tables
                     return False
                 return True

--- a/tests/dataset/test_split.py
+++ b/tests/dataset/test_split.py
@@ -1188,3 +1188,135 @@ class TestSplitDataset:
                 test_size=4,
                 element_table="NonExistentTable",
             )
+
+
+# =============================================================================
+# Unit Tests: split_dataset denormalization plumbing (issue #174)
+# =============================================================================
+
+
+class TestDenormalizationPlumbing:
+    """Verify split_dataset forwards row_per/via/ignore_unrelated_anchors
+    to ``get_denormalized_as_dataframe``.
+
+    Issue #174: before this fix, the denormalizer kwargs that the
+    underlying ``Denormalizer.as_dataframe`` accepts (``row_per``,
+    ``via``, ``ignore_unrelated_anchors``) were not exposed by
+    ``split_dataset``. As a result, stratifying on a column that
+    lived behind a feature-association bridge surfaced a confusing
+    ``row_per``-required error with no way to satisfy it. This test
+    pins the plumbing: the kwargs reach the denormalizer, and
+    ``row_per`` defaults to ``element_table`` when stratifying.
+    """
+
+    @staticmethod
+    def _stub_ml_and_dataset(captured: dict):
+        """Build minimal stand-ins that record denormalize kwargs.
+
+        We don't need a real catalog — split_dataset's stratify path
+        calls ``source_ds.list_dataset_members`` and
+        ``source_ds.get_denormalized_as_dataframe``, then runs the
+        selection in-memory and returns a ``dry_run`` result without
+        touching the catalog further (we use ``dry_run=True``).
+        """
+
+        class _StubDataset:
+            def list_dataset_members(self, *, recurse: bool = True):
+                # Two-column 6-row "dataset": six "Item" RIDs.
+                return {
+                    "Item": [{"RID": f"R{i}"} for i in range(6)],
+                }
+
+            def get_denormalized_as_dataframe(
+                self,
+                include_tables,
+                *,
+                row_per=None,
+                via=None,
+                ignore_unrelated_anchors=False,
+            ):
+                captured["include_tables"] = list(include_tables)
+                captured["row_per"] = row_per
+                captured["via"] = list(via) if via is not None else None
+                captured["ignore_unrelated_anchors"] = ignore_unrelated_anchors
+                # Return a balanced 2-class DataFrame keyed by Item.RID.
+                return pd.DataFrame(
+                    {
+                        "Item.RID": [f"R{i}" for i in range(6)],
+                        "Vocab.Class": ["A", "A", "A", "B", "B", "B"],
+                    }
+                )
+
+        class _StubML:
+            def lookup_dataset(self, rid: str):
+                return _StubDataset()
+
+        return _StubML(), _StubDataset()
+
+    @requires_sklearn
+    def test_row_per_defaults_to_element_table_on_stratify(self):
+        """When stratifying and ``row_per`` is None, default to ``element_table``."""
+        captured: dict = {}
+        ml, _ = self._stub_ml_and_dataset(captured)
+
+        result = split_dataset(
+            ml,
+            "DS-1",
+            test_size=2,
+            train_size=4,
+            seed=42,
+            stratify_by_column="Vocab.Class",
+            include_tables=["Item", "Vocab"],
+            element_table="Item",
+            dry_run=True,
+        )
+        assert isinstance(result, SplitResult)
+        # The denormalize call must have received the auto-defaulted row_per.
+        assert captured["row_per"] == "Item", (
+            f"row_per should default to element_table='Item', got {captured['row_per']!r}"
+        )
+        # via and ignore_unrelated_anchors default to None / False.
+        assert captured["via"] is None
+        assert captured["ignore_unrelated_anchors"] is False
+
+    @requires_sklearn
+    def test_row_per_explicit_passed_through(self):
+        """Explicit ``row_per`` overrides the element_table default."""
+        captured: dict = {}
+        ml, _ = self._stub_ml_and_dataset(captured)
+
+        split_dataset(
+            ml,
+            "DS-1",
+            test_size=2,
+            train_size=4,
+            seed=42,
+            stratify_by_column="Vocab.Class",
+            include_tables=["Item", "Vocab"],
+            element_table="Item",
+            row_per="Vocab",
+            dry_run=True,
+        )
+        assert captured["row_per"] == "Vocab"
+
+    @requires_sklearn
+    def test_via_and_ignore_unrelated_anchors_forwarded(self):
+        """``via`` and ``ignore_unrelated_anchors`` reach the denormalizer."""
+        captured: dict = {}
+        ml, _ = self._stub_ml_and_dataset(captured)
+
+        split_dataset(
+            ml,
+            "DS-1",
+            test_size=2,
+            train_size=4,
+            seed=42,
+            stratify_by_column="Vocab.Class",
+            include_tables=["Item", "Vocab"],
+            element_table="Item",
+            via=["Execution_Item_Vocab"],
+            ignore_unrelated_anchors=True,
+            dry_run=True,
+        )
+        assert captured["via"] == ["Execution_Item_Vocab"]
+        assert captured["ignore_unrelated_anchors"] is True

--- a/tests/local_db/conftest.py
+++ b/tests/local_db/conftest.py
@@ -427,6 +427,268 @@ def populated_denorm_diamond(
 
 
 # ---------------------------------------------------------------------------
+# Feature-association fixture (issue #174)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def denorm_schema_feature(tmp_path: Path) -> Path:
+    """Canned schema with a DerivaML feature-association table.
+
+    Extends :func:`denorm_schema` by adding:
+
+    - ``Execution`` table in the ``deriva-ml`` schema (provenance).
+    - ``Image_Classification`` vocabulary table in the ``isa`` schema
+      (the value table — i.e. the term).
+    - ``Execution_Image_Image_Classification`` association table with
+      three FKs (Image, Execution, Image_Classification) and a
+      ``Feature_Name`` column. This is the canonical shape of a
+      DerivaML feature value table — see ``DerivaModel.find_features``
+      for the runtime predicate.
+
+    Plus a *non-feature* 3-FK association,
+    ``Image_Subject_UnrelatedThing``, with three domain FKs but no
+    FK to ``Execution`` — used to verify
+    :meth:`_is_feature_association` correctly rejects 3-FK associations
+    that aren't features.
+
+    Used by the planner-rules tests in
+    :mod:`tests.local_db.test_planner_rules` to exercise the
+    transparency widening introduced for issue #174.
+    """
+    doc = _base_schema_doc()
+
+    # Add Dataset_Image association (same as denorm_schema)
+    doc["schemas"]["deriva-ml"]["tables"]["Dataset_Image"] = {
+        "table_name": "Dataset_Image",
+        "schema_name": "deriva-ml",
+        "column_definitions": [
+            {"name": "RID", "type": {"typename": "text"}, "nullok": False},
+            {"name": "RCT", "type": {"typename": "timestamptz"}},
+            {"name": "RMT", "type": {"typename": "timestamptz"}},
+            {"name": "RCB", "type": {"typename": "text"}},
+            {"name": "RMB", "type": {"typename": "text"}},
+            {"name": "Dataset", "type": {"typename": "text"}, "nullok": False},
+            {"name": "Image", "type": {"typename": "text"}, "nullok": False},
+        ],
+        "keys": [{"unique_columns": ["RID"]}],
+        "foreign_keys": [
+            {
+                "foreign_key_columns": [
+                    {"schema_name": "deriva-ml", "table_name": "Dataset_Image", "column_name": "Dataset"}
+                ],
+                "referenced_columns": [{"schema_name": "deriva-ml", "table_name": "Dataset", "column_name": "RID"}],
+            },
+            {
+                "foreign_key_columns": [
+                    {"schema_name": "deriva-ml", "table_name": "Dataset_Image", "column_name": "Image"}
+                ],
+                "referenced_columns": [{"schema_name": "isa", "table_name": "Image", "column_name": "RID"}],
+            },
+        ],
+    }
+
+    # Add Execution table (deriva-ml schema)
+    doc["schemas"]["deriva-ml"]["tables"]["Execution"] = {
+        "table_name": "Execution",
+        "schema_name": "deriva-ml",
+        "column_definitions": [
+            {"name": "RID", "type": {"typename": "text"}, "nullok": False},
+            {"name": "RCT", "type": {"typename": "timestamptz"}},
+            {"name": "RMT", "type": {"typename": "timestamptz"}},
+            {"name": "RCB", "type": {"typename": "text"}},
+            {"name": "RMB", "type": {"typename": "text"}},
+            {"name": "Description", "type": {"typename": "text"}, "nullok": True},
+        ],
+        "keys": [{"unique_columns": ["RID"]}],
+        "foreign_keys": [],
+    }
+
+    # Add Image_Classification vocabulary term table (isa schema)
+    doc["schemas"]["isa"]["tables"]["Image_Classification"] = {
+        "table_name": "Image_Classification",
+        "schema_name": "isa",
+        "column_definitions": [
+            {"name": "RID", "type": {"typename": "text"}, "nullok": False},
+            {"name": "RCT", "type": {"typename": "timestamptz"}},
+            {"name": "RMT", "type": {"typename": "timestamptz"}},
+            {"name": "RCB", "type": {"typename": "text"}},
+            {"name": "RMB", "type": {"typename": "text"}},
+            {"name": "Name", "type": {"typename": "text"}, "nullok": False},
+            {"name": "Description", "type": {"typename": "text"}, "nullok": True},
+        ],
+        "keys": [{"unique_columns": ["RID"]}, {"unique_columns": ["Name"]}],
+        "foreign_keys": [],
+    }
+
+    # Add Execution_Image_Image_Classification feature-assoc table.
+    # Three domain FKs: Image, Execution, Image_Classification.
+    # Includes a Feature_Name column to match the DerivaML runtime
+    # predicate (DerivaModel.find_features's is_feature check).
+    doc["schemas"]["deriva-ml"]["tables"]["Execution_Image_Image_Classification"] = {
+        "table_name": "Execution_Image_Image_Classification",
+        "schema_name": "deriva-ml",
+        "column_definitions": [
+            {"name": "RID", "type": {"typename": "text"}, "nullok": False},
+            {"name": "RCT", "type": {"typename": "timestamptz"}},
+            {"name": "RMT", "type": {"typename": "timestamptz"}},
+            {"name": "RCB", "type": {"typename": "text"}},
+            {"name": "RMB", "type": {"typename": "text"}},
+            {"name": "Feature_Name", "type": {"typename": "text"}, "nullok": False},
+            {"name": "Image", "type": {"typename": "text"}, "nullok": False},
+            {"name": "Execution", "type": {"typename": "text"}, "nullok": False},
+            {"name": "Image_Classification", "type": {"typename": "text"}, "nullok": False},
+        ],
+        "keys": [{"unique_columns": ["RID"]}],
+        "foreign_keys": [
+            {
+                "foreign_key_columns": [
+                    {
+                        "schema_name": "deriva-ml",
+                        "table_name": "Execution_Image_Image_Classification",
+                        "column_name": "Image",
+                    }
+                ],
+                "referenced_columns": [{"schema_name": "isa", "table_name": "Image", "column_name": "RID"}],
+            },
+            {
+                "foreign_key_columns": [
+                    {
+                        "schema_name": "deriva-ml",
+                        "table_name": "Execution_Image_Image_Classification",
+                        "column_name": "Execution",
+                    }
+                ],
+                "referenced_columns": [{"schema_name": "deriva-ml", "table_name": "Execution", "column_name": "RID"}],
+            },
+            {
+                "foreign_key_columns": [
+                    {
+                        "schema_name": "deriva-ml",
+                        "table_name": "Execution_Image_Image_Classification",
+                        "column_name": "Image_Classification",
+                    }
+                ],
+                "referenced_columns": [
+                    {"schema_name": "isa", "table_name": "Image_Classification", "column_name": "RID"}
+                ],
+            },
+        ],
+    }
+
+    # Add a non-feature 3-FK association (no FK to Execution) to verify
+    # the predicate rejects 3-FK shapes that aren't features.
+    doc["schemas"]["isa"]["tables"]["Image_Subject_UnrelatedThing"] = {
+        "table_name": "Image_Subject_UnrelatedThing",
+        "schema_name": "isa",
+        "column_definitions": [
+            {"name": "RID", "type": {"typename": "text"}, "nullok": False},
+            {"name": "RCT", "type": {"typename": "timestamptz"}},
+            {"name": "RMT", "type": {"typename": "timestamptz"}},
+            {"name": "RCB", "type": {"typename": "text"}},
+            {"name": "RMB", "type": {"typename": "text"}},
+            {"name": "Image", "type": {"typename": "text"}, "nullok": False},
+            {"name": "Subject", "type": {"typename": "text"}, "nullok": False},
+            {"name": "UnrelatedThing", "type": {"typename": "text"}, "nullok": False},
+        ],
+        "keys": [{"unique_columns": ["RID"]}],
+        "foreign_keys": [
+            {
+                "foreign_key_columns": [
+                    {
+                        "schema_name": "isa",
+                        "table_name": "Image_Subject_UnrelatedThing",
+                        "column_name": "Image",
+                    }
+                ],
+                "referenced_columns": [{"schema_name": "isa", "table_name": "Image", "column_name": "RID"}],
+            },
+            {
+                "foreign_key_columns": [
+                    {
+                        "schema_name": "isa",
+                        "table_name": "Image_Subject_UnrelatedThing",
+                        "column_name": "Subject",
+                    }
+                ],
+                "referenced_columns": [{"schema_name": "isa", "table_name": "Subject", "column_name": "RID"}],
+            },
+            {
+                "foreign_key_columns": [
+                    {
+                        "schema_name": "isa",
+                        "table_name": "Image_Subject_UnrelatedThing",
+                        "column_name": "UnrelatedThing",
+                    }
+                ],
+                "referenced_columns": [{"schema_name": "isa", "table_name": "UnrelatedThing", "column_name": "RID"}],
+            },
+        ],
+    }
+
+    # Add a 4-FK association to verify the predicate rejects multi-way
+    # associations (should NOT be transparent).
+    doc["schemas"]["isa"]["tables"]["FourWayAssoc"] = {
+        "table_name": "FourWayAssoc",
+        "schema_name": "isa",
+        "column_definitions": [
+            {"name": "RID", "type": {"typename": "text"}, "nullok": False},
+            {"name": "RCT", "type": {"typename": "timestamptz"}},
+            {"name": "RMT", "type": {"typename": "timestamptz"}},
+            {"name": "RCB", "type": {"typename": "text"}},
+            {"name": "RMB", "type": {"typename": "text"}},
+            {"name": "Image", "type": {"typename": "text"}, "nullok": False},
+            {"name": "Subject", "type": {"typename": "text"}, "nullok": False},
+            {"name": "UnrelatedThing", "type": {"typename": "text"}, "nullok": False},
+            {"name": "Execution", "type": {"typename": "text"}, "nullok": False},
+        ],
+        "keys": [{"unique_columns": ["RID"]}],
+        "foreign_keys": [
+            {
+                "foreign_key_columns": [{"schema_name": "isa", "table_name": "FourWayAssoc", "column_name": "Image"}],
+                "referenced_columns": [{"schema_name": "isa", "table_name": "Image", "column_name": "RID"}],
+            },
+            {
+                "foreign_key_columns": [{"schema_name": "isa", "table_name": "FourWayAssoc", "column_name": "Subject"}],
+                "referenced_columns": [{"schema_name": "isa", "table_name": "Subject", "column_name": "RID"}],
+            },
+            {
+                "foreign_key_columns": [
+                    {"schema_name": "isa", "table_name": "FourWayAssoc", "column_name": "UnrelatedThing"}
+                ],
+                "referenced_columns": [{"schema_name": "isa", "table_name": "UnrelatedThing", "column_name": "RID"}],
+            },
+            {
+                "foreign_key_columns": [
+                    {"schema_name": "isa", "table_name": "FourWayAssoc", "column_name": "Execution"}
+                ],
+                "referenced_columns": [{"schema_name": "deriva-ml", "table_name": "Execution", "column_name": "RID"}],
+            },
+        ],
+    }
+
+    out = tmp_path / "schema.json"
+    out.write_text(json.dumps(doc))
+    return out
+
+
+@pytest.fixture
+def denorm_feature_model(denorm_schema_feature: Path) -> Model:
+    """ERMrest Model with a DerivaML feature-association table."""
+    return Model.fromfile("file-system", denorm_schema_feature)
+
+
+@pytest.fixture
+def denorm_feature_deriva_model(denorm_feature_model: Model) -> DerivaModel:
+    """DerivaModel for the feature-association fixture."""
+    return DerivaModel(
+        model=denorm_feature_model,
+        ml_schema="deriva-ml",
+        domain_schemas={"isa"},
+    )
+
+
+# ---------------------------------------------------------------------------
 # Shared helpers
 # ---------------------------------------------------------------------------
 

--- a/tests/local_db/test_planner_rules.py
+++ b/tests/local_db/test_planner_rules.py
@@ -158,8 +158,7 @@ class TestPathAmbiguity:
             via=[],
         )
         assert result == [], (
-            f"Image↔Observation should have a single downstream FK path "
-            f"(direct), not a diamond. Got: {result}"
+            f"Image↔Observation should have a single downstream FK path (direct), not a diamond. Got: {result}"
         )
 
 
@@ -193,3 +192,279 @@ class TestPrepareWideTableIntegration:
             via=["Observation"],
         )
         assert "Image" in element_tables
+
+
+# ---------------------------------------------------------------------------
+# Transparency predicates (issue #174)
+# ---------------------------------------------------------------------------
+
+
+class TestTransparencyPredicates:
+    """Coverage for the transparency-predicate widening (issue #174).
+
+    A "transparent intermediate" is a table the planner walks
+    *through* without asking the caller to name it in ``include_tables``
+    or ``via``. The original predicate (:meth:`_is_topological_association`)
+    only recognized pure 2-FK association tables. Issue #174 widens
+    the rule to also include DerivaML feature-association tables —
+    3-FK tables whose third FK is the audit edge to the ML schema's
+    ``Execution`` table.
+
+    See the module-level "Transparency model" section in
+    ``denormalize_planner.py`` for the conceptual contract.
+    """
+
+    # -- Predicate behavior ---------------------------------------------
+
+    def test_topological_assoc_still_recognized(self, denorm_feature_deriva_model) -> None:
+        """The 2-FK predicate must still fire on pure assoc tables."""
+        model = denorm_feature_deriva_model
+        # Dataset_Image: 2 FKs (Dataset, Image).
+        assert model._planner._is_topological_association("Dataset_Image")
+        assert not model._planner._is_feature_association("Dataset_Image")
+
+    def test_feature_assoc_recognized(self, denorm_feature_deriva_model) -> None:
+        """3-FK feature-assoc with FK to Execution is a feature-assoc."""
+        model = denorm_feature_deriva_model
+        # Execution_Image_Image_Classification: 3 FKs (Image, Execution,
+        # Image_Classification). Has an FK to Execution → feature-assoc.
+        assert model._planner._is_feature_association("Execution_Image_Image_Classification")
+        # Strictly NOT a 2-FK topological association.
+        assert not model._planner._is_topological_association("Execution_Image_Image_Classification")
+        # But the union predicate (what the planner actually consults)
+        # still considers it transparent.
+        assert model._planner._is_transparent_intermediate("Execution_Image_Image_Classification")
+
+    def test_three_fk_without_execution_is_not_feature(self, denorm_feature_deriva_model) -> None:
+        """3-FK table without FK to Execution is NOT a feature-assoc.
+
+        ``Image_Subject_UnrelatedThing`` has three domain FKs but none
+        points at ``Execution`` — it's a genuine 3-way domain
+        association, which the caller must name explicitly to route
+        through.
+        """
+        model = denorm_feature_deriva_model
+        assert not model._planner._is_feature_association("Image_Subject_UnrelatedThing")
+        assert not model._planner._is_topological_association("Image_Subject_UnrelatedThing")
+        assert not model._planner._is_transparent_intermediate("Image_Subject_UnrelatedThing")
+
+    def test_four_fk_assoc_is_not_transparent(self, denorm_feature_deriva_model) -> None:
+        """4+ FK tables are not transparent even with an FK to Execution.
+
+        Multi-way associations have an arbitrary number of domain
+        edges, so the caller has to disambiguate which edge they
+        want — they can't be silently hopped.
+        """
+        model = denorm_feature_deriva_model
+        assert not model._planner._is_feature_association("FourWayAssoc")
+        assert not model._planner._is_topological_association("FourWayAssoc")
+        assert not model._planner._is_transparent_intermediate("FourWayAssoc")
+
+    def test_domain_table_is_not_transparent(self, denorm_feature_deriva_model) -> None:
+        """Plain domain tables (e.g. Image) are never transparent."""
+        model = denorm_feature_deriva_model
+        assert not model._planner._is_transparent_intermediate("Image")
+        assert not model._planner._is_transparent_intermediate("Subject")
+
+    # -- Reachability through feature-assoc bridges ---------------------
+
+    def test_outbound_reachable_hops_through_feature_assoc(self, denorm_feature_deriva_model) -> None:
+        """Image → feature-assoc → Image_Classification is reachable.
+
+        This is the regression test for issue #174 case A. Under the
+        old code, ``_outbound_reachable("Image", {"Image",
+        "Image_Classification"})`` returned ``set()`` because the
+        feature-assoc table failed the 2-FK predicate and the walker
+        couldn't bridge through it. Under the fix, the walker
+        recognizes feature-assoc tables as transparent and surfaces
+        ``Image_Classification`` as reachable.
+        """
+        model = denorm_feature_deriva_model
+        reachable = model._planner._outbound_reachable(
+            "Image",
+            {"Image", "Image_Classification"},
+        )
+        assert reachable == {"Image_Classification"}, (
+            f"Image should reach Image_Classification through the feature-assoc bridge, got {reachable}"
+        )
+
+    def test_outbound_reachable_does_not_hop_through_three_fk_domain(self, denorm_feature_deriva_model) -> None:
+        """A 3-FK domain-only assoc table is NOT a transparent bridge.
+
+        ``Image_Subject_UnrelatedThing`` has FKs to Image, Subject,
+        and UnrelatedThing. With only Image and UnrelatedThing in the
+        subgraph, the walker should NOT silently hop through the
+        3-way association — the third FK is a real domain edge and
+        the caller must signal intent.
+        """
+        model = denorm_feature_deriva_model
+        reachable = model._planner._outbound_reachable(
+            "Image",
+            {"Image", "UnrelatedThing"},
+        )
+        assert reachable == set(), (
+            f"Image must NOT reach UnrelatedThing through a 3-way "
+            f"domain assoc (caller has to route explicitly), got {reachable}"
+        )
+
+    # -- Sink finding ---------------------------------------------------
+
+    def test_find_sinks_multileaf_for_bridge_only_set(self, denorm_feature_deriva_model) -> None:
+        """With Image + Image_Classification (linked only by a feature
+        bridge), neither side is strictly downstream of the other.
+
+        Both endpoints sit upstream of the feature-assoc table. Under
+        strict-downstream sink-finding (no bidirectional bridge hop),
+        each candidate has empty strict-downstream set inside the
+        subgraph, so both are sinks. The planner raises MultiLeaf and
+        the caller must pick ``row_per=`` explicitly. This is the
+        actionable error message — under the old code the same shape
+        produced zero sinks (``NoSink``), which was harder to debug.
+
+        Issue #174: ``split_dataset(stratify_by_column=...)`` should
+        provide ``row_per=element_table`` on the user's behalf so the
+        explicit-row_per path resolves cleanly without forcing the
+        caller to pick.
+        """
+        from deriva_ml.core.exceptions import DerivaMLDenormalizeMultiLeaf
+
+        model = denorm_feature_deriva_model
+        sinks = model._planner._find_sinks(
+            include_tables=["Image", "Image_Classification"],
+            via=[],
+        )
+        assert sorted(sinks) == ["Image", "Image_Classification"], (
+            f"Both endpoints of a transparent bridge should be sink candidates under strict downstream, got {sinks}"
+        )
+        with pytest.raises(DerivaMLDenormalizeMultiLeaf):
+            model._planner._determine_row_per(
+                include_tables=["Image", "Image_Classification"],
+                via=[],
+                row_per=None,
+            )
+
+    # -- Sink finding with explicit row_per -----------------------------
+
+    def test_determine_row_per_explicit_image_succeeds(self, denorm_feature_deriva_model) -> None:
+        """row_per='Image' is accepted with the feature-assoc bridge.
+
+        With strict-downstream Rule 5, Image_Classification is NOT
+        considered downstream of Image — the bridge sits between them
+        but doesn't produce a fan-out from Image's perspective.
+        Explicit ``row_per=Image`` is therefore accepted, and the
+        symmetric ``row_per=Image_Classification`` is accepted too.
+        This is the call-site contract that ``split_dataset`` relies
+        on when plumbing ``row_per=element_table``.
+        """
+        model = denorm_feature_deriva_model
+        resolved_image = model._planner._determine_row_per(
+            include_tables=["Image", "Image_Classification"],
+            via=[],
+            row_per="Image",
+        )
+        assert resolved_image == "Image"
+
+        resolved_ic = model._planner._determine_row_per(
+            include_tables=["Image", "Image_Classification"],
+            via=[],
+            row_per="Image_Classification",
+        )
+        assert resolved_ic == "Image_Classification"
+
+    def test_outbound_reachable_image_to_classification_via_bridge(self, denorm_feature_deriva_model) -> None:
+        """Regression for issue #174 variant A.
+
+        ``include_tables=["Image_Classification"]`` (no Image). The
+        dataset member anchor table is Image. Under the old code,
+        ``_outbound_reachable("Image", {"Image_Classification"})``
+        returned ``set()`` because the feature-assoc table failed
+        the transparency predicate — and
+        :meth:`Denormalizer._classify_anchors` then flagged Image as
+        an unrelated anchor with no FK path to Image_Classification.
+
+        Under the fix, the bridge hop fires and Image_Classification
+        appears reachable — the anchor classifies as ``scoping``
+        rather than ``unrelated``.
+        """
+        model = denorm_feature_deriva_model
+        reachable = model._planner._outbound_reachable(
+            "Image",
+            {"Image_Classification"},
+        )
+        assert reachable == {"Image_Classification"}, (
+            f"Image anchor must reach Image_Classification through the "
+            f"feature-assoc bridge so anchor classification works "
+            f"(issue #174 variant A), got {reachable}"
+        )
+
+    # -- Strict downstream primitive -----------------------------------
+
+    # -- End-to-end prepare_wide_table over the feature-assoc bridge ----
+
+    def test_prepare_wide_table_succeeds_with_explicit_row_per(self, denorm_feature_deriva_model) -> None:
+        """The full planner entry point produces a plan for the issue
+        #174 case when ``row_per=`` is supplied.
+
+        This is the integration-level proof that the predicate +
+        strict-downstream changes compose correctly: the planner
+        succeeds (no exception), the plan keys the join tree on Image,
+        and — critically — the feature-association bridge appears in
+        the JOIN path. Under the old code the JOIN couldn't route
+        through the 3-FK feature-assoc (the transparency predicate
+        didn't fire), so even when ``row_per`` was accepted the
+        bridge step was missing and the projection wouldn't actually
+        connect Image to Image_Classification rows at query time.
+        """
+        model = denorm_feature_deriva_model
+        element_tables, denormalized_columns, _ = model._planner._prepare_wide_table(
+            dataset=None,
+            dataset_rid="DS-001",
+            include_tables=["Image", "Image_Classification"],
+            row_per="Image",
+        )
+        assert "Image" in element_tables, (
+            f"join plan should be keyed on the chosen row_per, got element_tables.keys()={list(element_tables.keys())}"
+        )
+        # The plan tuple is (path_names, join_conditions, join_types);
+        # path_names is the pre-order JOIN sequence. For the feature-
+        # assoc bridge to be wired correctly, the bridge must appear
+        # in the sequence between Image and Image_Classification.
+        path_names, _join_conditions, _join_types = element_tables["Image"]
+        assert "Execution_Image_Image_Classification" in path_names, (
+            f"join sequence must route through the feature-assoc bridge, got path_names={path_names}"
+        )
+        assert "Image_Classification" in path_names, (
+            f"Image_Classification must be reachable via the JOIN, got path_names={path_names}"
+        )
+
+    def test_strict_downstream_skips_bridge_hop(self, denorm_feature_deriva_model) -> None:
+        """Strict reach does NOT bridge-hop into the symmetric side.
+
+        Direct primitive-level coverage for the helper added in
+        issue #174.
+        """
+        model = denorm_feature_deriva_model
+        # Strict downstream from Image: feature-assoc references Image
+        # but isn't in the set, and we do NOT hop through it. So
+        # Image_Classification is NOT in strict downstream(Image).
+        strict = model._planner._outbound_reachable_strict(
+            "Image",
+            {"Image", "Image_Classification"},
+        )
+        assert strict == set(), (
+            f"strict downstream(Image) must be empty when the only "
+            f"path to Image_Classification is via a transparent bridge, "
+            f"got {strict}"
+        )
+
+        # By contrast, the standard bidirectional reach DOES surface
+        # the bridge hop — this is the connectivity primitive used
+        # by Denormalizer._classify_anchors and must remain
+        # bidirectional.
+        broad = model._planner._outbound_reachable(
+            "Image",
+            {"Image", "Image_Classification"},
+        )
+        assert broad == {"Image_Classification"}, (
+            f"bidirectional reach should still see Image_Classification through the bridge, got {broad}"
+        )


### PR DESCRIPTION
## Summary

`split_dataset(stratify_by_column=...)` failed with two confusing denormalizer errors when the stratify column lived on a feature value table (e.g. `Image_Classification.Image_Class`):

- **Variant A** — `include_tables=["Image_Classification"]`: `Anchors of table(s) ['Image'] have no FK path to any table in include_tables=['Image_Classification']`.
- **Variant B** — `include_tables=["Image", "Image_Classification"]`: `Multiple candidates for row_per: ['Image', 'Image_Classification']` with no kwarg exposed to disambiguate.

Closes #174.

## Diagnosis

`DenormalizePlanner._is_topological_association` required exactly 2 domain FKs to declare an association table "transparent." DerivaML feature-association tables (e.g. `Execution_Image_Image_Classification`) have **3** FKs — target, value, and the audit edge to `Execution` — so they failed the predicate. As a result:

- `_outbound_reachable` couldn't bridge through them, so the BFS from Image to `Image_Classification` returned empty (variant A: anchor classifier flagged Image as unrelated).
- Even when the BFS WAS bidirectional (it is for true 2-FK assocs), Rule 5 (downstream-leaf) rejected explicit `row_per=Image` because the bridge made Image_Classification appear "downstream" of Image — even though the bridge produces at most a 1:1:1 join (variant B's root cause).

The transparency predicate is correct as a structural concept; we just need to recognize one more shape (3 FKs with one Execution FK), and the cardinality check used by Rule 5 needs to be the strict-direct-FK variant, not the bidirectional-reachability variant.

## What changed

### Predicate widening (denormalize_planner.py)

- New `_is_feature_association` predicate: 3 domain FKs, exactly one targets the ML schema's `Execution` table. Sibling to the 2-FK `_is_topological_association`.
- New `_is_transparent_intermediate` helper: union of the two predicates. This is what the reachability primitives consult.
- `_outbound_reachable`, `_enumerate_paths`, `_find_path_ambiguities`, `_build_join_tree` now use the union predicate.

### Strict downstream for Rule 5 / Rule 2

- New `_outbound_reachable_strict`: direct-FK walk only, no bidirectional bridge hop. Used by `_determine_row_per` (Rule 5) and `_find_sinks` (Rule 2).
- Side effect: both endpoints of a bridge in `include_tables` with no explicit `row_per` now raise `DerivaMLDenormalizeMultiLeaf` (with both candidates listed) instead of `DerivaMLDenormalizeNoSink`. Strictly a better error message.

### Surface plumbing (dataset/split.py)

- `split_dataset(row_per=..., via=..., ignore_unrelated_anchors=...)` pass-through kwargs forwarded to `Denormalizer.as_dataframe`. When `stratify_by_column` is set and `row_per` is None, defaults to `element_table` automatically — the natural anchor when partitioning element rows through a feature bridge.
- CLI flags `--row-per`, `--via`, `--ignore-unrelated-anchors` on `deriva-ml-split-dataset`.

### Documentation

- New **"Transparency model"** section in the planner module docstring covering: what a transparent intermediate is; why feature-assoc tables qualify; what is intentionally NOT transparent (4+ FKs, 3-FK domain-only assocs).
- Google-style docstrings with runnable Example blocks on every new method.
- `split_dataset` docstring documents the new kwargs and adds Examples for stratified splits over feature bridges.
- CHANGELOG entry.

## Tests

### `tests/local_db/test_planner_rules.py::TestTransparencyPredicates` (new class, 12 tests)

Predicate behavior:
- `test_topological_assoc_still_recognized` — 2-FK predicate unchanged.
- `test_feature_assoc_recognized` — 3-FK with Execution FK detected.
- `test_three_fk_without_execution_is_not_feature` — domain 3-way assoc rejected.
- `test_four_fk_assoc_is_not_transparent` — 4+ FK rejected.
- `test_domain_table_is_not_transparent` — plain tables rejected.

Reachability:
- `test_outbound_reachable_hops_through_feature_assoc` — end-to-end reachability via the bridge (issue #174 variant B regression).
- `test_outbound_reachable_does_not_hop_through_three_fk_domain` — negative case.
- `test_outbound_reachable_image_to_classification_via_bridge` — anchor classification (issue #174 variant A regression).

Sink/row_per:
- `test_find_sinks_multileaf_for_bridge_only_set` — both endpoints are sinks under strict downstream.
- `test_determine_row_per_explicit_image_succeeds` — explicit `row_per` on either bridge endpoint is accepted.

Planner integration:
- `test_prepare_wide_table_succeeds_with_explicit_row_per` — full planner produces a JOIN plan whose path routes through the bridge.
- `test_strict_downstream_skips_bridge_hop` — direct coverage of `_outbound_reachable_strict`.

### `tests/dataset/test_split.py::TestDenormalizationPlumbing` (new class, 3 tests)

- `test_row_per_defaults_to_element_table_on_stratify` — kwarg defaulting.
- `test_row_per_explicit_passed_through` — explicit override.
- `test_via_and_ignore_unrelated_anchors_forwarded` — pass-through of the other two kwargs.

### New fixture

`denorm_schema_feature` / `denorm_feature_deriva_model` in `tests/local_db/conftest.py` — adds `Execution`, `Image_Classification` vocab, `Execution_Image_Image_Classification` feature-assoc, plus a 3-FK domain-only assoc and a 4-FK assoc as negative cases.

### Regression check

The new planner test `test_outbound_reachable_hops_through_feature_assoc` fails under the old planner code (`{result}` is `set()` because the bridge hop never fires) and passes under the new code (`{'Image_Classification'}`). Verified by stash/unstash.

Full test sweep: **366 passed, 3 skipped, 9 deselected, 0 failed** on `tests/local_db/ tests/model/` (excluding one pre-existing unrelated failure in `test_data_sources.py`).

## Test plan

- [x] `uv run python -m pytest tests/local_db/test_planner_rules.py -v` (24 passed, includes 12 new tests)
- [x] `uv run python -m pytest tests/dataset/test_split.py::TestDenormalizationPlumbing -v` (3 passed)
- [x] `uv run python -m pytest tests/local_db/ tests/model/` (366 passed, no regressions)
- [x] `uv run ruff format src tests` clean on touched files
- [ ] Live-catalog smoke: invoke `split_dataset(stratify_by_column="Image_Classification.Image_Class", include_tables=["Image", "Image_Classification"], element_table="Image", dry_run=True)` on demo schema (left for the reviewer / follow-up MCP wrapper PR).

## Follow-up

The MCP wrapper in `deriva-ml-mcp` will need a separate PR to surface `row_per`, `via`, and `ignore_unrelated_anchors` to MCP callers. That's outside the scope of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)