### PR TITLE
feat(dataset)!: split_dataset takes the caller's Execution (closes C02)

### DIFF
--- a/src/deriva_ml/dataset/split.py
+++ b/src/deriva_ml/dataset/split.py
@@ -24,18 +24,35 @@ Splitting Strategies:
         selection logic (balanced labels, filtered subsets, etc.).
 
 Example:
-    Simple random 80/20 split::
+    ``split_dataset`` runs inside an Execution the caller has already
+    opened. The caller's workflow identifies the code making the
+    splitting decision; deriva-ml never invents a workflow on the
+    caller's behalf, so this function is safe to call from
+    environments without a git checkout (notebook kernels, MCP
+    servers, scheduled jobs) as long as the caller has wired up a
+    workflow with honest provenance::
 
         from deriva_ml import DerivaML
         from deriva_ml.dataset.split import split_dataset
+        from deriva_ml.execution import ExecutionConfiguration
 
         ml = DerivaML("localhost", "9")
-        result = split_dataset(ml, "28D0", test_size=0.2, seed=42)
 
-    Three-way train/val/test split::
+        workflow = ml.create_workflow(
+            name="My splitting script",
+            workflow_type="Dataset_Split",
+            description="80/20 train/test for sleep-stage classifier v3",
+        )
+        config = ExecutionConfiguration(workflow=workflow)
+
+        with ml.create_execution(config) as exe:
+            result = split_dataset(ml, "28D0", exe, test_size=0.2, seed=42)
+        exe.upload_execution_outputs(clean_folder=True)
+
+    Three-way train/val/test split (same execution, reuse ``exe``)::
 
         result = split_dataset(
-            ml, "28D0",
+            ml, "28D0", exe,
             test_size=0.2,
             val_size=0.1,
             seed=42,
@@ -44,7 +61,7 @@ Example:
     Stratified split::
 
         result = split_dataset(
-            ml, "28D0",
+            ml, "28D0", exe,
             test_size=0.2,
             stratify_by_column="Image_Classification.Image_Class",
             include_tables=["Image", "Image_Classification"],
@@ -57,7 +74,7 @@ Example:
             return {"Training": train_indices, "Testing": test_indices}
 
         result = split_dataset(
-            ml, "28D0",
+            ml, "28D0", exe,
             test_size=100,
             selection_fn=my_selector,
             include_tables=["Image", "Image_Classification"],
@@ -82,8 +99,8 @@ from pydantic import BaseModel
 
 if TYPE_CHECKING:
     from deriva_ml import DerivaML
+    from deriva_ml.execution import Execution
 
-from deriva_ml.execution import ExecutionConfiguration
 from deriva_ml.core.logging_config import get_logger
 
 logger = get_logger(__name__)
@@ -426,23 +443,6 @@ def _resolve_sizes(
 # =============================================================================
 
 
-def _ensure_workflow_type(ml: DerivaML, workflow_type: str = "Dataset_Split") -> None:
-    """Ensure the workflow type exists in the catalog.
-
-    Args:
-        ml: Connected DerivaML instance.
-        workflow_type: Workflow type term name.
-    """
-    existing_types = {t.name for t in ml.list_vocabulary_terms("Workflow_Type")}
-    if workflow_type not in existing_types:
-        logger.info(f"Creating {workflow_type} workflow type...")
-        ml.add_term(
-            table="Workflow_Type",
-            term_name=workflow_type,
-            description="Workflow for splitting datasets into training/testing subsets",
-        )
-
-
 def _ensure_dataset_types(ml: DerivaML) -> None:
     """Ensure required dataset types exist.
 
@@ -482,6 +482,7 @@ def _ensure_dataset_types(ml: DerivaML) -> None:
 def split_dataset(
     ml: DerivaML,
     source_dataset_rid: str,
+    execution: Execution,
     *,
     # scikit-learn compatible parameters
     test_size: float | int = 0.2,
@@ -499,7 +500,6 @@ def split_dataset(
     element_table: str | None = None,
     include_tables: list[str] | None = None,
     selection_fn: SelectionFunction | None = None,
-    workflow_type: str = "Dataset_Split",
     dry_run: bool = False,
     # Denormalization-control parameters (issue #174)
     row_per: str | None = None,
@@ -524,6 +524,20 @@ def split_dataset(
     Args:
         ml: Connected DerivaML instance.
         source_dataset_rid: RID of the source dataset to split.
+        execution: A live :class:`Execution` the caller has already
+            opened (typically via ``with ml.create_execution(config) as
+            exe:``). All datasets created by this split — the parent
+            Split row and the Training / Validation / Testing children —
+            are attributed to *this* execution, which in turn is
+            attributed to the execution's workflow. The caller owns
+            execution provenance: their workflow URL and checksum
+            identify the code making the splitting decision, and
+            deriva-ml never invents a workflow on the caller's behalf.
+            The caller is responsible for committing the execution
+            (``exe.upload_execution_outputs()`` / context-manager exit).
+            ``split_dataset`` will write a ``split_config.json``
+            artifact into ``exe.working_dir`` that the caller's upload
+            will pick up.
         test_size: If float (0-1), fraction of data for testing.
             If int, absolute number of test samples. Default: 0.2.
         train_size: If float (0-1), fraction of data for training.
@@ -563,7 +577,6 @@ def split_dataset(
         selection_fn: Custom selection function conforming to the
             ``SelectionFunction`` protocol. Mutually exclusive with
             ``stratify_by_column``.
-        workflow_type: Workflow type vocabulary term. Default: "Dataset_Split".
         dry_run: If True, return what would happen without modifying catalog.
         row_per: Explicit leaf table for denormalization (passed
             through to :meth:`Dataset.get_denormalized_as_dataframe`).
@@ -905,128 +918,116 @@ def split_dataset(
         return result
 
     # -------------------------------------------------------------------------
-    # Ensure vocabulary terms exist
+    # Ensure dataset-type vocabulary terms exist (Training, Testing,
+    # Validation, Split, Labeled, Unlabeled). Workflow-type vocabulary is
+    # the caller's concern -- they registered the workflow that owns
+    # ``execution`` and chose its type.
     # -------------------------------------------------------------------------
-    _ensure_workflow_type(ml, workflow_type)
     _ensure_dataset_types(ml)
 
     # -------------------------------------------------------------------------
-    # Create execution and dataset hierarchy
+    # Create dataset hierarchy inside the caller's execution
     # -------------------------------------------------------------------------
     partitions_desc = ", ".join(f"{k}={v}" for k, v in partition_sizes.items())
     auto_description = f"Split of dataset {source_dataset_rid} ({strategy_desc}, {partitions_desc}, seed={seed})"
 
-    logger.info("Creating workflow and execution...")
-    workflow = ml.create_workflow(
-        name=f"Dataset Split: {source_dataset_rid}",
-        workflow_type=workflow_type,
-        description="Split dataset into training/testing/validation subsets",
-    )
-
-    config = ExecutionConfiguration(
-        workflow=workflow,
-        description=split_description or auto_description,
-    )
+    exe = execution
+    logger.info("Splitting inside caller's execution %s", exe.execution_rid)
 
     train_types = ["Training"] + (training_types or [])
     test_types = ["Testing"] + (testing_types or [])
     val_types = ["Validation"] + (validation_types or []) if val_size is not None else []
 
-    with ml.create_execution(config) as exe:
-        logger.info(f"  Execution RID: {exe.execution_rid}")
+    # Save split parameters as config artifact. The caller's execution
+    # is responsible for uploading this on its own ``upload_execution_outputs``;
+    # we never call upload here.
+    split_params = {
+        "source_dataset_rid": source_dataset_rid,
+        "test_size": test_size,
+        "train_size": train_size,
+        "val_size": val_size,
+        "partition_sizes": partition_sizes,
+        "shuffle": shuffle,
+        "seed": seed,
+        "stratify_by_column": stratify_by_column,
+        "stratify_missing": stratify_missing,
+        "element_table": element_table,
+        "include_tables": include_tables,
+        "row_per": row_per,
+        "via": via,
+        "ignore_unrelated_anchors": ignore_unrelated_anchors,
+        "training_types": train_types,
+        "testing_types": test_types,
+        "validation_types": val_types if val_types else None,
+        "strategy": strategy_desc,
+    }
+    params_file = Path(exe.working_dir) / "split_config.json"
+    params_file.write_text(json.dumps(split_params, indent=2))
+    logger.info(f"  Saved split parameters to {params_file}")
 
-        # Save split parameters as config artifact
-        split_params = {
-            "source_dataset_rid": source_dataset_rid,
-            "test_size": test_size,
-            "train_size": train_size,
-            "val_size": val_size,
-            "partition_sizes": partition_sizes,
-            "shuffle": shuffle,
-            "seed": seed,
-            "stratify_by_column": stratify_by_column,
-            "stratify_missing": stratify_missing,
-            "element_table": element_table,
-            "include_tables": include_tables,
-            "row_per": row_per,
-            "via": via,
-            "ignore_unrelated_anchors": ignore_unrelated_anchors,
-            "training_types": train_types,
-            "testing_types": test_types,
-            "validation_types": val_types if val_types else None,
-            "strategy": strategy_desc,
-        }
-        params_file = Path(exe.working_dir) / "split_config.json"
-        params_file.write_text(json.dumps(split_params, indent=2))
-        logger.info(f"  Saved split parameters to {params_file}")
+    # Create parent Split dataset
+    split_ds = exe.create_dataset(
+        description=split_description or auto_description,
+        dataset_types=["Split"],
+    )
+    logger.info(f"  Created Split dataset: {split_ds.dataset_rid}")
 
-        # Create parent Split dataset
-        split_ds = exe.create_dataset(
-            description=split_description or auto_description,
-            dataset_types=["Split"],
-        )
-        logger.info(f"  Created Split dataset: {split_ds.dataset_rid}")
+    # Create Training dataset
+    training_ds = exe.create_dataset(
+        description=(
+            f"Training subset ({partition_sizes['Training']} samples) of "
+            f"{source_dataset_rid} ({strategy_desc}, seed={seed})"
+        ),
+        dataset_types=train_types,
+    )
+    logger.info(f"  Created Training dataset: {training_ds.dataset_rid}")
 
-        # Create Training dataset
-        training_ds = exe.create_dataset(
+    # Create Validation dataset (if requested)
+    validation_ds = None
+    if val_size is not None:
+        validation_ds = exe.create_dataset(
             description=(
-                f"Training subset ({partition_sizes['Training']} samples) of "
+                f"Validation subset ({partition_sizes['Validation']} samples) of "
                 f"{source_dataset_rid} ({strategy_desc}, seed={seed})"
             ),
-            dataset_types=train_types,
+            dataset_types=val_types,
         )
-        logger.info(f"  Created Training dataset: {training_ds.dataset_rid}")
+        logger.info(f"  Created Validation dataset: {validation_ds.dataset_rid}")
 
-        # Create Validation dataset (if requested)
-        validation_ds = None
-        if val_size is not None:
-            validation_ds = exe.create_dataset(
-                description=(
-                    f"Validation subset ({partition_sizes['Validation']} samples) of "
-                    f"{source_dataset_rid} ({strategy_desc}, seed={seed})"
-                ),
-                dataset_types=val_types,
-            )
-            logger.info(f"  Created Validation dataset: {validation_ds.dataset_rid}")
+    # Create Testing dataset
+    testing_ds = exe.create_dataset(
+        description=(
+            f"Testing subset ({partition_sizes['Testing']} samples) of "
+            f"{source_dataset_rid} ({strategy_desc}, seed={seed})"
+        ),
+        dataset_types=test_types,
+    )
+    logger.info(f"  Created Testing dataset: {testing_ds.dataset_rid}")
 
-        # Create Testing dataset
-        testing_ds = exe.create_dataset(
-            description=(
-                f"Testing subset ({partition_sizes['Testing']} samples) of "
-                f"{source_dataset_rid} ({strategy_desc}, seed={seed})"
-            ),
-            dataset_types=test_types,
-        )
-        logger.info(f"  Created Testing dataset: {testing_ds.dataset_rid}")
+    # Link children to parent
+    child_rids = [training_ds.dataset_rid, testing_ds.dataset_rid]
+    if validation_ds is not None:
+        child_rids.insert(1, validation_ds.dataset_rid)
+    split_ds.add_dataset_members(child_rids, validate=False)
+    logger.info("  Linked child datasets to Split dataset")
 
-        # Link children to parent
-        child_rids = [training_ds.dataset_rid, testing_ds.dataset_rid]
-        if validation_ds is not None:
-            child_rids.insert(1, validation_ds.dataset_rid)
-        split_ds.add_dataset_members(child_rids, validate=False)
-        logger.info("  Linked child datasets to Split dataset")
-
-        # Add members to each partition
-        batch_size = 500
-        for part_name, ds in [
-            ("Training", training_ds),
-            ("Validation", validation_ds),
-            ("Testing", testing_ds),
-        ]:
-            if ds is None:
-                continue
-            rids = partition_rids[part_name]
-            logger.info(f"  Adding {len(rids)} members to {part_name} dataset...")
-            for i in range(0, len(rids), batch_size):
-                batch = rids[i : i + batch_size]
-                ds.add_dataset_members({element_table: batch}, validate=False)
-                added = min(i + batch_size, len(rids))
-                if added % 2000 == 0 or added >= len(rids):
-                    logger.info(f"    Added {added}/{len(rids)}")
-
-    # Upload execution outputs (after context manager exits)
-    logger.info("Uploading execution outputs...")
-    exe.upload_execution_outputs(clean_folder=True)
+    # Add members to each partition
+    batch_size = 500
+    for part_name, ds in [
+        ("Training", training_ds),
+        ("Validation", validation_ds),
+        ("Testing", testing_ds),
+    ]:
+        if ds is None:
+            continue
+        rids = partition_rids[part_name]
+        logger.info(f"  Adding {len(rids)} members to {part_name} dataset...")
+        for i in range(0, len(rids), batch_size):
+            batch = rids[i : i + batch_size]
+            ds.add_dataset_members({element_table: batch}, validate=False)
+            added = min(i + batch_size, len(rids))
+            if added % 2000 == 0 or added >= len(rids):
+                logger.info(f"    Added {added}/{len(rids)}")
 
     # -------------------------------------------------------------------------
     # Build result
@@ -1262,6 +1263,7 @@ def main() -> int:
 
     try:
         from deriva_ml import DerivaML
+        from deriva_ml.execution import ExecutionConfiguration
 
         # Connect
         logger.info(f"Connecting to {args.hostname}, catalog {args.catalog_id}")
@@ -1279,29 +1281,75 @@ def main() -> int:
         validation_types = [t.strip() for t in args.validation_types.split(",")] if args.validation_types else None
         via = [t.strip() for t in args.via.split(",")] if args.via else None
 
-        # Run the split
-        result = split_dataset(
-            ml=ml,
-            source_dataset_rid=args.dataset_rid,
-            test_size=args.test_size,
-            train_size=args.train_size,
-            val_size=args.val_size,
-            shuffle=not args.no_shuffle,
-            seed=args.seed,
-            stratify_by_column=args.stratify_by_column,
-            stratify_missing=args.stratify_missing,
-            split_description=args.description,
-            training_types=training_types,
-            testing_types=testing_types,
-            validation_types=validation_types,
-            element_table=args.element_table,
-            include_tables=include_tables,
-            row_per=args.row_per,
-            via=via,
-            ignore_unrelated_anchors=args.ignore_unrelated_anchors,
-            workflow_type=args.workflow_type,
-            dry_run=args.dry_run,
-        )
+        # Dry-run: skip workflow/execution overhead entirely. split_dataset's
+        # dry-run path doesn't touch the catalog and doesn't need a live
+        # execution -- pass a sentinel so the type-check is satisfied and the
+        # early-return at the top of split_dataset fires before any execution
+        # methods are called.
+        if args.dry_run:
+            result = split_dataset(
+                ml=ml,
+                source_dataset_rid=args.dataset_rid,
+                execution=None,  # type: ignore[arg-type]  -- dry-run returns before use
+                test_size=args.test_size,
+                train_size=args.train_size,
+                val_size=args.val_size,
+                shuffle=not args.no_shuffle,
+                seed=args.seed,
+                stratify_by_column=args.stratify_by_column,
+                stratify_missing=args.stratify_missing,
+                split_description=args.description,
+                training_types=training_types,
+                testing_types=testing_types,
+                validation_types=validation_types,
+                element_table=args.element_table,
+                include_tables=include_tables,
+                row_per=args.row_per,
+                via=via,
+                ignore_unrelated_anchors=args.ignore_unrelated_anchors,
+                dry_run=True,
+            )
+        else:
+            # The CLI itself is the caller -- it lives in a git checkout
+            # of deriva-ml, so its workflow URL/checksum come from this
+            # script's git context (via the Workflow validator's
+            # built-in introspection). The MCP server, by contrast,
+            # would never reach this code path -- it opens its own
+            # execution from a caller-supplied workflow_rid.
+            workflow = ml.create_workflow(
+                name=f"deriva-ml-split-dataset CLI: {args.dataset_rid}",
+                workflow_type=args.workflow_type,
+                description="Split dataset via the deriva-ml-split-dataset CLI",
+            )
+            with ml.create_execution(
+                ExecutionConfiguration(
+                    workflow=workflow,
+                    description=args.description or f"Split of {args.dataset_rid}",
+                )
+            ) as exe:
+                result = split_dataset(
+                    ml=ml,
+                    source_dataset_rid=args.dataset_rid,
+                    execution=exe,
+                    test_size=args.test_size,
+                    train_size=args.train_size,
+                    val_size=args.val_size,
+                    shuffle=not args.no_shuffle,
+                    seed=args.seed,
+                    stratify_by_column=args.stratify_by_column,
+                    stratify_missing=args.stratify_missing,
+                    split_description=args.description,
+                    training_types=training_types,
+                    testing_types=testing_types,
+                    validation_types=validation_types,
+                    element_table=args.element_table,
+                    include_tables=include_tables,
+                    row_per=args.row_per,
+                    via=via,
+                    ignore_unrelated_anchors=args.ignore_unrelated_anchors,
+                    dry_run=False,
+                )
+            exe.upload_execution_outputs(clean_folder=True)
 
         # Print summary
         if args.dry_run:

--- a/tests/dataset/test_split.py
+++ b/tests/dataset/test_split.py
@@ -636,7 +636,9 @@ class TestSplitDataset:
         """Create a dataset with enough members to split.
 
         Creates a table 'SplitTestItem' with 12 records and a dataset
-        containing all of them.
+        containing all of them. Also registers a ``Dataset_Split``
+        workflow-type vocabulary term so each test can open its own
+        splitting execution without re-adding the term.
 
         Returns:
             RID of the created dataset.
@@ -663,6 +665,7 @@ class TestSplitDataset:
 
         # Create workflow and dataset
         ml.add_term(MLVocab.workflow_type, "Setup", description="Setup workflow")
+        ml.add_term(MLVocab.workflow_type, "Dataset_Split", description="Dataset split workflow")
         ml.add_term("Dataset_Type", "Source", description="Source dataset")
         workflow = ml.create_workflow(
             name="Setup Workflow",
@@ -678,12 +681,33 @@ class TestSplitDataset:
 
         return dataset.dataset_rid
 
+    @staticmethod
+    def _split_in_execution(ml: DerivaML, source_rid: str, **kwargs) -> SplitResult:
+        """Open a split execution, run ``split_dataset``, and commit.
+
+        Tests use this to keep each call site to one line -- the
+        per-test workflow and execution are boilerplate that doesn't
+        vary across cases. Real callers (CLI, model-template scripts,
+        the MCP wrapper) open the execution themselves.
+        """
+        workflow = ml.create_workflow(
+            name="Test Split Workflow",
+            workflow_type="Dataset_Split",
+            description="Splitting workflow for tests",
+        )
+        with ml.create_execution(
+            ExecutionConfiguration(workflow=workflow, description="Test split")
+        ) as exe:
+            result = split_dataset(ml, source_rid, exe, **kwargs)
+        exe.upload_execution_outputs(clean_folder=True)
+        return result
+
     def test_basic_random_split(self, test_ml):
         """Test basic 80/20 random split."""
         ml = test_ml
         source_rid = self._setup_splittable_dataset(ml)
 
-        result = split_dataset(
+        result = self._split_in_execution(
             ml,
             source_rid,
             test_size=0.25,
@@ -709,7 +733,7 @@ class TestSplitDataset:
         ml = test_ml
         source_rid = self._setup_splittable_dataset(ml)
 
-        result = split_dataset(ml, source_rid, test_size=3, seed=42)
+        result = self._split_in_execution(ml, source_rid, test_size=3, seed=42)
 
         # Verify parent-child relationships
         split_ds = ml.lookup_dataset(result.split.rid)
@@ -723,7 +747,7 @@ class TestSplitDataset:
         ml = test_ml
         source_rid = self._setup_splittable_dataset(ml)
 
-        result = split_dataset(
+        result = self._split_in_execution(
             ml,
             source_rid,
             test_size=4,
@@ -746,7 +770,7 @@ class TestSplitDataset:
         ml = test_ml
         source_rid = self._setup_splittable_dataset(ml)
 
-        result = split_dataset(ml, source_rid, test_size=4, seed=42)
+        result = self._split_in_execution(ml, source_rid, test_size=4, seed=42)
 
         training_ds = ml.lookup_dataset(result.training.rid)
         testing_ds = ml.lookup_dataset(result.testing.rid)
@@ -761,12 +785,12 @@ class TestSplitDataset:
         ml = test_ml
         source_rid = self._setup_splittable_dataset(ml)
 
-        result1 = split_dataset(ml, source_rid, test_size=4, seed=42)
+        result1 = self._split_in_execution(ml, source_rid, test_size=4, seed=42)
         training_ds1 = ml.lookup_dataset(result1.training.rid)
         train_rids1 = {r["RID"] for r in training_ds1.list_dataset_members().get("SplitTestItem", [])}
 
         # Create another split with same parameters on same source
-        result2 = split_dataset(ml, source_rid, test_size=4, seed=42)
+        result2 = self._split_in_execution(ml, source_rid, test_size=4, seed=42)
         training_ds2 = ml.lookup_dataset(result2.training.rid)
         train_rids2 = {r["RID"] for r in training_ds2.list_dataset_members().get("SplitTestItem", [])}
 
@@ -777,7 +801,7 @@ class TestSplitDataset:
         ml = test_ml
         source_rid = self._setup_splittable_dataset(ml)
 
-        result = split_dataset(
+        result = self._split_in_execution(
             ml,
             source_rid,
             test_size=4,
@@ -804,7 +828,7 @@ class TestSplitDataset:
         initial_datasets = list(ml.find_datasets())
         initial_count = len(initial_datasets)
 
-        result = split_dataset(
+        result = self._split_in_execution(
             ml,
             source_rid,
             test_size=4,
@@ -844,7 +868,7 @@ class TestSplitDataset:
                 offset += size
             return result
 
-        result = split_dataset(
+        result = self._split_in_execution(
             ml,
             source_rid,
             test_size=4,
@@ -865,7 +889,7 @@ class TestSplitDataset:
             return {"Training": np.array([0]), "Testing": np.array([1])}
 
         with pytest.raises(ValueError, match="mutually exclusive"):
-            split_dataset(
+            self._split_in_execution(
                 ml,
                 source_rid,
                 test_size=4,
@@ -880,7 +904,7 @@ class TestSplitDataset:
         source_rid = self._setup_splittable_dataset(ml)
 
         with pytest.raises(ValueError, match="include_tables is required"):
-            split_dataset(
+            self._split_in_execution(
                 ml,
                 source_rid,
                 test_size=4,
@@ -896,7 +920,7 @@ class TestSplitDataset:
             return {"Training": np.array([0]), "Testing": np.array([1])}
 
         with pytest.raises(ValueError, match="include_tables is required"):
-            split_dataset(
+            self._split_in_execution(
                 ml,
                 source_rid,
                 test_size=4,
@@ -907,7 +931,7 @@ class TestSplitDataset:
         """Test that splitting an empty dataset raises ValueError."""
         ml = test_ml
 
-        # Create an empty dataset (no members)
+        # Create an empty dataset (no members) inside a setup execution.
         ml.add_term(MLVocab.workflow_type, "Setup", description="Setup workflow")
         ml.add_term("Dataset_Type", "Source", description="Source dataset")
         workflow = ml.create_workflow(
@@ -921,15 +945,18 @@ class TestSplitDataset:
             description="Empty dataset",
         )
 
+        # Reuse the same execution for the split attempt -- the ValueError
+        # fires before split_dataset reaches anything execution-specific,
+        # so we don't need a separate Dataset_Split workflow here.
         with pytest.raises(ValueError, match="no members"):
-            split_dataset(ml, empty_ds.dataset_rid, test_size=0.2)
+            split_dataset(ml, empty_ds.dataset_rid, execution, test_size=0.2)
 
     def test_provenance_tracking(self, test_ml):
         """Test that split creates proper execution provenance."""
         ml = test_ml
         source_rid = self._setup_splittable_dataset(ml)
 
-        result = split_dataset(ml, source_rid, test_size=4, seed=42)
+        result = self._split_in_execution(ml, source_rid, test_size=4, seed=42)
 
         # The split dataset should have execution history
         split_ds = ml.lookup_dataset(result.split.rid)
@@ -950,7 +977,7 @@ class TestSplitDataset:
         ml = test_ml
         source_rid = self._setup_splittable_dataset(ml)
 
-        result = split_dataset(ml, source_rid, test_size=4, seed=42)
+        result = self._split_in_execution(ml, source_rid, test_size=4, seed=42)
 
         # Versions should be valid PEP 440 strings — round-trip through
         # DatasetVersion.parse and have at least major.minor.patch in
@@ -967,7 +994,7 @@ class TestSplitDataset:
         ml = test_ml
         source_rid = self._setup_splittable_dataset(ml)
 
-        result = split_dataset(
+        result = self._split_in_execution(
             ml,
             source_rid,
             test_size=4,
@@ -987,7 +1014,7 @@ class TestSplitDataset:
         ml = test_ml
         source_rid = self._setup_splittable_dataset(ml)
 
-        result = split_dataset(
+        result = self._split_in_execution(
             ml,
             source_rid,
             test_size=2,
@@ -1011,7 +1038,7 @@ class TestSplitDataset:
         ml = test_ml
         source_rid = self._setup_splittable_dataset(ml)
 
-        result = split_dataset(
+        result = self._split_in_execution(
             ml,
             source_rid,
             test_size=2,
@@ -1032,7 +1059,7 @@ class TestSplitDataset:
         ml = test_ml
         source_rid = self._setup_splittable_dataset(ml)
 
-        result = split_dataset(
+        result = self._split_in_execution(
             ml,
             source_rid,
             test_size=2,
@@ -1059,7 +1086,7 @@ class TestSplitDataset:
         ml = test_ml
         source_rid = self._setup_splittable_dataset(ml)
 
-        result = split_dataset(
+        result = self._split_in_execution(
             ml,
             source_rid,
             test_size=2,
@@ -1086,7 +1113,7 @@ class TestSplitDataset:
         ml = test_ml
         source_rid = self._setup_splittable_dataset(ml)
 
-        result = split_dataset(
+        result = self._split_in_execution(
             ml,
             source_rid,
             test_size=2,
@@ -1105,7 +1132,7 @@ class TestSplitDataset:
         ml = test_ml
         source_rid = self._setup_splittable_dataset(ml)
 
-        result = split_dataset(ml, source_rid, test_size=4, seed=42)
+        result = self._split_in_execution(ml, source_rid, test_size=4, seed=42)
         assert result.strategy == "random"
 
     def test_strategy_field_dry_run(self, test_ml):
@@ -1113,7 +1140,9 @@ class TestSplitDataset:
         ml = test_ml
         source_rid = self._setup_splittable_dataset(ml)
 
-        result = split_dataset(ml, source_rid, test_size=4, seed=42, dry_run=True)
+        result = self._split_in_execution(
+            ml, source_rid, test_size=4, seed=42, dry_run=True
+        )
         assert result.strategy == "random"
         assert result.element_table == "SplitTestItem"
         assert result.seed == 42
@@ -1123,7 +1152,7 @@ class TestSplitDataset:
         ml = test_ml
         source_rid = self._setup_splittable_dataset(ml)
 
-        result = split_dataset(
+        result = self._split_in_execution(
             ml,
             source_rid,
             test_size=4,
@@ -1141,7 +1170,7 @@ class TestSplitDataset:
         source_rid = self._setup_splittable_dataset(ml)
 
         custom_desc = "My custom split for experiment X"
-        result = split_dataset(
+        result = self._split_in_execution(
             ml,
             source_rid,
             test_size=4,
@@ -1157,7 +1186,7 @@ class TestSplitDataset:
         ml = test_ml
         source_rid = self._setup_splittable_dataset(ml)
 
-        result = split_dataset(ml, source_rid, test_size=4, seed=42)
+        result = self._split_in_execution(ml, source_rid, test_size=4, seed=42)
 
         # All fields should be populated
         assert result.source == source_rid
@@ -1182,7 +1211,7 @@ class TestSplitDataset:
         source_rid = self._setup_splittable_dataset(ml)
 
         with pytest.raises(ValueError, match="no members"):
-            split_dataset(
+            self._split_in_execution(
                 ml,
                 source_rid,
                 test_size=4,
@@ -1221,11 +1250,11 @@ class TestSplitDataset:
         ml = test_ml
         source_rid = self._setup_splittable_dataset(ml)
 
-        result_a = split_dataset(ml, source_rid, test_size=3, seed=42)
+        result_a = self._split_in_execution(ml, source_rid, test_size=3, seed=42)
         assert isinstance(result_a, SplitResult)
 
         # Second split from the same source — must not crash.
-        result_b = split_dataset(ml, source_rid, test_size=4, seed=99)
+        result_b = self._split_in_execution(ml, source_rid, test_size=4, seed=99)
         assert isinstance(result_b, SplitResult)
         assert result_b.split.rid != result_a.split.rid
 
@@ -1246,7 +1275,7 @@ class TestSplitDataset:
         assert len(df) == 12
 
         # Then: a Curator-style split. Must not crash.
-        result = split_dataset(ml, source_rid, test_size=3, seed=42)
+        result = self._split_in_execution(ml, source_rid, test_size=3, seed=42)
         assert isinstance(result, SplitResult)
         assert result.training.count == 9
         assert result.testing.count == 3
@@ -1340,6 +1369,7 @@ class TestDenormalizationPlumbing:
         result = split_dataset(
             ml,
             "DS-1",
+            None,  # type: ignore[arg-type]  -- dry_run=True returns before use
             test_size=2,
             train_size=4,
             seed=42,
@@ -1366,6 +1396,7 @@ class TestDenormalizationPlumbing:
         split_dataset(
             ml,
             "DS-1",
+            None,  # type: ignore[arg-type]  -- dry_run=True returns before use
             test_size=2,
             train_size=4,
             seed=42,
@@ -1386,6 +1417,7 @@ class TestDenormalizationPlumbing:
         split_dataset(
             ml,
             "DS-1",
+            None,  # type: ignore[arg-type]  -- dry_run=True returns before use
             test_size=2,
             train_size=4,
             seed=42,


### PR DESCRIPTION
## Summary

Finding C02 from the 2026-05-21 multi-persona e2e Curator arc:
``deriva_ml_split_dataset`` (the MCP wrapper) crashed with
``[Errno 2] No such file or directory: 'git'`` whenever it ran inside
the MCP container, because ``split_dataset`` minted its own Workflow
internally and the Workflow Pydantic validator's git-introspection
fallback shells out to the (absent) ``git`` binary.

**The fix is architectural, not a workaround.** ``split_dataset`` no
longer creates a Workflow or Execution of its own. It now requires the
caller to pass in a live ``Execution`` they've already opened; the
caller's existing workflow attribution flows through naturally. The
function is then safe to run from any environment — including ones
without a git checkout — because it never invents provenance.

This is a **breaking change** to the Python signature. The downstream
MCP tool (``deriva_ml_split_dataset``) was simultaneously removed in
[deriva-ml-mcp 9fe47f6](https://github.com/informatics-isi-edu/deriva-ml-mcp/commit/9fe47f6)
in favor of the script-based ``catalog-operations-workflow`` pattern,
and the model template's [_cifar10_datasets.py](https://github.com/informatics-isi-edu/deriva-ml-model-template/commit/1e480e7)
demonstrates the new contract end-to-end.

## The new contract

```python
from deriva_ml import DerivaML, ExecutionConfiguration
from deriva_ml.dataset.split import split_dataset

ml = DerivaML(hostname, catalog_id)
workflow = ml.create_workflow(
    name=\"My splitting script\",
    workflow_type=\"Dataset_Split\",
    description=\"…\",
)
with ml.create_execution(ExecutionConfiguration(workflow=workflow, ...)) as exe:
    result = split_dataset(ml, source_rid, exe, test_size=0.2, seed=42)
exe.upload_execution_outputs(clean_folder=True)
```

The Execution is the third positional argument. ``split_dataset``
calls ``exe.create_dataset(...)`` to produce the Split / Training /
Testing / Validation rows and writes ``split_config.json`` to
``exe.working_dir``; it does **not** call
``exe.upload_execution_outputs`` (the caller owns commit timing). For
dry-runs the function returns before touching the execution, so unit
tests can pass ``None`` as a sentinel.

## What changed

**``src/deriva_ml/dataset/split.py``:**

- ``execution: Execution`` is the new third positional parameter.
- Removed the ``workflow_type`` kwarg.
- Removed the ``_ensure_workflow_type`` helper.
- Removed the internal ``ml.create_workflow(...)`` / ``ExecutionConfiguration(...)`` /
  ``ml.create_execution(...)`` calls; the ``with``-block disappears.
- Removed the trailing ``exe.upload_execution_outputs(clean_folder=True)``.
- Module-top docstring examples and the ``Args:`` block show the new contract.
- The ``deriva-ml-split-dataset`` CLI entry point opens its own
  Workflow + Execution (the CLI lives in a git checkout, so the
  standard Workflow validator path works fine there) and threads
  ``exe`` into ``split_dataset``.

**``tests/dataset/test_split.py``:**

- New ``_split_in_execution(ml, source_rid, **kwargs)`` test helper
  opens a per-test ``Dataset_Split`` workflow + execution, calls
  ``split_dataset`` inside it, commits, and returns the result.
- All 33 catalog-bound call sites use the helper (single-line at the
  call site; the workflow/execution boilerplate is amortized).
- The three ``TestDenormalizationPlumbing`` unit tests pass ``None``
  for the execution because they use ``dry_run=True``.
- The empty-dataset test re-uses its own setup execution for the
  expected-``ValueError`` call.

## Verification

```
$ DERIVA_ML_ALLOW_DIRTY=true uv run python -m pytest tests/dataset/test_split.py -k 'not TestSplitDataset'
================ 61 passed, 29 deselected, 6 warnings in 1.01s =================

$ uv run ruff check src/deriva_ml/dataset/split.py
All checks passed!
```

The 29 deselected tests are the live-catalog ``TestSplitDataset``
integration tests; they were exercised against a local catalog while
developing this change.

## Diff stats

```
src/deriva_ml/dataset/split.py | 352 +++++++++++++++++++++++------------------
tests/dataset/test_split.py    |  96 +++++++----
2 files changed, 264 insertions(+), 184 deletions(-)
```

## Related findings

- **C02** (this PR): ``git`` not on PATH in the MCP container —
  closed by removing the internal Workflow creation.
- ``deriva-ml-mcp`` 9fe47f6 removed the corresponding MCP tool.
- ``deriva-ml-model-template`` 1e480e7 demonstrates the new contract
  in ``src/scripts/_cifar10_datasets.py``.
- ``deriva-ml-skills`` 34fa125 rewrote the ``dataset-lifecycle`` skill
  to document the script-based path.

## Test plan

- [x] Unit tests in ``tests/dataset/test_split.py`` (61 pass).
- [x] Ruff clean on the modified module.
- [ ] Live-catalog ``TestSplitDataset`` integration tests pass against
      a localhost catalog after merge.
- [ ] Downstream ``uv sync --upgrade-package deriva-ml`` in
      ``deriva-ml-mcp`` and ``deriva-ml-model-template`` picks up the
      new contract and their test suites stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)