### PR TITLE
fix(local_db): hydrate PagedFetcher dedup state from engine on first access

### DIFF
--- a/src/deriva_ml/local_db/paged_fetcher.py
+++ b/src/deriva_ml/local_db/paged_fetcher.py
@@ -119,11 +119,46 @@ class PagedFetcher:
     def __init__(self, *, client: PagedClient, engine: Engine) -> None:
         self._client = client
         self._engine = engine
-        # Tracks already-inserted (table, column) → set of seen values, preventing
-        # double-inserts when the same fetcher is reused across multiple calls.
+        # Tracks already-inserted (table, column) → set of seen values. The
+        # set is hydrated lazily from the engine on first access via
+        # :meth:`_get_seen` so that fresh fetcher instances pointing at a
+        # workspace populated by a prior fetcher (or a prior session) do
+        # not re-fetch and re-INSERT rows that already exist locally.
         self._seen: dict[tuple[str, str], set[str]] = {}
         # Cached row counts per table, populated lazily by fetch_by_rids_or_predicate.
         self._counts: dict[str, int] = {}
+
+    def _get_seen(self, table: str, rid_column: str, target_table: Table) -> set[str]:
+        """Return the seen-set for ``(table, rid_column)``, hydrating it
+        from the engine on first access.
+
+        Reads the existing ``{rid_column}`` values from ``target_table``
+        and seeds the set with them, so fresh fetcher instances against
+        a workspace that already holds rows (from a prior fetcher in
+        the same process, or from a prior Python session that wrote to
+        the same on-disk SQLite) do not attempt to re-INSERT them.
+
+        Subsequent ``fetch_by_rids`` / ``fetch_predicate`` calls extend
+        this set in memory; the engine is only re-read on first access
+        for a given key. This keeps the dedup honest across multiple
+        ``PagedFetcher`` instances sharing one engine — the root cause
+        of the model-template 2026-05-21 finding 05 (``UNIQUE constraint
+        failed: Dataset.RID`` on the second live denormalize call).
+        """
+        key = (table, rid_column)
+        if key in self._seen:
+            return self._seen[key]
+        existing: set[str] = set()
+        col = target_table.columns.get(rid_column)
+        if col is not None:
+            from sqlalchemy import select as _select
+
+            with self._engine.connect() as conn:
+                for (rid,) in conn.execute(_select(col)):
+                    if rid is not None:
+                        existing.add(str(rid))
+        self._seen[key] = existing
+        return existing
 
     def fetch_predicate(
         self,
@@ -149,6 +184,7 @@ class PagedFetcher:
         Returns:
             Total number of rows inserted.
         """
+        seen = self._get_seen(table, "RID", target_table)
         n = 0
         after: tuple | None = None
         while True:
@@ -161,10 +197,14 @@ class PagedFetcher:
             )
             if not page:
                 break
-            self._insert_rows(target_table, page)
-            key = (table, "RID")
-            self._seen.setdefault(key, set()).update(str(r["RID"]) for r in page if "RID" in r)
-            n += len(page)
+            # Drop rows the engine already has — re-entry into this code
+            # path (a fresh PagedFetcher pointed at a populated engine)
+            # would otherwise crash on the INSERT.
+            new_rows = [r for r in page if str(r.get("RID")) not in seen]
+            if new_rows:
+                self._insert_rows(target_table, new_rows)
+            seen.update(str(r["RID"]) for r in page if "RID" in r)
+            n += len(new_rows)
             if len(page) < page_size:
                 break
             last = page[-1]
@@ -198,8 +238,7 @@ class PagedFetcher:
             Number of rows actually inserted (may be less than ``len(rids)`` if
             some RIDs were already in the seen-set or don't exist on the server).
         """
-        key = (table, rid_column)
-        seen = self._seen.setdefault(key, set())
+        seen = self._get_seen(table, rid_column, target_table)
         to_fetch = [r for r in dict.fromkeys(str(x) for x in rids) if r not in seen]
         if not to_fetch:
             return 0

--- a/tests/dataset/test_split.py
+++ b/tests/dataset/test_split.py
@@ -1189,6 +1189,84 @@ class TestSplitDataset:
                 element_table="NonExistentTable",
             )
 
+    # ------------------------------------------------------------------
+    # Regression tests for finding 05 — denormalize cache re-entry
+    # ------------------------------------------------------------------
+    #
+    # Finding 05 (deriva-ml-model-template/findings/setup/05): the local
+    # SQLite cache populated by the first live-catalog denormalize call
+    # is not consulted by the second call's PagedFetcher, so the second
+    # call's INSERT into Dataset crashes with UNIQUE constraint failed.
+    # Manifests in two ways:
+    #
+    #   (a) Two split_dataset calls against the same source in one
+    #       process — second call's denormalize crashes.
+    #   (b) Any split_dataset call in a session where the local DB
+    #       already has the source Dataset row from a prior session.
+    #
+    # Both shapes broke the model-template Phase 0 bootstrap (only
+    # 10 of 13 expected datasets created). Both are covered here.
+
+    def test_two_splits_same_source_in_one_process(self, test_ml):
+        """Two split_dataset calls against the same source must both succeed.
+
+        Phase 0 of the multi-persona test calls split_dataset twice
+        against the Training dataset (once for the full labeled split,
+        once for the small labeled split). Before the finding-05 fix,
+        the second call crashed inside the denormalizer with
+        ``UNIQUE constraint failed: Dataset.RID`` because the local
+        SQLite already held the source's Dataset row from the first
+        call's _populate_from_catalog.
+        """
+        ml = test_ml
+        source_rid = self._setup_splittable_dataset(ml)
+
+        result_a = split_dataset(ml, source_rid, test_size=3, seed=42)
+        assert isinstance(result_a, SplitResult)
+
+        # Second split from the same source — must not crash.
+        result_b = split_dataset(ml, source_rid, test_size=4, seed=99)
+        assert isinstance(result_b, SplitResult)
+        assert result_b.split.rid != result_a.split.rid
+
+    def test_split_after_prior_denormalize_of_source(self, test_ml, tmp_path):
+        """A standalone get_denormalized_as_dataframe on the source must
+        not poison a subsequent split_dataset against the same source.
+
+        This exercises the cross-call path without involving two splits
+        — exactly the shape an Analyst persona would hit when they
+        inspect the source dataset before kicking off a curated split.
+        """
+        ml = test_ml
+        source_rid = self._setup_splittable_dataset(ml)
+
+        # First: inspect the source as the Analyst would.
+        src = ml.lookup_dataset(source_rid)
+        df = src.get_denormalized_as_dataframe(include_tables=["SplitTestItem"])
+        assert len(df) == 12
+
+        # Then: a Curator-style split. Must not crash.
+        result = split_dataset(ml, source_rid, test_size=3, seed=42)
+        assert isinstance(result, SplitResult)
+        assert result.training.count == 9
+        assert result.testing.count == 3
+
+    def test_two_denormalize_calls_on_same_dataset(self, test_ml):
+        """Two get_denormalized_as_dataframe calls on the same live
+        Dataset must both succeed.
+
+        Minimal form of finding 05 — does not involve split_dataset.
+        """
+        ml = test_ml
+        source_rid = self._setup_splittable_dataset(ml)
+        src = ml.lookup_dataset(source_rid)
+
+        df_a = src.get_denormalized_as_dataframe(include_tables=["SplitTestItem"])
+        df_b = src.get_denormalized_as_dataframe(include_tables=["SplitTestItem"])
+
+        assert len(df_a) == len(df_b) == 12
+        assert list(df_a.columns) == list(df_b.columns)
+
 
 # =============================================================================
 # Unit Tests: split_dataset denormalization plumbing (issue #174)

--- a/tests/local_db/test_paged_fetcher.py
+++ b/tests/local_db/test_paged_fetcher.py
@@ -291,6 +291,96 @@ class TestFetchByRids:
 
         assert _rows_count(engine, table) == 5
 
+    def test_two_fetchers_same_engine_overlapping_rids(self, engine):
+        """Two PagedFetcher instances against one engine — second must not
+        crash on the rows the first inserted.
+
+        Regression for the finding-05 root cause: ``_populate_from_catalog``
+        builds a fresh ``PagedFetcher`` on every call, and the per-fetcher
+        ``_seen`` set starts empty. Before this test was added, the second
+        fetcher's ``fetch_by_rids`` would try to INSERT rows already in the
+        DB and raise ``UNIQUE constraint failed``.
+        """
+        rows = _make_rows(5)
+        client = FakePagedClient(rows_by_table={"Image": rows})
+        table = _make_target_table(engine, "Image")
+        rids = [r["RID"] for r in rows]
+
+        # First fetcher inserts all five rows.
+        fetcher_a = PagedFetcher(client=client, engine=engine)
+        fetcher_a.fetch_by_rids("Image", rids, table, batch_size=500)
+        assert _rows_count(engine, table) == 5
+
+        # Second fetcher (fresh instance, fresh _seen) requests the same
+        # RIDs. It must not crash on the duplicate INSERT.
+        fetcher_b = PagedFetcher(client=client, engine=engine)
+        fetcher_b.fetch_by_rids("Image", rids, table, batch_size=500)
+        assert _rows_count(engine, table) == 5
+
+    def test_fresh_fetcher_against_pre_populated_engine(self, engine):
+        """Cross-session simulation — engine has rows from a 'prior' run,
+        a fresh fetcher must cope.
+
+        The on-disk SQLite workspace persists across Python processes, so
+        a new ``DerivaML`` instance pointed at the same catalog sees rows
+        from the previous session. The fetcher must not blindly INSERT.
+        """
+        rows = _make_rows(5)
+        client = FakePagedClient(rows_by_table={"Image": rows})
+        table = _make_target_table(engine, "Image")
+        rids = [r["RID"] for r in rows]
+
+        # Simulate a prior session having populated the DB.
+        with engine.begin() as conn:
+            from sqlalchemy import insert as _insert
+
+            conn.execute(_insert(table), rows)
+        assert _rows_count(engine, table) == 5
+
+        # New fetcher (mimicking a fresh process / fresh DerivaML) tries
+        # to fetch the same RIDs. Must succeed without crash.
+        fetcher = PagedFetcher(client=client, engine=engine)
+        fetcher.fetch_by_rids("Image", rids, table, batch_size=500)
+        assert _rows_count(engine, table) == 5
+
+    def test_two_fetchers_partial_overlap(self, engine):
+        """Two fetchers, overlapping but not identical RID sets — new RIDs
+        must be inserted, overlapping ones must be no-ops.
+        """
+        rows = _make_rows(10)
+        client = FakePagedClient(rows_by_table={"Image": rows})
+        table = _make_target_table(engine, "Image")
+        rids = [r["RID"] for r in rows]
+
+        fetcher_a = PagedFetcher(client=client, engine=engine)
+        fetcher_a.fetch_by_rids("Image", rids[:6], table, batch_size=500)
+        assert _rows_count(engine, table) == 6
+
+        # Second fetcher requests RIDs 4..9 — 4 and 5 already present, 6..9 new.
+        fetcher_b = PagedFetcher(client=client, engine=engine)
+        fetcher_b.fetch_by_rids("Image", rids[4:], table, batch_size=500)
+        assert _rows_count(engine, table) == 10
+
+    def test_two_fetchers_predicate_then_rids_overlap(self, engine):
+        """First fetcher populates via the page/predicate path; second
+        fetcher's fetch_by_rids on the same RIDs must still cope.
+
+        This exercises the predicate→RID interleaving inside one engine
+        but across fetcher instances.
+        """
+        rows = _make_rows(5)
+        client = FakePagedClient(rows_by_table={"Image": rows})
+        table = _make_target_table(engine, "Image")
+        rids = [r["RID"] for r in rows]
+
+        fetcher_a = PagedFetcher(client=client, engine=engine)
+        fetcher_a.fetch_predicate("Image", predicate=None, target_table=table, sort=("RID",))
+        assert _rows_count(engine, table) == 5
+
+        fetcher_b = PagedFetcher(client=client, engine=engine)
+        fetcher_b.fetch_by_rids("Image", rids, table, batch_size=500)
+        assert _rows_count(engine, table) == 5
+
     def test_extra_columns_in_rows_are_silently_dropped(self, tmp_path: Path) -> None:
         engine = create_engine(f"sqlite:///{tmp_path / 'wd.sqlite'}", future=True)
         target = _make_target_table(engine)  # has RID, Filename, Subject


### PR DESCRIPTION
## Summary

Finding 05 from the 2026-05-21 multi-persona e2e dry run on the
deriva-ml-model-template:
[`findings/setup/05-local-db-not-idempotent-on-second-denormalize.md`](https://github.com/informatics-isi-edu/deriva-ml-model-template/blob/main/findings/setup/05-local-db-not-idempotent-on-second-denormalize.md).

Any second live-catalog denormalize call against a given dataset
crashed with:

```
sqlite3.IntegrityError: UNIQUE constraint failed: Dataset.RID
[SQL: INSERT INTO "deriva-ml"."Dataset" ...]
```

The bug surfaced first as "two ``split_dataset()`` calls against the
same source in one process don't work" — the model-template's
Phase 0 bootstrap creates 10 of 13 expected datasets because the
second ``split_dataset()`` (deriving ``small_labeled_split`` from
``Training``) crashes inside the denormalizer's
``_populate_from_catalog`` step.

Investigation showed the bug is broader than the original finding
text suggested. ``_populate_from_catalog()`` builds a fresh
``PagedFetcher`` on every call ([`denormalize.py:453`](https://github.com/informatics-isi-edu/deriva-ml/blob/ca593df1/src/deriva_ml/local_db/denormalize.py#L453)).
The fetcher's ``_seen`` dedup set starts empty, so its
``fetch_by_rids`` fires INSERT statements for RIDs that already exist
in the engine — written by a prior fetcher in the same process, **or
by a prior session against the same on-disk SQLite workspace**. The
cross-session form is the worse one: every ``deriva-ml-run`` after
the first against the same dataset crashes the same way.

## Fix

``PagedFetcher._seen`` is now lazily hydrated from the engine on
first access for a given ``(table, column)`` key, via a new private
``_get_seen()`` helper. ``fetch_by_rids()`` and ``fetch_predicate()``
both go through it instead of ``self._seen.setdefault(...)``.
``fetch_predicate()`` also now filters incoming pages against the
seen-set before INSERTing, so a fresh fetcher iterating a
predicate-paged table that's already in the engine doesn't crash.

Cost: one ``SELECT {rid_column} FROM {target_table}`` per
``(table, column)`` per fetcher lifetime. Trivial against
catalog-scale rows.

## Test plan

The existing ``test_no_duplicate_inserts`` and
``test_deduplication_across_calls`` both worked with **one**
``PagedFetcher`` instance — they would have caught a regression of
single-instance dedup, but they never exercised the
multi-fetcher / shared-engine path that the real
``_populate_from_catalog`` flow takes. New tests close that gap:

**``tests/local_db/test_paged_fetcher.py`` — 5 new unit tests:**
- ``test_two_fetchers_same_engine_overlapping_rids``
- ``test_fresh_fetcher_against_pre_populated_engine`` (cross-session simulation)
- ``test_two_fetchers_partial_overlap``
- ``test_two_fetchers_predicate_then_rids_overlap``

All four fail against ``main`` with ``UNIQUE constraint failed`` and
pass after the fix.

**``tests/dataset/test_split.py`` — 3 new integration tests:**
- ``test_two_splits_same_source_in_one_process``
- ``test_split_after_prior_denormalize_of_source``
- ``test_two_denormalize_calls_on_same_dataset``

These mirror the user-facing manifestations (Curator value-add, Analyst denormalize success criterion, and the Phase 0 small_labeled split).

**Regression check:**
- [x] All 35 ``test_paged_fetcher.py`` tests pass.
- [x] All 90 ``test_split.py`` tests pass.
- [x] End-to-end: a fresh ``load-cifar10 --create-catalog ... --num-images 500`` against an unpatched localhost now creates all 13 expected datasets including the previously-blocked ``Small_Labeled_Split`` family (RIDs ``BSJ``, ``BST``, ``BT4`` on catalog 161).
- [x] Cross-session repro (a fresh DerivaML against a workspace whose ``Dataset`` table already has rows): both denormalize calls return 250 rows × 12 cols.

## Related

Closes the open finding from
[deriva-ml-model-template/findings/setup/05](https://github.com/informatics-isi-edu/deriva-ml-model-template/blob/main/findings/setup/05-local-db-not-idempotent-on-second-denormalize.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)