### PR TITLE
feat(exceptions): typed exceptions for find_association (#180)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,38 @@ All notable changes to this project are documented here.
   that want true isolation should follow the canonical pattern of
   `dest_dir = working_dir / "downloads" / asset_rid`.
 
+## Unreleased — Issue #180: typed exceptions for `find_association` failure modes
+
+### Changed
+
+- **`DerivaModel.find_association` now raises typed subclasses
+  (#180).** The two failure modes — "no association exists" and
+  "multiple associations exist" — used to surface as bare
+  `DerivaMLException` with diagnostic prose in the message, forcing
+  callers that needed to distinguish them to pattern-match on the
+  message text. Both modes now raise a dedicated subclass:
+
+  - `NoAssociationException` (`DerivaMLNotFoundError` subtree) when
+    no association table connects the two endpoints.
+  - `AmbiguousAssociationException` (`DerivaMLDataError` subtree)
+    when more than one association table connects them; carries the
+    `count` field.
+
+  Both subclasses inherit from `DerivaMLException`, so existing
+  callers that `except DerivaMLException:` continue to work. Callers
+  that previously string-matched on `"No association tables found"`
+  should switch to `except NoAssociationException:` — the load-bearing
+  change is the type, not the message text. The companion update in
+  `deriva-ml-mcp` (`tools/asset.py` `_get_asset_detail_impl`) is filed
+  as a follow-up PR there.
+
+  In-repo callers that intentionally swallowed "no association"
+  errors via broad `except Exception:` blocks (`asset/asset.py`,
+  `core/mixins/asset.py`, `core/mixins/execution.py`,
+  `execution/bag_commit.py`) have been tightened to
+  `except NoAssociationException:` — real errors now propagate as
+  intended.
+
 ## Unreleased — Issue #177: dry-run multirun exit log noise
 
 ### Fixed

--- a/src/deriva_ml/asset/asset.py
+++ b/src/deriva_ml/asset/asset.py
@@ -31,6 +31,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from deriva_ml.core.definitions import RID
+from deriva_ml.core.exceptions import NoAssociationException
 
 if TYPE_CHECKING:
     from deriva_ml.execution.execution_record import ExecutionRecord
@@ -149,7 +150,7 @@ class Asset:
         asset_table_obj = self._ml_instance.model.name_to_table(self.asset_table)
         try:
             type_assoc_table, asset_fk, _ = self._ml_instance.model.find_association(asset_table_obj, "Asset_Type")
-        except Exception:
+        except NoAssociationException:
             # No type association for this asset table
             self._asset_types = []
             return

--- a/src/deriva_ml/core/exceptions.py
+++ b/src/deriva_ml/core/exceptions.py
@@ -16,11 +16,13 @@ Exception Hierarchy:
     │   ├── DerivaMLNotFoundError (entity not found)
     │   │   ├── DerivaMLDatasetNotFound (dataset lookup failures)
     │   │   ├── DerivaMLTableNotFound (table lookup failures)
-    │   │   └── DerivaMLInvalidTerm (vocabulary term not found)
+    │   │   ├── DerivaMLInvalidTerm (vocabulary term not found)
+    │   │   └── NoAssociationException (find_association: zero matches)
     │   ├── DerivaMLTableTypeError (wrong table type)
     │   ├── DerivaMLValidationError (data validation failures)
     │   ├── DerivaMLCycleError (cycle detected in relationships)
-    │   └── DerivaMLStateInconsistency (SQLite/catalog state disagreement)
+    │   ├── DerivaMLStateInconsistency (SQLite/catalog state disagreement)
+    │   └── AmbiguousAssociationException (find_association: multiple matches)
     │
     ├── DerivaMLExecutionError (execution lifecycle)
     │   ├── DerivaMLWorkflowError (workflow issues)
@@ -67,6 +69,8 @@ __all__ = [
     "DerivaMLMaterializeLimitExceeded",
     "DerivaMLCycleError",
     "DerivaMLStateInconsistency",
+    "NoAssociationException",
+    "AmbiguousAssociationException",
     "DerivaMLExecutionError",
     "DerivaMLWorkflowError",
     "DerivaMLDirtyWorkflowError",
@@ -426,6 +430,75 @@ class DerivaMLStateInconsistency(DerivaMLDataError):
     """
 
     pass
+
+
+class NoAssociationException(DerivaMLNotFoundError):
+    """Raised when no association table connects two tables.
+
+    Surfaced by :meth:`deriva_ml.model.catalog.DerivaModel.find_association`
+    when the caller asked for the unique association linking ``table1`` and
+    ``table2`` but no such association exists. Carrying this as a distinct
+    type (rather than a bare :class:`DerivaMLException`) lets callers
+    distinguish the legitimate "no link" case from real errors without
+    pattern-matching on the exception message.
+
+    Args:
+        table1: Name of the first endpoint table.
+        table2: Name of the second endpoint table.
+
+    Attributes:
+        table1: Name of the first endpoint table.
+        table2: Name of the second endpoint table.
+
+    Example:
+        Branch on the typed exception instead of message text::
+
+            >>> from deriva_ml.core.exceptions import NoAssociationException
+            >>> try:  # doctest: +SKIP
+            ...     model.find_association("Image", "Subject")
+            ... except NoAssociationException:
+            ...     # legitimate: there is no association
+            ...     assoc = None
+    """
+
+    def __init__(self, table1: str, table2: str) -> None:
+        super().__init__(f"No association tables found between {table1} and {table2}.")
+        self.table1 = table1
+        self.table2 = table2
+
+
+class AmbiguousAssociationException(DerivaMLDataError):
+    """Raised when multiple association tables connect two tables.
+
+    Surfaced by :meth:`deriva_ml.model.catalog.DerivaModel.find_association`
+    when more than one association table links ``table1`` and ``table2``
+    (e.g. an old ``Image_Dataset`` and a newer ``Dataset_Image`` both
+    persist on the same catalog). The caller must disambiguate by
+    referencing the desired association table by name.
+
+    Args:
+        table1: Name of the first endpoint table.
+        table2: Name of the second endpoint table.
+        count: Number of association tables that matched.
+
+    Attributes:
+        table1: Name of the first endpoint table.
+        table2: Name of the second endpoint table.
+        count: Number of association tables that matched.
+
+    Example:
+        >>> from deriva_ml.core.exceptions import AmbiguousAssociationException
+        >>> try:  # doctest: +SKIP
+        ...     model.find_association("Image", "Dataset")
+        ... except AmbiguousAssociationException as e:
+        ...     print(f"{e.count} association tables between {e.table1} and {e.table2}")
+    """
+
+    def __init__(self, table1: str, table2: str, count: int) -> None:
+        super().__init__(f"There are {count} association tables between {table1} and {table2}.")
+        self.table1 = table1
+        self.table2 = table2
+        self.count = count
 
 
 # =============================================================================

--- a/src/deriva_ml/core/mixins/asset.py
+++ b/src/deriva_ml/core/mixins/asset.py
@@ -26,7 +26,7 @@ _ermrest_model = importlib.import_module("deriva.core.ermrest_model")
 Table = _ermrest_model.Table
 
 from deriva_ml.core.definitions import RID, AssetTableDef, ColumnDefinition, MLVocab, VocabularyTerm
-from deriva_ml.core.exceptions import DerivaMLException
+from deriva_ml.core.exceptions import DerivaMLException, NoAssociationException
 from deriva_ml.schema.annotations import asset_annotation
 
 if TYPE_CHECKING:
@@ -341,13 +341,15 @@ class AssetMixin:
         asset_types = []
         try:
             type_assoc_table, asset_fk, _ = self.model.find_association(asset_table, "Asset_Type")
+        except NoAssociationException:
+            # No type association for this asset table
+            pass
+        else:
             type_path = pb.schemas[type_assoc_table.schema.name].tables[type_assoc_table.name]
             types = list(
                 type_path.filter(type_path.columns[asset_fk] == asset_rid).attributes(type_path.Asset_Type).fetch()
             )
             asset_types = [t["Asset_Type"] for t in types]
-        except Exception:
-            pass  # No type association for this asset table
 
         return Asset(
             catalog=self,  # type: ignore[arg-type]

--- a/src/deriva_ml/core/mixins/execution.py
+++ b/src/deriva_ml/core/mixins/execution.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING, Any, Callable, Iterable
 
 from deriva_ml.core.connection_mode import ConnectionMode
 from deriva_ml.core.definitions import RID
-from deriva_ml.core.exceptions import DerivaMLException
+from deriva_ml.core.exceptions import DerivaMLException, NoAssociationException
 from deriva_ml.core.sort import SortSpec, resolve_sort
 from deriva_ml.execution.execution_configuration import ExecutionConfiguration
 from deriva_ml.execution.execution_snapshot import ExecutionSnapshot
@@ -1084,7 +1084,9 @@ class ExecutionMixin:
         """
         try:
             assoc_table, asset_fk, _exec_fk = self.model.find_association(asset_table, "Execution")
-        except Exception:
+        except NoAssociationException:
+            # Asset table has no <AssetTable>_Execution tracking — legitimate
+            # case for catalogs that don't track execution provenance per asset.
             return None
 
         pb = self.pathBuilder()

--- a/src/deriva_ml/execution/bag_commit.py
+++ b/src/deriva_ml/execution/bag_commit.py
@@ -66,7 +66,7 @@ from deriva_ml.asset.aux_classes import AssetFilePath
 from deriva_ml.core.constants import INTENTIONAL_FK_CYCLES
 from deriva_ml.core.definitions import MLVocab
 from deriva_ml.core.ermrest import UploadProgress
-from deriva_ml.core.exceptions import DerivaMLException
+from deriva_ml.core.exceptions import DerivaMLException, NoAssociationException
 from deriva_ml.core.logging_config import get_logger
 from deriva_ml.core.upload_layout import asset_type_path, flat_asset_dir
 
@@ -567,7 +567,8 @@ def load_execution_bag(
             match_by_columns[(schema, table.name)] = ["URL"]
             try:
                 type_assoc, _, _ = model.find_association(table.name, "Asset_Type")
-            except Exception:  # noqa: BLE001 — defensive; no asset-type table
+            except NoAssociationException:
+                # No asset-type association for this asset table — skip.
                 continue
             match_by_columns[(type_assoc.schema.name, type_assoc.name)] = [
                 table.name,

--- a/src/deriva_ml/model/catalog.py
+++ b/src/deriva_ml/model/catalog.py
@@ -38,10 +38,12 @@ from deriva_ml.core.definitions import (
     _is_system_schema,
 )
 from deriva_ml.core.exceptions import (
+    AmbiguousAssociationException,
     DerivaMLException,
     DerivaMLFeatureNotFound,
     DerivaMLReadOnlyError,
     DerivaMLTableTypeError,
+    NoAssociationException,
 )
 from deriva_ml.core.logging_config import get_logger
 from deriva_ml.core.validation import VALIDATION_CONFIG
@@ -499,9 +501,14 @@ class DerivaModel:
             (one referencing ``table1``, one referencing ``table2``).
 
         Raises:
-            DerivaMLException: If no association connects the two tables,
-                or if multiple associations connect them (in which case
-                the caller should disambiguate by name).
+            NoAssociationException: If no association table connects the
+                two tables. Callers that legitimately handle the "no link"
+                case (e.g. probing whether an asset table is tracked
+                through ``Execution``) should catch this specific subclass
+                rather than the broader :class:`DerivaMLException`.
+            AmbiguousAssociationException: If multiple association tables
+                connect the two tables. The caller must disambiguate by
+                naming the desired association table directly.
         """
         table1 = self.name_to_table(table1)
         table2 = self.name_to_table(table2)
@@ -515,11 +522,9 @@ class DerivaModel:
         if len(tables) == 1:
             return tables[0]
         elif len(tables) == 0:
-            raise DerivaMLException(f"No association tables found between {table1.name} and {table2.name}.")
+            raise NoAssociationException(table1.name, table2.name)
         else:
-            raise DerivaMLException(
-                f"There are {len(tables)} association tables between {table1.name} and {table2.name}."
-            )
+            raise AmbiguousAssociationException(table1.name, table2.name, len(tables))
 
     def is_asset(self, table: TableInput) -> bool:
         """Check whether ``table`` is a proper asset table.

--- a/tests/core/test_exceptions.py
+++ b/tests/core/test_exceptions.py
@@ -8,6 +8,7 @@ def test_offline_error_is_configuration_error():
         DerivaMLConfigurationError,
         DerivaMLOfflineError,
     )
+
     err = DerivaMLOfflineError("create_execution requires online mode")
     assert isinstance(err, DerivaMLConfigurationError)
     assert "create_execution" in str(err)
@@ -18,9 +19,8 @@ def test_state_inconsistency_error_is_data_error():
         DerivaMLDataError,
         DerivaMLStateInconsistency,
     )
-    err = DerivaMLStateInconsistency(
-        "SQLite says running, catalog says aborted for EXE-A"
-    )
+
+    err = DerivaMLStateInconsistency("SQLite says running, catalog says aborted for EXE-A")
     assert isinstance(err, DerivaMLDataError)
 
 
@@ -29,6 +29,49 @@ def test_derivaml_schema_pinned_inherits_configuration_error():
         DerivaMLConfigurationError,
         DerivaMLSchemaPinned,
     )
+
     err = DerivaMLSchemaPinned("refresh_schema refused: cache is pinned")
     assert isinstance(err, DerivaMLConfigurationError)
     assert "pinned" in str(err)
+
+
+def test_no_association_exception_inherits_not_found_and_base():
+    """``NoAssociationException`` is a ``DerivaMLNotFoundError`` so callers
+    that already ``except DerivaMLException:`` continue to work, but the
+    typed subclass enables narrow catches that don't string-match the
+    exception message."""
+    from deriva_ml.core.exceptions import (
+        DerivaMLException,
+        DerivaMLNotFoundError,
+        NoAssociationException,
+    )
+
+    err = NoAssociationException("Image", "Subject")
+    assert isinstance(err, DerivaMLNotFoundError)
+    assert isinstance(err, DerivaMLException)
+    assert err.table1 == "Image"
+    assert err.table2 == "Subject"
+    assert "No association tables found" in str(err)
+    assert "Image" in str(err)
+    assert "Subject" in str(err)
+
+
+def test_ambiguous_association_exception_inherits_data_error_and_base():
+    """``AmbiguousAssociationException`` is a ``DerivaMLDataError`` so
+    ``except DerivaMLException:`` still catches it. The ``count`` field
+    is structured rather than buried in the message."""
+    from deriva_ml.core.exceptions import (
+        AmbiguousAssociationException,
+        DerivaMLDataError,
+        DerivaMLException,
+    )
+
+    err = AmbiguousAssociationException("Image", "Dataset", 2)
+    assert isinstance(err, DerivaMLDataError)
+    assert isinstance(err, DerivaMLException)
+    assert err.table1 == "Image"
+    assert err.table2 == "Dataset"
+    assert err.count == 2
+    assert "2 association tables" in str(err)
+    assert "Image" in str(err)
+    assert "Dataset" in str(err)

--- a/tests/model/test_find_association.py
+++ b/tests/model/test_find_association.py
@@ -1,0 +1,118 @@
+"""Integration tests for ``DerivaModel.find_association`` typed exceptions.
+
+These tests exercise the real catalog model rather than mocks, because
+``find_association`` walks association tables via ``Table.find_associations``
+which has no clean stub surface. The "no association" case is exercised
+against the unmodified demo schema. The "multiple associations" case
+requires building a second association table at test time, because
+``Table.find_associations`` only recognises tables that carry a composite
+key over their FK columns — a property absent from the demo schema's
+deliberately redundant ``Image_Dataset_Legacy`` table.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from deriva_ml.core.definitions import ColumnDefinition, TableDefinition
+from deriva_ml.core.enums import BuiltinTypes
+from deriva_ml.core.exceptions import (
+    AmbiguousAssociationException,
+    DerivaMLException,
+    NoAssociationException,
+)
+
+
+class TestFindAssociationTypedExceptions:
+    """``find_association`` surfaces failure modes via typed exceptions.
+
+    Before issue #180, both failure modes raised the bare
+    :class:`DerivaMLException`, forcing callers to string-match the
+    error message to distinguish them. The typed subclasses replace
+    that contract.
+    """
+
+    def test_no_association_raises_no_association_exception(self, test_ml):
+        """Two domain tables with no association raise ``NoAssociationException``.
+
+        ``Subject`` and ``ClinicalRecord`` exist in the demo schema but
+        are not linked by any association table — ``ClinicalRecord`` is
+        linked to ``Observation`` via ``ClinicalRecord_Observation``,
+        which in turn links to ``Subject``, but there is no direct
+        ``Subject``-``ClinicalRecord`` association table.
+        """
+        with pytest.raises(NoAssociationException) as exc_info:
+            test_ml.model.find_association("Subject", "ClinicalRecord")
+        # Carries the structured field rather than burying it in the message.
+        assert exc_info.value.table1 == "Subject"
+        assert exc_info.value.table2 == "ClinicalRecord"
+
+    def test_ambiguous_association_raises_ambiguous_exception(self, test_ml):
+        """Two true association tables between the same pair raise ``AmbiguousAssociationException``.
+
+        Build the ambiguity at test time: create two source tables and
+        register them as dataset element types under different names.
+        ``_define_association`` produces a real association definition
+        (composite key over the FK columns), so both tables are detected
+        by ``Table.find_associations``.
+        """
+        ml = test_ml
+        # Create a fresh source table to associate with Dataset twice.
+        source_table = ml.model.create_table(
+            TableDefinition(
+                name="AmbiguousAssocSource",
+                columns=[ColumnDefinition(name="Name", type=BuiltinTypes.text)],
+            )
+        )
+
+        # First association: the auto-generated Dataset_<SourceTable>.
+        ml.add_dataset_element_type(source_table)
+
+        # Second association: a manually named association table linking
+        # the same two endpoints. ``_define_association`` builds a real
+        # association (composite key over the FK columns) so it surfaces
+        # via ``Table.find_associations``.
+        dataset_table = ml.model.name_to_table("Dataset")
+        second_def = ml.model._define_association(
+            associates=[dataset_table, source_table],
+            table_name="Dataset_AmbiguousAssocSource_Alt",
+        )
+        ml.model.create_table(second_def)
+
+        with pytest.raises(AmbiguousAssociationException) as exc_info:
+            ml.model.find_association(source_table, dataset_table)
+        assert exc_info.value.table1 == source_table.name
+        assert exc_info.value.table2 == dataset_table.name
+        assert exc_info.value.count >= 2
+
+    def test_no_association_still_caught_by_base_exception(self, test_ml):
+        """Legacy ``except DerivaMLException:`` callers still catch the new subclass.
+
+        Inheritance is not a backwards-compat shim — it's the correct
+        Pythonic relationship. This test pins the contract so a future
+        refactor that reparents the exception away from
+        ``DerivaMLException`` is caught.
+        """
+        with pytest.raises(DerivaMLException):
+            test_ml.model.find_association("Subject", "ClinicalRecord")
+
+    def test_ambiguous_association_still_caught_by_base_exception(self, test_ml):
+        """Same as above, for the ambiguous case."""
+        ml = test_ml
+        source_table = ml.model.create_table(
+            TableDefinition(
+                name="AmbiguousAssocSourceBase",
+                columns=[ColumnDefinition(name="Name", type=BuiltinTypes.text)],
+            )
+        )
+        ml.add_dataset_element_type(source_table)
+
+        dataset_table = ml.model.name_to_table("Dataset")
+        second_def = ml.model._define_association(
+            associates=[dataset_table, source_table],
+            table_name="Dataset_AmbiguousAssocSourceBase_Alt",
+        )
+        ml.model.create_table(second_def)
+
+        with pytest.raises(DerivaMLException):
+            ml.model.find_association(source_table, dataset_table)


### PR DESCRIPTION
Closes #180.

## Summary

`DerivaModel.find_association` previously raised the bare
`DerivaMLException` for both failure modes — "no association exists"
and "multiple associations exist" — forcing callers that needed to
distinguish them to pattern-match on the exception message text.
That made the message text load-bearing without saying so anywhere,
and any prose tightening would silently break downstream callers
(notably deriva-ml-mcp's `_get_asset_detail_impl` post-PR #43).

This change splits the failure modes into two dedicated subclasses:

- `NoAssociationException` (under `DerivaMLNotFoundError`) — no
  association table connects the two endpoints. Carries
  `table1`/`table2` as structured attributes.
- `AmbiguousAssociationException` (under `DerivaMLDataError`) —
  more than one association table connects them. Carries the
  `count` field.

Both subclasses inherit from `DerivaMLException`, so existing
`except DerivaMLException:` callers keep working — inheritance is
the correct Pythonic relationship, not a backwards-compat shim.

## In-repo caller updates

In-repo callers that intentionally swallowed "no association" via
broad `except Exception:` blocks have been tightened to
`except NoAssociationException:`, so real errors (transient ermrest
5xx, auth failures, etc.) now propagate as intended:

- `src/deriva_ml/asset/asset.py` — `_load_asset_types`
- `src/deriva_ml/core/mixins/asset.py` — `lookup_asset` type-fetch
- `src/deriva_ml/core/mixins/execution.py` — `_producer_of_asset`
- `src/deriva_ml/execution/bag_commit.py` — match-by-columns build

## Cross-repo follow-up (out of scope here)

The deriva-ml-mcp `tools/asset.py` `_get_asset_detail_impl` wrapper
currently keys on the literal message text:

```python
if "No association tables found" in msg and "Execution" in msg:
    ...
```

That update lives in the deriva-ml-mcp repo and will be filed as a
separate follow-up PR after this one merges and a deriva-ml release
is cut. Order: this PR → deriva-ml release → deriva-ml-mcp PR.

## Tests

- `tests/core/test_exceptions.py` — unit tests for the two new
  classes (inheritance chain, structured attributes, message
  content).
- `tests/model/test_find_association.py` (new) — integration tests
  against a live catalog. The "no association" case uses
  `Subject`/`ClinicalRecord` from the demo schema. The "ambiguous"
  case builds a second association table at test time because
  `Table.find_associations` only recognises tables with a composite
  FK key (a property absent from the demo schema's deliberately
  redundant `Image_Dataset_Legacy`).

Pre-fix sanity check: stashed the `find_association` source change
and re-ran the new tests under the old `DerivaMLException` raises.
The two new `pytest.raises(NoAssociationException)` /
`pytest.raises(AmbiguousAssociationException)` tests fail as
expected; the two "still caught by base exception" tests pass
under both old and new code (confirming the inheritance contract).

## Test plan

- [x] `uv run python -m pytest tests/core/test_exceptions.py tests/model/test_find_association.py -v` — 9 passed
- [x] `uv run python -m pytest tests/model/ tests/asset/ tests/execution/test_bag_commit_unit.py tests/execution/test_asset_role_auto_tag.py -v` — all changed code paths green (9 pre-existing `BagDataSource.asset_localization` failures are unrelated and present on main)
- [x] `uv run ruff check` / `uv run ruff format` on touched files — clean (pre-existing baseline preserved)
- [x] Pre-fix sanity check: new tests fail under old `find_association` raises, pass under new