### PR TITLE
fix(schema): apply acl_config AFTER create_ml_schema so per-table bindings land

### DIFF
--- a/src/deriva_ml/schema/create_schema.py
+++ b/src/deriva_ml/schema/create_schema.py
@@ -592,6 +592,14 @@ def create_ml_catalog(
     model.configure_baseline_catalog()
     policy_file = files("deriva_ml.schema").joinpath("policy.json")
 
+    # The deriva-ml schema must exist *before* acl_config runs, otherwise
+    # policy.json's per-table binding rule (which matches all non-``public``
+    # schemas) has nothing to bind to, and ``row_owner_guard`` is silently
+    # applied to zero tables. The failure mode is invisible until a
+    # non-curator user PATCHes ``Execution_Metadata`` and gets HTTP 403.
+    # See ``tests/schema/test_acl_application.py``.
+    create_ml_schema(catalog, project_name=project_name)
+
     # Apply the catalog ACL policy via deriva.config.acl_config. We invoke
     # it as a module via the *current* interpreter (sys.executable -m ...)
     # rather than through PATH lookup of the deriva-acl-config console
@@ -631,8 +639,6 @@ def create_ml_catalog(
             f"row-level update/delete bindings will not work. "
             f"stderr:\n{e.stderr}"
         ) from e
-
-    create_ml_schema(catalog, project_name=project_name)
 
     # Create alias if requested
     if catalog_alias:

--- a/tests/schema/test_acl_application.py
+++ b/tests/schema/test_acl_application.py
@@ -5,19 +5,25 @@ shells out to ``deriva.config.acl_config`` with ``policy.json``
 to install per-row update/delete protection. The end-to-end
 behavior had no test; a regression that silently broke the
 ``deriva-acl-config`` invocation (e.g., missing policy file,
-swallowed CalledProcessError) would leave new catalogs without
+swallowed CalledProcessError, or running it before the
+deriva-ml schema exists) would leave new catalogs without
 ``row_owner_guard`` protection.
 
-This test verifies that after ``create_ml_catalog`` returns:
+This test verifies that after ``create_ml_catalog`` returns,
+every table in the ``deriva-ml`` schema carries the
+``row_owner_guard`` binding in its ``acl_bindings`` field. The
+binding lives as a first-class catalog-model field, not buried
+in annotations — see deriva-py's ``Table.acl_bindings`` (a JSON
+dict managed independently of ``Table.annotations``).
 
-1. The catalog model carries an ``acl_bindings`` annotation
-   somewhere in the catalog or schema annotations.
-2. The bindings include ``row_owner_guard`` (or an equivalent
-   per-row binding).
-
-The exact place ``deriva-acl-config`` writes the bindings can
-shift between deriva-py versions; we assert presence at any
-ACL-binding-capable level rather than pinning a specific path.
+The original (now-fixed) regression: ``create_ml_catalog``
+called ``acl_config`` *before* ``create_ml_schema``, so the
+policy's per-table binding rule (which targets all non-public
+schemas) matched zero tables. The deriva-ml tables were
+silently created later without bindings; non-curator users
+hit HTTP 403 on every Execution_Metadata PATCH because
+``row_owner_guard`` (the binding that would have authorized
+"users can update rows they created") was never applied.
 
 Pattern follows ``test_vocab_fk_convention.py``. Requires
 DERIVA_HOST.
@@ -29,24 +35,6 @@ import json
 from importlib.resources import files
 
 import pytest
-
-
-def _find_row_owner_guard(node) -> bool:
-    """Recursively search a JSON-ish structure for ``row_owner_guard``."""
-    if isinstance(node, dict):
-        for k, v in node.items():
-            if k == "row_owner_guard":
-                return True
-            if _find_row_owner_guard(v):
-                return True
-    elif isinstance(node, list):
-        for item in node:
-            if _find_row_owner_guard(item):
-                return True
-    elif isinstance(node, str):
-        if node == "row_owner_guard":
-            return True
-    return False
 
 
 @pytest.mark.integration
@@ -76,25 +64,27 @@ def test_create_ml_catalog_applies_row_owner_guard() -> None:
     try:
         model = catalog.getCatalogModel()
 
-        # deriva-acl-config writes ACL bindings at the catalog or
-        # schema level (varies by version). Check both.
-        found = _find_row_owner_guard(model.annotations)
-        if not found:
-            for schema in model.schemas.values():
-                if _find_row_owner_guard(schema.annotations):
-                    found = True
-                    break
-                for table in schema.tables.values():
-                    if _find_row_owner_guard(table.annotations):
-                        found = True
-                        break
-                if found:
-                    break
-
-        assert found, (
-            "row_owner_guard not found anywhere in the catalog model "
-            "after create_ml_catalog. The deriva-acl-config invocation "
-            "in create_ml_catalog may have silently failed."
+        # deriva-acl-config writes per-table bindings into
+        # ``table.acl_bindings`` (a first-class catalog-model field,
+        # not buried in annotations). Walk the deriva-ml schema and
+        # require row_owner_guard on every table — the per-table
+        # binding rule in policy.json applies to all non-public
+        # schemas, so a single missing table flags either a
+        # configure ordering bug (acl_config ran before
+        # create_ml_schema) or a policy regression.
+        deriva_ml = model.schemas["deriva-ml"]
+        missing = [
+            tname
+            for tname, table in deriva_ml.tables.items()
+            if "row_owner_guard" not in (table.acl_bindings or {})
+        ]
+        assert not missing, (
+            f"row_owner_guard binding missing on deriva-ml tables: "
+            f"{sorted(missing)}. acl_config must run *after* "
+            f"create_ml_schema, otherwise the per-table binding rule "
+            f"finds no tables to bind to. See create_schema.py "
+            f"ordering of create_ml_schema vs the acl_config "
+            f"subprocess."
         )
     finally:
         catalog.delete_ermrest_catalog(really=True)


### PR DESCRIPTION
## Summary

- `create_ml_catalog` ran `deriva-acl-config` *before* `create_ml_schema`, so the policy's per-table rule (which targets all non-public schemas) matched zero tables. Every catalog created by deriva-ml since this ordering took shape has been missing `row_owner_guard` on its deriva-ml tables.
- Masked because tests run as catalog-owner with full ACLs. Production users hit HTTP 403 the first time a non-curator PATCHes `Execution_Metadata` (which is what asset uploads do).
- Fix: swap the order. `configure_baseline_catalog()` already gives the catalog-owner write access, so `create_ml_schema` works fine pre-ACL; `acl_config` then runs against the now-existing deriva-ml tables and binds `row_owner_guard` to each.

## The test that surfaced it

`tests/schema/test_acl_application.py` was *also* buggy: it searched `model.annotations` / `schema.annotations` / `table.annotations` for `row_owner_guard`, but the binding lives in `Table.acl_bindings` — a first-class catalog-model field managed independently of annotations. Even with the production ordering fixed, the test would have stayed red.

The rewritten assertion walks `model.schemas["deriva-ml"].tables` and requires `"row_owner_guard" in table.acl_bindings` for every one. Failure message points directly at the ordering issue.

Test and fix ship together — the test is what surfaced the bug; without it the regression would still be invisible.

## Test plan

- [x] `uv run pytest tests/schema/test_acl_application.py -v` — passes against live `DERIVA_HOST=localhost`.
- [x] `uv run pytest tests/schema/` — full schema test suite passes (25 tests).
- [x] Manual probe: every deriva-ml table on a freshly-created catalog carries `acl_bindings: {'row_owner_guard': {...}}`. Pre-fix, every one had `acl_bindings: {}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)