### PR TITLE
fix(execution): silence misleading dry-run exit warning (#177)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,14 @@
 
 All notable changes to this project are documented here.
 
-## Unreleased -- Issue #177: dry-run multirun exit log noise
+## Unreleased — Issue #177: dry-run multirun exit log noise
 
 ### Fixed
 
 - **Misleading dry-run exit warning for the placeholder parent
   execution RID (#177).** When running a Hydra multirun with
   `dry_run=true`, the parent supervisor uses `DRY_RUN_RID` (`"0000"`)
-  as a placeholder for its execution_rid -- dry-run mode intentionally
+  as a placeholder for its execution_rid — dry-run mode intentionally
   skips writing the parent's row to the workspace SQLite registry.
   At process exit, `_complete_parent_execution` (the atexit handler
   in `src/deriva_ml/execution/runner.py`) unconditionally called
@@ -17,8 +17,8 @@ All notable changes to this project are documented here.
   `DerivaMLStateInconsistency` from the read-through `start_time`
   property. The handler caught the exception and emitted a WARNING
   reading "Failed to complete parent execution: Execution 0000 no
-  longer in workspace registry..." -- alarming text for behavior
-  that is correct by design. The handler now short-circuits on the
+  longer in workspace registry..." — alarming text for behavior that
+  is correct by design. The handler now short-circuits on the
   `DRY_RUN_RID` placeholder, logs an INFO message explaining the
   skip, and never touches `execution_stop` /
   `upload_execution_outputs` for the placeholder.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to this project are documented here.
 
+## Unreleased -- Issue #177: dry-run multirun exit log noise
+
+### Fixed
+
+- **Misleading dry-run exit warning for the placeholder parent
+  execution RID (#177).** When running a Hydra multirun with
+  `dry_run=true`, the parent supervisor uses `DRY_RUN_RID` (`"0000"`)
+  as a placeholder for its execution_rid -- dry-run mode intentionally
+  skips writing the parent's row to the workspace SQLite registry.
+  At process exit, `_complete_parent_execution` (the atexit handler
+  in `src/deriva_ml/execution/runner.py`) unconditionally called
+  `execution_stop()` on the placeholder, which raised
+  `DerivaMLStateInconsistency` from the read-through `start_time`
+  property. The handler caught the exception and emitted a WARNING
+  reading "Failed to complete parent execution: Execution 0000 no
+  longer in workspace registry..." -- alarming text for behavior
+  that is correct by design. The handler now short-circuits on the
+  `DRY_RUN_RID` placeholder, logs an INFO message explaining the
+  skip, and never touches `execution_stop` /
+  `upload_execution_outputs` for the placeholder.
+
 ## Unreleased — Per-asset download paths keyed by RID (collision-free by construction)
 
 ### Fixed

--- a/src/deriva_ml/execution/execution.py
+++ b/src/deriva_ml/execution/execution.py
@@ -1521,11 +1521,13 @@ class Execution:
         After a successful load, marks every pending manifest
         entry as ``uploaded`` (matches the legacy contract that
         the manifest reflects the destination's state after a
-        commit). The transient bag dir is left in place so
-        post-mortem inspection is possible if needed; the caller's
-        ``clean_folder`` flag determines whether the surrounding
-        ``execution_root`` (which contains the bag dir) is also
-        removed.
+        commit). The transient bag dir is left in place at
+        ``working_dir/upload/{execution_rid}/`` so post-mortem
+        inspection is possible if needed; users may delete the
+        ``upload/{rid}/`` directory by hand once they no longer
+        need it. The caller's ``clean_folder`` flag controls
+        cleanup of the separate ``execution_root`` only (see
+        :meth:`upload_execution_outputs`).
 
         Returns:
             ``{"{schema}/{table}": [AssetFilePath, ...]}`` for the
@@ -1537,7 +1539,12 @@ class Execution:
             report_to_asset_map,
         )
 
-        bag_dir = Path(self._working_dir) / f"commit-bag-{self.execution_rid}"
+        # Issue #178: per-execution upload staging lives under a
+        # dedicated ``upload/`` parent — not at the cache root, where
+        # it used to sit beside ``cache/`` and ``schema-cache.json``
+        # and was easy to mistake for cache state. The cache root now
+        # contains only caches; per-execution scratch is here.
+        bag_dir = Path(self._working_dir) / "upload" / self.execution_rid
         if bag_dir.exists():
             # An earlier (failed) attempt may have left a partial
             # bag on disk. Wipe it so the build starts clean —

--- a/src/deriva_ml/execution/runner.py
+++ b/src/deriva_ml/execution/runner.py
@@ -150,6 +150,8 @@ from typing import TYPE_CHECKING, Any, TypeVar
 
 from hydra.core.hydra_config import HydraConfig
 from hydra_zen import builds
+
+from deriva_ml.core.constants import DRY_RUN_RID
 from deriva_ml.core.logging_config import get_logger
 
 logger = get_logger(__name__)
@@ -220,14 +222,29 @@ def _complete_parent_execution() -> None:
 
     This is registered as an atexit handler to ensure the parent execution
     is properly completed and its outputs uploaded when the process exits.
+
+    Dry-run multiruns intentionally skip recording the parent execution in
+    the workspace SQLite registry; the placeholder ``DRY_RUN_RID`` is used
+    as its execution_rid. Calling ``execution_stop()`` on that placeholder
+    raises ``DerivaMLStateInconsistency`` because the read-through
+    properties (``start_time``, ``status``) cannot find a row to read.
+    Short-circuit on the placeholder so the dry-run exit path stays
+    log-clean -- there is nothing to stop or upload when the parent was
+    never persisted.
     """
     global _multirun_state
 
     if _multirun_state.parent_execution is None:
         return
 
+    parent = _multirun_state.parent_execution
     try:
-        parent = _multirun_state.parent_execution
+        if _multirun_state.parent_execution_rid == DRY_RUN_RID:
+            logging.info(
+                f"Dry-run: parent execution not recorded in workspace registry "
+                f"(expected for dry-run mode, {_multirun_state.job_sequence} child jobs)"
+            )
+            return
 
         # Stop the parent execution timing
         parent.execution_stop()

--- a/tests/execution/test_runner.py
+++ b/tests/execution/test_runner.py
@@ -1,18 +1,21 @@
 """Tests for the execution runner module."""
 
-import pytest
-from unittest.mock import Mock, patch, MagicMock
-from functools import partial
+import logging
+from unittest.mock import MagicMock, Mock, patch
 
+import pytest
+
+from deriva_ml.core.constants import DRY_RUN_RID
+from deriva_ml.core.exceptions import DerivaMLStateInconsistency
 from deriva_ml.execution.runner import (
-    run_model,
+    _complete_parent_execution,
+    _get_job_num,
+    _is_multirun,
+    _multirun_state,
     create_model_config,
     reset_multirun_state,
-    _is_multirun,
-    _get_job_num,
-    _multirun_state,
+    run_model,
 )
-from deriva_ml.execution import ExecutionConfiguration, Workflow
 
 
 class TestMultirunDetection:
@@ -393,3 +396,97 @@ class TestRunModelUploadCallContract:
             f"Execution.upload_execution_outputs: {unsupported}. "
             f"Real method accepts: {real_params - {'self'}}."
         )
+
+
+class TestCompleteParentExecutionDryRun:
+    """Regression tests for the atexit handler under dry-run multirun.
+
+    Issue #177: the parent supervisor for a dry-run multirun uses
+    ``DRY_RUN_RID`` ("0000") as its execution_rid placeholder because the
+    parent is intentionally never written to the workspace SQLite registry.
+    The atexit handler used to unconditionally call ``execution_stop()`` on
+    the placeholder, which raised ``DerivaMLStateInconsistency`` from the
+    read-through ``start_time``/``status`` properties. The handler caught
+    the exception and emitted a WARNING reading
+    "Failed to complete parent execution: Execution 0000 no longer in
+    workspace registry..." -- alarming text for behavior that is correct
+    by design.
+
+    These tests pin the fix: the handler must short-circuit on the
+    ``DRY_RUN_RID`` placeholder, log a clear INFO message, and never touch
+    ``execution_stop`` / ``upload_execution_outputs`` on the placeholder.
+    """
+
+    @pytest.fixture(autouse=True)
+    def reset_state(self):
+        """Reset multirun state before and after each test."""
+        reset_multirun_state()
+        yield
+        reset_multirun_state()
+
+    def test_dry_run_placeholder_does_not_warn(self, caplog):
+        """No warning text about the placeholder RID escapes to the log.
+
+        The handler used to call ``execution_stop()`` on a parent whose
+        registry row never existed, catch ``DerivaMLStateInconsistency``,
+        and log a WARNING. After the fix the placeholder is short-circuited
+        before any registry-touching method runs.
+        """
+        # Build a parent execution that mimics a dry-run placeholder:
+        # execution_stop / upload_execution_outputs would (under the bug)
+        # raise DerivaMLStateInconsistency because no SQLite row exists.
+        parent = MagicMock()
+        parent.execution_rid = DRY_RUN_RID
+        parent.execution_stop.side_effect = DerivaMLStateInconsistency(
+            f"Execution {DRY_RUN_RID} no longer in workspace registry."
+        )
+        parent.upload_execution_outputs.side_effect = DerivaMLStateInconsistency(
+            f"Execution {DRY_RUN_RID} no longer in workspace registry."
+        )
+
+        _multirun_state.parent_execution = parent
+        _multirun_state.parent_execution_rid = DRY_RUN_RID
+        _multirun_state.job_sequence = 3
+
+        with caplog.at_level(logging.INFO):
+            _complete_parent_execution()
+
+        # No warnings (or higher) about the placeholder or registry.
+        warnings = [r for r in caplog.records if r.levelno >= logging.WARNING]
+        for record in warnings:
+            assert DRY_RUN_RID not in record.getMessage()
+            assert "no longer in workspace registry" not in record.getMessage()
+            assert "Failed to complete parent execution" not in record.getMessage()
+        assert warnings == [], f"Unexpected warnings: {[r.getMessage() for r in warnings]}"
+
+        # An INFO line explains the skip.
+        info_messages = [r.getMessage() for r in caplog.records if r.levelno == logging.INFO]
+        assert any("Dry-run" in m and "not recorded" in m for m in info_messages), (
+            f"Expected dry-run skip INFO message, got: {info_messages}"
+        )
+
+        # The registry-touching methods were not invoked on the placeholder.
+        parent.execution_stop.assert_not_called()
+        parent.upload_execution_outputs.assert_not_called()
+
+    def test_real_parent_still_completed_normally(self, caplog):
+        """Non-placeholder parents still go through the full stop/upload path.
+
+        Guards against an over-eager short-circuit that would silently skip
+        real parent executions.
+        """
+        parent = MagicMock()
+        parent.execution_rid = "1-ABCD"
+        parent.upload_execution_outputs.return_value = {}
+
+        _multirun_state.parent_execution = parent
+        _multirun_state.parent_execution_rid = "1-ABCD"
+        _multirun_state.job_sequence = 2
+
+        with caplog.at_level(logging.INFO):
+            _complete_parent_execution()
+
+        parent.execution_stop.assert_called_once()
+        parent.upload_execution_outputs.assert_called_once()
+        info_messages = [r.getMessage() for r in caplog.records if r.levelno == logging.INFO]
+        assert any("Completed parent execution: 1-ABCD" in m for m in info_messages)

--- a/tests/execution/test_upload_workdir_layout.py
+++ b/tests/execution/test_upload_workdir_layout.py
@@ -1,0 +1,286 @@
+"""Regression tests for issue #178 — upload staging layout.
+
+Per-execution upload staging used to live at
+``<working_dir>/commit-bag-{rid}/`` — right at the cache root,
+beside ``cache/`` and ``schema-cache.json``. A user grepping for
+cache state to free disk space would encounter the directory and
+either delete it mid-upload or wonder why it existed (the name
+"commit-bag" is opaque to anyone not familiar with the bag-commit
+internals).
+
+Issue #178 moved per-execution scratch under a dedicated
+``upload/{rid}/`` parent. The cache root now contains only caches.
+
+These tests pin the new path shape so a regression to the old
+layout fails loudly. They avoid the need for a live catalog by
+mocking the bag-commit collaborators that follow the path-build
+step.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from deriva_ml.execution.execution import Execution
+
+
+def _fresh_rid() -> str:
+    """Return a unique synthetic RID string for path-shape tests.
+
+    The workspace policy bans hardcoded RIDs in tests — they make
+    bugs cluster on the same string and hide layout regressions
+    that only show up for RIDs with particular characters. A UUID
+    suffix gives every call a distinct, throwaway RID.
+
+    Returns:
+        A string of the form ``"TEST-<hex>"`` suitable as a
+        synthetic ``execution_rid``.
+
+    Example:
+        >>> rid = _fresh_rid()
+        >>> rid.startswith("TEST-")
+        True
+        >>> len(rid) > len("TEST-")
+        True
+    """
+    return f"TEST-{uuid.uuid4().hex[:12].upper()}"
+
+
+def _make_mocked_execution(working_dir: Path, execution_rid: str) -> Execution:
+    """Build a minimal :class:`Execution` for path-shape assertions.
+
+    Bypasses the full ``__init__`` (which expects a live
+    ``DerivaML`` instance, a configured workflow, etc.) and sets
+    only the attributes that :meth:`Execution._bag_commit_upload`
+    touches before it hands off to the bag-commit collaborators.
+    The collaborators themselves are mocked at the call site so
+    the test never reaches a catalog.
+
+    Args:
+        working_dir: Filesystem location to use as the
+            ``self._working_dir`` cache root.
+        execution_rid: Synthetic RID for ``self.execution_rid``.
+
+    Returns:
+        A partly-initialised :class:`Execution` ready for the
+        ``_bag_commit_upload`` path-shape test below.
+    """
+    exe = object.__new__(Execution)
+    exe._working_dir = working_dir
+    exe._logger = logging.getLogger(f"test.execution.{execution_rid}")
+
+    # ``_bag_commit_upload`` reads pending features and manifest
+    # rows after the path is built. Stub the manifest store on
+    # ``_ml_object.workspace`` so the ``_manifest_store`` /
+    # ``_get_manifest`` properties resolve without a real
+    # workspace; load_execution_bag is mocked separately at the
+    # call site to skip the catalog work.
+    manifest_stub = MagicMock()
+    manifest_stub.pending_assets.return_value = {}
+    manifest_stub.mark_uploaded_batch = MagicMock()
+
+    manifest_store_stub = MagicMock()
+    manifest_store_stub.list_pending_feature_records.return_value = []
+
+    ml_object_stub = MagicMock()
+    ml_object_stub.workspace.manifest_store.return_value = manifest_store_stub
+
+    exe._ml_object = ml_object_stub
+    # ``_get_manifest`` lazily builds an AssetManifest with the
+    # workspace store. Short-circuit the lazy path so the test
+    # never instantiates the real class.
+    exe._manifest = manifest_stub
+    exe._set_asset_descriptions = MagicMock()
+
+    # ``execution_rid`` is set as an instance attribute during
+    # __init__ (see Execution.__init__ — assigned post-insert or
+    # to DRY_RUN_RID for dry runs). We bypassed __init__, so set
+    # it directly.
+    exe.execution_rid = execution_rid
+    return exe
+
+
+def test_bag_commit_upload_uses_upload_subdir(tmp_path: Path) -> None:
+    """Bag dir lives at ``working_dir/upload/{rid}/`` — not at the cache root.
+
+    Captures the ``bag_dir`` argument passed to
+    :func:`deriva_ml.execution.bag_commit.build_execution_bag` and
+    asserts it has the new layout. A regression to
+    ``working_dir/commit-bag-{rid}/`` makes this fail.
+    """
+    rid = _fresh_rid()
+    exe = _make_mocked_execution(tmp_path, rid)
+
+    captured: dict[str, Path] = {}
+
+    def _fake_build(_execution, bag_dir: Path, *, progress_callback=None):
+        captured["bag_dir"] = Path(bag_dir)
+        return bag_dir
+
+    fake_report = SimpleNamespace(total_rows_inserted=0, table_stats={})
+
+    with (
+        patch(
+            "deriva_ml.execution.bag_commit.build_execution_bag",
+            side_effect=_fake_build,
+        ),
+        patch(
+            "deriva_ml.execution.bag_commit.load_execution_bag",
+            return_value=fake_report,
+        ),
+        patch(
+            "deriva_ml.execution.bag_commit.report_to_asset_map",
+            return_value={},
+        ),
+    ):
+        exe._bag_commit_upload()
+
+    assert "bag_dir" in captured, "build_execution_bag was never called"
+    bag_dir = captured["bag_dir"]
+    expected = tmp_path / "upload" / rid
+    assert bag_dir == expected, (
+        f"bag_dir was {bag_dir!r}; expected {expected!r}. "
+        "Per issue #178, per-execution staging lives at "
+        "working_dir/upload/{rid}/, not at the cache root."
+    )
+
+
+def test_bag_commit_upload_does_not_pollute_cache_root(tmp_path: Path) -> None:
+    """The cache root must not gain a ``commit-bag-*`` or ``upload-*`` sibling.
+
+    After ``_bag_commit_upload`` runs, the immediate children of
+    ``working_dir`` (the cache root) should NOT include any
+    ``commit-bag-`` directories or ``upload-{rid}`` style entries.
+    The only new entry should be the ``upload/`` parent.
+    """
+    rid = _fresh_rid()
+    exe = _make_mocked_execution(tmp_path, rid)
+
+    # Touch the bag_dir from inside the fake build to simulate
+    # the real BagBuilder, which creates output_dir on entry.
+    def _fake_build(_execution, bag_dir: Path, *, progress_callback=None):
+        Path(bag_dir).mkdir(parents=True, exist_ok=True)
+        return bag_dir
+
+    fake_report = SimpleNamespace(total_rows_inserted=0, table_stats={})
+
+    with (
+        patch(
+            "deriva_ml.execution.bag_commit.build_execution_bag",
+            side_effect=_fake_build,
+        ),
+        patch(
+            "deriva_ml.execution.bag_commit.load_execution_bag",
+            return_value=fake_report,
+        ),
+        patch(
+            "deriva_ml.execution.bag_commit.report_to_asset_map",
+            return_value={},
+        ),
+    ):
+        exe._bag_commit_upload()
+
+    cache_root_children = {p.name for p in tmp_path.iterdir()}
+
+    bad = [name for name in cache_root_children if name.startswith("commit-bag-") or name.startswith(f"upload-{rid}")]
+    assert not bad, (
+        f"Cache root gained scratch siblings {bad!r}; "
+        "per-execution staging must live under upload/, not at "
+        "the cache root."
+    )
+    assert "upload" in cache_root_children, (
+        f"Expected an ``upload`` parent under the cache root after a bag commit; saw {sorted(cache_root_children)!r}."
+    )
+
+    # And the RID-specific subdir must be under upload/.
+    assert (tmp_path / "upload" / rid).is_dir(), (
+        f"Expected {tmp_path / 'upload' / rid} to exist after the fake build_execution_bag created it."
+    )
+
+
+def test_bag_commit_upload_wipes_stale_attempt(tmp_path: Path) -> None:
+    """A pre-existing bag dir at the new path is wiped before rebuild.
+
+    The path-build step calls ``shutil.rmtree(bag_dir)`` if a
+    prior attempt left a partial bag in place. Verify that
+    behaviour still works at the new ``upload/{rid}/`` location.
+    """
+    rid = _fresh_rid()
+    exe = _make_mocked_execution(tmp_path, rid)
+
+    stale = tmp_path / "upload" / rid
+    stale.mkdir(parents=True)
+    stale_marker = stale / "STALE_MARKER"
+    stale_marker.write_text("stale")
+    assert stale_marker.exists()
+
+    def _fake_build(_execution, bag_dir: Path, *, progress_callback=None):
+        # After the rmtree, the dir should be gone. Re-create empty.
+        assert not Path(bag_dir).exists(), "Stale bag dir was not removed before build_execution_bag was called."
+        Path(bag_dir).mkdir(parents=True)
+        return bag_dir
+
+    fake_report = SimpleNamespace(total_rows_inserted=0, table_stats={})
+
+    with (
+        patch(
+            "deriva_ml.execution.bag_commit.build_execution_bag",
+            side_effect=_fake_build,
+        ),
+        patch(
+            "deriva_ml.execution.bag_commit.load_execution_bag",
+            return_value=fake_report,
+        ),
+        patch(
+            "deriva_ml.execution.bag_commit.report_to_asset_map",
+            return_value={},
+        ),
+    ):
+        exe._bag_commit_upload()
+
+    assert not stale_marker.exists(), "Stale marker survived; the prior-attempt wipe did not run."
+
+
+@pytest.mark.parametrize("_run", range(3))
+def test_bag_commit_upload_path_is_dynamic(_run: int, tmp_path: Path) -> None:
+    """Path shape holds for many distinct RIDs.
+
+    Parametrised to make sure the path-build step is not
+    accidentally hardcoded to a single RID format. ``_run`` is
+    unused — each invocation just gives ``_fresh_rid`` a chance
+    to mint a new RID.
+    """
+    rid = _fresh_rid()
+    exe = _make_mocked_execution(tmp_path, rid)
+
+    captured: dict[str, Path] = {}
+
+    def _fake_build(_execution, bag_dir: Path, *, progress_callback=None):
+        captured["bag_dir"] = Path(bag_dir)
+        return bag_dir
+
+    fake_report = SimpleNamespace(total_rows_inserted=0, table_stats={})
+
+    with (
+        patch(
+            "deriva_ml.execution.bag_commit.build_execution_bag",
+            side_effect=_fake_build,
+        ),
+        patch(
+            "deriva_ml.execution.bag_commit.load_execution_bag",
+            return_value=fake_report,
+        ),
+        patch(
+            "deriva_ml.execution.bag_commit.report_to_asset_map",
+            return_value={},
+        ),
+    ):
+        exe._bag_commit_upload()
+
+    assert captured["bag_dir"] == tmp_path / "upload" / rid


### PR DESCRIPTION
## Summary

Closes #177.

## Diagnosis

When a Hydra multirun runs with `dry_run=true`, `runner.py`
creates a parent supervisor execution and registers an `atexit`
handler (`_complete_parent_execution`) to stop and upload it on
process exit. In dry-run mode the parent uses `DRY_RUN_RID`
(`"0000"`) as its execution_rid placeholder and is intentionally
*never* written to the workspace SQLite registry.

The handler unconditionally called `parent.execution_stop()`,
which reads `self.start_time` via `_get_registry_row`. That read
raises `DerivaMLStateInconsistency` ("Execution 0000 no longer in
workspace registry...") -- the row never existed in the first
place. The handler caught the exception and emitted a WARNING:

```
WARNING root:runner.py:243 Failed to complete parent execution: Execution 0000 no longer in workspace registry.
```

Exit code stayed 0 and behavior was correct, but the warning text
suggests a state-consistency problem and users reading the log
think something went wrong.

## Change

`_complete_parent_execution` now short-circuits when the parent's
execution_rid is the `DRY_RUN_RID` placeholder, before any
registry-touching call. It logs an INFO line that says exactly
what happened (no stop, no upload, "expected for dry-run mode")
so a reader can tell this skip from a real failure. The
placeholder check uses the existing `DRY_RUN_RID` constant from
`deriva_ml.core.constants`.

Real (non-placeholder) parents still go through the full
`execution_stop` + `upload_execution_outputs` path -- a second
test pins that contract.

## Regression test

`tests/execution/test_runner.py::TestCompleteParentExecutionDryRun`:

- `test_dry_run_placeholder_does_not_warn` -- builds a parent
  whose `execution_stop` / `upload_execution_outputs` would (under
  the bug) raise `DerivaMLStateInconsistency`, invokes the handler,
  asserts no WARNING is logged about `0000` or "no longer in
  workspace registry", and asserts an INFO message about the
  dry-run skip is logged. Confirmed FAILS under old code with
  the exact warning text the issue reports.
- `test_real_parent_still_completed_normally` -- ensures
  non-placeholder parents still call both `execution_stop` and
  `upload_execution_outputs` and log the normal completion
  message.

## Test plan

- [x] `uv run python -m pytest tests/execution/test_runner.py -v` -- 18 passed
- [x] `uv run ruff check src/deriva_ml/execution/runner.py tests/execution/test_runner.py`
- [x] `uv run ruff format src/deriva_ml/execution/runner.py tests/execution/test_runner.py`
- [x] Pre-fix sanity check: stashed the runner.py change, ran the new test, confirmed it FAILS under old code with the exact warning text the issue reports. Restored the fix.

CHANGELOG: "Misleading dry-run exit warning for the placeholder parent execution RID (#177)."