### PR TITLE
fix(execution): warn before download_asset overwrites different bytes (#181)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to this project are documented here.
 
+## Unreleased — Issue #181: download_asset overwrite warning
+
+### Changed
+
+- **`Execution.download_asset` now logs a WARNING before overwriting
+  a non-identical existing file (#181).** PR #179 RID-keyed the
+  platform-default per-asset `dest_dir` so the in-platform download
+  path is collision-free, but `download_asset` itself still silently
+  overwrote when callers building custom download flows passed the
+  same `dest_dir` to two downloads whose `Filename`s collided. The
+  new guard — a module-level `_check_overwrite_safe` helper called at
+  both the regular-download and cache-hit-symlink write sites in
+  `src/deriva_ml/execution/execution.py` — hashes the existing file
+  and compares against the catalog's recorded MD5. If the bytes
+  match, the overwrite is idempotent and stays silent (cache
+  repopulation, retry). If they differ — or if the catalog has no
+  MD5 to compare against — a WARNING fires naming the asset RID, the
+  colliding path, and both MD5s. **Behavior change, not breaking**:
+  the overwrite still happens, return value is unchanged, no
+  exception is raised. Callers that legitimately need overwrite
+  semantics see a new log line they can ignore or filter; callers
+  that want true isolation should follow the canonical pattern of
+  `dest_dir = working_dir / "downloads" / asset_rid`.
+
 ## Unreleased — Issue #177: dry-run multirun exit log noise
 
 ### Fixed

--- a/src/deriva_ml/execution/execution.py
+++ b/src/deriva_ml/execution/execution.py
@@ -30,6 +30,7 @@ call must happen AFTER exiting the context manager to ensure proper status track
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import os
@@ -135,6 +136,85 @@ def _format_duration(start: "datetime | None", end: "datetime | None") -> str:
     hours, remainder = divmod(delta.total_seconds(), 3600)
     minutes, seconds = divmod(remainder, 60)
     return f"{round(hours, 0)}H {round(minutes, 0)}min {round(seconds, 4)}sec"
+
+
+def _check_overwrite_safe(
+    asset_filename: Path,
+    expected_md5: str | None,
+    asset_rid: RID,
+) -> None:
+    """Log a WARNING when ``download_asset`` is about to overwrite different bytes.
+
+    Issue #181 protects callers building custom download flows on top of
+    ``Execution.download_asset`` from the silent-overwrite footgun: when two
+    downloads share ``dest_dir`` and ``Filename`` but resolve to different
+    bytes, the second one wins and the first one vanishes without a trace.
+    PR #179 RID-keyed the platform-default ``dest_dir`` so the in-platform
+    call site is collision-free; this helper guards ad-hoc callers.
+
+    The check is *advisory* — overwrites are still permitted. The helper
+    just surfaces the collision at fault time. Three branches:
+
+    1. ``asset_filename`` does not exist: nothing to overwrite, return.
+    2. ``asset_filename`` exists and ``expected_md5`` matches its on-disk
+       md5: idempotent re-download (cache repopulation, retry, or genuinely
+       identical content), return silently.
+    3. Otherwise: log WARNING naming the asset RID, the colliding path,
+       and both md5s. If ``expected_md5`` is None (catalog doesn't record
+       MD5, or the value is missing from ``asset_record``), the conservative
+       choice is to warn anyway — without the catalog MD5 we cannot prove
+       the overwrite is idempotent.
+
+    Args:
+        asset_filename: The on-disk path ``download_asset`` is about to
+            write to (``dest_dir / asset_record["Filename"]``).
+        expected_md5: The MD5 of the bytes about to be written, typically
+            ``asset_record.get("MD5")``. Pass None when unknown.
+        asset_rid: RID of the asset being downloaded — included in the
+            WARNING for diagnostics.
+
+    Returns:
+        None. Side-effects only (a single WARNING log line when the
+        overwrite is non-idempotent or unverifiable).
+
+    Example:
+        >>> from pathlib import Path
+        >>> _check_overwrite_safe(Path("/nonexistent/file"), "abc123", "RID1")
+        >>> # No log, file does not exist.
+    """
+    if not asset_filename.exists() and not asset_filename.is_symlink():
+        return
+
+    on_disk_md5: str | None = None
+    try:
+        # Follow symlinks so the cache-hit branch (symlink to a cache
+        # entry) compares against the cache entry's bytes, which is what
+        # the next download will overwrite via unlink + symlink.
+        target = asset_filename.resolve() if asset_filename.is_symlink() else asset_filename
+        if target.is_file():
+            hasher = hashlib.md5()
+            with target.open("rb") as fp:
+                for chunk in iter(lambda: fp.read(8192), b""):
+                    hasher.update(chunk)
+            on_disk_md5 = hasher.hexdigest()
+    except OSError:
+        # If we cannot read the file (permissions, broken symlink, etc.)
+        # err on the side of warning — the overwrite is unverifiable.
+        on_disk_md5 = None
+
+    if expected_md5 is not None and on_disk_md5 is not None and expected_md5 == on_disk_md5:
+        return
+
+    logger.warning(
+        "download_asset: overwriting existing file at %s with asset %s "
+        "(existing md5=%s, expected md5=%s). "
+        "Pass a unique dest_dir per asset to avoid collisions; the canonical "
+        "pattern is dest_dir = working_dir / 'downloads' / asset_rid.",
+        asset_filename,
+        asset_rid,
+        on_disk_md5 if on_disk_md5 is not None else "<unreadable>",
+        expected_md5 if expected_md5 is not None else "<unknown>",
+    )
 
 
 class Execution:
@@ -1274,19 +1354,24 @@ class Execution:
     ) -> AssetFilePath:
         """Download an asset from a URL and place it in a local directory.
 
-        The file is written to ``dest_dir / asset_record["Filename"]``. The
-        caller owns ``dest_dir`` and is responsible for collision avoidance
-        when downloading multiple assets — two calls that share both
-        ``dest_dir`` and ``Filename`` will overwrite each other. When invoked
-        by ``_initialize_execution`` the per-asset ``dest_dir`` is keyed by
-        ``asset_rid`` so the on-disk layout is collision-free by
-        construction; ad-hoc callers should follow the same convention.
+        The file is written to ``dest_dir / asset_record["Filename"]``.
+        Overwrites any existing file at that path, with a WARNING logged
+        when the existing content is byte-different from the asset's
+        expected MD5 (issue #181). Idempotent re-downloads — the existing
+        file's md5 already matches the catalog's recorded MD5 — log
+        nothing. Callers that need silent overwrites can accept the
+        WARNING; callers that need genuine isolation should pass a unique
+        ``dest_dir`` per asset. The canonical pattern is
+        ``dest_dir = working_dir / 'downloads' / asset_rid``, which is
+        what ``_initialize_execution`` uses internally so the
+        platform-default download path is collision-free by construction.
 
         Args:
             asset_rid: RID of the asset.
-            dest_dir: Destination directory for the asset. Must be unique
-                across concurrent ``download_asset`` calls when ``Filename``
-                may collide.
+            dest_dir: Destination directory for the asset. When ``Filename``
+                may collide across concurrent ``download_asset`` calls,
+                pass a unique directory per asset to avoid the WARNING and
+                the silent overwrite it guards against.
             update_catalog: Whether to update the catalog execution information after downloading.
             use_cache: If True, check the cache directory for a previously downloaded copy
                 with a matching MD5 checksum before downloading. Cached copies are stored
@@ -1311,18 +1396,24 @@ class Execution:
         asset_metadata = {k: v for k, v in asset_record.items() if k in self._model.asset_metadata(asset_table)}
         asset_url = asset_record["URL"]
         asset_filename = dest_dir / asset_record["Filename"]
+        expected_md5 = asset_record.get("MD5")
 
         # Check cache before downloading
         cache_hit = False
         if use_cache:
-            md5 = asset_record.get("MD5")
+            md5 = expected_md5
             if md5:
                 asset_cache_dir = self._ml_object.cache_dir / "assets"
                 asset_cache_dir.mkdir(parents=True, exist_ok=True)
                 cache_key = f"{asset_rid}_{md5}"
                 cached_file = asset_cache_dir / cache_key / asset_record["Filename"]
                 if cached_file.exists():
-                    # Cache hit — symlink from cache to destination
+                    # Cache hit — symlink from cache to destination. The
+                    # cached file's bytes ARE the asset's expected bytes
+                    # by construction (cache_key includes md5), so reuse
+                    # ``expected_md5`` as the "about to be written" md5
+                    # in the overwrite check.
+                    _check_overwrite_safe(asset_filename, expected_md5, asset_rid)
                     self._logger.info(f"Using cached asset {asset_rid} (MD5: {md5})")
                     if asset_filename.exists() or asset_filename.is_symlink():
                         asset_filename.unlink()
@@ -1330,6 +1421,7 @@ class Execution:
                     cache_hit = True
 
         if not cache_hit:
+            _check_overwrite_safe(asset_filename, expected_md5, asset_rid)
             hs = HatracStore("https", self._ml_object.host_name, self._ml_object.credential)
             hs.get_obj(path=asset_url, destfilename=asset_filename.as_posix())
 

--- a/tests/execution/test_download_asset_overwrite.py
+++ b/tests/execution/test_download_asset_overwrite.py
@@ -1,0 +1,323 @@
+"""Tests for the ``download_asset`` overwrite-warning guard (issue #181).
+
+PR #179 RID-keyed the platform-default per-asset ``dest_dir`` so the
+in-platform download path is collision-free by construction. Callers
+building their own download flows on top of ``Execution.download_asset``,
+however, can still pass the same ``dest_dir`` to two downloads whose
+``Filename``s collide and lose data silently.
+
+Issue #181 closes that hole with a *warn-then-overwrite* guard. The
+guard is implemented as the module-level helper
+:func:`deriva_ml.execution.execution._check_overwrite_safe`, called
+once on the regular download branch and once on the cache-hit symlink
+branch. This file pins the guard's behaviour at two layers:
+
+1. Direct unit tests against the helper — exhaustive coverage of the
+   md5-match / md5-mismatch / md5-unknown / no-existing-file branches
+   without touching the catalog. Fast, deterministic, and these are
+   what really prove the contract.
+
+2. Integration tests that exercise the guard through
+   ``Execution.download_asset`` against the live test catalog. These
+   prove the helper is wired in at both write sites (regular download
+   at line ~1346 and cache-hit symlink at line ~1338 in the
+   post-fix file).
+
+Reference: ``deriva-ml/src/deriva_ml/execution/execution.py``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import pytest
+
+from deriva_ml import ExecAssetType, MLAsset
+from deriva_ml.execution.execution import (
+    Execution,
+    ExecutionConfiguration,
+    _check_overwrite_safe,
+)
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+
+def _write(path: Path, data: bytes) -> str:
+    """Write ``data`` to ``path`` and return its hex md5.
+
+    Args:
+        path: Destination file. Parent directory must already exist.
+        data: Raw bytes to write.
+
+    Returns:
+        The hex-digest md5 of ``data``.
+
+    Example:
+        >>> import tempfile, pathlib
+        >>> with tempfile.TemporaryDirectory() as d:
+        ...     md5 = _write(pathlib.Path(d) / "f", b"hello")
+        ...     md5
+        '5d41402abc4b2a76b9719d911017c592'
+    """
+    path.write_bytes(data)
+    return hashlib.md5(data).hexdigest()
+
+
+def _warning_records(caplog: pytest.LogCaptureFixture) -> list[logging.LogRecord]:
+    """Return the WARNING records from ``deriva_ml`` captured in ``caplog``.
+
+    Args:
+        caplog: pytest's log-capture fixture.
+
+    Returns:
+        The subset of records at WARNING level emitted by the ``deriva_ml``
+        logger hierarchy.
+
+    Example:
+        >>> # Filter caplog.records for the records this guard cares about
+        >>> # without picking up unrelated warnings from other libraries.
+        ...
+    """
+    return [r for r in caplog.records if r.levelno == logging.WARNING and r.name.startswith("deriva_ml")]
+
+
+# =============================================================================
+# Unit tests against _check_overwrite_safe (no live catalog)
+# =============================================================================
+
+
+class TestCheckOverwriteSafeUnit:
+    """Direct unit tests against the helper.
+
+    These cover every branch of the helper without exercising any
+    catalog code. The integration tests below prove the wiring; these
+    prove the contract.
+    """
+
+    def test_no_warning_when_destination_missing(self, tmp_path, caplog):
+        """No existing file → no warning."""
+        target = tmp_path / "missing.bin"
+        assert not target.exists()
+
+        with caplog.at_level(logging.WARNING, logger="deriva_ml"):
+            _check_overwrite_safe(target, expected_md5="abc123", asset_rid="RID-1")
+
+        assert _warning_records(caplog) == []
+
+    def test_no_warning_on_idempotent_overwrite(self, tmp_path, caplog):
+        """Existing bytes' md5 matches expected_md5 → silent overwrite."""
+        target = tmp_path / "idempotent.bin"
+        md5 = _write(target, b"identical bytes")
+
+        with caplog.at_level(logging.WARNING, logger="deriva_ml"):
+            _check_overwrite_safe(target, expected_md5=md5, asset_rid="RID-1")
+
+        assert _warning_records(caplog) == []
+
+    def test_warning_on_different_bytes(self, tmp_path, caplog):
+        """Existing bytes' md5 differs from expected_md5 → WARNING."""
+        target = tmp_path / "collide.bin"
+        existing_md5 = _write(target, b"first asset's bytes")
+        expected_md5 = hashlib.md5(b"second asset's bytes").hexdigest()
+        assert existing_md5 != expected_md5
+
+        with caplog.at_level(logging.WARNING, logger="deriva_ml"):
+            _check_overwrite_safe(target, expected_md5=expected_md5, asset_rid="RID-COLLIDE")
+
+        warnings = _warning_records(caplog)
+        assert len(warnings) == 1
+        msg = warnings[0].getMessage()
+        assert "RID-COLLIDE" in msg
+        assert str(target) in msg
+        assert existing_md5 in msg
+        assert expected_md5 in msg
+
+    def test_warning_when_expected_md5_unknown(self, tmp_path, caplog):
+        """No catalog MD5 → conservative WARNING (cannot prove idempotent)."""
+        target = tmp_path / "unknown_md5.bin"
+        _write(target, b"some bytes")
+
+        with caplog.at_level(logging.WARNING, logger="deriva_ml"):
+            _check_overwrite_safe(target, expected_md5=None, asset_rid="RID-UNKNOWN")
+
+        warnings = _warning_records(caplog)
+        assert len(warnings) == 1
+        msg = warnings[0].getMessage()
+        assert "RID-UNKNOWN" in msg
+        assert "<unknown>" in msg
+
+    def test_warning_on_symlink_pointing_to_different_bytes(self, tmp_path, caplog):
+        """Cache-hit branch: existing symlink to a non-matching cache entry → WARNING.
+
+        ``download_asset`` symlinks into a per-cache-key directory. When a
+        caller re-uses the same ``dest_dir`` for a second asset that
+        happens to share the same ``Filename``, the existing symlink
+        points at the *first* asset's cached bytes — overwriting it
+        silently swaps which asset the path resolves to. The helper
+        catches that case by hashing through the symlink (it calls
+        ``Path.resolve``).
+        """
+        cache_first = tmp_path / "cache_first.bin"
+        existing_md5 = _write(cache_first, b"asset one bytes")
+        link = tmp_path / "link.bin"
+        link.symlink_to(cache_first)
+
+        expected_md5 = hashlib.md5(b"asset two bytes").hexdigest()
+
+        with caplog.at_level(logging.WARNING, logger="deriva_ml"):
+            _check_overwrite_safe(link, expected_md5=expected_md5, asset_rid="RID-CACHE-COLLIDE")
+
+        warnings = _warning_records(caplog)
+        assert len(warnings) == 1
+        msg = warnings[0].getMessage()
+        assert "RID-CACHE-COLLIDE" in msg
+        assert existing_md5 in msg
+
+    def test_no_warning_on_symlink_pointing_to_matching_bytes(self, tmp_path, caplog):
+        """Cache-hit branch: existing symlink to the SAME cache entry → silent.
+
+        Re-resolving an asset whose cached file is already the
+        destination's symlink target is fully idempotent — the next
+        ``unlink`` + ``symlink_to`` lands on identical bytes.
+        """
+        cached = tmp_path / "cached.bin"
+        md5 = _write(cached, b"identical cached bytes")
+        link = tmp_path / "link.bin"
+        link.symlink_to(cached)
+
+        with caplog.at_level(logging.WARNING, logger="deriva_ml"):
+            _check_overwrite_safe(link, expected_md5=md5, asset_rid="RID-CACHE-OK")
+
+        assert _warning_records(caplog) == []
+
+
+# =============================================================================
+# Integration tests through Execution.download_asset (live catalog)
+# =============================================================================
+
+
+@pytest.fixture
+def test_workflow(workflow_terms):
+    """Create a test workflow for the download tests."""
+    ml = workflow_terms
+    return ml.create_workflow(
+        name="Issue 181 Test Workflow",
+        workflow_type="Test Workflow",
+        description="Workflow for issue #181 overwrite-warning tests",
+    )
+
+
+@pytest.fixture
+def basic_execution(workflow_terms, test_workflow):
+    """Create a basic execution for download tests."""
+    ml = workflow_terms
+    config = ExecutionConfiguration(
+        description="Issue 181 Test Execution",
+        workflow=test_workflow,
+    )
+    return ml.create_execution(config)
+
+
+def _create_test_asset(execution: Execution, filename: str, content: str) -> None:
+    """Mirror of the suite's ``create_test_asset`` helper, kept local for clarity."""
+    asset_path = execution.asset_file_path(
+        MLAsset.execution_asset,
+        f"TestAsset/{filename}",
+        asset_types=ExecAssetType.model_file,
+    )
+    with asset_path.open("w") as fp:
+        fp.write(content)
+
+
+class TestDownloadAssetOverwriteIntegration:
+    """End-to-end tests that prove the guard is wired into ``download_asset``."""
+
+    def test_warns_when_two_assets_collide_in_dest_dir(self, workflow_terms, test_workflow, caplog):
+        """Downloading two distinct assets with the same Filename into one dest_dir warns."""
+        ml = workflow_terms
+
+        # Upload two assets with the same Filename across two separate
+        # executions — distinct RIDs, distinct MD5s, but the catalog's
+        # ``Filename`` column resolves to ``collide.txt`` for both.
+        # Two executions (rather than one with two files in distinct
+        # subdirs) sidesteps any local-folder dedup that happens
+        # before upload.
+        config_a = ExecutionConfiguration(description="Issue 181 Asset A", workflow=test_workflow)
+        exec_a = ml.create_execution(config_a)
+        with exec_a.execute() as execution:
+            _create_test_asset(execution, "collide.txt", "first asset")
+        uploaded_a = exec_a.upload_execution_outputs()
+        rid_a = uploaded_a["deriva-ml/Execution_Asset"][0].asset_rid
+
+        config_b = ExecutionConfiguration(description="Issue 181 Asset B", workflow=test_workflow)
+        exec_b = ml.create_execution(config_b)
+        with exec_b.execute() as execution:
+            _create_test_asset(execution, "collide.txt", "second asset bytes are different")
+        uploaded_b = exec_b.upload_execution_outputs()
+        rid_b = uploaded_b["deriva-ml/Execution_Asset"][0].asset_rid
+
+        assert rid_a != rid_b
+
+        # Now download both into the same dest_dir. The second call must
+        # warn before clobbering the first one's bytes.
+        download_config = ExecutionConfiguration(
+            description="Issue 181 Collide Download",
+            workflow=test_workflow,
+        )
+        download_execution = ml.create_execution(download_config)
+
+        with TemporaryDirectory() as tmpdir:
+            dest = Path(tmpdir)
+            download_execution.download_asset(rid_a, dest, update_catalog=False)
+
+            caplog.clear()
+            with caplog.at_level(logging.WARNING, logger="deriva_ml"):
+                download_execution.download_asset(rid_b, dest, update_catalog=False)
+
+            warnings = _warning_records(caplog)
+            collide_warnings = [w for w in warnings if "download_asset" in w.getMessage()]
+            assert len(collide_warnings) == 1, (
+                f"expected exactly one download_asset overwrite WARNING; got {[w.getMessage() for w in warnings]}"
+            )
+            msg = collide_warnings[0].getMessage()
+            assert rid_b in msg
+            assert str(dest / "collide.txt") in msg
+
+            # Asset B's bytes should win on disk.
+            with (dest / "collide.txt").open() as f:
+                assert f.read() == "second asset bytes are different"
+
+    def test_does_not_warn_on_idempotent_redownload(self, basic_execution, caplog):
+        """Downloading the same asset twice into the same dest_dir is silent."""
+        ml = basic_execution._ml_object
+
+        with basic_execution.execute() as execution:
+            _create_test_asset(execution, "idempotent.txt", "stable bytes")
+
+        uploaded = basic_execution.upload_execution_outputs()
+        asset_rid = uploaded["deriva-ml/Execution_Asset"][0].asset_rid
+
+        download_config = ExecutionConfiguration(
+            description="Issue 181 Idempotent Download",
+            workflow=basic_execution.configuration.workflow,
+        )
+        download_execution = ml.create_execution(download_config)
+
+        with TemporaryDirectory() as tmpdir:
+            dest = Path(tmpdir)
+            download_execution.download_asset(asset_rid, dest, update_catalog=False)
+
+            caplog.clear()
+            with caplog.at_level(logging.WARNING, logger="deriva_ml"):
+                download_execution.download_asset(asset_rid, dest, update_catalog=False)
+
+            warnings = _warning_records(caplog)
+            collide_warnings = [w for w in warnings if "download_asset" in w.getMessage()]
+            assert collide_warnings == [], (
+                f"idempotent re-download should not warn; got {[w.getMessage() for w in collide_warnings]}"
+            )


### PR DESCRIPTION
## Summary

Closes #181.

PR #179 RID-keyed the platform-default per-asset `dest_dir` so the in-platform download path is collision-free by construction. But `download_asset` itself still silently overwrote when callers building custom download flows passed the same `dest_dir` to two downloads whose `Filename`s collided — the exact class of bug PR #179 fixed at the platform call site, but for ad-hoc callers.

This PR adds an advisory overwrite-warning guard (Option A from the issue): the overwrite still happens, but a WARNING fires when it would clobber different bytes.

- New module-level helper `_check_overwrite_safe(asset_filename, expected_md5, asset_rid)` in `src/deriva_ml/execution/execution.py` (location: src/deriva_ml/execution/execution.py:141).
- Called at both `download_asset` write sites: the regular `hs.get_obj(...)` branch and the cache-hit `symlink_to(...)` branch.
- Hashes the existing file (following symlinks so the cache-hit case compares cached bytes) and compares against the catalog's recorded MD5. Three branches:
  - No existing file: silent.
  - Existing md5 matches expected: silent (idempotent re-download — cache repopulation, retry, identical content).
  - Otherwise (mismatch, or expected_md5 is `None`): WARNING naming the asset RID, the colliding path, and both md5s.
- Updated `download_asset` docstring describing the new semantics.

**Behavior change, not breaking**: overwrite still happens, return value unchanged, no exception raised. Callers that legitimately need overwrite semantics see a new log line they can ignore or filter.

## Test plan

- [x] `uv run python -m pytest tests/execution/test_download_asset_overwrite.py -v` — 6 unit + 2 integration + 1 doctest, all pass.
- [x] Pre-fix sanity: with the helper's `logger.warning(...)` neutered, the three "warning expected" unit tests fail with `assert 0 == 1`; restoring the warning makes all six pass.
- [x] `uv run python -m pytest tests/execution/test_execution.py::TestExecutionAssets tests/execution/test_execution.py::TestAssetCaching -v` — all 15 existing asset/cache tests still pass.
- [x] `uv run ruff check src/deriva_ml/execution/execution.py tests/execution/test_download_asset_overwrite.py` — no new lint errors (pre-existing `DatasetCollection` F821 is unrelated).
- [x] `uv run ruff format` clean.

## CHANGELOG

`Unreleased — Issue #181: download_asset overwrite warning`. Logged as a behavior change (new WARNING logs), explicitly noted as not breaking (no return-value change, no exception).

🤖 Generated with [Claude Code](https://claude.com/claude-code)