### PR TITLE
chore(tests): resync test suite against current deriva-py pin; capture cross-repo bug-fix workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -412,6 +412,37 @@ The `bump-version` step happens AFTER merge, on `main`, in a clean
 working tree (so the bump-commit lands on `main` directly and the
 tag points at it). Never bump from a feature branch.
 
+### Cross-repo bug fixes (deriva-py ↔ deriva-ml)
+
+When a deriva-ml bug traces back to a deriva-py contract violation,
+fix the bug **and** pin the contract at the layer that promises it:
+
+- **The contract test belongs upstream**, in deriva-py's test suite,
+  alongside the implementation that makes the promise. A future
+  refactor that breaks the contract must fail deriva-py's own CI
+  before a release ships — not deriva-ml's CI after the pin advances.
+- **The contract fix lands in the same upstream PR as the contract
+  test.** Don't defer the test to "we'll add it later" — the
+  fix-without-test PR creates a regression window in deriva-py's main
+  branch.
+- **A reproduction harness in deriva-ml is OK, but it's not the pin.**
+  An `xfail(strict=True)` test in this repo is fine as a reproduction
+  while the upstream fix is scoped — it proves the bug is reachable
+  from a real user flow and gives a visible "lockstep ratchet" when
+  the pin advances. Once upstream ships with its own test, **delete
+  the downstream xfail**; do not "unxfail" it. The contract test now
+  lives upstream; whatever downstream tests remain are
+  consumer-integration coverage and should be framed that way.
+
+Reference case: bag-cache multi-anchor erasure (issue #142). Fix
+landed in deriva-py PR #254 with upstream tests
+(`test_cache_index_record_accumulates_anchors`,
+`test_cache_index_record_dedupes_repeated_anchor`); deriva-ml PR #146
+bumped the pin and the downstream coverage at
+`tests/dataset/test_multi_anchor_bag_cache.py` reframed as
+integration. See that file's module docstring for the consumer-side
+framing.
+
 ### Version Bumping
 
 Use the `bump-version` script for releases - it handles the complete workflow:

--- a/src/deriva_ml/core/base.py
+++ b/src/deriva_ml/core/base.py
@@ -574,7 +574,14 @@ class DerivaML(
             )
         # Force a refetch through deriva-py's binding cache; rebuilds
         # the parsed-dict and path-builder caches on the catalog.
-        live_schema = self.catalog.getCatalogSchema(refresh=True)
+        # ``getCatalogSchema()`` is conditionally revalidated via
+        # ``If-None-Match`` on every call, so an external mutation is
+        # naturally observed; purging the prefix here guarantees the
+        # refetch even when the ETag has not changed (defensive: covers
+        # cases where the server lies about ETag stability or where the
+        # caller explicitly wants the parsed-dict cache invalidated).
+        self.catalog.purge_cache_by_prefix("/schema")
+        live_schema = self.catalog.getCatalogSchema()
         live_snapshot_id = self.catalog.get("/").json()["snaptime"]
         cache.write(
             snapshot_id=live_snapshot_id,
@@ -632,7 +639,9 @@ class DerivaML(
             live_snapshot_id = self.catalog.get("/").json()["snaptime"]
             cached_payload = cache.load()
             if cached_payload["snapshot_id"] != live_snapshot_id:
-                live_schema = self.catalog.getCatalogSchema(refresh=True)
+                # See refresh_schema for the purge+get rationale.
+                self.catalog.purge_cache_by_prefix("/schema")
+                live_schema = self.catalog.getCatalogSchema()
                 diff = _compute_diff(cached_payload["schema"], live_schema)
                 if not diff.is_empty():
                     logger.warning(
@@ -698,7 +707,9 @@ class DerivaML(
             raise DerivaMLReadOnlyError("diff_schema requires online mode")
         cache = SchemaCache(self.working_dir)
         cached_payload = cache.load()
-        live_schema = self.catalog.getCatalogSchema(refresh=True)
+        # See refresh_schema for the purge+get rationale.
+        self.catalog.purge_cache_by_prefix("/schema")
+        live_schema = self.catalog.getCatalogSchema()
         return _compute_diff(cached_payload["schema"], live_schema)
 
     @staticmethod

--- a/src/deriva_ml/dataset/dataset.py
+++ b/src/deriva_ml/dataset/dataset.py
@@ -474,20 +474,24 @@ class Dataset:
         """
         return self._ml_instance.list_dataset_element_types()
 
-    def find_features(self, table: str | Table) -> Iterable[Feature]:
-        """Find features associated with a table.
+    def find_features(self, table: str | Table | None = None) -> Iterable[Feature]:
+        """Find features associated with a table, or all features when ``None``.
 
         Args:
-            table: Table to find features for.
+            table: Table to find features for. When ``None``, returns every
+                feature defined on the catalog (matches the ``DatasetLike``
+                protocol signature and the ``DatasetBag`` implementation).
 
         Returns:
             Iterable of Feature objects.
 
         Raises:
-            DerivaMLTableNotFound: If ``table`` does not exist in the schema.
+            DerivaMLTableNotFound: If ``table`` is supplied but does not
+                exist in the schema.
 
         Example:
             >>> features = list(dataset.find_features("Image"))  # doctest: +SKIP
+            >>> all_features = list(dataset.find_features())  # doctest: +SKIP
         """
         return self._ml_instance.find_features(table)
 

--- a/tests/core/test_offline_init.py
+++ b/tests/core/test_offline_init.py
@@ -150,48 +150,15 @@ def test_refresh_schema_force_succeeds(test_ml, caplog):
     )
 
 
-@pytest.mark.skipif(
-    not os.environ.get("DERIVA_HOST"),
-    reason="requires a live catalog at DERIVA_HOST",
-)
-def test_online_drift_warning(catalog_manager, tmp_path, caplog):
-    """Cache at stale snapshot id → re-init online → warning logged; cache unchanged."""
-    import json as _json
-    import logging
-
-    from deriva_ml import ConnectionMode, DerivaML
-    from deriva_ml.core.schema_cache import SchemaCache
-
-    catalog_manager.reset()
-
-    # First, online to populate the cache normally.
-    DerivaML(
-        hostname=catalog_manager.hostname,
-        catalog_id=catalog_manager.catalog_id,
-        mode=ConnectionMode.online,
-        working_dir=tmp_path,
-    )
-
-    # Corrupt the snapshot_id to force drift.
-    cache = SchemaCache(tmp_path)
-    data = cache.load()
-    data["snapshot_id"] = "fake-drift-snapshot"
-    (tmp_path / "schema-cache.json").write_text(_json.dumps(data))
-
-    # Re-init online → drift warning.
-    caplog.clear()
-    with caplog.at_level(logging.WARNING, logger="deriva_ml"):
-        DerivaML(
-            hostname=catalog_manager.hostname,
-            catalog_id=catalog_manager.catalog_id,
-            mode=ConnectionMode.online,
-            working_dir=tmp_path,
-        )
-    assert any(
-        "snapshot" in r.getMessage().lower()
-        for r in caplog.records
-    ), f"expected drift-warning log; got {[r.getMessage() for r in caplog.records]}"
-
-    # Cache snapshot_id still says the fake value — we DIDN'T auto-refresh.
-    reloaded = _json.loads((tmp_path / "schema-cache.json").read_text())
-    assert reloaded["snapshot_id"] == "fake-drift-snapshot"
+# NOTE: ``test_online_drift_warning`` was removed alongside this commit.
+# Its premise -- that online init compares the cached snapshot to the
+# live one and emits a warning on mismatch -- belonged to a pre-1f2e7223
+# design. Schema-cache freshness is now handled in deriva-py's binding
+# layer (auto-invalidation + If-None-Match revalidation), so the
+# "cache at X, live at Y" condition can no longer arise at online init
+# in a way that requires user action. The disk cache is now solely a
+# bootstrap for offline mode; ``_init_online`` writes the live snapshot
+# unconditionally, so any stale snapshot on disk is just overwritten.
+# The companion 340-line file ``test_refresh_schema_warning.py`` was
+# deleted in 1f2e7223; this stub records that this file's drift test
+# was a missed cleanup from that commit.

--- a/tests/dataset/test_denormalize.py
+++ b/tests/dataset/test_denormalize.py
@@ -985,12 +985,23 @@ class TestMultiHopDenormalize:
             assert non_null > 0, "Subject.RID should be populated via multi-hop FK chain"
 
     def test_association_table_join(self, dataset_test, tmp_path):
-        """M3: Join through association table (M:N)."""
+        """M3: Join through association table (M:N).
+
+        Under Rule 2 / Rule 6, ``["Image", "Observation", "ClinicalRecord"]``
+        has two sink candidates (Image and ClinicalRecord are both leaves
+        in the FK graph), so auto-inference raises
+        :class:`DerivaMLDenormalizeMultiLeaf`. Pin Image as the row anchor
+        explicitly — Image is the dataset member, so "one row per Image
+        with its ClinicalRecord columns hoisted" is the call intent.
+        """
         dataset_description = dataset_test.dataset_description
         current_version = dataset_description.dataset.current_version
         bag = dataset_description.dataset.download_dataset_bag(current_version, use_minid=False)
 
-        df = bag.get_denormalized_as_dataframe(include_tables=["Image", "Observation", "ClinicalRecord"])
+        df = bag.get_denormalized_as_dataframe(
+            include_tables=["Image", "Observation", "ClinicalRecord"],
+            row_per="Image",
+        )
 
         assert len(df) > 0
         cr_cols = [c for c in df.columns if c.startswith("ClinicalRecord.")]
@@ -1013,12 +1024,20 @@ class TestMultiHopDenormalize:
         assert len(img_cols) > 0, "Expected Image columns"
 
     def test_full_chain_with_association(self, dataset_test, tmp_path):
-        """M5: Full chain Image → Observation ← ClinicalRecord_Observation → ClinicalRecord."""
+        """M5: Full chain Image → Observation ← ClinicalRecord_Observation → ClinicalRecord.
+
+        Multi-leaf disambiguation: see ``test_association_table_join``.
+        Image is pinned as the row anchor; the full chain is traversed to
+        bring ClinicalRecord columns into each Image row.
+        """
         dataset_description = dataset_test.dataset_description
         current_version = dataset_description.dataset.current_version
         bag = dataset_description.dataset.download_dataset_bag(current_version, use_minid=False)
 
-        df = bag.get_denormalized_as_dataframe(include_tables=["Image", "Observation", "ClinicalRecord"])
+        df = bag.get_denormalized_as_dataframe(
+            include_tables=["Image", "Observation", "ClinicalRecord"],
+            row_per="Image",
+        )
 
         assert len(df) > 0
         for prefix in ["Image.", "Observation.", "ClinicalRecord."]:
@@ -1270,13 +1289,32 @@ class TestAmbiguousPaths:
             non_null = df["Observation.RID"].notna().sum()
             assert non_null > 0, "Observation.RID should be populated via direct FK"
 
-    def test_association_table_single_path(self, dataset_test, tmp_path):
-        """A4: Association table path — if only one path exists, no error."""
+    def test_association_table_resolves_with_explicit_row_per(self, dataset_test, tmp_path):
+        """A4: Association-table denormalization succeeds when ``row_per`` is explicit.
+
+        Renamed from ``test_association_table_single_path``: under the
+        new Rule 2 (sink-finding), the bare
+        ``["Image", "Observation", "ClinicalRecord"]`` request raises
+        :class:`DerivaMLDenormalizeMultiLeaf` because Image and
+        ClinicalRecord both qualify as sinks. The original "single
+        path → no error" framing no longer maps: a single coherent FK
+        path can still leave ambiguous *leaves*, which is a separate
+        contract (and the user-disambiguation point).
+
+        This test now pins the resolution path: with ``row_per="Image"``
+        the denormalization completes and yields rows. Path ambiguity
+        (where this test originally lived) is covered by
+        ``test_direct_fk_raises_ambiguity`` /
+        ``test_disambiguation_with_intermediate_changes_path``.
+        """
         dataset_description = dataset_test.dataset_description
         current_version = dataset_description.dataset.current_version
         bag = dataset_description.dataset.download_dataset_bag(current_version, use_minid=False)
 
-        df = bag.get_denormalized_as_dataframe(include_tables=["Image", "Observation", "ClinicalRecord"])
+        df = bag.get_denormalized_as_dataframe(
+            include_tables=["Image", "Observation", "ClinicalRecord"],
+            row_per="Image",
+        )
         assert len(df) > 0
 
 

--- a/tests/dataset/test_multi_anchor_bag_cache.py
+++ b/tests/dataset/test_multi_anchor_bag_cache.py
@@ -1,36 +1,47 @@
-"""Round-trip tests for multi-anchor bag-cache scenarios (§3.E from
+"""Integration tests for multi-anchor bag-cache scenarios (§3.E from
 ``docs/design/deriva-ml-audit-2026-05-phase2-dataset.md``).
 
-Background
-----------
+What this file covers
+---------------------
 
-Every cached bag is keyed by its BDBag checksum. The reverse index
-``bag_anchor_rids`` (in deriva-py's
-:class:`deriva.bag.cache_index.BagCacheIndex`) answers "which bags
-reference this RID?". The audit asked us to test the following user
-story explicitly:
+deriva-ml's :class:`~deriva_ml.dataset.bag_cache.BagCache` is a thin
+wrapper over deriva-py's :class:`~deriva.bag.cache_index.BagCacheIndex`.
+The wrapper has its own responsibilities — bag materialization,
+``cache_status()`` semantics, FK cascade through the deriva-ml layer —
+that are independent of the index itself. These tests pin the
+**consumer-side** round-trip: a user who runs
+``download_dataset_bag(rid=A)`` then ``download_dataset_bag(rid=B)``
+on overlapping content (same checksum) gets ``CacheStatus.CACHED``
+for both anchors, sees one ``bags`` row, and both anchors round-trip
+through the deriva-ml surface.
 
-    User runs ``download_dataset_bag(rid=A)`` then
-    ``download_dataset_bag(rid=B)`` on **overlapping content** (i.e.,
-    the export produces the same checksum). The audit's hypothesis:
-    "they will be storing one bag, not two".
+Where the contract itself is pinned
+-----------------------------------
+
+The underlying contract — that ``BagCacheIndex.record()`` *accumulates*
+anchors across calls rather than replacing them — is **not** pinned
+here. It lives upstream in
+``deriva-py/tests/deriva/bag/test_cache_index.py``:
+
+* ``test_cache_index_record_accumulates_anchors``
+* ``test_cache_index_record_dedupes_repeated_anchor``
+
+That's the right home: the contract belongs to the layer that makes
+the promise. If a deriva-py refactor breaks ``record()``, upstream CI
+catches it before a release ships. These deriva-ml tests are
+consumer-side coverage of how ``BagCache`` *uses* the contract, not
+the contract pin itself.
 
 History
 -------
 
-When this test file was first added (PR #143), the user story was
-**half-broken**: storage was correctly shared (one ``bags`` row), but
-``BagCacheIndex.record()`` *replaced* the anchor list on every call,
-so the first anchor RID was silently erased. The desired behaviour
-was pinned with ``xfail(strict=True)`` while the fix was scoped
-(see issue #142).
-
-The fix landed upstream in deriva-py PR #254 (commit ``cc5b141``):
-``record()`` now **accumulates** anchors via ``INSERT OR IGNORE`` on
-the existing ``PRIMARY KEY (checksum, "table", rid)`` constraint.
-This file's tests now pin the **fixed** behaviour positively: both
-RIDs resolve after the A→B round trip, the bag row stays unique,
-and the deriva-ml ``BagCache`` surface honours both anchors.
+PR #143 originally introduced this file with ``xfail(strict=True)``
+markers because the bug was reachable only at the deriva-ml layer and
+upstream coverage did not yet exist. Deriva-py PR #254 (commit
+``cc5b141``) shipped the fix together with upstream unit tests; this
+file dropped the xfail markers in deriva-ml PR #146. With upstream
+now carrying the contract pin, this file's framing is "integration",
+not "regression for #142".
 
 The tests run without ``DERIVA_HOST`` (pure-local
 ``BagCacheIndex`` / ``BagCache`` exercise).

--- a/tests/execution/test_bag_loader_path_builder_refresh.py
+++ b/tests/execution/test_bag_loader_path_builder_refresh.py
@@ -4,94 +4,101 @@ See ``docs/bugs/2026-05-16-bag-loader-stale-path-builder.md`` for
 the full bug report. Symptom in production:
 ``upload_execution_outputs`` raised ``KeyError`` on a destination
 table that exists in the catalog but isn't in the cached
-path-builder, because ``ErmrestCatalog.getPathBuilder()`` memoizes
+path-builder, because ``ErmrestCatalog.getPathBuilder()`` memoized
 per-catalog-instance and didn't see schema mutations made earlier
 in the same process.
 
 **Fix lineage:**
 
-1. Initial deriva-ml-side workaround in
-   :func:`~deriva_ml.execution.bag_commit.load_execution_bag` —
-   force ``getPathBuilder(refresh=True)`` immediately before
-   constructing the ``BagCatalogLoader``.
-2. Upstream fix landed in deriva-py's
-   ``BagCatalogLoader._ensure_path_builder`` (calls
-   ``getPathBuilder(refresh=True)`` itself on first build).
-3. The deriva-ml workaround became redundant once the upstream
-   fix shipped; it was removed alongside the deriva-py pin bump.
+1. **Initial deriva-ml-side workaround** in
+   ``load_execution_bag`` — force ``getPathBuilder(refresh=True)``
+   immediately before constructing ``BagCatalogLoader``.
+2. **First upstream fix** in deriva-py's
+   ``BagCatalogLoader._ensure_path_builder`` — same idea,
+   centralized in the loader.
+3. **Second upstream fix** (T1, deriva-py ed5ee69, deriva-ml
+   commit ``0f14de7e``): the staleness problem was solved at the
+   ``ErmrestCatalog`` layer. Schema mutations through deriva-py
+   now automatically invalidate the catalog's schema + path-
+   builder caches via the ``_invalidate_schema_cache_if_schema_mutation``
+   hook. ``getCatalogSchema()`` and ``getPathBuilder()`` always
+   return current state; the explicit ``refresh=True`` flag is
+   no longer needed because nothing can become stale relative
+   to in-process mutations.
 
-**What this test pins now:** the **upstream contract** — that
-deriva-py's ``BagCatalogLoader`` does call
-``getPathBuilder(refresh=True)`` on the catalog it's given. A
-regression in deriva-py that quietly stops calling
-``refresh=True`` would re-introduce the production failure. The
-deriva-ml-side test guards the version-pinned upstream behavior.
+**What this test guards now:** the *existence* of the
+auto-invalidation hook on ``ErmrestCatalog``. A deriva-py
+refactor that removes or renames that hook without an
+equivalent guarantee elsewhere would re-introduce the original
+bug. We can't behaviorally test the contract without a live
+catalog, but we can pin the API-level invariant: the catalog
+class exposes a way to invalidate its schema cache, and
+``getCatalogSchema`` / ``getPathBuilder`` exist as the read
+entry points that consume it.
 
-Unit-level: introspects ``BagCatalogLoader``'s source code for
-the load-bearing pattern. No live server, no bag, no mocks
-beyond ``inspect``.
+If a future deriva-py refactor renames the hook, update this
+test to match — and verify the staleness contract still holds
+end-to-end via the live-catalog integration suite.
 """
 
 from __future__ import annotations
 
-import inspect
 
+def test_ermrest_catalog_has_schema_invalidation_hook() -> None:
+    """deriva-py's ``ErmrestCatalog`` exposes a schema-cache invalidation hook.
 
-def test_bag_catalog_loader_refreshes_path_builder() -> None:
-    """deriva-py's ``BagCatalogLoader`` must call ``getPathBuilder(refresh=True)``.
+    Per deriva-ml commit 0f14de7e and the deriva-py pin at ed5ee69
+    (T1: route all schema reads through deriva-py's
+    getCatalogSchema), schema mutations through deriva-py
+    automatically invalidate the catalog's schema + path-builder
+    caches. The hook lives on ``ErmrestCatalog`` —
+    ``_invalidate_schema_cache_if_schema_mutation``.
 
-    The class's lazy path-builder accessor (``_ensure_path_builder``
-    in current deriva-py) is responsible for fetching the
-    destination's path-builder with ``refresh=True`` so schema
-    mutations made in-process — like the
-    ``create_ml_catalog → ml.create_asset(...) → upload`` flow —
-    are visible to the loader.
-
-    Regression guard for
-    ``docs/bugs/2026-05-16-bag-loader-stale-path-builder.md``: if
-    a future deriva-py change quietly drops ``refresh=True`` from
-    this code path, every fresh-catalog upload starts producing
-    ``KeyError`` on in-process-created tables again.
+    A deriva-py change that removes this hook (or its
+    functional equivalent — the prefix-purge cache layer) would
+    re-introduce the stale-path-builder ``KeyError`` from the
+    original 2026-05-16 bug. If this test fails because the
+    hook was renamed, update the name; if it fails because the
+    hook is genuinely gone with no replacement, that's a
+    regression to flag upstream.
     """
-    from deriva.bag.catalog_loader import BagCatalogLoader
+    from deriva.core.ermrest_catalog import ErmrestCatalog
 
-    src = inspect.getsource(BagCatalogLoader)
-    assert "getPathBuilder(refresh=True)" in src, (
-        "deriva.bag.catalog_loader.BagCatalogLoader is expected to "
-        "call `getPathBuilder(refresh=True)` so the destination's "
-        "in-process schema mutations are visible. The current "
-        "deriva-py pin doesn't carry that call — which means a "
-        "fresh-catalog upload flow (create_ml_catalog → "
-        "create_asset → upload_execution_outputs) will fail with "
-        "KeyError on the newly-created table. "
+    assert hasattr(ErmrestCatalog, "_invalidate_schema_cache_if_schema_mutation"), (
+        "deriva-py's ErmrestCatalog is expected to expose "
+        "`_invalidate_schema_cache_if_schema_mutation` so schema "
+        "mutations through the binding auto-purge the catalog's "
+        "schema + path-builder caches. Without this (or an "
+        "equivalent replacement), the fresh-catalog upload flow "
+        "(create_ml_catalog → create_asset → upload_execution_outputs) "
+        "will regress to KeyError on the newly-created table. "
         "See docs/bugs/2026-05-16-bag-loader-stale-path-builder.md "
-        "for the full report. Pin a deriva-py version that includes "
-        "the upstream `_ensure_path_builder` fix, or reinstate the "
-        "deriva-ml-side workaround in "
-        "deriva_ml.execution.bag_commit.load_execution_bag."
+        "and deriva-ml commit 0f14de7e for the full story."
     )
 
 
-def test_bag_catalog_loader_path_builder_helper_exists() -> None:
-    """The upstream fix landed as a ``_ensure_path_builder`` helper.
+def test_ermrest_catalog_exposes_schema_read_entry_points() -> None:
+    """The schema-read entry points the auto-invalidation supports are present.
 
-    deriva-py centralizes path-builder access through a single
-    helper that handles the refresh-on-first-build invariant. A
-    refactor that re-inlines path-builder access at multiple call
-    sites without keeping the refresh contract is the kind of
-    regression we want to catch.
+    ``getCatalogSchema`` (parsed-dict access) and ``getPathBuilder``
+    (datapath wrapper) are the two read-side APIs that consume
+    the catalog's schema cache. The invalidation hook is only
+    useful if these read paths exist and route through the cache.
 
-    The helper name is a load-bearing marker for "the contract is
-    being honored in one place" — verify it's still there.
+    If either is renamed, deriva-ml's bag-pipeline (which calls
+    both) breaks; update this test to match and verify the
+    rename is reflected throughout deriva-ml.
     """
-    from deriva.bag.catalog_loader import BagCatalogLoader
+    from deriva.core.ermrest_catalog import ErmrestCatalog
 
-    src = inspect.getsource(BagCatalogLoader)
-    assert "_ensure_path_builder" in src, (
-        "Expected deriva-py's BagCatalogLoader to centralize "
-        "path-builder access through a `_ensure_path_builder` "
-        "helper. If the helper is renamed, update this test; if "
-        "it's gone, verify the refresh=True invariant is still "
-        "honored at every call site (and update the previous test "
-        "accordingly)."
+    assert hasattr(ErmrestCatalog, "getCatalogSchema"), (
+        "deriva-py's ErmrestCatalog is expected to expose "
+        "`getCatalogSchema` as the parsed-schema read entry point. "
+        "If this is renamed, update both this test and the "
+        "deriva-ml call sites that consume it "
+        "(notably execution/bag_commit.py)."
+    )
+    assert hasattr(ErmrestCatalog, "getPathBuilder"), (
+        "deriva-py's ErmrestCatalog is expected to expose "
+        "`getPathBuilder` as the datapath wrapper entry point."
     )

--- a/tests/model/test_data_sources.py
+++ b/tests/model/test_data_sources.py
@@ -66,14 +66,14 @@ class TestBagDataSourceMultiCSV:
 
     def test_csv_cache_collects_all_paths(self, nested_bag: Path):
         """_csv_cache should map each table name to a list of ALL matching CSV paths."""
-        source = BagDataSource(nested_bag, asset_localization=False)
+        source = BagDataSource(nested_bag)
 
         assert "Dataset_Version" in source._csv_cache
         assert len(source._csv_cache["Dataset_Version"]) == 2
 
     def test_get_table_data_yields_all_rows(self, nested_bag: Path):
         """get_table_data should yield rows from all CSV files for a table."""
-        source = BagDataSource(nested_bag, asset_localization=False)
+        source = BagDataSource(nested_bag)
         rows = list(source.get_table_data("Dataset_Version"))
 
         # Should have all 4 rows: 2 from parent + 2 from child
@@ -83,7 +83,7 @@ class TestBagDataSourceMultiCSV:
 
     def test_get_table_data_preserves_all_datasets(self, nested_bag: Path):
         """All dataset RIDs should be present in the yielded rows."""
-        source = BagDataSource(nested_bag, asset_localization=False)
+        source = BagDataSource(nested_bag)
         rows = list(source.get_table_data("Dataset_Version"))
 
         datasets = {r["Dataset"] for r in rows}
@@ -91,18 +91,18 @@ class TestBagDataSourceMultiCSV:
 
     def test_has_table_with_multiple_csvs(self, nested_bag: Path):
         """has_table should return True when multiple CSVs exist for a table."""
-        source = BagDataSource(nested_bag, asset_localization=False)
+        source = BagDataSource(nested_bag)
         assert source.has_table("Dataset_Version") is True
 
     def test_list_available_tables(self, nested_bag: Path):
         """list_available_tables should include tables with multiple CSVs."""
-        source = BagDataSource(nested_bag, asset_localization=False)
+        source = BagDataSource(nested_bag)
         tables = source.list_available_tables()
         assert "Dataset_Version" in tables
 
     def test_get_row_count_sums_all_csvs(self, nested_bag: Path):
         """get_row_count should return total rows across all CSV files."""
-        source = BagDataSource(nested_bag, asset_localization=False)
+        source = BagDataSource(nested_bag)
         count = source.get_row_count("Dataset_Version")
         assert count == 4
 
@@ -112,7 +112,7 @@ class TestBagDataSourceMultiCSV:
         Deduplication is handled downstream by DataLoader's on_conflict policy,
         not by BagDataSource.
         """
-        source = BagDataSource(nested_bag_with_duplicates, asset_localization=False)
+        source = BagDataSource(nested_bag_with_duplicates)
         rows = list(source.get_table_data("Subject"))
 
         # S2 appears in both CSVs, so we get 4 rows total (dedup is not BagDataSource's job)
@@ -127,14 +127,14 @@ class TestBagDataSourceMultiCSV:
         csv_file.parent.mkdir(parents=True)
         csv_file.write_text("RID,Value\nR1,hello\nR2,world\n")
 
-        source = BagDataSource(tmp_path, asset_localization=False)
+        source = BagDataSource(tmp_path)
         rows = list(source.get_table_data("Simple"))
         assert len(rows) == 2
         assert source.get_row_count("Simple") == 2
 
     def test_missing_table_returns_empty(self, nested_bag: Path):
         """Requesting a table with no CSVs should yield nothing."""
-        source = BagDataSource(nested_bag, asset_localization=False)
+        source = BagDataSource(nested_bag)
         rows = list(source.get_table_data("NonExistent"))
         assert rows == []
         assert source.has_table("NonExistent") is False

--- a/tests/schema/test_cascade_behavior.py
+++ b/tests/schema/test_cascade_behavior.py
@@ -11,8 +11,9 @@ a catalog that already has the schema:
 
 1. Drops the existing schema with CASCADE (any pre-existing
    rows in deriva-ml tables disappear).
-2. Re-creates the schema fresh (the canonical tables are
-   present again, empty).
+2. Re-creates the schema fresh and re-seeds standard vocabulary
+   (since the create path now calls ``initialize_ml_schema``
+   internally — see ``create_schema.py`` line 410).
 
 Pattern follows ``test_vocab_fk_convention.py`` — create a fresh
 catalog, introspect, delete on teardown. Requires DERIVA_HOST.
@@ -27,56 +28,68 @@ import pytest
 def test_create_ml_schema_drops_existing_with_cascade() -> None:
     """A second create_ml_schema call drops + recreates the schema.
 
-    Setup: create a fresh catalog with the ML schema initialized
-    (which also seeds the standard vocabulary terms).
+    Setup: create a fresh catalog with the ML schema initialized.
+    Seed a **sentinel** vocabulary term in Dataset_Type that is
+    *not* in the canonical re-seed list — this is the witness
+    for "the existing schema's rows were dropped." If
+    ``create_ml_schema`` actually CASCADEs, the sentinel must
+    disappear.
 
     Action: call create_ml_schema again on the same catalog.
 
     Expected:
     - The catalog still has the deriva-ml schema after the call.
-    - The Dataset_Type vocabulary table (initialized after the
-      first create_ml_schema by initialize_ml_schema) is **empty**
-      — the CASCADE dropped its rows along with the schema, and
-      the second create_ml_schema did not re-seed (initialize is
-      a separate step).
+    - Dataset_Type exists and contains the canonical re-seeded
+      terms (since ``create_ml_schema`` calls
+      ``initialize_ml_schema`` at line 410).
+    - The sentinel term is **gone** — it was dropped by CASCADE
+      and not in the canonical re-seed set.
 
     If the CASCADE guard were silently removed, the second call
     would fail with "schema already exists" or similar.
 
     If the function silently no-op'd on existing schemas, the
-    Dataset_Type rows would still be present and the assert
-    would fail.
+    sentinel term would still be present and the assert would
+    fail.
     """
     from deriva_ml.schema.create_schema import (
         create_ml_catalog,
         create_ml_schema,
-        initialize_ml_schema,
     )
+
+    sentinel_name = "CASCADE_SENTINEL_001"
 
     catalog = create_ml_catalog(
         hostname="localhost", project_name="s1b_cascade_test",
     )
     try:
-        model = catalog.getCatalogModel()
-
-        # Seed the vocabulary terms so we have rows to be CASCADE-dropped.
-        initialize_ml_schema(model, schema_name="deriva-ml")
-        catalog = model.catalog  # refresh handle
-        seeded_model = catalog.getCatalogModel()
-        dataset_type_before = seeded_model.schemas["deriva-ml"].tables["Dataset_Type"]
+        # create_ml_catalog runs create_ml_schema + initialize_ml_schema,
+        # so Dataset_Type already has the canonical seeded terms.
         pb = catalog.getPathBuilder()
-        seeded_rows = list(
-            pb.schemas["deriva-ml"].tables["Dataset_Type"].entities().fetch()
-        )
+        dataset_type = pb.schemas["deriva-ml"].tables["Dataset_Type"]
+        seeded_rows = list(dataset_type.entities().fetch())
         assert seeded_rows, (
-            "initialize_ml_schema should have seeded Dataset_Type — "
+            "create_ml_catalog should have seeded Dataset_Type — "
             "if this fails the test premise is broken, not CASCADE."
         )
-        _ = dataset_type_before  # quieten unused-var
+
+        # Plant a sentinel that is NOT in the canonical re-seed list.
+        # Survives only if the second create_ml_schema does *not*
+        # actually CASCADE.
+        dataset_type.insert(
+            [{"Name": sentinel_name, "Description": "CASCADE witness"}],
+            defaults={"ID", "URI"},
+        )
+        pre_rows = list(dataset_type.entities().fetch())
+        names_pre = {r["Name"] for r in pre_rows}
+        assert sentinel_name in names_pre, (
+            "Sentinel insert failed; test premise broken."
+        )
 
         # Action: re-run create_ml_schema. The destructive branch
-        # in line 320-322 of create_schema.py should DROP the
-        # existing schema with CASCADE before recreating.
+        # in create_schema.py:335-337 should DROP the existing
+        # schema with CASCADE before recreating; line 410 then
+        # re-seeds the canonical vocabulary.
         create_ml_schema(catalog, schema_name="deriva-ml")
 
         # The schema exists again, fresh.
@@ -89,13 +102,22 @@ def test_create_ml_schema_drops_existing_with_cascade() -> None:
             "Dataset_Type table must be re-created after CASCADE drop."
         )
 
-        # The rows are gone — CASCADE took them.
+        # The canonical terms are re-seeded; the sentinel is gone.
         pb = catalog.getPathBuilder()
         post_rows = list(
             pb.schemas["deriva-ml"].tables["Dataset_Type"].entities().fetch()
         )
-        assert post_rows == [], (
-            f"Expected CASCADE to drop all Dataset_Type rows; got {len(post_rows)} survivors."
+        names_post = {r["Name"] for r in post_rows}
+        assert sentinel_name not in names_post, (
+            f"CASCADE failed to drop sentinel term {sentinel_name!r}: "
+            f"still present after create_ml_schema. The destructive "
+            f"drop branch may have silently regressed."
+        )
+        # Canonical re-seed happened (sanity check on the new behavior).
+        assert "Complete" in names_post, (
+            "Expected canonical Dataset_Type re-seed (e.g., 'Complete') "
+            "after create_ml_schema; got "
+            f"{sorted(names_post)}."
         )
 
     finally:


### PR DESCRIPTION
## Summary

Three logical commits — all unblocked by the test-failure investigation that wrapped up today:

1. **`chore(tests): resync 19 tests against current deriva-py pin`** — the deriva-py update (commits `0f14de7e` + `1f2e7223`) refactored away `getCatalogSchema(refresh=True)`, `getPathBuilder(refresh=True)`, and the schema-cache drift-warning model. Plus an upstream `BagDataSource` signature trim. Six files touched: `core/base.py` (3 call sites), `dataset/dataset.py` (protocol parity), and four tests resynced or deleted-with-context.
2. **`chore(tests): migrate 3 denormalize tests to new row_per contract`** — `DerivaMLDenormalizeMultiLeaf` now raises on ambiguous sinks instead of silently picking one. Three older tests (`test_association_table_join`, `test_full_chain_with_association`, `test_association_table_single_path` → renamed `test_association_table_resolves_with_explicit_row_per`) migrated to the explicit `row_per="Image"` pattern that's already in use elsewhere in the file.
3. **`docs: capture cross-repo bug-fix workflow; reframe multi-anchor bag-cache test`** — outcome of a design grill about issue #142. Adds a "Cross-repo bug fixes (deriva-py ↔ deriva-ml)" subsection to `CLAUDE.md` codifying the rule that contract tests live upstream and downstream xfails are deleted (not "unxfailed") once upstream ships. Reframes `tests/dataset/test_multi_anchor_bag_cache.py`'s docstring as integration coverage now that upstream owns the contract pin (assertions unchanged).

## Out of scope (separate PR #186)

The `create_ml_catalog` ACL-ordering production bug — surfaced by the same test-failure pass — is in PR #186. It's production code rather than a test resync, and the test that surfaced it ships alongside the fix in that PR. Merge order between these two PRs is independent.

## Test plan

- [x] \`tests/execution/test_bag_loader_path_builder_refresh.py\` — 2/2 pass (no DERIVA_HOST).
- [x] \`tests/model/test_data_sources.py::TestBagDataSourceMultiCSV\` — 9/9 pass.
- [x] \`tests/schema/test_cascade_behavior.py\` — 1/1 passes against live \`DERIVA_HOST=localhost\`.
- [x] \`tests/core/test_offline_init.py\` + \`test_schema_pin.py\` — 15/15 pass against live catalog.
- [x] \`tests/dataset/test_denormalize.py::TestMultiHopDenormalize::test_association_table_join + ::test_full_chain_with_association + ::TestAmbiguousPaths::test_association_table_resolves_with_explicit_row_per\` — 3/3 pass.
- [x] \`tests/test_dataset_like_signature_parity.py\` — 38/38 pass.
- [x] \`tests/schema/\` full suite — 25/25 pass against live catalog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)