### PR TITLE
fix(local_db): honest estimated_row_count when row_per is downstream of anchor (closes A02)

### DIFF
--- a/docs/design/denormalization.md
+++ b/docs/design/denormalization.md
@@ -284,6 +284,7 @@ deletion/update freshness cases until we decide to fix.
 | F3 | Stale local data when server mutates between calls (deletes, updates) | Cache is write-through, never invalidated. | Documented as a known limitation. See §6. Test cases marked `xfail`. |
 | F4 | `_collect_fk_values` walks "values currently present in the engine" to decide what to fetch from the server. If a parent table's membership was updated server-side after the engine cached it, downstream fetches use the stale parent set. | Same root cause as F3. | Same status — known limitation, tracked. |
 | F5 | Path-walk order silently determines which rows get loaded when two element tables share intermediate tables | `_populate_from_catalog_inner` walks `join_tables` in dict iteration order; the order isn't part of the documented contract. | Not currently a bug, because every fetch must visit each (table, rid_column, rid) tuple at least once. Pin to the test matrix in §8 so a regression here would be caught. |
+| **F6** | `describe()` / `preflight_count` reports `estimated_row_count.total = 0` while the actual fetch returns rows | The estimator counted anchors whose table literally equals `row_per`. When `row_per` is downstream of the anchor table (the common feature-table case), no anchor matches and the sum is silently 0. Mathematically the cardinality is N rows per anchor for an unknown-from-anchor-data N. | Fixed by honest "unknown" semantics: when anchors are downstream of `row_per`, `in_scope_row_per_rows` and `total` return `None` and a `reason` field tells the caller why. The case-1 path (anchor == row_per) still returns an exact integer. Originally surfaced as 2026-05-21 finding A02 (Analyst arc). |
 
 ---
 
@@ -332,6 +333,15 @@ are marked `unit`.
 | C.5x | Mutation → re-denormalize. **Deletion or update** server-side between calls. | live, `xfail` | freshness limitation — see §6 |
 | C.6 | `split_dataset` then live denormalize of the parent | live | parent's feature rows visible |
 | C.7 | Live denormalize a Split parent containing children | live | members from children appear |
+
+### Layer E — `describe()` / preflight estimated_row_count
+
+| # | Scenario | Kind | Assert |
+|---|---|---|---|
+| E.1 | Anchor table == `row_per` (case 1) | live | exact integer estimate == anchor count |
+| E.2 | **Anchor table is downstream of `row_per` (case 2 — feature-table common case)** | live | **`in_scope_row_per_rows` and `total` are `None`; a `reason` field is present (A02 regression)** |
+| E.3 | Mixed scoping anchors (some at `row_per`, some downstream) | live | honest `None` with reason (the case-2 contribution can't be added to the case-1 count) |
+| E.4 | All anchors orphan (no FK path) | live | `orphan_rows` is exact, `in_scope_row_per_rows == 0`, `total == orphan_rows` |
 
 ### Layer D — Cross-channel parity
 

--- a/src/deriva_ml/local_db/denormalizer.py
+++ b/src/deriva_ml/local_db/denormalizer.py
@@ -588,8 +588,19 @@ class Denormalizer:
               suggestions}`` dicts, one per Rule 6 ambiguity. Empty
               when the plan is unambiguous.
             - ``estimated_row_count``: ``{in_scope_row_per_rows,
-              orphan_rows, total}`` — coarse anchor-based estimate.
-              Fields are ``None`` when estimation couldn't be computed.
+              orphan_rows, total}``, optionally with a ``reason`` field.
+              Anchor-based estimate; honest about unknowns. ``total``
+              is exact when every scoping anchor sits at ``row_per``
+              (case 1 of §3.7). When any scoping anchor is downstream
+              of ``row_per`` (the common feature-table case), the
+              per-anchor fan-out is unknown without a catalog query —
+              ``in_scope_row_per_rows`` and ``total`` come back as
+              ``None`` and a ``reason`` string names the downstream
+              tables. ``orphan_rows`` is always exact (an orphan
+              contributes exactly one row regardless of ``row_per``
+              cardinality). Originally surfaced as 2026-05-21 finding
+              A02; documented in ``docs/design/denormalization.md`` §7
+              row F6.
             - ``anchors``: ``{total, by_type}`` — counts of anchor RIDs
               grouped by table.
             - ``source``: ``"catalog"`` for live Datasets, ``"local"``
@@ -709,15 +720,33 @@ class Denormalizer:
             anchors = {}
         anchors_by_type = {t: len(rids) for t, rids in anchors.items()}
 
-        # ── estimated row count (crude — refined in future work) ────────────
-        # For v1: report how many anchors would be scoping vs orphan.
-        estimated = {
+        # ── estimated row count (anchor-based; honest about unknowns) ───────
+        #
+        # Three cases (see ``docs/design/denormalization.md`` §6 freshness
+        # caveat and the 2026-05-21 finding A02 history):
+        #
+        # 1. Anchor table == row_per → in_scope is exact (1 row per anchor).
+        # 2. Anchor table reaches row_per via FK chain (downstream or
+        #    upstream) but is NOT row_per itself → cardinality is N rows
+        #    per anchor for some N ≥ 0 that depends on per-anchor data the
+        #    estimator does not have without a catalog query. Honest answer:
+        #    None (with a `reason` field so the caller knows why).
+        # 3. Anchor table has no FK path to row_per → orphan (case 3 of
+        #    Rule 7; counted in orphan_rows).
+        #
+        # The pre-A02 implementation only honored case 1 (filtered on
+        # ``table == resolved_row_per``) and silently returned 0 for case
+        # 2. That meant ``preflight_count`` reported 0 for every
+        # feature-table denormalize (the common case where row_per is a
+        # downstream feature table and anchors are Image / Subject /
+        # whatever the dataset elements are). The 2026-05-21 e2e Analyst
+        # arc consumed the silent 0 as truth and reported A02.
+        estimated: dict[str, Any] = {
             "in_scope_row_per_rows": None,
             "orphan_rows": None,
             "total": None,
         }
         if resolved_row_per is not None:
-            # Count anchors classified as scoping (includes row_per anchors)
             try:
                 scoping, orphans, _ = self._classify_anchors(
                     anchors,
@@ -726,13 +755,44 @@ class Denormalizer:
                     row_per=resolved_row_per,
                     ignore_unrelated_anchors=True,  # describe shouldn't raise
                 )
-                in_scope = sum(len(rids) for table, rids in scoping.items() if table == resolved_row_per)
+                # Split scoping into "anchors sitting at row_per"
+                # (case 1, exact contribution) and "anchors elsewhere
+                # but reaching row_per via FK chain" (case 2, unknown
+                # fan-out).
+                at_row_per_count = sum(
+                    len(rids) for table, rids in scoping.items() if table == resolved_row_per
+                )
+                downstream_anchor_tables = [
+                    table
+                    for table, rids in scoping.items()
+                    if table != resolved_row_per and rids
+                ]
                 orphan_count = sum(len(rids) for rids in orphans.values())
-                estimated = {
-                    "in_scope_row_per_rows": in_scope,
-                    "orphan_rows": orphan_count,
-                    "total": in_scope + orphan_count,
-                }
+
+                if downstream_anchor_tables:
+                    # Case 2 dominates: we can't honestly state a total
+                    # without per-anchor fan-out info. Surface what we
+                    # DO know (orphan_rows is exact) and a reason for
+                    # the unknown fields.
+                    estimated = {
+                        "in_scope_row_per_rows": None,
+                        "orphan_rows": orphan_count,
+                        "total": None,
+                        "reason": (
+                            f"anchor table(s) {downstream_anchor_tables} are "
+                            f"downstream of row_per={resolved_row_per!r}; "
+                            "cardinality is N rows per anchor for unknown N. "
+                            "Run the actual fetch to count, or query the "
+                            "catalog directly for an exact figure."
+                        ),
+                    }
+                else:
+                    # Case 1 only: estimate is exact.
+                    estimated = {
+                        "in_scope_row_per_rows": at_row_per_count,
+                        "orphan_rows": orphan_count,
+                        "total": at_row_per_count + orphan_count,
+                    }
             except Exception:
                 pass
 

--- a/tests/dataset/test_describe_denormalized.py
+++ b/tests/dataset/test_describe_denormalized.py
@@ -244,3 +244,142 @@ class TestDatasetDescribeDenormalized:
         # We don't assert it's non-empty here because other test schemas may
         # not include the diamond; just verify it's well-formed.
         assert isinstance(info["ambiguities"], list)
+
+
+class TestEstimatedRowCount:
+    """Regression tests for ``estimated_row_count`` in ``describe()`` —
+    the spec §5 plan-dict field that the 2026-05-21 e2e Analyst arc
+    surfaced as finding A02 (preflight returns 0 while the actual
+    fetch returns rows).
+
+    The estimator counts anchors whose table equals ``row_per`` and
+    sums them into ``in_scope_row_per_rows``. That formula is correct
+    only when anchors sit *at* ``row_per``. When ``row_per`` is
+    downstream of the anchor table — the common feature-table case —
+    the formula returns 0 even though the join will produce N rows
+    per anchor.
+
+    Contract pinned here:
+
+    - Anchor table == row_per → estimate is exact (anchor count).
+    - Anchor table is downstream of row_per via FK chain → estimate
+      is ``None`` (honest: we don't know without a catalog query).
+      A reason string is included so callers can tell why.
+    - Anchor unreachable from row_per → orphan (existing behaviour).
+    """
+
+    @staticmethod
+    def _find_dataset_with_image_anchors(ml):
+        """Locate a dataset in the demo fixture that has Image members
+        as anchors.
+
+        ``catalog_with_datasets`` creates a hierarchy; ``find_datasets()``
+        returns the lot, and ``[0]`` is not guaranteed to be the one
+        with Image members. Iterate and pick the first dataset whose
+        ``describe_denormalized(["Image"])`` reports Image anchors > 0.
+        """
+        for dataset in ml.find_datasets():
+            info = dataset.describe_denormalized(["Image"])
+            if info["anchors"]["by_type"].get("Image", 0) > 0:
+                return dataset
+        raise AssertionError(
+            "No dataset in catalog_with_datasets has Image anchors; "
+            "demo fixture changed?"
+        )
+
+    def test_estimate_exact_when_anchor_is_row_per(
+        self, catalog_with_datasets: "tuple[DerivaML, object]"
+    ):
+        """Anchors at the row_per table give an exact estimate.
+
+        Demo fixture has Image anchors; with row_per='Image', the
+        estimator can compute the exact in-scope row count (== Image
+        anchor count) without any catalog query.
+
+        Note: the demo fixture may also include other anchor types
+        (Subject, etc.) that reach Image. The "anchor==row_per case
+        is exact" claim only holds when ALL scoping anchors are at
+        row_per. If the fixture has mixed-cardinality anchors, the
+        estimator honestly returns None — which is correct, and this
+        test then validates *that* behavior instead.
+        """
+        ml, _ = catalog_with_datasets
+        dataset = self._find_dataset_with_image_anchors(ml)
+
+        info = dataset.describe_denormalized(["Image"], row_per="Image")
+        estimated = info["estimated_row_count"]
+        anchors_by_type = info["anchors"]["by_type"]
+        image_anchors = anchors_by_type.get("Image", 0)
+        other_anchor_types = {t: c for t, c in anchors_by_type.items() if t != "Image" and c > 0}
+
+        assert image_anchors > 0, "Demo dataset should have Image anchors"
+
+        if other_anchor_types:
+            # Mixed-cardinality fixture: estimator can't be exact, so
+            # the honest answer is None.
+            assert estimated["in_scope_row_per_rows"] is None, (
+                f"Fixture has non-Image anchors {other_anchor_types}; "
+                f"estimator should return None (mixed cardinality), got "
+                f"{estimated['in_scope_row_per_rows']}"
+            )
+            assert estimated["total"] is None
+            assert "reason" in estimated
+        else:
+            # Pure Image-anchor fixture: estimate is exact.
+            assert estimated["in_scope_row_per_rows"] == image_anchors, (
+                f"Anchor==row_per case should report exact count "
+                f"({image_anchors}); got {estimated['in_scope_row_per_rows']}"
+            )
+            assert estimated["total"] == image_anchors
+
+    def test_estimate_unknown_when_row_per_downstream_of_anchor(
+        self, catalog_with_datasets: "tuple[DerivaML, object]"
+    ):
+        """Regression for 2026-05-21 finding A02.
+
+        When ``row_per`` is downstream of the anchor table (via FK
+        chain), the actual row count is N rows per anchor for some
+        N ≥ 0 that depends on per-anchor feature populations. The
+        estimator can't compute that from anchors alone, so the
+        honest answer is ``None`` (with a reason), NOT a silent 0.
+
+        The demo's ``Execution_Image_Quality`` feature table is
+        downstream of ``Image``: each Image may have 0..N quality
+        feature rows. With row_per=Execution_Image_Quality and
+        anchors at Image, the pre-A02-fix code returned
+        ``in_scope_row_per_rows: 0`` because no anchor table matched
+        ``row_per`` literally. Post-fix, the estimate is None with a
+        reason flag.
+        """
+        ml, _ = catalog_with_datasets
+        dataset = self._find_dataset_with_image_anchors(ml)
+
+        info = dataset.describe_denormalized(
+            ["Image", "Execution_Image_Quality"],
+            row_per="Execution_Image_Quality",
+        )
+        estimated = info["estimated_row_count"]
+        anchors_by_type = info["anchors"]["by_type"]
+        image_anchors = anchors_by_type.get("Image", 0)
+
+        assert image_anchors > 0, "Demo dataset should have Image anchors"
+
+        # The honest answer is "unknown" — we don't have a per-anchor
+        # fan-out estimate without querying the catalog. Pre-fix this
+        # was silently 0, which the e2e Analyst arc consumed as
+        # truth. The contract: when we can't compute, say so.
+        assert estimated["in_scope_row_per_rows"] is None, (
+            f"row_per downstream of anchor: estimate should be None "
+            f"(unknown), not {estimated['in_scope_row_per_rows']} "
+            f"(silently 0 was finding A02)."
+        )
+        assert estimated["total"] is None
+        # Reason field tells the caller WHY the estimate is unknown.
+        assert "reason" in estimated, (
+            "estimated_row_count should include a 'reason' field when "
+            "the count cannot be computed honestly."
+        )
+        assert "downstream" in estimated["reason"].lower(), (
+            f"reason should mention the downstream relationship: got "
+            f"{estimated['reason']!r}"
+        )


### PR DESCRIPTION
## Summary

Finding A02 from the 2026-05-21 multi-persona e2e Analyst arc:
``Denormalizer.describe()`` (and the MCP `preflight_count=True` mode
that delegates to it) returned ``estimated_row_count.total = 0`` while
the actual fetch returned 50 rows. Documented in the model-template
finding
[`findings/analyst/02-denormalize-row-count-estimate-says-zero.md`](https://github.com/informatics-isi-edu/deriva-ml-model-template/blob/main/findings/analyst/02-denormalize-row-count-estimate-says-zero.md).

## The bug

The estimator (``denormalizer.py:712-737`` pre-fix) computed
``in_scope_row_per_rows`` as:

```python
in_scope = sum(len(rids) for table, rids in scoping.items() if table == resolved_row_per)
```

This filters scoping anchors to those whose table literally equals
``row_per``. When ``row_per`` is **downstream** of the anchor table
(the common feature-table case — e.g., ``row_per=Execution_Image_Image_Classification``
with anchors at ``Image``), no anchor matches and the sum is 0. The
caller is silently told there are 0 rows; the subsequent fetch then
returns 50, 300, or however many feature-rows × anchor-count.

This is **classification case 2** in the planner's own
``_classify_anchors`` (Rule 7 of the semantic spec): an anchor that
reaches ``row_per`` via an FK chain is *scoping*, not orphan, but
its per-anchor fan-out cardinality is unknown without a catalog
query.

## The fix

Distinguish the three cases (per
`docs/design/denormalization.md` §7 row F6):

1. **Anchor table == row_per:** exact integer (1 row per anchor).
2. **Anchor reaches row_per via FK chain but is NOT row_per:**
   cardinality is N rows per anchor for unknown N. Return ``None``
   for ``in_scope_row_per_rows`` and ``total``; include a
   ``reason`` field naming the downstream tables so the caller
   knows why.
3. **Orphan anchors:** counted in ``orphan_rows`` (existing logic).

``orphan_rows`` is always exact (each orphan contributes exactly
one row regardless of ``row_per`` cardinality).

Mixed scoping (some anchors at row_per, some downstream) falls
into case 2 — we can't honestly add the case-2 contribution to the
case-1 count.

## Why "None with a reason" rather than computing the real count

Computing the real per-anchor fan-out requires a catalog query
(one `COUNT` against the feature table per anchor RID, or one
aggregate query over the dataset members' image RIDs). That's a
real network roundtrip for what's supposed to be a cheap
``describe()`` / preflight call. The honest-unknown semantics
fits the existing "describe is cheap, never raises, may have
unknown fields" contract that the docstring already advertises.
If a future caller wants a real number, they should run the
actual fetch (and pay for it explicitly).

## Test plan

Added ``TestEstimatedRowCount`` to ``tests/dataset/test_describe_denormalized.py``:

- ``test_estimate_exact_when_anchor_is_row_per`` — case 1 pinning.
  Handles the demo fixture's potential mixed-anchor situation
  (Image + Subject); when scoping is mixed the estimate is
  honestly ``None``.
- ``test_estimate_unknown_when_row_per_downstream_of_anchor`` —
  the A02 regression. With ``include_tables=["Image",
  "Execution_Image_Quality"]`` and ``row_per=Execution_Image_Quality``,
  asserts ``in_scope_row_per_rows is None``, ``total is None``,
  and a ``reason`` field contains "downstream".

Pre-fix the second test fails with ``assert 0 is None``; post-fix
both pass.

**Regression check:**

- [x] All 14 ``test_describe_denormalized.py`` tests pass.
- [x] All 39 ``test_paged_fetcher.py`` tests pass.
- [x] All 90 ``test_split.py`` tests pass.
- [x] Live verification on catalog 163 (the e2e finding catalog):
  CC6 + Execution_Image_Image_Classification preflight now returns
  ``in_scope_row_per_rows: None``, ``total: None``, with reason
  ``"anchor table(s) ['Image'] are downstream of
  row_per='Execution_Image_Image_Classification'; cardinality is N
  rows per anchor for unknown N. Run the actual fetch to count, or
  query the catalog directly for an exact figure."``. Pre-fix this
  was a silent 0.

## Documentation

- ``docs/design/denormalization.md`` §7 fragility map: new row F6
  documenting the describe-estimator-says-0 bug class.
- ``docs/design/denormalization.md`` §8 test matrix: new Layer E
  (estimated_row_count) with 4 cases.
- ``Denormalizer.describe()`` docstring updated to spell out the
  honest-unknown semantics.

## Related

Closes A02 (model-template
`findings/analyst/02-denormalize-row-count-estimate-says-zero.md`).
Builds on PR #189 (stateless ``PagedFetcher`` for A01); the design
doc already cited A02 as a separate F-row, and this PR fills it in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)