### PR TITLE
feat(config): add validate_config_file and bootstrap_config APIs

### DIFF
--- a/src/deriva_ml/config/__init__.py
+++ b/src/deriva_ml/config/__init__.py
@@ -54,6 +54,12 @@ Example:
 from __future__ import annotations
 
 from deriva_ml.config.ast_walker import parse_config_file
+from deriva_ml.config.bootstrap import (
+    BootstrapReport,
+    BootstrapSkipped,
+    BootstrapSuggestion,
+    ConfigKind,
+)
 from deriva_ml.config.validation import (
     ConfigEntry,
     ConfigEntryReason,
@@ -62,9 +68,13 @@ from deriva_ml.config.validation import (
 )
 
 __all__ = [
+    "BootstrapReport",
+    "BootstrapSkipped",
+    "BootstrapSuggestion",
     "ConfigEntry",
     "ConfigEntryResult",
     "ConfigEntryReason",
+    "ConfigKind",
     "ConfigValidationReport",
     "parse_config_file",
 ]

--- a/src/deriva_ml/config/__init__.py
+++ b/src/deriva_ml/config/__init__.py
@@ -1,0 +1,70 @@
+"""Config-file validation for DerivaML hydra-zen config files.
+
+This module exposes the read-side helpers that
+``deriva-ml-skills/write-hydra-config`` documents: parse a
+``src/configs/*.py`` file via AST, find every
+``DatasetSpecConfig``/``AssetSpecConfig``/``Workflow``/``DerivaMLConfig``
+constructor call, and validate each against the catalog. The validator
+never executes the file -- AST-only -- so it's safe against arbitrary
+user code in the configs/ dir.
+
+The write-side helpers (the "after I created this dataset, want me to
+add it to datasets.py?" offer) live in the dataset-lifecycle,
+work-with-assets, and execution-lifecycle skills as per-context skill
+prose. See
+``deriva-ml-skills/docs/superpowers/plans/2026-05-22-config-validator-bootstrap-design.md``
+for the full design rationale.
+
+Public surface:
+
+- :class:`ConfigEntry` -- one ``*Config(...)`` constructor call found in
+  a file, with location info.
+- :class:`ConfigEntryResult` -- per-entry validation result, used in
+  the report.
+- :class:`ConfigValidationReport` -- top-level report from
+  :meth:`DerivaML.validate_config_file` /
+  :meth:`DerivaML.validate_config_directory`.
+- :func:`parse_config_file` -- AST-only parser; returns the
+  :class:`ConfigEntry` list for one file. Useful for tests and for
+  callers that want to inspect what would be validated without making
+  catalog calls.
+
+The :class:`DerivaML` validator methods live on
+:class:`~deriva_ml.core.mixins.dataset.DatasetMixin` alongside the
+existing :meth:`DerivaML.validate_dataset_specs` and
+:meth:`DerivaML.validate_execution_configuration`.
+
+Example:
+    Parse a config file without touching the catalog::
+
+        >>> from deriva_ml.config import parse_config_file
+        >>> entries, parse_errors = parse_config_file("src/configs/datasets.py")  # doctest: +SKIP
+        >>> for e in entries:  # doctest: +SKIP
+        ...     print(e.line, e.entry_kind, e.rid, e.version)
+
+    Validate against a catalog::
+
+        >>> report = ml.validate_config_file("src/configs/datasets.py")  # doctest: +SKIP
+        >>> if not report.all_valid:  # doctest: +SKIP
+        ...     for r in report.results:
+        ...         if not r.valid:
+        ...             print(r.file, r.line, r.rid, r.reasons)
+"""
+
+from __future__ import annotations
+
+from deriva_ml.config.ast_walker import parse_config_file
+from deriva_ml.config.validation import (
+    ConfigEntry,
+    ConfigEntryReason,
+    ConfigEntryResult,
+    ConfigValidationReport,
+)
+
+__all__ = [
+    "ConfigEntry",
+    "ConfigEntryResult",
+    "ConfigEntryReason",
+    "ConfigValidationReport",
+    "parse_config_file",
+]

--- a/src/deriva_ml/config/ast_walker.py
+++ b/src/deriva_ml/config/ast_walker.py
@@ -1,0 +1,379 @@
+"""AST-based parser for DerivaML hydra-zen config files.
+
+Parses ``src/configs/*.py`` files via Python's ``ast`` module and
+finds every ``*Config(...)``/``Workflow(...)`` constructor call. The
+parser does NOT execute the file, so it's safe against arbitrary
+user code in the configs/ dir.
+
+The four recognized constructor names:
+
+- ``DatasetSpecConfig`` -- dataset entries; ``rid=`` and ``version=`` kwargs
+- ``AssetSpecConfig`` -- asset entries; ``rid=`` (and optional ``cache=``)
+- ``Workflow`` -- workflow entries; ``rid=`` kwarg
+- ``DerivaMLConfig`` -- connection entries; ``hostname=`` and ``catalog_id=``
+
+Edge cases the walker handles:
+
+- ``with_description(DatasetSpecConfig(...), "...")`` -- the wrapper
+  is unwrapped; we recurse into its arguments.
+- ``builds(DatasetSpec, rid=..., version=...)`` -- hydra-zen's lazy
+  partial. The first positional arg names the spec class; we treat
+  the call shape like the named-constructor.
+- Module-level constant resolution: ``TRAINING_RID = "2-B4C8"`` at
+  module scope makes ``rid=TRAINING_RID`` resolvable. Only simple
+  name = literal-string assignments at module scope are resolved;
+  anything more complex emits a ``ConfigEntry`` with ``rid=None``
+  (which the validator then surfaces as ``rid_unresolvable``).
+- Comments are naturally skipped by AST parsing.
+
+Matching is by call-name only, not by import. Identical names from
+unrelated modules are picked up; callers diagnose false matches via
+the file + line + col fields on :class:`ConfigEntry`.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+import tokenize
+
+from deriva_ml.config.validation import (
+    ConfigEntry,
+    ConfigEntryKind,
+    ConfigFileParseError,
+)
+
+# Names we recognize as constructor calls worth validating. ``builds()``
+# is recognized only as a *wrapper* -- the inner spec class name (the
+# first positional arg) is what determines ``entry_kind``.
+_KNOWN_KINDS: set[str] = {
+    "DatasetSpecConfig",
+    "AssetSpecConfig",
+    "Workflow",
+    "DerivaMLConfig",
+}
+
+# Wrapper calls we unwrap to find the inner spec constructor.
+# - ``with_description(spec, description)`` -- first positional arg
+# - ``builds(<spec_class>, **kwargs)`` -- treat ``<spec_class>`` as the kind
+_UNWRAP_WRAPPERS: set[str] = {"with_description"}
+
+
+def parse_config_file(
+    path: str | os.PathLike[str],
+) -> tuple[list[ConfigEntry], ConfigFileParseError | None]:
+    """Parse one config file and return its entries.
+
+    Args:
+        path: Path to the file. Read with ``tokenize.open()`` so the
+            file's declared encoding is respected.
+
+    Returns:
+        A pair ``(entries, parse_error)``. ``entries`` is the list of
+        ``ConfigEntry`` constructor calls found (empty if the file
+        had none). ``parse_error`` is a :class:`ConfigFileParseError`
+        if the file couldn't be parsed, else ``None``. The two are
+        mutually exclusive: a parse error means ``entries`` is empty.
+
+    Does not raise on syntax errors -- the parse error is returned
+    structurally so callers walking many files can record it without
+    aborting the walk.
+    """
+    file_str = os.fspath(path)
+    try:
+        with tokenize.open(file_str) as handle:
+            source = handle.read()
+    except (OSError, SyntaxError) as exc:
+        # tokenize.open can raise SyntaxError on encoding declarations
+        # it doesn't like; record but don't propagate.
+        return [], ConfigFileParseError(
+            file=file_str,
+            line=getattr(exc, "lineno", None),
+            message=str(exc),
+        )
+
+    try:
+        tree = ast.parse(source, filename=file_str)
+    except SyntaxError as exc:
+        return [], ConfigFileParseError(
+            file=file_str,
+            line=exc.lineno,
+            message=exc.msg or "syntax error",
+        )
+
+    source_lines = source.splitlines()
+    name_map = _collect_module_constants(tree)
+
+    visitor = _CallVisitor(
+        file=file_str,
+        source_lines=source_lines,
+        name_map=name_map,
+    )
+    visitor.visit(tree)
+    return visitor.entries, None
+
+
+# ---------------------------------------------------------------------------
+# Module-level constant resolution
+# ---------------------------------------------------------------------------
+
+
+def _collect_module_constants(tree: ast.AST) -> dict[str, str]:
+    """Build a name -> string-constant map for module-scope assignments.
+
+    Only resolves simple ``NAME = "literal"`` shapes. Anything more
+    complex (tuple unpacking, function call, expression) is ignored
+    on purpose -- the validator surfaces unresolved references as
+    ``rid_unresolvable`` rather than guessing.
+    """
+    name_map: dict[str, str] = {}
+    if not isinstance(tree, ast.Module):
+        return name_map
+
+    for stmt in tree.body:
+        if isinstance(stmt, ast.Assign):
+            value = stmt.value
+            if not isinstance(value, ast.Constant) or not isinstance(value.value, str):
+                continue
+            for target in stmt.targets:
+                if isinstance(target, ast.Name):
+                    name_map[target.id] = value.value
+        elif isinstance(stmt, ast.AnnAssign):
+            # `FOO: str = "..."` shape
+            value = stmt.value
+            if not isinstance(value, ast.Constant) or not isinstance(value.value, str):
+                continue
+            target = stmt.target
+            if isinstance(target, ast.Name):
+                name_map[target.id] = value.value
+    return name_map
+
+
+# ---------------------------------------------------------------------------
+# Visitor
+# ---------------------------------------------------------------------------
+
+
+class _CallVisitor(ast.NodeVisitor):
+    """Walks the AST collecting :class:`ConfigEntry` objects.
+
+    Handles wrapper unwrapping (`with_description`, `builds`,
+    hydra-zen `store(<spec_class>, ...)`) and constant resolution
+    (`rid=SOME_NAME` -> looks up SOME_NAME in ``name_map``).
+    """
+
+    def __init__(
+        self,
+        *,
+        file: str,
+        source_lines: list[str],
+        name_map: dict[str, str],
+    ) -> None:
+        self.file = file
+        self.source_lines = source_lines
+        self.name_map = name_map
+        self.entries: list[ConfigEntry] = []
+        # Track which Call nodes have already been classified through
+        # a wrapper so we don't double-count when generic_visit then
+        # descends into them.
+        self._claimed: set[int] = set()
+
+    def visit_Call(self, node: ast.Call) -> None:
+        if id(node) in self._claimed:
+            # Already counted via a wrapper; just recurse for nested calls.
+            self.generic_visit(node)
+            return
+
+        kind, target_call = self._classify_call(node)
+        if kind is not None and target_call is not None:
+            entry = self._build_entry(kind, target_call)
+            if entry is not None:
+                self.entries.append(entry)
+                # Mark the inner call as claimed so descending into it
+                # via generic_visit doesn't double-emit.
+                if target_call is not node:
+                    self._claimed.add(id(target_call))
+        # Recurse so nested calls are still found
+        # (e.g. assets_store(spec=AssetSpecConfig(...)) -- both the outer
+        # assets_store call and the inner AssetSpecConfig become candidates
+        # for visit_Call; the inner one is what classifies as a known kind).
+        self.generic_visit(node)
+
+    # -- classification --------------------------------------------------
+
+    def _classify_call(
+        self,
+        node: ast.Call,
+    ) -> tuple[ConfigEntryKind | None, ast.Call | None]:
+        """Determine if this call is a known constructor (possibly via wrapper).
+
+        Returns ``(kind, call_node)``. ``kind`` is the spec-class name;
+        ``call_node`` is the AST node whose kwargs hold the spec fields
+        (which may be ``node`` itself or an inner call when wrapped).
+        Returns ``(None, None)`` if this call is neither a known
+        constructor nor a recognized wrapper around one.
+        """
+        name = _call_name(node)
+        if name in _KNOWN_KINDS:
+            return name, node  # type: ignore[return-value]
+
+        if name == "builds":
+            # builds(<spec_class>, **kwargs) -- treat as the spec class.
+            inner_name = _builds_target_name(node)
+            if inner_name in _KNOWN_KINDS:
+                # builds()'s kwargs ARE the spec's kwargs (modulo the
+                # first positional which names the class). So the call
+                # node to read kwargs from is `node` itself.
+                return inner_name, node  # type: ignore[return-value]
+            # builds() target_name might also be a DatasetSpec or AssetSpec
+            # (without the Config suffix) -- normalize.
+            if inner_name == "DatasetSpec":
+                return "DatasetSpecConfig", node
+            if inner_name == "AssetSpec":
+                return "AssetSpecConfig", node
+            return None, None
+
+        if name in _UNWRAP_WRAPPERS:
+            # with_description(<inner_call>, "...") -- recurse on the
+            # first positional arg if it's itself a Call.
+            if node.args and isinstance(node.args[0], ast.Call):
+                return self._classify_call(node.args[0])
+            return None, None
+
+        # Hydra-zen store-call shape: ``deriva_store(DerivaMLConfig,
+        # name="...", hostname="...", ...)``. The first positional arg
+        # names the spec class; the call's kwargs are the spec fields.
+        # This is the canonical shape for ``configs/deriva.py`` and the
+        # builds-style entries in datasets.py / assets.py / workflow.py.
+        if node.args and isinstance(node.args[0], (ast.Name, ast.Attribute)):
+            first = node.args[0]
+            first_name = first.id if isinstance(first, ast.Name) else first.attr
+            if first_name in _KNOWN_KINDS:
+                return first_name, node  # type: ignore[return-value]
+            if first_name == "DatasetSpec":
+                return "DatasetSpecConfig", node
+            if first_name == "AssetSpec":
+                return "AssetSpecConfig", node
+
+        return None, None
+
+    # -- entry construction ---------------------------------------------
+
+    def _build_entry(
+        self,
+        kind: ConfigEntryKind,
+        call: ast.Call,
+    ) -> ConfigEntry | None:
+        """Pull the kwargs off a known constructor call into a :class:`ConfigEntry`."""
+        kwargs = _kwarg_map(call)
+        rid = self._resolve_str_value(kwargs.get("rid"))
+        version = self._resolve_str_value(kwargs.get("version"))
+        hostname = self._resolve_str_value(kwargs.get("hostname"))
+
+        catalog_id_raw = kwargs.get("catalog_id")
+        catalog_id: str | None = None
+        if isinstance(catalog_id_raw, ast.Constant):
+            if isinstance(catalog_id_raw.value, str):
+                catalog_id = catalog_id_raw.value
+            elif isinstance(catalog_id_raw.value, int):
+                catalog_id = str(catalog_id_raw.value)
+
+        cache_raw = kwargs.get("cache")
+        cache: bool | None = None
+        if isinstance(cache_raw, ast.Constant) and isinstance(cache_raw.value, bool):
+            cache = cache_raw.value
+
+        snippet = self._snippet_for(call)
+
+        return ConfigEntry(
+            file=self.file,
+            line=call.lineno,
+            col=call.col_offset,
+            entry_kind=kind,
+            rid=rid,
+            version=version,
+            hostname=hostname,
+            catalog_id=catalog_id,
+            cache=cache,
+            snippet=snippet,
+        )
+
+    def _resolve_str_value(self, node: ast.expr | None) -> str | None:
+        """Resolve a kwarg value to a string. Returns None if not resolvable.
+
+        Handles:
+        - string literal: ``"2-B4C8"``
+        - module-level constant: ``TRAINING_RID``
+        Anything else (function call, attribute access, expression) is
+        treated as unresolvable.
+        """
+        if node is None:
+            return None
+        if isinstance(node, ast.Constant):
+            if isinstance(node.value, str):
+                return node.value
+            return None
+        if isinstance(node, ast.Name):
+            return self.name_map.get(node.id)
+        return None
+
+    def _snippet_for(self, node: ast.Call) -> str | None:
+        """Return a short excerpt of the source around the call."""
+        if not self.source_lines:
+            return None
+        idx = node.lineno - 1
+        if idx < 0 or idx >= len(self.source_lines):
+            return None
+        return self.source_lines[idx].strip()
+
+
+# ---------------------------------------------------------------------------
+# Small AST utilities
+# ---------------------------------------------------------------------------
+
+
+def _call_name(node: ast.Call) -> str | None:
+    """Return the name of the called function, or None if not a simple name.
+
+    Handles:
+    - ``Foo(...)`` -> ``"Foo"``
+    - ``mod.Foo(...)`` -> ``"Foo"`` (the attribute name)
+    """
+    func = node.func
+    if isinstance(func, ast.Name):
+        return func.id
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    return None
+
+
+def _builds_target_name(node: ast.Call) -> str | None:
+    """For ``builds(<target>, ...)``, return ``<target>``'s name.
+
+    ``builds`` accepts the target as its first positional arg, which can
+    be either a ``Name`` (the class is in scope) or an ``Attribute``
+    (e.g. ``mod.Spec``).
+    """
+    if not node.args:
+        return None
+    arg = node.args[0]
+    if isinstance(arg, ast.Name):
+        return arg.id
+    if isinstance(arg, ast.Attribute):
+        return arg.attr
+    return None
+
+
+def _kwarg_map(node: ast.Call) -> dict[str, ast.expr]:
+    """Return a {arg-name -> value-expr} map for a call's kwargs.
+
+    For ``builds(SomeSpec, rid="X", version="Y")``, the map is
+    ``{"rid": <Constant 'X'>, "version": <Constant 'Y'>}``.
+    Keyword-only args (no name -- ``**kwargs``) are skipped.
+    """
+    out: dict[str, ast.expr] = {}
+    for kw in node.keywords:
+        if kw.arg is None:
+            continue
+        out[kw.arg] = kw.value
+    return out

--- a/src/deriva_ml/config/bootstrap.py
+++ b/src/deriva_ml/config/bootstrap.py
@@ -1,0 +1,188 @@
+"""Bootstrap suggested config entries by reading the catalog.
+
+Pure-read companion to :meth:`DerivaML.validate_config_file`. Returns
+structured suggestions; does NOT write files. The skill prose
+(``/deriva-ml:dataset-lifecycle``, ``/deriva-ml:work-with-assets``,
+``/deriva-ml:write-hydra-config``) owns the format-and-write side.
+
+Public surface:
+
+- :class:`BootstrapSuggestion` -- one suggested config entry, with
+  enough info for the caller to format a ``DatasetSpecConfig(...)``
+  / ``AssetSpecConfig(...)`` / etc. line.
+- :class:`BootstrapReport` -- top-level report grouping suggestions
+  by kind, with per-entity rationale strings.
+
+The :class:`DerivaML` driver method lives on
+:class:`~deriva_ml.core.mixins.dataset.DatasetMixin` alongside the
+existing validators.
+
+Example:
+    Get suggestions for the standard four config groups::
+
+        >>> report = ml.bootstrap_config()  # doctest: +SKIP
+        >>> for s in report.suggestions:  # doctest: +SKIP
+        ...     print(f"# {s.rationale}")
+        ...     print(f"# config name: {s.config_name}")
+        ...     print(s.spec_string)
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+ConfigKind = Literal["deriva_ml", "datasets", "assets", "workflow"]
+
+# Default Dataset_Type terms the bootstrap suggests entries for.
+# These are the partition-role tags that experiments typically pin.
+# ``Split`` parents and ``Complete`` are included because users do
+# sometimes consume them directly (e.g. for ablation studies).
+DEFAULT_DATASET_TYPE_FILTER: tuple[str, ...] = (
+    "Training",
+    "Testing",
+    "Validation",
+    "Complete",
+    "Labeled",
+)
+
+
+class BootstrapSuggestion(BaseModel):
+    """One suggested config entry.
+
+    Attributes:
+        kind: Which config group this entry belongs to. The skill
+            consumer routes it to the matching file
+            (``deriva_ml`` -> ``configs/deriva.py``, ``datasets`` ->
+            ``configs/datasets.py``, etc.).
+        config_name: A sensible ``name=`` value to use in the
+            ``<group>_store(name=..., ...)`` registration. Derived
+            from the entity's description / friendly name; the caller
+            may rename it.
+        rid: The catalog RID this entry pins.
+        version: For dataset entries, the released version to pin.
+            ``None`` for kinds that don't take a version (assets,
+            workflows, deriva_ml).
+        spec_string: A ready-to-paste Python expression -- e.g.
+            ``DatasetSpecConfig(rid="2-B4C8", version="0.4.0")``.
+            Constructed by the bootstrap so the caller doesn't have
+            to remember the canonical syntax for each kind.
+        description: Human-readable description from the catalog
+            (dataset description, asset filename, workflow name).
+            Useful for the ``with_description(...)`` wrap.
+        rationale: Why this entry was suggested -- e.g. "Training
+            dataset type; latest released version 0.4.0". The skill
+            shows this to the user when offering the suggestion.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    kind: ConfigKind
+    config_name: str
+    rid: str
+    version: str | None = None
+    spec_string: str
+    description: str | None = None
+    rationale: str
+
+
+class BootstrapSkipped(BaseModel):
+    """An entity the bootstrap considered but didn't suggest.
+
+    Attributes:
+        kind: The config group the entity would have belonged to.
+        rid: The entity's RID.
+        reason: Human-readable reason the entity was skipped --
+            e.g. "no released version", "dataset_type=Split (parent
+            container, navigate to children instead)".
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    kind: ConfigKind
+    rid: str
+    reason: str
+
+
+class BootstrapReport(BaseModel):
+    """Result returned by :meth:`DerivaML.bootstrap_config`.
+
+    Attributes:
+        catalog: ``{"hostname": ..., "catalog_id": ...}`` -- the
+            catalog the suggestions came from. Echoed so the caller
+            knows what to put in ``deriva.py``.
+        suggestions: The proposed entries, grouped (by being typed
+            with ``kind``) but not segregated -- the caller filters
+            by ``kind`` to route into files.
+        skipped: Entities considered but not suggested, with reason.
+            Useful for explaining the empty case ("found 12 datasets,
+            none had a released version") without forcing the caller
+            to re-query the catalog.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    catalog: dict[str, str] = Field(default_factory=dict)
+    suggestions: list[BootstrapSuggestion] = Field(default_factory=list)
+    skipped: list[BootstrapSkipped] = Field(default_factory=list)
+
+
+def _sanitize_config_name(text: str | None, fallback: str) -> str:
+    """Turn an entity description into a usable Python identifier.
+
+    ``"Small CIFAR-10 labeled split: stratified 400/100"`` ->
+    ``"small_cifar_10_labeled_split"``.
+
+    Args:
+        text: The free-form description to sanitize.
+        fallback: A safe default (typically the RID) when text is
+            empty or yields no usable characters.
+
+    Returns:
+        A lowercase identifier-safe string. Never empty.
+    """
+    if not text:
+        return fallback.replace("-", "_").lower()
+    # Strip non-alphanumeric, collapse runs of underscores, lowercase.
+    cleaned_chars = []
+    last_was_underscore = False
+    for ch in text:
+        if ch.isalnum():
+            cleaned_chars.append(ch.lower())
+            last_was_underscore = False
+        elif not last_was_underscore:
+            cleaned_chars.append("_")
+            last_was_underscore = True
+    name = "".join(cleaned_chars).strip("_")
+    # Truncate very long descriptions; 40 chars keeps things readable.
+    if len(name) > 40:
+        name = name[:40].rstrip("_")
+    if not name or not name[0].isalpha():
+        name = "ds_" + name if name else fallback.replace("-", "_").lower()
+    return name
+
+
+def _format_dataset_spec(rid: str, version: str) -> str:
+    """Format a ``DatasetSpecConfig(rid=..., version=...)`` line."""
+    return f'DatasetSpecConfig(rid="{rid}", version="{version}")'
+
+
+def _format_asset_spec(rid: str, *, cache: bool = False) -> str:
+    """Format an ``AssetSpecConfig(rid=..., cache=...)`` line."""
+    if cache:
+        return f'AssetSpecConfig(rid="{rid}", cache=True)'
+    return f'AssetSpecConfig(rid="{rid}")'
+
+
+def _format_workflow_spec(rid: str) -> str:
+    """Format a ``Workflow(rid=...)`` line."""
+    return f'Workflow(rid="{rid}")'
+
+
+def _format_deriva_ml_spec(hostname: str, catalog_id: str) -> str:
+    """Format the ``deriva_store(DerivaMLConfig, ...)`` call body."""
+    return (
+        f'deriva_store(DerivaMLConfig, name="default_deriva", '
+        f'hostname="{hostname}", catalog_id="{catalog_id}")'
+    )

--- a/src/deriva_ml/config/validation.py
+++ b/src/deriva_ml/config/validation.py
@@ -1,0 +1,201 @@
+"""Pydantic models for the config-file validation API.
+
+These models are returned by :meth:`DerivaML.validate_config_file` /
+:meth:`DerivaML.validate_config_directory`. The models live in their
+own module so they can cross a boundary: the deriva-ml-mcp tool
+wrapper serializes them with ``.model_dump()`` and downstream agents
+consume the JSON.
+
+The validation methods themselves are metadata-only catalog queries
+(no bag download, no source execution). Parsing is AST-only -- the
+file is never executed. This makes the surface safe to point at
+arbitrary user code in ``src/configs/``.
+
+Example:
+    Inspect a validation report::
+
+        >>> report = ml.validate_config_file("src/configs/datasets.py")  # doctest: +SKIP
+        >>> for r in report.results:  # doctest: +SKIP
+        ...     if not r.valid:
+        ...         print(f"{r.file}:{r.line} {r.entry_kind}({r.rid!r}) -> {r.reasons}")
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+# ---------------------------------------------------------------------------
+# Vocabularies
+# ---------------------------------------------------------------------------
+
+ConfigEntryKind = Literal[
+    "DatasetSpecConfig",
+    "AssetSpecConfig",
+    "Workflow",
+    "DerivaMLConfig",
+]
+
+ConfigEntryReason = Literal[
+    # RID + entity-kind problems (one of these means the entry doesn't
+    # resolve in the catalog at all).
+    "rid_not_found",
+    "not_a_dataset",
+    "not_an_asset",
+    "not_a_workflow",
+    # Version problems (datasets only).
+    "version_missing",
+    "version_not_found",
+    # AST extraction problems -- the parser found the constructor but
+    # couldn't pull the RID. Doesn't mean the entry is bad; means the
+    # validator can't reason about it (it skips the catalog call).
+    "rid_unresolvable",
+    # Connection problems (DerivaMLConfig entries only).
+    "catalog_unreachable",
+    "catalog_hostname_mismatch",
+    "catalog_id_mismatch",
+]
+
+
+# ---------------------------------------------------------------------------
+# Parsed entry -- AST-only, no catalog hit yet
+# ---------------------------------------------------------------------------
+
+
+class ConfigEntry(BaseModel):
+    """One ``*Config(...)`` (or ``Workflow(...)``) constructor call found in a file.
+
+    Produced by :func:`parse_config_file`. Used as input to the
+    catalog-side validators and as one half of :class:`ConfigEntryResult`.
+
+    Attributes:
+        file: Path to the config file the entry was found in.
+            Relative paths are accepted; the validator does not
+            resolve them.
+        line: 1-based line number of the constructor call.
+        col: 0-based column number of the constructor call.
+        entry_kind: The constructor name. One of ``DatasetSpecConfig``,
+            ``AssetSpecConfig``, ``Workflow``, ``DerivaMLConfig``.
+            Matching is by name (not by import); identical names from
+            unrelated modules will also be picked up. This is
+            intentional -- callers can use the line + column to
+            diagnose false matches.
+        rid: The ``rid=`` kwarg's value as a string. ``None`` when the
+            kwarg is missing, when it's not a string literal (e.g.
+            assigned from an unresolved local variable), or when the
+            entry uses positional args this parser does not handle.
+            ``None`` triggers ``rid_unresolvable`` at validation time
+            rather than an error -- bad RIDs in configs are bugs the
+            user wants to see surfaced, not exceptions during the
+            walk.
+        version: The ``version=`` kwarg's value as a string. ``None``
+            for entries that don't take a version (assets, workflows,
+            connection configs) or for entries where the kwarg is
+            missing.
+        hostname: The ``hostname=`` kwarg's value (DerivaMLConfig only).
+            ``None`` for other entry kinds.
+        catalog_id: The ``catalog_id=`` kwarg's value (DerivaMLConfig
+            only). ``None`` for other entry kinds.
+        cache: The ``cache=`` kwarg's value (AssetSpecConfig only).
+        snippet: A short text excerpt around the call site, included
+            for human-readable error messages. Not parsed.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    file: str
+    line: int
+    col: int
+    entry_kind: ConfigEntryKind
+    rid: str | None = None
+    version: str | None = None
+    hostname: str | None = None
+    catalog_id: str | None = None
+    cache: bool | None = None
+    snippet: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Validation result models
+# ---------------------------------------------------------------------------
+
+
+class ConfigEntryResult(BaseModel):
+    """Result of validating one :class:`ConfigEntry`.
+
+    Attributes:
+        entry: The parsed entry that was validated. Echoed back so
+            callers can match results to inputs.
+        valid: True when ``reasons`` is empty.
+        reasons: List of failure reasons. Empty when ``valid`` is True.
+        actual_table: When ``not_a_*`` is set, the name of the table
+            the RID actually points at. Useful for diagnosing copy-
+            paste between configs (e.g. an asset RID pasted into
+            datasets.py).
+        available_versions: When ``version_not_found`` is set, up to
+            20 known versions for the dataset (newest first). None
+            otherwise.
+        resolved_name: Friendly name from the catalog -- dataset
+            description, asset filename, or workflow name. Only set
+            when ``valid``.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    entry: ConfigEntry
+    valid: bool
+    reasons: list[ConfigEntryReason] = Field(default_factory=list)
+    actual_table: str | None = None
+    available_versions: list[str] | None = None
+    resolved_name: str | None = None
+
+
+class ConfigFileParseError(BaseModel):
+    """A file the validator couldn't parse.
+
+    Attributes:
+        file: Path that failed to parse.
+        line: 1-based line of the syntax error (best-effort -- the
+            ``SyntaxError`` location is used directly).
+        message: ``SyntaxError`` message verbatim.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    file: str
+    line: int | None
+    message: str
+
+
+# ---------------------------------------------------------------------------
+# Top-level report
+# ---------------------------------------------------------------------------
+
+
+class ConfigValidationReport(BaseModel):
+    """Result returned by :meth:`DerivaML.validate_config_file` /
+    :meth:`DerivaML.validate_config_directory`.
+
+    Attributes:
+        file_count: Number of files processed (parsed successfully).
+        entry_count: Total number of constructor entries found across
+            all files. Includes entries that were unresolvable at
+            parse time.
+        all_valid: True iff every entry in ``results`` is valid AND
+            ``parse_errors`` is empty. An empty ``results`` list with
+            no parse errors is reported as ``all_valid=True``.
+        results: Per-entry results. Ordered first by file (input
+            order), then by line within each file.
+        parse_errors: Files that failed to parse. A single broken file
+            does not abort the walk -- the validator keeps going so
+            issues in the other files still surface.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    file_count: int = 0
+    entry_count: int = 0
+    all_valid: bool = True
+    results: list[ConfigEntryResult] = Field(default_factory=list)
+    parse_errors: list[ConfigFileParseError] = Field(default_factory=list)

--- a/src/deriva_ml/core/mixins/dataset.py
+++ b/src/deriva_ml/core/mixins/dataset.py
@@ -19,6 +19,17 @@ from pydantic import validate_call
 
 from deriva_ml.asset.aux_classes import AssetSpec
 from deriva_ml.config.ast_walker import parse_config_file
+from deriva_ml.config.bootstrap import (
+    DEFAULT_DATASET_TYPE_FILTER,
+    BootstrapReport,
+    BootstrapSkipped,
+    BootstrapSuggestion,
+    _format_asset_spec,
+    _format_dataset_spec,
+    _format_deriva_ml_spec,
+    _format_workflow_spec,
+    _sanitize_config_name,
+)
 from deriva_ml.config.validation import (
     ConfigEntry,
     ConfigEntryResult,
@@ -859,6 +870,226 @@ class DatasetMixin:
             all_valid=(not parse_errors) and all(r.valid for r in results),
             results=results,
             parse_errors=parse_errors,
+        )
+
+    def bootstrap_config(
+        self,
+        *,
+        kinds: list[str] | None = None,
+        dataset_type_filter: list[str] | None = None,
+    ) -> BootstrapReport:
+        """Suggest config entries by reading the catalog.
+
+        Walks the catalog and produces structured :class:`BootstrapSuggestion`
+        objects -- one per dataset / asset / workflow row a fresh
+        project's ``src/configs/`` might want to pin. Does NOT write
+        files. The skill prose layer formats the suggestions into the
+        right config file (per-skill ownership of "which file" --
+        ``dataset-lifecycle`` for datasets, ``work-with-assets`` for
+        assets, ``write-hydra-config`` for the umbrella).
+
+        Three use cases:
+
+        - **New project, empty configs/.** Run unfiltered to see every
+          candidate entry; pick the subset that's relevant.
+        - **Catalog clone or environment switch.** Bootstrap to repoint
+          configs at the new catalog, then validate to catch any
+          stragglers.
+        - **Incremental update.** Pass ``kinds=["datasets"]`` to see
+          fresh dataset suggestions after a release without
+          enumerating assets / workflows.
+
+        Args:
+            kinds: Which config groups to suggest entries for. Default
+                is all four (``deriva_ml``, ``datasets``, ``assets``,
+                ``workflow``). Skipping ``experiments``,
+                ``multiruns``, ``model_config`` is intentional --
+                those are project code, not catalog state.
+            dataset_type_filter: When suggesting datasets, restrict
+                to these ``Dataset_Type`` terms. Default is
+                ``["Training", "Testing", "Validation", "Complete",
+                "Labeled"]`` -- the partition-role + annotation tags
+                experiments typically pin. Pass ``[]`` (empty list)
+                to include every type. Pass ``None`` (default) to
+                use the default filter.
+
+        Returns:
+            A :class:`BootstrapReport` with suggestions grouped (by
+            ``kind`` field), and a ``skipped`` list explaining why
+            specific entities weren't suggested.
+
+        Example:
+            One-shot bootstrap::
+
+                >>> report = ml.bootstrap_config()  # doctest: +SKIP
+                >>> for s in report.suggestions:  # doctest: +SKIP
+                ...     print(s.kind, s.config_name, s.spec_string)
+        """
+        requested_kinds = set(kinds) if kinds is not None else {
+            "deriva_ml",
+            "datasets",
+            "assets",
+            "workflow",
+        }
+        if dataset_type_filter is None:
+            type_filter = set(DEFAULT_DATASET_TYPE_FILTER)
+        else:
+            type_filter = set(dataset_type_filter)  # may be empty (= no filter)
+
+        suggestions: list[BootstrapSuggestion] = []
+        skipped: list[BootstrapSkipped] = []
+
+        if "deriva_ml" in requested_kinds:
+            suggestions.append(
+                BootstrapSuggestion(
+                    kind="deriva_ml",
+                    config_name="default_deriva",
+                    rid="",  # connection groups don't pin a RID
+                    spec_string=_format_deriva_ml_spec(
+                        str(getattr(self, "host_name", "")),
+                        str(getattr(self, "catalog_id", "")),
+                    ),
+                    description=(
+                        f"Connection to {getattr(self, 'host_name', '?')} "
+                        f"catalog {getattr(self, 'catalog_id', '?')}"
+                    ),
+                    rationale="Connection group; pin this DerivaML instance.",
+                )
+            )
+
+        if "datasets" in requested_kinds:
+            datasets_iter = self.find_datasets()  # type: ignore[attr-defined]
+            for ds in datasets_iter:
+                ds_rid = ds.dataset_rid
+                ds_types = list(ds.dataset_types or [])
+                # Apply type filter if non-empty.
+                if type_filter and not (set(ds_types) & type_filter):
+                    skipped.append(
+                        BootstrapSkipped(
+                            kind="datasets",
+                            rid=ds_rid,
+                            reason=(
+                                f"dataset_types={ds_types} -- not in filter "
+                                f"{sorted(type_filter)}"
+                            ),
+                        )
+                    )
+                    continue
+                # Need a released version to pin -- dev labels would
+                # break reproducibility on consumers.
+                current = ds.current_version  # type: ignore[attr-defined]
+                if current is None:
+                    skipped.append(
+                        BootstrapSkipped(
+                            kind="datasets",
+                            rid=ds_rid,
+                            reason="no current version",
+                        )
+                    )
+                    continue
+                version_str = str(current)
+                if ".dev" in version_str or ".post" in version_str:
+                    skipped.append(
+                        BootstrapSkipped(
+                            kind="datasets",
+                            rid=ds_rid,
+                            reason=(
+                                f"current_version={version_str!r} is a dev label; "
+                                "call deriva_ml_release(...) to mint a released version"
+                            ),
+                        )
+                    )
+                    continue
+                desc = getattr(ds, "description", "") or ""
+                config_name = _sanitize_config_name(desc, fallback=ds_rid)
+                primary_type = (
+                    next(iter(set(ds_types) & type_filter), None)
+                    if type_filter
+                    else (ds_types[0] if ds_types else "Dataset")
+                )
+                rationale = (
+                    f"Dataset type {primary_type or '?'}; latest released "
+                    f"version {version_str}."
+                )
+                suggestions.append(
+                    BootstrapSuggestion(
+                        kind="datasets",
+                        config_name=config_name,
+                        rid=ds_rid,
+                        version=version_str,
+                        spec_string=_format_dataset_spec(ds_rid, version_str),
+                        description=desc or None,
+                        rationale=rationale,
+                    )
+                )
+
+        if "assets" in requested_kinds:
+            for table in self.list_asset_tables():  # type: ignore[attr-defined]
+                # Skip the built-in DerivaML asset tables -- they hold
+                # auto-generated metadata files (execution config dumps,
+                # uploaded notebooks). Users don't pin those by RID
+                # from experiment configs; they're navigated through
+                # the producing execution.
+                if table.name in {"Execution_Metadata", "Execution_Asset"}:
+                    skipped.append(
+                        BootstrapSkipped(
+                            kind="assets",
+                            rid=table.name,
+                            reason=(
+                                "built-in ml-schema asset table; navigate via "
+                                "Execution_RID rather than pinning by asset RID"
+                            ),
+                        )
+                    )
+                    continue
+                assets = self.list_assets(table)  # type: ignore[attr-defined]
+                for asset in assets:
+                    asset_rid = asset.asset_rid
+                    filename = getattr(asset, "filename", None) or ""
+                    config_name = _sanitize_config_name(filename, fallback=asset_rid)
+                    suggestions.append(
+                        BootstrapSuggestion(
+                            kind="assets",
+                            config_name=config_name,
+                            rid=asset_rid,
+                            spec_string=_format_asset_spec(asset_rid),
+                            description=filename or None,
+                            rationale=(
+                                f"Asset in {table.name}"
+                                + (f" ({filename})" if filename else "")
+                            ),
+                        )
+                    )
+
+        if "workflow" in requested_kinds:
+            workflows = self.find_workflows()  # type: ignore[attr-defined]
+            for wf in workflows:
+                wf_rid = getattr(wf, "rid", None)
+                if wf_rid is None:
+                    continue  # in-memory Workflow without a catalog row
+                wf_name = getattr(wf, "name", "") or ""
+                config_name = _sanitize_config_name(wf_name, fallback=wf_rid)
+                suggestions.append(
+                    BootstrapSuggestion(
+                        kind="workflow",
+                        config_name=config_name,
+                        rid=wf_rid,
+                        spec_string=_format_workflow_spec(wf_rid),
+                        description=wf_name or None,
+                        rationale=(
+                            "Existing Workflow row; pin by RID to reuse "
+                            "across executions."
+                        ),
+                    )
+                )
+
+        return BootstrapReport(
+            catalog={
+                "hostname": str(getattr(self, "host_name", "")),
+                "catalog_id": str(getattr(self, "catalog_id", "")),
+            },
+            suggestions=suggestions,
+            skipped=skipped,
         )
 
     # -- private helpers ------------------------------------------------

--- a/src/deriva_ml/core/mixins/dataset.py
+++ b/src/deriva_ml/core/mixins/dataset.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 # Deriva imports - use importlib to avoid shadowing by local 'deriva.py' files
 import importlib
+import os
 from typing import TYPE_CHECKING, Any, Callable, Iterable
 
 _ermrest_model = importlib.import_module("deriva.core.ermrest_model")
@@ -17,6 +18,13 @@ Table = _ermrest_model.Table
 from pydantic import validate_call
 
 from deriva_ml.asset.aux_classes import AssetSpec
+from deriva_ml.config.ast_walker import parse_config_file
+from deriva_ml.config.validation import (
+    ConfigEntry,
+    ConfigEntryResult,
+    ConfigFileParseError,
+    ConfigValidationReport,
+)
 from deriva_ml.core.definitions import RID
 from deriva_ml.core.exceptions import DerivaMLException, DerivaMLTableTypeError
 from deriva_ml.core.sort import SortSpec, resolve_sort
@@ -706,6 +714,153 @@ class DatasetMixin:
             cross_spec_issues=cross_spec_issues,
         )
 
+    def validate_config_file(
+        self,
+        path: str | os.PathLike[str],
+    ) -> ConfigValidationReport:
+        """Validate every spec constructor in one hydra-zen config file.
+
+        Parses the file via AST (no execution) and validates each
+        ``DatasetSpecConfig`` / ``AssetSpecConfig`` / ``Workflow`` /
+        ``DerivaMLConfig`` constructor call against the catalog.
+
+        Composes the existing :meth:`validate_dataset_specs`,
+        :meth:`_validate_asset_spec`, :meth:`_validate_workflow_rid`
+        primitives. For ``DerivaMLConfig`` entries the validator
+        compares the entry's ``hostname`` and ``catalog_id`` against
+        the catalog this :class:`DerivaML` instance is connected to;
+        a mismatch is reported but doesn't make catalog calls.
+
+        Args:
+            path: Path to the file. Accepts ``str``, ``Path``, or any
+                ``os.PathLike``.
+
+        Returns:
+            A :class:`ConfigValidationReport` with one
+            :class:`ConfigEntryResult` per constructor call found
+            (in source order). Files that fail to parse produce a
+            single :class:`ConfigFileParseError`; the entry list is
+            empty in that case.
+
+        Does not raise on syntax errors or missing files -- both are
+        reported structurally so a caller validating many files can
+        record them without aborting the walk.
+
+        Example:
+            Validate one file::
+
+                >>> report = ml.validate_config_file(  # doctest: +SKIP
+                ...     "src/configs/datasets.py"
+                ... )
+                >>> for r in report.results:  # doctest: +SKIP
+                ...     if not r.valid:
+                ...         print(r.entry.file, r.entry.line, r.reasons)
+        """
+        entries, parse_error = parse_config_file(path)
+        parse_errors: list[ConfigFileParseError] = (
+            [parse_error] if parse_error is not None else []
+        )
+        results = self._validate_config_entries(entries)
+        return ConfigValidationReport(
+            file_count=1 if parse_error is None else 0,
+            entry_count=len(entries),
+            all_valid=(not parse_errors) and all(r.valid for r in results),
+            results=results,
+            parse_errors=parse_errors,
+        )
+
+    def validate_config_directory(
+        self,
+        configs_dir: str | os.PathLike[str],
+        *,
+        recursive: bool = True,
+    ) -> ConfigValidationReport:
+        """Validate every ``*.py`` config file under ``configs_dir``.
+
+        Walks the directory, parses each Python file, validates every
+        constructor call against the catalog, and aggregates the per-
+        file reports into one :class:`ConfigValidationReport`. A
+        single broken file does not abort the walk -- the error is
+        recorded in ``parse_errors`` and the validator continues with
+        the next file.
+
+        Args:
+            configs_dir: Path to the configs directory (typically
+                ``src/configs``). ``__init__.py`` files are included;
+                ``__pycache__`` and dot-prefixed directories are
+                skipped.
+            recursive: When ``True`` (default), recurse into
+                subdirectories. ``configs/dev/`` per-environment
+                overrides are picked up.
+
+        Returns:
+            A :class:`ConfigValidationReport` with all entries from
+            all files, ordered first by file path then by line.
+
+        Example:
+            Validate the whole tree::
+
+                >>> report = ml.validate_config_directory(  # doctest: +SKIP
+                ...     "src/configs"
+                ... )
+                >>> if not report.all_valid:  # doctest: +SKIP
+                ...     for r in report.results:
+                ...         if not r.valid:
+                ...             print(r.entry.file, r.entry.line, r.reasons)
+                ...     for pe in report.parse_errors:
+                ...         print("UNPARSEABLE:", pe.file, pe.message)
+        """
+        from pathlib import Path as _Path
+
+        root = _Path(os.fspath(configs_dir))
+        if not root.exists():
+            return ConfigValidationReport(
+                file_count=0,
+                entry_count=0,
+                all_valid=False,
+                results=[],
+                parse_errors=[
+                    ConfigFileParseError(
+                        file=str(root),
+                        line=None,
+                        message=f"directory not found: {root}",
+                    )
+                ],
+            )
+
+        py_files: list[_Path] = []
+        if root.is_file():
+            if root.suffix == ".py":
+                py_files = [root]
+        else:
+            walker = root.rglob("*.py") if recursive else root.glob("*.py")
+            for p in walker:
+                # Skip __pycache__ and any dot-prefixed dir.
+                if any(part == "__pycache__" or part.startswith(".") for part in p.parts):
+                    continue
+                py_files.append(p)
+        py_files.sort()
+
+        all_entries: list[ConfigEntry] = []
+        parse_errors: list[ConfigFileParseError] = []
+        file_count = 0
+        for f in py_files:
+            entries, parse_error = parse_config_file(f)
+            if parse_error is not None:
+                parse_errors.append(parse_error)
+                continue
+            file_count += 1
+            all_entries.extend(entries)
+
+        results = self._validate_config_entries(all_entries)
+        return ConfigValidationReport(
+            file_count=file_count,
+            entry_count=len(all_entries),
+            all_valid=(not parse_errors) and all(r.valid for r in results),
+            results=results,
+            parse_errors=parse_errors,
+        )
+
     # -- private helpers ------------------------------------------------
 
     @staticmethod
@@ -953,3 +1108,143 @@ class DatasetMixin:
                 )
 
         return issues
+
+    def _validate_config_entries(
+        self,
+        entries: list[ConfigEntry],
+    ) -> list[ConfigEntryResult]:
+        """Validate parsed config entries against the catalog.
+
+        Groups entries by kind and batches dataset validation through
+        :meth:`validate_dataset_specs` (which has per-RID caching);
+        loops the per-RID validators for assets and workflows;
+        compares ``DerivaMLConfig`` entries against this connection's
+        hostname/catalog_id.
+
+        Args:
+            entries: List of parsed entries from :func:`parse_config_file`.
+
+        Returns:
+            One :class:`ConfigEntryResult` per input entry, in the
+            same order.
+        """
+        # Bucket by kind so dataset validation can be batched.
+        dataset_entries: list[tuple[int, ConfigEntry]] = []
+        asset_entries: list[tuple[int, ConfigEntry]] = []
+        workflow_entries: list[tuple[int, ConfigEntry]] = []
+        deriva_entries: list[tuple[int, ConfigEntry]] = []
+        unresolvable_idx: set[int] = set()
+
+        for i, e in enumerate(entries):
+            if e.entry_kind == "DerivaMLConfig":
+                deriva_entries.append((i, e))
+                continue
+            if e.rid is None:
+                unresolvable_idx.add(i)
+                continue
+            if e.entry_kind == "DatasetSpecConfig":
+                dataset_entries.append((i, e))
+            elif e.entry_kind == "AssetSpecConfig":
+                asset_entries.append((i, e))
+            elif e.entry_kind == "Workflow":
+                workflow_entries.append((i, e))
+
+        results: list[ConfigEntryResult | None] = [None] * len(entries)
+
+        # Unresolvable -- AST couldn't pull a RID. Surface, don't guess.
+        for i in unresolvable_idx:
+            results[i] = ConfigEntryResult(
+                entry=entries[i],
+                valid=False,
+                reasons=["rid_unresolvable"],
+            )
+
+        # Datasets -- batch through validate_dataset_specs.
+        if dataset_entries:
+            specs_for_validate: list[DatasetSpec] = []
+            for _, e in dataset_entries:
+                # version_missing is OUR diagnostic; the singular
+                # validator requires a version. Default missing
+                # versions to a sentinel so they round-trip through
+                # validate_dataset_specs as version_not_found, and we
+                # rewrite the reason afterwards.
+                version = e.version or "0.0.0"
+                specs_for_validate.append(DatasetSpec(rid=e.rid, version=version))
+            ds_report = self.validate_dataset_specs(specs=specs_for_validate)
+            for (idx, entry), spec_result in zip(dataset_entries, ds_report.results):
+                reasons: list[Any] = list(spec_result.reasons)
+                if entry.version is None and "version_not_found" in reasons:
+                    # Replace the misleading inner reason with our own.
+                    reasons = [r for r in reasons if r != "version_not_found"]
+                    reasons.append("version_missing")
+                results[idx] = ConfigEntryResult(
+                    entry=entry,
+                    valid=spec_result.valid and entry.version is not None,
+                    reasons=reasons,
+                    actual_table=spec_result.actual_table,
+                    available_versions=spec_result.available_versions,
+                    resolved_name=spec_result.dataset_name,
+                )
+
+        # Assets -- per-RID loop (lookup_asset has no batched form yet).
+        for idx, entry in asset_entries:
+            asset_result = self._validate_asset_spec(AssetSpec(rid=entry.rid))
+            results[idx] = ConfigEntryResult(
+                entry=entry,
+                valid=asset_result.valid,
+                reasons=list(asset_result.reasons),
+                actual_table=asset_result.actual_table,
+                resolved_name=asset_result.filename,
+            )
+
+        # Workflows -- per-RID.
+        for idx, entry in workflow_entries:
+            wf_result = self._validate_workflow_rid(entry.rid)
+            results[idx] = ConfigEntryResult(
+                entry=entry,
+                valid=wf_result.valid,
+                reasons=list(wf_result.reasons),
+                actual_table=wf_result.actual_table,
+                resolved_name=wf_result.workflow_name,
+            )
+
+        # DerivaMLConfig -- compare against THIS connection's host/catalog.
+        # No catalog call here; we just check the entry matches what
+        # self is connected to. A heavy "is the catalog reachable"
+        # check would re-issue every call validate_dataset_specs
+        # already does -- caller decides separately whether to test
+        # the connection (a single deriva_ml_list_datasets call is
+        # enough).
+        self_hostname = getattr(self, "host_name", None)
+        self_catalog_id = getattr(self, "catalog_id", None)
+        for idx, entry in deriva_entries:
+            reasons: list[Any] = []
+            if entry.hostname and self_hostname and entry.hostname != self_hostname:
+                reasons.append("catalog_hostname_mismatch")
+            if entry.catalog_id and self_catalog_id is not None:
+                if str(entry.catalog_id) != str(self_catalog_id):
+                    reasons.append("catalog_id_mismatch")
+            results[idx] = ConfigEntryResult(
+                entry=entry,
+                valid=not reasons,
+                reasons=reasons,
+                resolved_name=(
+                    f"{self_hostname or '?'}/{self_catalog_id or '?'}"
+                    if not reasons
+                    else None
+                ),
+            )
+
+        # Replace any leftover Nones with an internal-error result.
+        # Shouldn't happen if the bucketing covers every kind, but
+        # defense in depth.
+        return [
+            r
+            if r is not None
+            else ConfigEntryResult(
+                entry=entries[i],
+                valid=False,
+                reasons=["rid_unresolvable"],
+            )
+            for i, r in enumerate(results)
+        ]

--- a/tests/config/test_ast_walker.py
+++ b/tests/config/test_ast_walker.py
@@ -1,0 +1,350 @@
+"""Unit tests for :func:`deriva_ml.config.parse_config_file`.
+
+The walker is a pure-Python AST visitor with no catalog dependency,
+so these tests are fast and don't need any fixtures beyond temp
+files. Coverage targets:
+
+- Each recognized constructor shape (bare, ``builds(...)`` wrapper,
+  ``with_description(...)`` wrapper, ``store(<Class>, ...)``).
+- Module-level constant resolution.
+- Unresolvable RIDs surface as ``rid=None`` (not as an exception).
+- Syntax errors return a :class:`ConfigFileParseError`, not an
+  exception.
+- Comments are skipped.
+- ``__pycache__`` paths are not visited (tested indirectly via
+  ``validate_config_directory``).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from deriva_ml.config import parse_config_file
+from deriva_ml.config.validation import ConfigFileParseError
+
+
+def _write(tmp_path: Path, source: str, name: str = "configs.py") -> Path:
+    p = tmp_path / name
+    p.write_text(source)
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Bare-constructor shapes
+# ---------------------------------------------------------------------------
+
+
+def test_bare_dataset_spec_config(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        """
+from deriva_ml.dataset import DatasetSpecConfig
+datasets_store(name="x", spec=DatasetSpecConfig(rid="1-AAAA", version="0.1.0"))
+""",
+    )
+    entries, err = parse_config_file(path)
+    assert err is None
+    assert len(entries) == 1
+    e = entries[0]
+    assert e.entry_kind == "DatasetSpecConfig"
+    assert e.rid == "1-AAAA"
+    assert e.version == "0.1.0"
+    assert e.line == 3
+
+
+def test_bare_asset_spec_config(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        """
+assets_store(name="w", spec=AssetSpecConfig(rid="1-BBBB", cache=True))
+""",
+    )
+    entries, err = parse_config_file(path)
+    assert err is None
+    assert len(entries) == 1
+    e = entries[0]
+    assert e.entry_kind == "AssetSpecConfig"
+    assert e.rid == "1-BBBB"
+    assert e.cache is True
+
+
+def test_bare_workflow(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        """
+workflow_store(name="t", spec=Workflow(rid="1-CCCC"))
+""",
+    )
+    entries, err = parse_config_file(path)
+    assert err is None
+    assert len(entries) == 1
+    assert entries[0].entry_kind == "Workflow"
+    assert entries[0].rid == "1-CCCC"
+
+
+# ---------------------------------------------------------------------------
+# Wrapper shapes
+# ---------------------------------------------------------------------------
+
+
+def test_with_description_wrapper(tmp_path: Path) -> None:
+    """``with_description(DatasetSpecConfig(...), "...")`` unwraps to the inner spec."""
+    path = _write(
+        tmp_path,
+        """
+from deriva_ml.execution import with_description
+datasets_store(
+    name="x",
+    spec=with_description(
+        DatasetSpecConfig(rid="1-AAAA", version="0.2.0"),
+        "training set",
+    ),
+)
+""",
+    )
+    entries, err = parse_config_file(path)
+    assert err is None
+    # Should emit exactly ONE entry, not two -- the inner call is
+    # claimed by the wrapper's classification.
+    assert len(entries) == 1
+    e = entries[0]
+    assert e.entry_kind == "DatasetSpecConfig"
+    assert e.rid == "1-AAAA"
+    assert e.version == "0.2.0"
+
+
+def test_builds_with_known_class(tmp_path: Path) -> None:
+    """``builds(Workflow, rid=...)`` is treated as the Workflow class."""
+    path = _write(
+        tmp_path,
+        """
+from hydra_zen import builds
+workflow_store(name="t", spec=builds(Workflow, rid="1-DDDD"))
+""",
+    )
+    entries, err = parse_config_file(path)
+    assert err is None
+    assert len(entries) == 1
+    e = entries[0]
+    assert e.entry_kind == "Workflow"
+    assert e.rid == "1-DDDD"
+
+
+def test_builds_with_unsuffixed_spec_name(tmp_path: Path) -> None:
+    """``builds(DatasetSpec, ...)`` (no ``Config`` suffix) normalizes to ``DatasetSpecConfig``."""
+    path = _write(
+        tmp_path,
+        """
+datasets_store(name="x", spec=builds(DatasetSpec, rid="1-EEEE", version="0.3.0"))
+""",
+    )
+    entries, err = parse_config_file(path)
+    assert err is None
+    assert len(entries) == 1
+    e = entries[0]
+    assert e.entry_kind == "DatasetSpecConfig"
+    assert e.rid == "1-EEEE"
+    assert e.version == "0.3.0"
+
+
+def test_deriva_store_positional_class(tmp_path: Path) -> None:
+    """``deriva_store(DerivaMLConfig, hostname=..., catalog_id=...)`` is recognized."""
+    path = _write(
+        tmp_path,
+        """
+deriva_store(
+    DerivaMLConfig,
+    name="default_deriva",
+    hostname="data.example.org",
+    catalog_id="42",
+)
+""",
+    )
+    entries, err = parse_config_file(path)
+    assert err is None
+    assert len(entries) == 1
+    e = entries[0]
+    assert e.entry_kind == "DerivaMLConfig"
+    assert e.hostname == "data.example.org"
+    assert e.catalog_id == "42"
+    # `name=` is a hydra-zen store kwarg, not a DerivaMLConfig field.
+    # We intentionally don't capture it -- the validator doesn't need it.
+
+
+def test_deriva_store_int_catalog_id(tmp_path: Path) -> None:
+    """``catalog_id=`` is sometimes a literal int; normalize to str."""
+    path = _write(
+        tmp_path,
+        """
+deriva_store(
+    DerivaMLConfig,
+    hostname="localhost",
+    catalog_id=7,
+)
+""",
+    )
+    entries, err = parse_config_file(path)
+    assert err is None
+    assert entries[0].catalog_id == "7"
+
+
+# ---------------------------------------------------------------------------
+# Module-level constant resolution
+# ---------------------------------------------------------------------------
+
+
+def test_resolves_module_level_constants(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        """
+TRAINING_RID = "1-AAAA"
+TEST_RID: str = "1-BBBB"
+datasets_store(name="train", spec=DatasetSpecConfig(rid=TRAINING_RID, version="0.1.0"))
+datasets_store(name="test", spec=DatasetSpecConfig(rid=TEST_RID, version="0.1.0"))
+""",
+    )
+    entries, err = parse_config_file(path)
+    assert err is None
+    rids = [e.rid for e in entries]
+    assert rids == ["1-AAAA", "1-BBBB"]
+
+
+def test_unresolvable_constant_returns_none(tmp_path: Path) -> None:
+    """Constants not found in the module-level name map yield ``rid=None``."""
+    path = _write(
+        tmp_path,
+        """
+def get_rid():
+    return "1-XYZW"
+datasets_store(name="x", spec=DatasetSpecConfig(rid=get_rid(), version="0.1.0"))
+""",
+    )
+    entries, err = parse_config_file(path)
+    assert err is None
+    assert len(entries) == 1
+    assert entries[0].rid is None
+
+
+def test_unresolvable_local_assignment(tmp_path: Path) -> None:
+    """Names assigned inside functions don't pollute the module-level map."""
+    path = _write(
+        tmp_path,
+        """
+def _wrap():
+    INNER = "1-NOPE"
+    return DatasetSpecConfig(rid=INNER, version="0.1.0")
+datasets_store(name="x", spec=DatasetSpecConfig(rid=INNER, version="0.1.0"))
+""",
+    )
+    entries, err = parse_config_file(path)
+    assert err is None
+    # Both entries are emitted (the one inside the function AND the
+    # one at module scope). Neither resolves -- INNER is not at
+    # module scope.
+    for e in entries:
+        assert e.rid is None
+
+
+# ---------------------------------------------------------------------------
+# Negative / edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_comments_with_constructor_text_are_ignored(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        """
+# DatasetSpecConfig(rid="FAKE-RID", version="0.0.0") in a comment
+datasets_store(name="x", spec=DatasetSpecConfig(rid="1-REAL", version="0.1.0"))
+""",
+    )
+    entries, err = parse_config_file(path)
+    assert err is None
+    assert len(entries) == 1
+    assert entries[0].rid == "1-REAL"
+
+
+def test_syntax_error_returns_parse_error(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        """
+this is not python code (((
+""",
+    )
+    entries, err = parse_config_file(path)
+    assert entries == []
+    assert err is not None
+    assert isinstance(err, ConfigFileParseError)
+    assert err.line is not None
+
+
+def test_missing_file_returns_parse_error(tmp_path: Path) -> None:
+    entries, err = parse_config_file(tmp_path / "nope.py")
+    assert entries == []
+    assert err is not None
+    assert "nope.py" in err.file
+
+
+def test_empty_file_returns_empty_entries(tmp_path: Path) -> None:
+    path = _write(tmp_path, "")
+    entries, err = parse_config_file(path)
+    assert err is None
+    assert entries == []
+
+
+def test_no_known_constructors_returns_empty(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        """
+from hydra_zen import builds
+some_other_store(SomeOtherConfig, name="x")
+do_something(SomethingElse, rid="1-AAAA")
+""",
+    )
+    entries, err = parse_config_file(path)
+    assert err is None
+    assert entries == []
+
+
+def test_missing_version_kwarg(tmp_path: Path) -> None:
+    """Missing version is captured as ``version=None``; validator handles it."""
+    path = _write(
+        tmp_path,
+        """
+datasets_store(name="x", spec=DatasetSpecConfig(rid="1-AAAA"))
+""",
+    )
+    entries, err = parse_config_file(path)
+    assert err is None
+    assert len(entries) == 1
+    assert entries[0].rid == "1-AAAA"
+    assert entries[0].version is None
+
+
+def test_snippet_captures_source_line(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        """
+datasets_store(name="x", spec=DatasetSpecConfig(rid="1-AAAA", version="0.1.0"))
+""",
+    )
+    entries, err = parse_config_file(path)
+    assert err is None
+    assert entries[0].snippet is not None
+    assert "DatasetSpecConfig" in entries[0].snippet
+
+
+def test_multiple_entries_in_order(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        """
+datasets_store(name="a", spec=DatasetSpecConfig(rid="1-AAAA", version="0.1.0"))
+datasets_store(name="b", spec=DatasetSpecConfig(rid="1-BBBB", version="0.2.0"))
+datasets_store(name="c", spec=DatasetSpecConfig(rid="1-CCCC", version="0.3.0"))
+""",
+    )
+    entries, err = parse_config_file(path)
+    assert err is None
+    rids = [e.rid for e in entries]
+    assert rids == ["1-AAAA", "1-BBBB", "1-CCCC"]
+    assert [e.line for e in entries] == [2, 3, 4]

--- a/tests/config/test_bootstrap.py
+++ b/tests/config/test_bootstrap.py
@@ -1,0 +1,369 @@
+"""Unit tests for :meth:`DerivaML.bootstrap_config`.
+
+These tests stub the catalog-read primitives the method composes
+(``find_datasets``, ``list_asset_tables``, ``list_assets``,
+``find_workflows``) so the suite runs without a live catalog. The
+stubs are intentionally minimal -- shape-of-data only -- because the
+bootstrap method's value-add is *what it suggests*, not how it reads
+the catalog.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from deriva_ml.config import BootstrapReport
+from deriva_ml.config.bootstrap import _sanitize_config_name
+from deriva_ml.core.mixins.dataset import DatasetMixin
+
+# ---------------------------------------------------------------------------
+# Stubs
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _StubDataset:
+    dataset_rid: str
+    dataset_types: list[str] = field(default_factory=list)
+    current_version: str | None = "0.1.0"
+    description: str = ""
+
+
+@dataclass
+class _StubAsset:
+    asset_rid: str
+    filename: str = ""
+
+
+@dataclass
+class _StubAssetTable:
+    name: str
+
+
+@dataclass
+class _StubWorkflow:
+    rid: str
+    name: str = ""
+
+
+class _StubMixin(DatasetMixin):
+    """Minimal :class:`DatasetMixin` for bootstrap tests."""
+
+    def __init__(
+        self,
+        *,
+        host_name: str = "data.example.org",
+        catalog_id: str = "42",
+        datasets: list[_StubDataset] | None = None,
+        asset_tables: list[_StubAssetTable] | None = None,
+        assets_by_table: dict[str, list[_StubAsset]] | None = None,
+        workflows: list[_StubWorkflow] | None = None,
+    ) -> None:
+        self.host_name = host_name
+        self.catalog_id = catalog_id
+        self._datasets = datasets or []
+        self._asset_tables = asset_tables or []
+        self._assets_by_table = assets_by_table or {}
+        self._workflows = workflows or []
+
+    # Stub the catalog-read primitives. Each replaces the real mixin
+    # method without invoking ermrest.
+    def find_datasets(self, deleted: bool = False, sort=None):  # type: ignore[override]
+        return list(self._datasets)
+
+    def list_asset_tables(self):  # type: ignore[override]
+        return list(self._asset_tables)
+
+    def list_assets(self, table: Any):  # type: ignore[override]
+        name = table.name if hasattr(table, "name") else str(table)
+        return list(self._assets_by_table.get(name, []))
+
+    def find_workflows(self, sort=None):  # type: ignore[override]
+        return list(self._workflows)
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+def test_bootstrap_returns_one_per_kind_minimum() -> None:
+    """A catalog with content of every kind produces at least one entry per kind."""
+    ml = _StubMixin(
+        datasets=[
+            _StubDataset(
+                dataset_rid="1-AAAA",
+                dataset_types=["Training", "Labeled"],
+                current_version="0.4.0",
+                description="CIFAR-10 training images",
+            ),
+        ],
+        asset_tables=[_StubAssetTable(name="Image")],
+        assets_by_table={
+            "Image": [_StubAsset(asset_rid="1-BBBB", filename="model_weights.pt")],
+        },
+        workflows=[_StubWorkflow(rid="1-CCCC", name="train_cifar10")],
+    )
+    report = ml.bootstrap_config()
+
+    assert isinstance(report, BootstrapReport)
+    assert report.catalog == {"hostname": "data.example.org", "catalog_id": "42"}
+    kinds = [s.kind for s in report.suggestions]
+    assert "deriva_ml" in kinds
+    assert "datasets" in kinds
+    assert "assets" in kinds
+    assert "workflow" in kinds
+
+
+def test_dataset_suggestion_pins_released_version() -> None:
+    ml = _StubMixin(
+        datasets=[
+            _StubDataset(
+                dataset_rid="1-AAAA",
+                dataset_types=["Training"],
+                current_version="0.4.0",
+                description="training set",
+            ),
+        ],
+    )
+    report = ml.bootstrap_config(kinds=["datasets"])
+    assert len(report.suggestions) == 1
+    s = report.suggestions[0]
+    assert s.kind == "datasets"
+    assert s.rid == "1-AAAA"
+    assert s.version == "0.4.0"
+    assert 'rid="1-AAAA"' in s.spec_string
+    assert 'version="0.4.0"' in s.spec_string
+
+
+def test_dataset_with_dev_version_is_skipped() -> None:
+    ml = _StubMixin(
+        datasets=[
+            _StubDataset(
+                dataset_rid="1-AAAA",
+                dataset_types=["Training"],
+                current_version="0.4.0.post1.dev3",  # dev label
+                description="training set",
+            ),
+        ],
+    )
+    report = ml.bootstrap_config(kinds=["datasets"])
+    assert report.suggestions == []
+    assert len(report.skipped) == 1
+    assert report.skipped[0].rid == "1-AAAA"
+    assert "dev label" in report.skipped[0].reason
+
+
+def test_dataset_with_no_current_version_is_skipped() -> None:
+    ml = _StubMixin(
+        datasets=[
+            _StubDataset(
+                dataset_rid="1-AAAA",
+                dataset_types=["Training"],
+                current_version=None,
+            ),
+        ],
+    )
+    report = ml.bootstrap_config(kinds=["datasets"])
+    assert report.suggestions == []
+    assert len(report.skipped) == 1
+    assert report.skipped[0].reason == "no current version"
+
+
+# ---------------------------------------------------------------------------
+# Filters
+# ---------------------------------------------------------------------------
+
+
+def test_dataset_type_filter_default_excludes_non_matching() -> None:
+    """Default filter is Training/Testing/Validation/Complete/Labeled."""
+    ml = _StubMixin(
+        datasets=[
+            _StubDataset(dataset_rid="1-AA", dataset_types=["Training"], current_version="0.1.0"),
+            _StubDataset(dataset_rid="1-BB", dataset_types=["Split"], current_version="0.1.0"),  # excluded
+            _StubDataset(dataset_rid="1-CC", dataset_types=["Foo"], current_version="0.1.0"),  # excluded
+        ],
+    )
+    report = ml.bootstrap_config(kinds=["datasets"])
+    rids = [s.rid for s in report.suggestions]
+    assert rids == ["1-AA"]
+    skipped_rids = [s.rid for s in report.skipped]
+    assert "1-BB" in skipped_rids
+    assert "1-CC" in skipped_rids
+
+
+def test_dataset_type_filter_empty_means_all_types() -> None:
+    """``dataset_type_filter=[]`` includes every type."""
+    ml = _StubMixin(
+        datasets=[
+            _StubDataset(dataset_rid="1-AA", dataset_types=["Split"], current_version="0.1.0"),
+            _StubDataset(dataset_rid="1-BB", dataset_types=["Foo"], current_version="0.1.0"),
+        ],
+    )
+    report = ml.bootstrap_config(kinds=["datasets"], dataset_type_filter=[])
+    rids = sorted(s.rid for s in report.suggestions)
+    assert rids == ["1-AA", "1-BB"]
+
+
+def test_dataset_type_filter_custom() -> None:
+    """A custom filter narrows to exactly the requested types."""
+    ml = _StubMixin(
+        datasets=[
+            _StubDataset(dataset_rid="1-AA", dataset_types=["Training"], current_version="0.1.0"),
+            _StubDataset(dataset_rid="1-BB", dataset_types=["Validation"], current_version="0.1.0"),
+        ],
+    )
+    report = ml.bootstrap_config(
+        kinds=["datasets"], dataset_type_filter=["Validation"]
+    )
+    rids = [s.rid for s in report.suggestions]
+    assert rids == ["1-BB"]
+
+
+# ---------------------------------------------------------------------------
+# Kinds gating
+# ---------------------------------------------------------------------------
+
+
+def test_kinds_gates_what_is_returned() -> None:
+    ml = _StubMixin(
+        datasets=[_StubDataset(dataset_rid="1-AA", dataset_types=["Training"])],
+        asset_tables=[_StubAssetTable(name="Image")],
+        assets_by_table={"Image": [_StubAsset(asset_rid="1-BB")]},
+        workflows=[_StubWorkflow(rid="1-CC")],
+    )
+    report = ml.bootstrap_config(kinds=["datasets"])
+    assert {s.kind for s in report.suggestions} == {"datasets"}
+
+
+def test_kinds_none_returns_all_four() -> None:
+    ml = _StubMixin(
+        datasets=[],
+        asset_tables=[],
+        workflows=[],
+    )
+    # Even with empty content, the deriva_ml suggestion always fires
+    # (it's catalog-state-independent -- just pins the connection).
+    report = ml.bootstrap_config()
+    assert {s.kind for s in report.suggestions} == {"deriva_ml"}
+
+
+# ---------------------------------------------------------------------------
+# Asset suggestions
+# ---------------------------------------------------------------------------
+
+
+def test_assets_skip_builtin_metadata_tables() -> None:
+    """``Execution_Metadata`` and ``Execution_Asset`` are skipped."""
+    ml = _StubMixin(
+        asset_tables=[
+            _StubAssetTable(name="Image"),
+            _StubAssetTable(name="Execution_Metadata"),
+            _StubAssetTable(name="Execution_Asset"),
+        ],
+        assets_by_table={
+            "Image": [_StubAsset(asset_rid="1-AA", filename="img.png")],
+            "Execution_Metadata": [_StubAsset(asset_rid="1-XX", filename="config.json")],
+            "Execution_Asset": [_StubAsset(asset_rid="1-YY", filename="weights.pt")],
+        },
+    )
+    report = ml.bootstrap_config(kinds=["assets"])
+    rids = [s.rid for s in report.suggestions]
+    assert rids == ["1-AA"]
+    skipped_rids = [s.rid for s in report.skipped]
+    assert "Execution_Metadata" in skipped_rids
+    assert "Execution_Asset" in skipped_rids
+
+
+# ---------------------------------------------------------------------------
+# Workflow suggestions
+# ---------------------------------------------------------------------------
+
+
+def test_workflow_with_no_rid_is_silently_dropped() -> None:
+    """An in-memory Workflow without a catalog RID isn't suggested."""
+    ml = _StubMixin(
+        workflows=[
+            _StubWorkflow(rid="1-AA", name="trainer"),
+            _StubWorkflow(rid=None, name="just-in-memory"),  # type: ignore[arg-type]
+        ],
+    )
+    report = ml.bootstrap_config(kinds=["workflow"])
+    rids = [s.rid for s in report.suggestions]
+    assert rids == ["1-AA"]
+
+
+# ---------------------------------------------------------------------------
+# config_name sanitization
+# ---------------------------------------------------------------------------
+
+
+def test_sanitize_config_name_uses_description() -> None:
+    assert _sanitize_config_name("CIFAR-10 Training Set!", "fallback") == "cifar_10_training_set"
+
+
+def test_sanitize_config_name_falls_back_when_empty() -> None:
+    assert _sanitize_config_name("", "1-XYZW") == "1_xyzw"
+
+
+def test_sanitize_config_name_falls_back_when_unusable() -> None:
+    assert _sanitize_config_name("!!!", "1-AB") == "1_ab"
+
+
+def test_sanitize_config_name_prepends_ds_when_starts_with_digit() -> None:
+    # "8 little cats" sanitizes to "8_little_cats"; we prepend "ds_" so
+    # the result is a valid Python identifier.
+    name = _sanitize_config_name("8 little cats", "fallback")
+    assert name.startswith("ds_")
+
+
+def test_sanitize_config_name_truncates_long_strings() -> None:
+    long_desc = "a" * 80
+    name = _sanitize_config_name(long_desc, "fb")
+    assert len(name) <= 40
+
+
+# ---------------------------------------------------------------------------
+# Spec string formatting
+# ---------------------------------------------------------------------------
+
+
+def test_dataset_spec_string_is_ready_to_paste() -> None:
+    ml = _StubMixin(
+        datasets=[
+            _StubDataset(
+                dataset_rid="1-AA",
+                dataset_types=["Training"],
+                current_version="0.4.0",
+            ),
+        ],
+    )
+    report = ml.bootstrap_config(kinds=["datasets"])
+    s = report.suggestions[0]
+    assert s.spec_string == 'DatasetSpecConfig(rid="1-AA", version="0.4.0")'
+
+
+def test_asset_spec_string_is_ready_to_paste() -> None:
+    ml = _StubMixin(
+        asset_tables=[_StubAssetTable(name="Image")],
+        assets_by_table={"Image": [_StubAsset(asset_rid="1-BB", filename="x.png")]},
+    )
+    report = ml.bootstrap_config(kinds=["assets"])
+    s = report.suggestions[0]
+    assert s.spec_string == 'AssetSpecConfig(rid="1-BB")'
+
+
+def test_workflow_spec_string_is_ready_to_paste() -> None:
+    ml = _StubMixin(workflows=[_StubWorkflow(rid="1-CC")])
+    report = ml.bootstrap_config(kinds=["workflow"])
+    s = report.suggestions[0]
+    assert s.spec_string == 'Workflow(rid="1-CC")'
+
+
+def test_deriva_ml_spec_string_uses_connection_state() -> None:
+    ml = _StubMixin(host_name="example.com", catalog_id="99")
+    report = ml.bootstrap_config(kinds=["deriva_ml"])
+    s = report.suggestions[0]
+    assert 'hostname="example.com"' in s.spec_string
+    assert 'catalog_id="99"' in s.spec_string

--- a/tests/config/test_validate_config_file.py
+++ b/tests/config/test_validate_config_file.py
@@ -1,0 +1,419 @@
+"""Unit tests for :meth:`DerivaML.validate_config_file` and :meth:`validate_config_directory`.
+
+These tests stub the dataset/asset/workflow validation primitives the
+new methods compose, so the suite exercises the integration boundary
+(AST -> per-kind buckets -> per-RID validators -> aggregated report)
+without needing a live catalog. The primitives themselves
+(``validate_dataset_specs``, ``_validate_asset_spec``,
+``_validate_workflow_rid``) have their own unit suites.
+
+Coverage targets:
+
+- A clean config with one entry of each kind returns ``all_valid=True``.
+- A config with a bad dataset RID surfaces ``rid_not_found`` with the
+  parsed entry echoed back.
+- A config with a missing ``version=`` kwarg surfaces
+  ``version_missing`` (a diagnostic that doesn't exist on the
+  underlying spec validators).
+- A config with an unresolvable RID (``rid=some_func()``) surfaces
+  ``rid_unresolvable`` without calling the catalog primitives.
+- A DerivaMLConfig entry whose hostname doesn't match the connection
+  surfaces ``catalog_hostname_mismatch``.
+- A directory walk skips ``__pycache__`` and dot-prefixed paths.
+- A directory walk continues past a single unparseable file.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from deriva_ml.asset.aux_classes import AssetSpec
+from deriva_ml.config import ConfigValidationReport
+from deriva_ml.core.mixins.dataset import DatasetMixin
+from deriva_ml.dataset.aux_classes import DatasetSpec
+from deriva_ml.dataset.validation import (
+    AssetSpecResult,
+    DatasetSpecResult,
+    DatasetSpecValidationReport,
+    WorkflowSpecResult,
+)
+
+# ---------------------------------------------------------------------------
+# Stub mixin: provides just enough surface for the tested methods.
+# ---------------------------------------------------------------------------
+
+
+class _StubMixin(DatasetMixin):
+    """A DatasetMixin instance with stubbed primitives.
+
+    The primitives this mixin's ``validate_config_file`` calls into are
+    ``validate_dataset_specs``, ``_validate_asset_spec``, and
+    ``_validate_workflow_rid``. We patch them via instance methods so
+    the tests can inject canned per-RID responses without going near
+    the real catalog code paths.
+    """
+
+    def __init__(
+        self,
+        *,
+        host_name: str = "data.example.org",
+        catalog_id: str = "42",
+        dataset_results_by_rid: dict[str, DatasetSpecResult] | None = None,
+        asset_results_by_rid: dict[str, AssetSpecResult] | None = None,
+        workflow_results_by_rid: dict[str, WorkflowSpecResult] | None = None,
+    ) -> None:
+        self.host_name = host_name
+        self.catalog_id = catalog_id
+        self._dataset_results = dataset_results_by_rid or {}
+        self._asset_results = asset_results_by_rid or {}
+        self._workflow_results = workflow_results_by_rid or {}
+
+    # The mixin's ``validate_dataset_specs`` walks ``ml.resolve_rid``
+    # etc.; override to return canned results based on RID.
+    def validate_dataset_specs(self, specs, **_):  # type: ignore[override]
+        results = []
+        for s in specs:
+            canned = self._dataset_results.get(s.rid)
+            if canned is None:
+                # Default: spec is valid (we don't know the rid yet, so
+                # assume well-formed).
+                results.append(
+                    DatasetSpecResult(spec=s, valid=True, resolved_version=str(s.version))
+                )
+            else:
+                # Echo the spec back with the canned outcome's reasons.
+                results.append(
+                    DatasetSpecResult(
+                        spec=s,
+                        valid=canned.valid,
+                        reasons=list(canned.reasons),
+                        actual_table=canned.actual_table,
+                        available_versions=canned.available_versions,
+                        dataset_name=canned.dataset_name,
+                    )
+                )
+        return DatasetSpecValidationReport(
+            all_valid=all(r.valid for r in results),
+            results=results,
+        )
+
+    def _validate_asset_spec(self, spec):  # type: ignore[override]
+        canned = self._asset_results.get(spec.rid)
+        if canned is None:
+            return AssetSpecResult(spec=spec, valid=True, asset_table="Image")
+        return AssetSpecResult(
+            spec=spec,
+            valid=canned.valid,
+            reasons=list(canned.reasons),
+            actual_table=canned.actual_table,
+            asset_table=canned.asset_table,
+            filename=canned.filename,
+        )
+
+    def _validate_workflow_rid(self, rid):  # type: ignore[override]
+        canned = self._workflow_results.get(rid)
+        if canned is None:
+            return WorkflowSpecResult(rid=rid, valid=True, workflow_name="canned-workflow")
+        return canned
+
+
+def _write(tmp_path: Path, source: str, name: str = "configs.py") -> Path:
+    p = tmp_path / name
+    p.write_text(source)
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+def test_clean_config_returns_all_valid(tmp_path: Path) -> None:
+    src = """
+datasets_store(name="train", spec=DatasetSpecConfig(rid="1-AAAA", version="0.1.0"))
+assets_store(name="w", spec=AssetSpecConfig(rid="1-BBBB", cache=True))
+workflow_store(name="t", spec=Workflow(rid="1-CCCC"))
+deriva_store(DerivaMLConfig, hostname="data.example.org", catalog_id="42")
+"""
+    path = _write(tmp_path, src)
+    ml = _StubMixin()
+    report = ml.validate_config_file(path)
+
+    assert isinstance(report, ConfigValidationReport)
+    assert report.file_count == 1
+    assert report.entry_count == 4
+    assert report.all_valid is True
+    assert all(r.valid for r in report.results)
+    assert [r.entry.entry_kind for r in report.results] == [
+        "DatasetSpecConfig",
+        "AssetSpecConfig",
+        "Workflow",
+        "DerivaMLConfig",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Failure modes
+# ---------------------------------------------------------------------------
+
+
+def test_dataset_rid_not_found(tmp_path: Path) -> None:
+    src = 'datasets_store(name="x", spec=DatasetSpecConfig(rid="1-NOPE", version="0.1.0"))\n'
+    path = _write(tmp_path, src)
+    ml = _StubMixin(
+        dataset_results_by_rid={
+            "1-NOPE": DatasetSpecResult(
+                spec=DatasetSpec(rid="1-NOPE", version="0.1.0"),
+                valid=False,
+                reasons=["rid_not_found"],
+            ),
+        },
+    )
+    report = ml.validate_config_file(path)
+    assert report.all_valid is False
+    assert len(report.results) == 1
+    r = report.results[0]
+    assert r.valid is False
+    assert "rid_not_found" in r.reasons
+    assert r.entry.rid == "1-NOPE"
+
+
+def test_dataset_version_not_found_surfaces_available_versions(tmp_path: Path) -> None:
+    src = 'datasets_store(name="x", spec=DatasetSpecConfig(rid="1-AAAA", version="9.9.9"))\n'
+    path = _write(tmp_path, src)
+    ml = _StubMixin(
+        dataset_results_by_rid={
+            "1-AAAA": DatasetSpecResult(
+                spec=DatasetSpec(rid="1-AAAA", version="9.9.9"),
+                valid=False,
+                reasons=["version_not_found"],
+                available_versions=["0.4.0", "0.3.0", "0.2.0"],
+            ),
+        },
+    )
+    report = ml.validate_config_file(path)
+    r = report.results[0]
+    assert r.valid is False
+    assert "version_not_found" in r.reasons
+    assert r.available_versions == ["0.4.0", "0.3.0", "0.2.0"]
+
+
+def test_missing_version_yields_version_missing(tmp_path: Path) -> None:
+    """A DatasetSpecConfig with no ``version=`` kwarg yields the
+    ``version_missing`` diagnostic instead of the misleading
+    ``version_not_found``."""
+    src = 'datasets_store(name="x", spec=DatasetSpecConfig(rid="1-AAAA"))\n'
+    path = _write(tmp_path, src)
+    ml = _StubMixin(
+        dataset_results_by_rid={
+            # Default valid -- the canned RID exists, but the entry has
+            # no version, so the wrapper rewrites to version_missing.
+            "1-AAAA": DatasetSpecResult(
+                spec=DatasetSpec(rid="1-AAAA", version="0.0.0"),
+                valid=False,
+                reasons=["version_not_found"],
+                available_versions=["0.1.0"],
+            ),
+        },
+    )
+    report = ml.validate_config_file(path)
+    r = report.results[0]
+    assert r.valid is False
+    assert "version_missing" in r.reasons
+    # The version_not_found inner reason has been rewritten.
+    assert "version_not_found" not in r.reasons
+
+
+def test_unresolvable_rid_does_not_call_catalog(tmp_path: Path) -> None:
+    """An ``rid=some_func()`` shape surfaces ``rid_unresolvable`` without
+    making any catalog calls (the AST couldn't extract a RID to look up)."""
+    src = """
+def get_rid():
+    return "1-ZZZZ"
+datasets_store(name="x", spec=DatasetSpecConfig(rid=get_rid(), version="0.1.0"))
+"""
+    path = _write(tmp_path, src)
+    # Empty stub map -- if anyone called validate_dataset_specs with a
+    # canned-rid lookup, the default-valid branch would trip a False
+    # positive on our assertion.
+    ml = _StubMixin()
+    # Wrap validate_dataset_specs so we can assert it wasn't called.
+    real_validate = ml.validate_dataset_specs
+    call_count = {"n": 0}
+
+    def counting_validate(specs, **kw):  # type: ignore[no-redef]
+        call_count["n"] += 1
+        return real_validate(specs, **kw)
+
+    ml.validate_dataset_specs = counting_validate  # type: ignore[method-assign]
+    report = ml.validate_config_file(path)
+
+    assert call_count["n"] == 0, "no catalog call should happen for unresolvable RIDs"
+    assert len(report.results) == 1
+    assert report.results[0].valid is False
+    assert "rid_unresolvable" in report.results[0].reasons
+
+
+def test_deriva_ml_hostname_mismatch(tmp_path: Path) -> None:
+    src = """
+deriva_store(DerivaMLConfig, hostname="other.example.org", catalog_id="42")
+"""
+    path = _write(tmp_path, src)
+    ml = _StubMixin(host_name="data.example.org", catalog_id="42")
+    report = ml.validate_config_file(path)
+    r = report.results[0]
+    assert r.valid is False
+    assert "catalog_hostname_mismatch" in r.reasons
+
+
+def test_deriva_ml_catalog_id_mismatch(tmp_path: Path) -> None:
+    src = """
+deriva_store(DerivaMLConfig, hostname="data.example.org", catalog_id="999")
+"""
+    path = _write(tmp_path, src)
+    ml = _StubMixin(host_name="data.example.org", catalog_id="42")
+    report = ml.validate_config_file(path)
+    r = report.results[0]
+    assert r.valid is False
+    assert "catalog_id_mismatch" in r.reasons
+
+
+# ---------------------------------------------------------------------------
+# Asset / workflow failure modes
+# ---------------------------------------------------------------------------
+
+
+def test_asset_not_found(tmp_path: Path) -> None:
+    src = 'assets_store(name="w", spec=AssetSpecConfig(rid="1-NOPE"))\n'
+    path = _write(tmp_path, src)
+    ml = _StubMixin(
+        asset_results_by_rid={
+            "1-NOPE": AssetSpecResult(
+                spec=AssetSpec(rid="1-NOPE"),
+                valid=False,
+                reasons=["rid_not_found"],
+            ),
+        },
+    )
+    report = ml.validate_config_file(path)
+    r = report.results[0]
+    assert r.valid is False
+    assert "rid_not_found" in r.reasons
+
+
+def test_workflow_not_a_workflow(tmp_path: Path) -> None:
+    src = 'workflow_store(name="t", spec=Workflow(rid="1-WRNG"))\n'
+    path = _write(tmp_path, src)
+    ml = _StubMixin(
+        workflow_results_by_rid={
+            "1-WRNG": WorkflowSpecResult(
+                rid="1-WRNG",
+                valid=False,
+                reasons=["not_a_workflow"],
+                actual_table="Dataset",
+            ),
+        },
+    )
+    report = ml.validate_config_file(path)
+    r = report.results[0]
+    assert r.valid is False
+    assert "not_a_workflow" in r.reasons
+    assert r.actual_table == "Dataset"
+
+
+# ---------------------------------------------------------------------------
+# Parse errors
+# ---------------------------------------------------------------------------
+
+
+def test_unparseable_file_recorded_in_parse_errors(tmp_path: Path) -> None:
+    path = _write(tmp_path, "this is not python (((\n")
+    ml = _StubMixin()
+    report = ml.validate_config_file(path)
+    assert report.file_count == 0
+    assert report.entry_count == 0
+    assert report.all_valid is False
+    assert len(report.parse_errors) == 1
+    assert "syntax" in report.parse_errors[0].message.lower() or report.parse_errors[0].message
+
+
+def test_missing_file_recorded_in_parse_errors(tmp_path: Path) -> None:
+    ml = _StubMixin()
+    report = ml.validate_config_file(tmp_path / "nope.py")
+    assert report.file_count == 0
+    assert report.parse_errors
+
+
+# ---------------------------------------------------------------------------
+# Directory walk
+# ---------------------------------------------------------------------------
+
+
+def test_directory_walk_includes_subdirs(tmp_path: Path) -> None:
+    (tmp_path / "datasets.py").write_text(
+        'datasets_store(name="x", spec=DatasetSpecConfig(rid="1-AAAA", version="0.1.0"))\n'
+    )
+    subdir = tmp_path / "dev"
+    subdir.mkdir()
+    (subdir / "datasets.py").write_text(
+        'datasets_store(name="y", spec=DatasetSpecConfig(rid="1-BBBB", version="0.2.0"))\n'
+    )
+    ml = _StubMixin()
+    report = ml.validate_config_directory(tmp_path)
+    assert report.entry_count == 2
+
+
+def test_directory_walk_skips_pycache(tmp_path: Path) -> None:
+    cache = tmp_path / "__pycache__"
+    cache.mkdir()
+    (cache / "bogus.py").write_text(
+        'this is not python (((\n'  # Would be a parse error if visited.
+    )
+    (tmp_path / "datasets.py").write_text(
+        'datasets_store(name="x", spec=DatasetSpecConfig(rid="1-AAAA", version="0.1.0"))\n'
+    )
+    ml = _StubMixin()
+    report = ml.validate_config_directory(tmp_path)
+    # Only the real file should have been visited.
+    assert report.file_count == 1
+    assert report.parse_errors == []
+    assert report.entry_count == 1
+
+
+def test_directory_walk_continues_past_unparseable_file(tmp_path: Path) -> None:
+    (tmp_path / "broken.py").write_text("this is not python (((\n")
+    (tmp_path / "good.py").write_text(
+        'datasets_store(name="x", spec=DatasetSpecConfig(rid="1-AAAA", version="0.1.0"))\n'
+    )
+    ml = _StubMixin()
+    report = ml.validate_config_directory(tmp_path)
+    # The good file's entry was still found.
+    assert report.entry_count == 1
+    # The broken file is in parse_errors.
+    assert len(report.parse_errors) == 1
+    # ...and the report says NOT all valid because of the parse error.
+    assert report.all_valid is False
+
+
+def test_directory_walk_missing_dir_returns_parse_error(tmp_path: Path) -> None:
+    ml = _StubMixin()
+    report = ml.validate_config_directory(tmp_path / "nope")
+    assert report.file_count == 0
+    assert len(report.parse_errors) == 1
+    assert "not found" in report.parse_errors[0].message
+
+
+def test_directory_walk_non_recursive(tmp_path: Path) -> None:
+    (tmp_path / "datasets.py").write_text(
+        'datasets_store(name="x", spec=DatasetSpecConfig(rid="1-AAAA", version="0.1.0"))\n'
+    )
+    subdir = tmp_path / "dev"
+    subdir.mkdir()
+    (subdir / "datasets.py").write_text(
+        'datasets_store(name="y", spec=DatasetSpecConfig(rid="1-BBBB", version="0.2.0"))\n'
+    )
+    ml = _StubMixin()
+    report = ml.validate_config_directory(tmp_path, recursive=False)
+    # Only the top-level file is visited.
+    assert report.entry_count == 1
+    assert report.results[0].entry.rid == "1-AAAA"


### PR DESCRIPTION
## Summary

Implements the platform-side half of the config ↔ catalog reconciliation
design captured in
[`deriva-ml-skills/docs/superpowers/plans/2026-05-22-config-validator-bootstrap-design.md`](https://github.com/informatics-isi-edu/deriva-ml-skills/blob/main/docs/superpowers/plans/2026-05-22-config-validator-bootstrap-design.md).

Two new APIs on \`DerivaML\` (mixin methods on \`DatasetMixin\` alongside the
existing \`validate_dataset_specs\` / \`validate_execution_configuration\`):

- **\`validate_config_file(path)\` / \`validate_config_directory(configs_dir)\`** —
  parse hydra-zen config files via AST (no execution) and validate every
  \`DatasetSpecConfig\` / \`AssetSpecConfig\` / \`Workflow\` / \`DerivaMLConfig\`
  constructor call against the catalog. Returns a structured per-entry
  report. Single broken file in a directory walk doesn't abort.
- **\`bootstrap_config(*, kinds, dataset_type_filter)\`** — query the catalog
  and suggest config entries for a fresh project. Returns
  \`BootstrapSuggestion\` objects with ready-to-paste \`spec_string\` lines
  and a \`rationale\` the calling skill shows the user. Pure read; never
  writes files.

## Design choice

Hybrid: catalog reads land here as platform APIs, file writes stay as
skill prose (\`dataset-lifecycle\`, \`work-with-assets\`,
\`execution-lifecycle\` each own the "offer to update src/configs/" UX
for the operations they perform). The design doc enumerates why
file-mutation APIs were considered and rejected — too fragile against
hand-edited Python.

## What's in this PR

### \`src/deriva_ml/config/\` (new module)

- \`ast_walker.py\` — pure-Python AST visitor. Handles bare constructors,
  \`with_description(...)\` wrappers, \`builds(...)\` hydra-zen partials,
  hydra-zen \`store(<spec_class>, ...)\` shape, module-level constant
  resolution. Wrapper double-counting prevented via a claimed-node set.
- \`validation.py\` — Pydantic report models (\`ConfigEntry\`,
  \`ConfigEntryResult\`, \`ConfigValidationReport\`,
  \`ConfigFileParseError\`).
- \`bootstrap.py\` — \`BootstrapSuggestion\`, \`BootstrapSkipped\`,
  \`BootstrapReport\` models + spec-string formatters +
  \`_sanitize_config_name\` helper.
- \`__init__.py\` — public surface (only the report models and
  \`parse_config_file\`; the validator + bootstrap methods themselves
  live on \`DatasetMixin\` for API symmetry with the existing
  validators).

### \`src/deriva_ml/core/mixins/dataset.py\` (extended)

- \`validate_config_file(path)\` / \`validate_config_directory(configs_dir, *, recursive=True)\`
- \`bootstrap_config(*, kinds=None, dataset_type_filter=None)\`
- \`_validate_config_entries(entries)\` private helper that buckets by
  kind and composes the existing per-kind validators
  (\`validate_dataset_specs\`, \`_validate_asset_spec\`,
  \`_validate_workflow_rid\`).

### \`tests/config/\` (new test directory)

- \`test_ast_walker.py\` — 19 tests, pure unit. Each constructor shape,
  each wrapper, constant resolution, syntax errors as parse errors
  (not exceptions), comments ignored, ordering preserved.
- \`test_validate_config_file.py\` — 16 tests via a stub mixin. Happy
  path, every reason in the failure-mode vocabulary, directory walk
  (subdirs, \`__pycache__\` skip, continue-past-parse-error,
  non-recursive mode).
- \`test_bootstrap.py\` — 20 tests via stubs of \`find_datasets\` /
  \`list_asset_tables\` / \`list_assets\` / \`find_workflows\`. Happy path,
  filter behavior (default / empty / custom), kinds gating, dev-version
  skip, built-in metadata table skip, RID-less workflow drop,
  \`_sanitize_config_name\` edge cases, spec_string format per kind.

## Verification

\`\`\`
\$ uv run python -m pytest tests/config/
============== 55 passed, 6 warnings in 0.08s ==============

\$ uv run python -m pytest tests/dataset/test_validate_dataset_spec_unit.py \
                          tests/dataset/test_validate_execution_configuration_unit.py
============== 28 passed, 6 warnings in 0.50s ==============

\$ uv run ruff check src/deriva_ml/config/ src/deriva_ml/core/mixins/dataset.py tests/config/
All checks passed!
\`\`\`

Six warnings are pre-existing Pydantic-V2 deprecations unrelated to
this PR.

## Out of scope

- File mutation. The platform never writes config files; skill prose
  owns that side.
- Cross-file consistency. The current \`validate_config_directory\`
  validates each entry against the catalog but doesn't check that
  an \`experiments.py\` reference points at a name registered in
  \`datasets.py\`. Cross-file checks would lift to a
  \`validate_project\` classmethod (deferred per design doc §"Out of
  scope").
- Format preservation. AST-based validation reads source but
  doesn't rewrite it. If mutation lands later, we use \`libcst\`
  (not \`ast\`) for round-trip-safe edits.

## Followups

After this lands and a deriva-ml patch release is cut:

1. deriva-ml-mcp: add \`deriva_ml_bootstrap_config\` and
   \`deriva_ml_validate_config_file\` MCP tool wrappers.
2. deriva-ml-skills (\`write-hydra-config\`): replace the "until the
   tool lands, compose existing MCP tools" passages with the new
   single-call shape.
3. deriva-ml-mcp lockfile bump + release; deriva-ml-model-template
   lockfile bump; deriva-mcp container rebuild against the new
   sibling versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)