### PR TITLE
fix(execution): RID-key per-asset download path (collision-free)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 All notable changes to this project are documented here.
 
+## Unreleased — Per-asset download paths keyed by RID (collision-free by construction)
+
+### Fixed
+
+- **Silent overwrite when two input assets share a Filename.**
+  `Execution._initialize_execution` previously placed each downloaded
+  asset at
+  `<working_dir>/<exec_rid>/downloaded-assets/<asset_table>/<Filename>`,
+  keyed only by the asset table. Two assets from the same table that
+  happened to share a `Filename` (a common case for `predictions.csv`
+  files emitted by parallel multirun children) collided on disk: the
+  second download overwrote the first, while `execution.asset_paths`
+  still reported two distinct `AssetFilePath` entries that both pointed
+  at the same (last-written) bytes. Surfaced via the deriva-ml-model-template
+  ROC notebook reporting identical accuracies for two distinct model
+  variants. The new layout is
+  `<working_dir>/<exec_rid>/downloaded-assets/<asset_table>/<asset_rid>/<Filename>`
+  — collision-free by construction.
+
+### Changed
+
+- **On-disk layout for downloaded input assets (breaking).** Per-asset
+  download directories now include the asset RID. Callers reading
+  files via `AssetFilePath.file_name` from `execution.asset_paths`
+  (the documented contract) are unaffected — the canonical access path
+  is unchanged. Only callers that hand-constructed paths from the
+  asset table and filename need to update; that pattern was never
+  supported and is now documented as such on `download_asset`,
+  `_initialize_execution`, and the `Execution.asset_paths` attribute.
+
 ## Unreleased — Issue #174: split_dataset stratify works for feature-target columns
 
 ### Fixed

--- a/docs/user-guide/executions.md
+++ b/docs/user-guide/executions.md
@@ -90,7 +90,7 @@ exe.upload_execution_outputs()
 - `exe.execution_rid` — the RID of the catalog Execution record; use it to look up the run later.
 - `exe.working_dir` — the local scratch directory for this execution; do not write output files here directly (they will not be uploaded). Use `asset_file_path()` instead.
 - `exe.datasets` — the list of `DatasetSpec` objects from the configuration; iterate these to download each declared dataset.
-- `exe.asset_paths` — a `dict[str, list[AssetFilePath]]` mapping asset table name → list of paths for downloaded input assets.
+- `exe.asset_paths` — a `dict[str, list[AssetFilePath]]` mapping asset table name → list of paths for downloaded input assets. Each asset lands at `<working_dir>/<exec_rid>/downloaded-assets/<asset_table>/<asset_rid>/<Filename>` (RID-keyed so two assets sharing a filename do not collide). Always read via `AssetFilePath.file_name`; do not hand-construct paths from the table or filename.
 
 ## How to write asset files
 

--- a/src/deriva_ml/execution/execution.py
+++ b/src/deriva_ml/execution/execution.py
@@ -157,7 +157,13 @@ class Execution:
         configuration (ExecutionConfiguration): Execution settings and parameters.
         workflow_rid (RID): RID of the associated workflow.
         status (ExecutionStatus): Current execution status (read-through from SQLite).
-        asset_paths (list[AssetFilePath]): Paths to execution assets.
+        asset_paths (dict[str, list[AssetFilePath]]): Mapping of asset-table name to
+            the list of ``AssetFilePath`` objects for input assets downloaded by
+            ``_initialize_execution``. Each downloaded asset lands at
+            ``<working_dir>/<exec_rid>/downloaded-assets/<asset_table>/<asset_rid>/<Filename>``
+            — keyed by asset RID, so two assets that share the same ``Filename`` do
+            not collide on disk. Read files via ``AssetFilePath.file_name``; do not
+            hand-construct paths from the asset table or filename.
         start_time (datetime | None): When execution started.
         stop_time (datetime | None): When execution completed.
 
@@ -569,7 +575,12 @@ class Execution:
         """Initialize the execution environment.
 
         Sets up the working directory, downloads required datasets and assets,
-        and saves initial configuration metadata.
+        and saves initial configuration metadata. Each input asset is placed at
+        ``<working_dir>/<exec_rid>/downloaded-assets/<asset_table>/<asset_rid>/<Filename>``
+        so two assets that share an asset table and ``Filename`` do not collide
+        on disk. After initialization, ``self.asset_paths`` maps asset-table
+        name to the list of ``AssetFilePath`` objects produced; use
+        ``AssetFilePath.file_name`` as the canonical read path.
 
         Args:
             reload: Optional RID of a previously initialized execution to reload.
@@ -616,8 +627,18 @@ class Execution:
             else:
                 rid_info_table = rid_info.table
             asset_table = rid_info_table.name
+            # Key per-asset download directory by ``asset_rid`` so two
+            # assets from the same table that happen to share the same
+            # ``Filename`` (a common case for prediction CSVs emitted by
+            # parallel multirun children) land on disjoint paths. Keying
+            # only by ``asset_table`` caused the second download to
+            # silently overwrite the first while still producing two
+            # ``AssetFilePath`` entries that pointed at the same bytes.
             dest_dir = (
-                execution_root(self._ml_object.working_dir, self.execution_rid) / "downloaded-assets" / asset_table
+                execution_root(self._ml_object.working_dir, self.execution_rid)
+                / "downloaded-assets"
+                / asset_table
+                / asset_rid
             )
             dest_dir.mkdir(parents=True, exist_ok=True)
             self.asset_paths.setdefault(asset_table, []).append(
@@ -1253,9 +1274,19 @@ class Execution:
     ) -> AssetFilePath:
         """Download an asset from a URL and place it in a local directory.
 
+        The file is written to ``dest_dir / asset_record["Filename"]``. The
+        caller owns ``dest_dir`` and is responsible for collision avoidance
+        when downloading multiple assets — two calls that share both
+        ``dest_dir`` and ``Filename`` will overwrite each other. When invoked
+        by ``_initialize_execution`` the per-asset ``dest_dir`` is keyed by
+        ``asset_rid`` so the on-disk layout is collision-free by
+        construction; ad-hoc callers should follow the same convention.
+
         Args:
             asset_rid: RID of the asset.
-            dest_dir: Destination directory for the asset.
+            dest_dir: Destination directory for the asset. Must be unique
+                across concurrent ``download_asset`` calls when ``Filename``
+                may collide.
             update_catalog: Whether to update the catalog execution information after downloading.
             use_cache: If True, check the cache directory for a previously downloaded copy
                 with a matching MD5 checksum before downloading. Cached copies are stored
@@ -1268,6 +1299,8 @@ class Execution:
 
         Returns:
             An AssetFilePath with the path to the downloaded (or cached) asset file.
+            ``AssetFilePath.file_name`` is the canonical access path — read from it
+            rather than hand-constructing a path from the asset table or filename.
         """
 
         asset_table = _asset_table if _asset_table is not None else self._ml_object.resolve_rid(asset_rid).table

--- a/tests/execution/test_execution.py
+++ b/tests/execution/test_execution.py
@@ -1186,6 +1186,115 @@ class TestAssetCaching:
         assert cache_assets_dir.exists()
         assert len(list(cache_assets_dir.iterdir())) == 1
 
+    def test_two_inputs_same_filename_do_not_collide(self, workflow_terms, test_workflow):
+        """Two input assets sharing a Filename land at disjoint RID-keyed paths.
+
+        Regression test for the silent-overwrite bug where
+        ``_initialize_execution`` keyed the per-asset download directory by
+        ``asset_table`` only. Two assets in the same table with the same
+        catalog ``Filename`` (a common case for ``predictions.csv`` from
+        parallel multirun children) overwrote each other on disk while both
+        ``AssetFilePath`` entries silently pointed at the same bytes.
+
+        The fix keys the directory by ``asset_rid`` so the layout is
+        ``<working_dir>/<exec_rid>/downloaded-assets/<asset_table>/<asset_rid>/<Filename>``
+        — collision-free by construction.
+
+        Proves: (1) both files exist with their original bytes, (2)
+        ``execution.asset_paths`` reports two distinct paths, (3) the
+        path layout is RID-keyed.
+        """
+        ml = workflow_terms
+
+        # Create two distinct uploads that produce two Execution_Asset
+        # rows whose Filename is identical. Two separate executions, both
+        # writing a file named "predictions.csv" with different bytes —
+        # mirrors the multirun-children-emit-prediction-CSV failure mode.
+        upload_a = ml.create_execution(
+            ExecutionConfiguration(
+                description="Producer A",
+                workflow=test_workflow,
+            )
+        )
+        with upload_a.execute() as exe:
+            asset_path = exe.asset_file_path(
+                MLAsset.execution_asset,
+                "ProducerA/predictions.csv",
+                asset_types=ExecAssetType.model_file,
+            )
+            with asset_path.open("w") as f:
+                f.write("producer-a-bytes")
+        uploaded_a = upload_a.upload_execution_outputs()
+        rid_a = uploaded_a["deriva-ml/Execution_Asset"][0].asset_rid
+
+        upload_b = ml.create_execution(
+            ExecutionConfiguration(
+                description="Producer B",
+                workflow=test_workflow,
+            )
+        )
+        with upload_b.execute() as exe:
+            asset_path = exe.asset_file_path(
+                MLAsset.execution_asset,
+                "ProducerB/predictions.csv",
+                asset_types=ExecAssetType.model_file,
+            )
+            with asset_path.open("w") as f:
+                f.write("producer-b-bytes")
+        uploaded_b = upload_b.upload_execution_outputs()
+        rid_b = uploaded_b["deriva-ml/Execution_Asset"][0].asset_rid
+
+        # Sanity: two distinct RIDs sharing the same catalog Filename is
+        # the precondition the bug needed to bite.
+        assert rid_a != rid_b
+        assert ml._retrieve_rid(rid_a)["Filename"] == "predictions.csv"
+        assert ml._retrieve_rid(rid_b)["Filename"] == "predictions.csv"
+
+        # Now configure a downstream execution that consumes BOTH assets.
+        # Under the old code, the second download landed on the same path
+        # as the first and silently overwrote it.
+        consumer = ml.create_execution(
+            ExecutionConfiguration(
+                description="Consumer",
+                workflow=test_workflow,
+                assets=[rid_a, rid_b],
+            )
+        )
+
+        paths = consumer.asset_paths["Execution_Asset"]
+        assert len(paths) == 2, "Both input assets must be reported"
+
+        path_a = next(p for p in paths if p.asset_rid == rid_a)
+        path_b = next(p for p in paths if p.asset_rid == rid_b)
+
+        # (1) The two AssetFilePath objects point at distinct files on disk.
+        assert Path(path_a.file_name) != Path(path_b.file_name), (
+            "Two input assets must not share a file_name path "
+            "(this is the regression — old code keyed dest_dir by table only)"
+        )
+
+        # (2) Each file exists and contains the bytes its producer wrote;
+        # the second download did not overwrite the first.
+        assert path_a.exists()
+        assert path_b.exists()
+        with Path(path_a.file_name).open() as f:
+            assert f.read() == "producer-a-bytes"
+        with Path(path_b.file_name).open() as f:
+            assert f.read() == "producer-b-bytes"
+
+        # (3) The on-disk layout matches the documented contract:
+        # <working_dir>/<exec_rid>/downloaded-assets/<asset_table>/<asset_rid>/<Filename>.
+        # Assert against the structural shape — no hardcoded RIDs.
+        for path, rid in [(path_a, rid_a), (path_b, rid_b)]:
+            file_path = Path(path.file_name)
+            assert file_path.name == "predictions.csv"
+            assert file_path.parent.name == rid, (
+                f"Expected per-asset directory keyed by asset_rid={rid}, got {file_path.parent.name}"
+            )
+            assert file_path.parent.parent.name == "Execution_Asset"
+            assert file_path.parent.parent.parent.name == "downloaded-assets"
+            assert file_path.parent.parent.parent.parent.name == consumer.execution_rid
+
 
 # =============================================================================
 # TestExecutionDatasets - Dataset Operations Tests


### PR DESCRIPTION
## Summary

`Execution._initialize_execution` keyed each per-asset download
directory by ``asset_table`` only. Two assets in the same table that
shared a catalog ``Filename`` (a common case for prediction CSVs
emitted by parallel multirun children) overwrote each other on disk
while ``execution.asset_paths`` still reported two distinct
``AssetFilePath`` entries that both pointed at the same
(last-written) bytes. The fix appends ``asset_rid`` to the directory,
making the layout collision-free by construction:

```
<working_dir>/<exec_rid>/downloaded-assets/<asset_table>/<asset_rid>/<Filename>
```

`AssetFilePath.file_name` remains the canonical access path; callers
reading ``execution.asset_paths`` are unaffected. Per workspace
CLAUDE.md ("no backwards-compat shims") there is no fallback to the
old layout -- callers that hand-constructed paths from the asset
table and filename (which was never the documented contract) must
update.

This bug surfaced in the deriva-ml-model-template ROC analysis
notebook: both multirun children uploaded prediction CSVs named
``prediction_probabilities.csv``, and the ROC notebook listed both as
inputs. ``pd.read_csv(asset_path.file_name)`` loaded the same
last-written bytes for both, reporting 98% / 98% when the correct
answer was 94% / 98%. See
informatics-isi-edu/deriva-ml-model-template#16 for the template-side
workaround / context.

## Changes

### Source
- `src/deriva_ml/execution/execution.py:619-639` -- `_initialize_execution`
  appends ``asset_rid`` to ``dest_dir``.

### Docstrings updated
- `Execution` class docstring -- ``asset_paths`` attribute now
  documents the on-disk layout and the canonical-read contract; fixed
  stale ``list[AssetFilePath]`` type annotation to the actual
  ``dict[str, list[AssetFilePath]]``.
- `Execution._initialize_execution` docstring -- documents the
  RID-keyed layout and ``AssetFilePath.file_name`` as the canonical
  read path.
- `Execution.download_asset` docstring -- clarifies that callers own
  ``dest_dir`` collision avoidance, calls out the
  ``_initialize_execution`` convention, and reiterates that
  ``AssetFilePath.file_name`` is canonical.
- `docs/user-guide/executions.md` -- ``exe.asset_paths`` entry now
  spells out the RID-keyed layout and the canonical-read rule.

### Tests
- `tests/execution/test_execution.py::TestAssetCaching::test_two_inputs_same_filename_do_not_collide`
  -- new regression test. Creates two ``Execution_Asset`` rows with
  the same catalog ``Filename`` (``predictions.csv``), configures a
  downstream execution to download both, and asserts:
    1. ``execution.asset_paths`` reports two distinct file paths
    2. Both files exist with the bytes their producers wrote
       (i.e. the second download did not overwrite the first)
    3. The on-disk layout matches
       ``<working_dir>/<exec_rid>/downloaded-assets/<asset_table>/<asset_rid>/<Filename>``
       (asserted structurally; no hardcoded RIDs)

  Confirmed the test FAILS under the old code (both ``file_name``
  paths collided at ``.../Execution_Asset/predictions.csv``) and
  PASSES under the new code.

### CHANGELOG
- New "Unreleased" entry: "Per-asset download paths keyed by RID
  (collision-free by construction)" with Fixed + Changed sections.

## Test plan

- [x] `uv run python -m pytest tests/execution/test_execution.py -v`
  -- 60 passed, 1 skipped (pre-existing skip)
- [x] `uv run python -m pytest tests/asset/ tests/catalog/` --
  123 passed
- [x] `uv run ruff format src/deriva_ml/execution/execution.py
  tests/execution/test_execution.py`
- [x] Regression test verified to FAIL under old code, PASS under new
  (stashed the source change, re-ran the test, confirmed the
  collision assertion fired).

The two pre-existing failures in
`tests/execution/test_bag_loader_path_builder_refresh.py` are not
related to this change (they assert against a deriva-py internal
helper renamed upstream) -- confirmed they fail on `main` at the same
commit.

## Notes

Per workspace CLAUDE.md, breaking-change-but-no-shim policy applies:
the on-disk path layout for downloaded input assets is the
breaking-change surface. Single, clean change; no fallback to the
table-only layout.

Related: informatics-isi-edu/deriva-ml-model-template#16