### PR TITLE
docs: 2026-05-22 dual-perspective pre-release audit reports

### DIFF
--- a/docs/audits/2026-05-22-engineer-audit-asset.md
+++ b/docs/audits/2026-05-22-engineer-audit-asset.md
@@ -1,0 +1,612 @@
+# deriva-ml pre-release engineer audit (v1.37.1) — `asset/`
+
+Reviewed the asset subsystem under
+`/Users/carl/GitHub/DerivaML/deriva-ml/src/deriva_ml/asset/` (six
+files, 986 LoC) and the corresponding test surface
+`/Users/carl/GitHub/DerivaML/deriva-ml/tests/asset/` (four files,
+1 325 LoC) at the v1.37.1 release point. Cross-references against the
+rest of `src/deriva_ml/` (notably `execution/execution.py`,
+`execution/bag_commit.py`, `core/upload_layout.py`,
+`local_db/manifest_store.py`, and `core/mixins/asset.py`) confirm the
+in-tree consumers of the asset surface. Severity scale: P0 (block
+release), P1 (must fix this release), P2 (next release), P3 (cleanup
+when convenient).
+
+## Summary
+
+Overall posture: **the manifest-first storage layer is the strongest
+part of the subsystem**. `manifest.py` is small (270 LoC), single-
+purpose, well-documented, and well-tested (the `test_manifest.py`
+suite covers crash recovery, point-query semantics, the batch
+wrappers, and the JSON serializer in 642 LoC). The lower-level
+`local_db/manifest_store.py` carries the SQLite contracts cleanly. The
+NULL-sentinel processor is also tight: 43 LoC of code paired with 113
+LoC of focused unit tests.
+
+The weaker areas are:
+
+1. **`asset.py` (the `Asset` live-catalog wrapper)** — three near-
+   identical `find_association("Asset_Type") → pathBuilder → filter`
+   blocks across `_load_asset_types`, `add_asset_type`, and
+   `remove_asset_type`. The class also has zero coverage for
+   `find_features`, `download`, and the `update_catalog` parameter on
+   `download`. The retired `list_feature_values` stub raises
+   `DerivaMLException` rather than `AttributeError`, which is the
+   wrong typed exception under the codebase's exception hierarchy.
+
+2. **`aux_classes.py` `AssetSpec` vs `AssetSpecConfig` divergence** —
+   the hydra-zen mirror omits `asset_role`. `AssetSpec` accepts it and
+   `ExecutionConfiguration` honors it, but no hydra-zen config can
+   express it. This is either a real gap or `asset_role` should be
+   dropped from `AssetSpec`; the inconsistency itself is the smell.
+
+3. **Cross-module duplication of the alphabetic-sort invariant** —
+   `core/upload_layout.py:214` sorts `metadata_columns` for the regex
+   directory order, `execution/bag_commit.py:264` separately sorts the
+   same call site for the bag-build row emit, and neither has a unit
+   test pinning the invariant. If a future refactor changes either
+   call's sort key (or drops it), the failure mode is silent
+   corruption of NULL-sentinel column ordering at upload time.
+
+4. **No integration test that an asset-manifest entry survives a
+   process kill mid-upload and resumes correctly with the same RID.**
+   The unit-level "crash recovery" test (`test_resume_after_crash`)
+   uses two `AssetManifest` instances over the same store; it does
+   not cover the full execution → bag-commit → catalog round-trip
+   that the `MANIFEST_VERSION = 2` design promises. This is the most
+   important missing test for a release that ships the
+   write-through-fsync claim.
+
+5. **Public-API/private-API smell** — `_asset_record_class` starts
+   with an underscore but is re-exported from
+   `deriva_ml.asset.__init__` and consumed by
+   `core/mixins/asset.py:450` (`asset_record_class`). Either un-
+   underscore it or move the import to a `_internal` submodule;
+   exporting a leading-underscore name from `__init__` is the
+   contract violation `# A private helper used by mixin code` was
+   meant to prevent.
+
+Counts: **34 findings** (1 P0, 7 P1, 17 P2, 9 P3) across the five
+modules, plus 5 cross-module coverage gaps and 4 duplication
+candidates.
+
+---
+
+## `asset/asset.py` — Asset live-catalog wrapper
+
+### A1. `list_feature_values` raises `DerivaMLException`, not `AttributeError` [P1]
+
+`asset.py:224-241`. The retired method raises
+`DerivaMLException("Asset.list_feature_values() has been retired.
+Use ml.feature_values(asset_table, feature_name) instead.")`. The
+project's stated convention for retired-method stubs is to raise
+`AttributeError` (so `hasattr()` and IDE tooling treat it as absent)
+or to delete the method entirely. The feature-module retirement
+audit (`docs/design/deriva-ml-audit-2026-05-phase3-feature.md`) shows
+this same pattern was deliberately converted *away* from
+`DerivaMLException` for retired container methods. Either align with
+that — raise `AttributeError` — or delete the stub now that
+`feature_values` has been the documented entry point through one
+release cycle. Tests pin the current behavior at
+`test_asset.py` (none — no regression test exists for the retired
+stub; if it changes silently, no one notices).
+
+### A2. Three duplicated `find_association("Asset_Type")` blocks [P1]
+
+`asset.py:147-164` (`_load_asset_types`), `asset.py:243-263`
+(`add_asset_type`), `asset.py:265-285` (`remove_asset_type`) all do:
+
+```python
+asset_table_obj = self._ml_instance.model.name_to_table(self.asset_table)
+type_assoc_table, asset_fk, _ = self._ml_instance.model.find_association(asset_table_obj, "Asset_Type")
+pb = self._ml_instance.pathBuilder()
+type_path = pb.schemas[type_assoc_table.schema.name].tables[type_assoc_table.name]
+```
+
+A private helper `self._asset_type_path()` returning `(type_path,
+asset_fk)` would eliminate ~18 LoC and pin the column-name convention
+in one place. The current shape also re-resolves the table every
+call, where caching `asset_table_obj` and `(type_assoc_table,
+asset_fk)` on the `Asset` instance is the more obvious move (these
+are derived from `self.asset_table`, which is immutable for the
+lifetime of the wrapper).
+
+### A3. `Asset.download` has no test [P1]
+
+`asset.py:287-310`. The method is documented as a download primitive
+(used by `lookup_asset(...).download(Path)`). It writes to
+`dest_dir / self.filename` via `hatrac.get_obj`. The `update_catalog`
+parameter is declared but **never read inside the method body** —
+the docstring claims it "tracks this asset as an input to the
+current execution", but no execution-context tracking happens here.
+This is a docstring-vs-implementation drift, not just a missing test:
+either implement the tracking (which probably belongs on
+`Execution.download_asset`, where it already exists) or drop the
+parameter from the signature.
+
+### A4. `Asset.find_features` has no test [P2]
+
+`asset.py:205-222`. Calls through to `ml.find_features(asset_table)`,
+which is itself tested in `tests/feature/`, but no test pins the
+Asset-side wrapper. A 4-line smoke test confirming a feature defined
+on an asset table is returned by `asset.find_features()` is enough.
+
+### A5. `Asset.execution_rid` makes a lazy catalog call from a property [P2]
+
+`asset.py:166-178`. Property-access doing a catalog round-trip is the
+kind of footgun that bites in N+1 loops (e.g. iterating
+`ml.find_assets()` and asking each for `.execution_rid`). The lazy
+load mirrors `asset_types`, but `asset_types` is at least bounded by
+a single association fetch; `execution_rid` calls
+`list_executions(asset_role="Output")` which goes through
+`list_asset_executions → lookup_execution` per call. Document the
+N+1 cost or make it explicit (`get_creating_execution()` method
+instead of a property).
+
+### A6. `Asset.__init__` declares `asset_types` as `list[str] | None` then stores `[]` [P3]
+
+`asset.py:93,126`. The `or []` idiom is fine, but the property at
+line 137-145 checks `if not self._asset_types` and triggers a load
+— meaning a caller who legitimately constructs an asset with
+**zero** types gets a per-property-read catalog hit. Use a sentinel
+(`_UNSET = object()`) or a `_types_loaded: bool` flag to distinguish
+"never loaded" from "loaded and empty".
+
+### A7. `get_metadata` returns `{}` for missing records instead of raising [P2]
+
+`asset.py:312-328`. If `asset_rid` no longer exists at the catalog
+(deleted, snapshot mismatch), the method silently returns `{}`. The
+sibling `lookup_asset` raises `DerivaMLException` for the same case.
+Empty dict vs. exception is an asymmetry callers can't easily
+distinguish from "row exists but has no metadata columns" (which is
+itself impossible — every catalog row has at least RID/RCB/RMB
+columns, but a downstream consumer can't know that). Raise.
+
+### A8. `get_chaise_url` hardcodes `https://` and `/chaise/record/#` [P3]
+
+`asset.py:330-345`. No test, no construction via deriva-py's URL
+helpers. If a deployment ever uses `http://` (test catalogs do) or
+a Chaise path prefix, the URL is wrong. At minimum: a `protocol`
+fallback or a call to `self._ml_instance.catalog.host_proto` if such
+an attribute exists.
+
+### A9. Class-docstring example block uses `# doctest: +SKIP` on the class-level docstring [P3]
+
+`asset.py:13-25` (module docstring) and `asset.py:72-80` (class
+docstring) both annotate every `>>>` line with `# doctest: +SKIP`.
+This works but clutters the rendered docs. The convention used
+elsewhere (see `feature.py` audit) is to lift the SKIP into a top-
+of-block directive when every line is skipped. Cosmetic.
+
+---
+
+## `asset/asset_record.py` — Dynamic Pydantic records
+
+### B1. `_asset_record_class` exported from `__init__` despite leading underscore [P1]
+
+`asset/__init__.py:13`. The naming says "private helper", the export
+says "public API". `core/mixins/asset.py:450` calls it as
+`_asset_record_class`. Either:
+
+- Rename to `asset_record_class` (the mixin already wraps it under
+  that name; the underscore prefix is the inconsistency), or
+- Drop from `__all__` and the `__init__` re-export and let mixin
+  code import it from `deriva_ml.asset.asset_record` directly.
+
+The first is preferable — it's already documented in the module-
+level docstring at `asset_record.py:1-12`.
+
+### B2. `_map_column_type` swallows unknown types as `str` [P2]
+
+`asset_record.py:39-55`. The catch-all `case _: return str` means a
+column with an unrecognized ERMrest type (e.g., a future
+`geography` or a typo'd typename in the model JSON) becomes a `str`
+Pydantic field. The unit test at
+`test_manifest.py:466-475` only covers the documented mappings;
+there is no negative test confirming that an unknown type either
+raises or warns. Add a log warning at minimum.
+
+### B3. Date / timestamp / timestamptz all map to `str` [P2]
+
+`asset_record.py:50-51`. Pydantic supports `date` and `datetime`
+natively with parsing. Choosing `str` is a documented decision but
+it means metadata round-trips lose type information — a caller who
+constructs `ImageAsset(Acquisition_Date="2026-01-15")` gets back the
+same string with no validation that it parses. At minimum, document
+*why* str was chosen (likely: avoid JSON-roundtrip headaches in the
+manifest store).
+
+### B4. No test for `_asset_record_class` end-to-end [P1]
+
+`tests/asset/test_manifest.py:466-511` tests the base class and
+mapping in isolation but never calls `_asset_record_class(model,
+"Image")` against a real catalog or a mocked model. The mixin entry
+point `ml.asset_record_class("Image")` has zero test coverage
+(`grep -r "asset_record_class" tests/` returns nothing). A
+fixture-driven test that creates an asset table with three metadata
+columns (text, int, optional float) and confirms the generated
+class accepts/rejects values appropriately is the missing
+regression net.
+
+### B5. `_asset_record_class` does not deduplicate when called twice [P3]
+
+`asset_record.py:92-100`. `create_model("ImageAssetRecord", ...)`
+returns a fresh class every call. Two calls for the same table name
+yield two distinct classes — `isinstance` checks across them fail.
+Document this or cache by `(model_id, asset_table_name)`.
+
+### B6. `Config.arbitrary_types_allowed = True` is unnecessary [P3]
+
+`asset_record.py:34-36`. Every type produced by `_map_column_type`
+is a Python builtin (`str`/`int`/`float`/`bool`/`Any`). The flag is
+load-bearing only if a future column type maps to a non-Pydantic-
+native type. Drop until needed.
+
+---
+
+## `asset/aux_classes.py` — AssetFilePath, AssetSpec, AssetSpecConfig
+
+### C1. `AssetSpecConfig` lacks `asset_role` field [P0]
+
+`aux_classes.py:172` (AssetSpec) vs `aux_classes.py:198-202`
+(AssetSpecConfig). `AssetSpec` has `asset_role: str = "Input"` and
+`tests/dataset/test_validate_execution_configuration_unit.py:281`
+exercises both Input and Output roles. The hydra-zen `@hydrated_dataclass(AssetSpec)`
+wrapper declares only `rid` and `cache` —
+no `asset_role`. A user writing a hydra-zen config has no way to
+specify `asset_role="Output"` for an asset. The
+`@hydrated_dataclass(AssetSpec)` would normally pick up the fields
+from the wrapped class, but the explicit `rid: str` and `cache:
+bool` shadow it. This is a P0 because it's a silent functional
+gap shipping in a release that documents the hydra-zen surface as
+the recommended config interface.
+
+Repro: try to set `asset_role="Output"` on a hydra-zen asset
+config. There is no way.
+
+### C2. `AssetSpec` validates `asset_role` as a free-form string [P1]
+
+`aux_classes.py:173`. `asset_role: str = "Input"` — no enum
+validation, no membership check against the `Asset_Role` vocabulary.
+Typo `"Imput"` or `"input"` (lowercase) flows through to
+`ExecutionConfiguration` and either no-ops silently or fails at the
+catalog. Either Literal-type the field (`Literal["Input",
+"Output"]`) or validate against `MLVocab.asset_role` via a
+`@field_validator`.
+
+### C3. `AssetFilePath.with_segments` returns plain `Path`, but `parent`/`parents` are silently downgraded [P2]
+
+`aux_classes.py:136-144`. The docstring explains *why* — `Path`
+subclass methods call `type(self)(*args)` and `AssetFilePath`
+requires extra constructor args. The fix is correct, but the
+behavioral consequence isn't tested: after `afp.parent`, callers
+can't access `afp.asset_table` or `afp.asset_rid` on the parent.
+`test_path_parent_and_resolve` (`test_manifest.py:340-356`) checks
+`isinstance(parent, Path)` but doesn't assert that the asset
+metadata is **gone**. Add the assertion so the behavior is pinned —
+or, better, replace the `Path` subclassing with composition (an
+`AssetFilePath` that *has* a `Path` and proxies file ops). The
+subclass design is a long-standing footgun the codebase has now
+worked around three times.
+
+### C4. `_bind_manifest` is named with a leading underscore but called from `execution.py:2013` (cross-package) [P2]
+
+`aux_classes.py:80-86`. `execution.asset_file_path` is the documented
+public entry point; it constructs an `AssetFilePath` and binds it
+via `result._bind_manifest(manifest, manifest_key)`. The underscore
+says "private", the call site says "package-internal API". Either:
+
+- Rename to `bind_manifest` (it's an internal protocol between
+  Execution and AssetFilePath; the underscore is misleading), or
+- Use `__init__` keyword arguments instead of post-construction
+  binding (cleaner, but more disruptive).
+
+### C5. `AssetFilePath.metadata` setter mutates `asset_metadata` and the manifest, but `set_asset_types` only updates the manifest if bound [P2]
+
+`aux_classes.py:102-122` vs `124-134`. `metadata.setter` writes to
+both `self.asset_metadata` (always) and the manifest (if bound).
+`set_asset_types` writes to `self.asset_types` (always) and the
+manifest (if bound). Symmetric. Good.
+
+But: `metadata` *getter* reads from the manifest if bound, falling
+back to `asset_metadata`. There is no symmetric getter for
+`asset_types` — callers reach into `self.asset_types` directly, and
+if the manifest was updated by another process or via
+`update_asset_types` from elsewhere, the in-memory copy is stale.
+Either add a `types` property that reads from the manifest, or
+document that `asset_types` is the only field with stale-read risk.
+
+### C6. `AssetSpec` docstring example doesn't show the `asset_role` field [P3]
+
+`aux_classes.py:167-170`. The two examples shown are bare-RID and
+`cache=True`. Add `AssetSpec(rid="3JSE", asset_role="Output")` for
+the documented capability — or, if C1 leads to dropping
+`asset_role` from `AssetSpec`, this becomes moot.
+
+### C7. `_check_bare_rid` validator returns `None` for `None` input [P2]
+
+`aux_classes.py:178-182`. `return {"rid": data} if isinstance(data,
+str) else data` — if `data` is `None`, returns `None`, which then
+fails the rest of Pydantic validation with an unclear error.
+Acceptable, but a one-line guard (`if data is None: raise
+ValueError("AssetSpec requires a RID")`) would surface a better
+message.
+
+### C8. `AssetFilePath.asset_name` backward-compat alias has no deprecation path [P3]
+
+`aux_classes.py:147-150`. The "backward compatibility alias" returns
+`self.asset_table`. Either it's deprecated (then add a
+`DeprecationWarning`) or it's a permanent alias (then drop the
+"backward compatibility" framing). The CLAUDE.md "No backwards-
+compat shims" rule applies here — if nothing in `src/` reads
+`asset_name`, delete.
+
+Grep confirms: `grep -rn "\.asset_name" src/ tests/` returns only
+the test at `test_manifest.py:376` (which exists *because* the alias
+exists). Drop both.
+
+---
+
+## `asset/manifest.py` — Persistent manifest
+
+### D1. `MANIFEST_VERSION = 2` is never checked on load [P1]
+
+`manifest.py:74`. The class-level constant is documented as "bumped:
+storage layer changed" — but no code reads it. `to_json()` emits it
+into the dict; no loader validates it. If a v3 ever lands, there is
+no migration trigger. Either:
+
+- Remove the version field (it's vestigial), or
+- Wire a check in `ManifestStore.ensure_schema` or
+  `AssetManifest.__init__` that loads the version from the store
+  metadata and raises on mismatch.
+
+The migration test at
+`tests/local_db/test_manifest_migration.py` confirms migration
+*from* the old JSON format exists, but no version-bump test exists
+for the SQLite layer itself.
+
+### D2. `_validate_pending_asset_metadata_iter` sorts entries inside the loop [P2]
+
+`manifest.py:215`. `for key, _schema, asset_table, metadata in
+sorted(entries):` — `sorted()` materializes the entire iterable.
+For a small manifest this is fine; for an execution with thousands
+of pending assets, this is an unnecessary O(n log n) walk *and*
+a list materialization where the function only needs a stable
+iteration order for the error message. Either:
+
+- Defer sorting until after `missing_by_key` is built (sort the
+  keys of that dict instead of the input iterator), or
+- Document the upper bound on `entries` size.
+
+### D3. `_validate_pending_asset_metadata_iter` takes `schema` but ignores it [P3]
+
+`manifest.py:202-203,215`. The tuple shape is `(key, schema,
+asset_table, metadata)` but `_schema` is discarded. If schema is
+never needed, drop it from the tuple shape and the call site at
+`manifest.py:267`. Less surface, less to break.
+
+### D4. `_json_default` has no test for `Decimal` or `UUID` [P3]
+
+`manifest.py:23-35`. Handles `datetime`, `date`, `Path` — all
+plausible. But ERMrest can return `numeric` columns as Python
+`Decimal` (deriva-py's typed-row API), and asset RIDs are sometimes
+passed around as `uuid.UUID` in tests. The serializer raises
+`TypeError` for both. Either add cases or document that callers
+must coerce.
+
+### D5. `AssetEntry.status` field accepts arbitrary strings [P2]
+
+`manifest.py:50`. `status: str = "pending"  # pending | uploaded |
+failed`. The comment documents three values; the type allows any
+string. A typo (`"upload"`, `"complete"`) writes silently and
+breaks the `pending_assets()`/`uploaded_assets()` filters. Use a
+`Literal["pending", "uploaded", "failed"]` or an `Enum`.
+
+### D6. `AssetEntry.from_dict` silently drops unknown fields [P2]
+
+`manifest.py:58-60`. `cls(**{k: v for k, v in data.items() if k in
+cls.__dataclass_fields__})`. The intent is forward-compatibility
+(reading a future manifest version with extra fields), but the
+silent drop also masks bugs (a typo'd field name in caller code).
+Log a warning when unknown fields are dropped.
+
+### D7. `mark_uploaded` docstring claims the bulk delegation but mark_uploaded passes raw key without existence check [P2]
+
+`manifest.py:129-136`. The docstring says "Delegates to the bulk
+path with a one-element list; the store layer's single-row method
+retains the existence check that raises ``KeyError`` for missing
+keys." Inspecting `local_db/manifest_store.py:320-337` confirms
+this: `mark_asset_uploaded` calls `_require_asset` then
+`mark_assets_uploaded([(key, rid)])`. So the manifest-layer wrapper
+*itself* doesn't enforce — it relies on the store. Fine, but the
+two-layer split makes the contract harder to reason about. A
+comment in `manifest.py:129` pointing at the store's
+`_require_asset` would help.
+
+### D8. `to_json` returns the legacy format but `_json_default` is referenced only in the docstring [P3]
+
+`manifest.py:187-198`. The docstring says "Serialize with
+``json.dumps(manifest.to_json(), default=_json_default)``" but the
+function doesn't do that itself — every caller must remember the
+incantation. Wrap into a `to_json_str() -> str` convenience that
+encapsulates the serializer call.
+
+### D9. `pending_assets()` / `uploaded_assets()` go through `list_assets()` in the store [P2]
+
+`local_db/manifest_store.py:260-280`. Both filters delegate to
+`list_assets()` (full SELECT) and filter client-side. SQLite has an
+index `ix_assets_exec_status` (line 146-151) but it's unused by
+these filters — they always pull every row. For an execution with
+thousands of assets at upload time, this materializes the entire
+set just to throw most away. Push the status filter into the SQL.
+
+This is a `local_db/` concern but the public API contract
+`AssetManifest.pending_assets()` is in `asset/manifest.py:114` —
+fix at the store layer, no public API change.
+
+### D10. `manifest.assets` is a property that does a full SELECT per access [P2]
+
+`manifest.py:84-86`. `self._store.list_assets(self._execution_rid)`
+runs on every `.assets` access. Tests like
+`test_asset.py:90,93,94,96` access `.assets["Image/scan.jpg"]` —
+each access is a fresh round-trip. The fix doc-comment at
+`aux_classes.py:88-95` is the precedent (point-query getter); apply
+the same logic here: cache or document.
+
+Particularly painful: `to_json()` at line 197 calls `self.assets`
+inside a comprehension; the comprehension reads `assets` once, but
+this is non-obvious to a future caller who might add a second
+access in the same function.
+
+---
+
+## `asset/null_sentinel_processor.py` — NULL-sentinel translator
+
+### E1. `process()` imports `NULL_SENTINEL` lazily on every call [P3]
+
+`null_sentinel_processor.py:38-39`. `from
+deriva_ml.core.upload_layout import NULL_SENTINEL` inside the loop
+hot path. The import is cached by Python after the first call, but
+the symbol could just as well be module-scope. Move to the top.
+
+### E2. Sentinel-collision risk documented but not asserted in tests [P2]
+
+`null_sentinel_processor.py:25-28`. The docstring warns: "if a user's
+legitimate metadata value equals the sentinel string, it will be
+corrupted to NULL." No test exists that exercises this edge case
+(asserting either: (a) we corrupt, accept it, or (b) we detect and
+raise). Add a regression test pinning the documented behavior so a
+future change to "detect and raise" doesn't accidentally regress
+case (a).
+
+### E3. `__init__` reads `metadata` from kwargs but `BaseProcessor` might not forward it [P2]
+
+`null_sentinel_processor.py:31-36`. The comment "BaseProcessor stores
+kwargs on self.kwargs; the metadata dict is passed via
+kwargs["metadata"] by deriva-py's _execute_processors" documents a
+deriva-py implementation detail. The unit tests bypass deriva-py
+entirely (constructing the processor directly with `metadata=...`).
+A smoke test that confirms the processor actually fires *via the
+deriva-py pipeline* with a real `asset_table_upload_spec` is
+missing — `test_asset_table_upload_spec_includes_null_sentinel_processor_when_metadata_present`
+proves the wiring exists, not that it executes.
+
+### E4. `process()` iterates with `list(self.metadata.items())` to mutate during iteration [P3]
+
+`null_sentinel_processor.py:41-43`. The `list(...)` is correct
+(avoiding dict-mutation-during-iteration), but a comment explaining
+why the list copy is needed would prevent a future "clean up the
+unused list" PR.
+
+---
+
+## Cross-module coverage gaps
+
+### X1. No end-to-end resume test with a real catalog kill [P1]
+
+Tests cover `test_resume_after_crash` at the `AssetManifest` layer
+(`test_manifest.py:223-240`) using two manifest instances over the
+same store. There is no test that exercises a full execution
+lifecycle: stage assets → kill the process (e.g., `os.kill` in a
+subprocess fixture) → resume the execution → confirm pending assets
+finish uploading and uploaded assets are skipped. Given that
+write-through+fsync is the headline claim of the v1 manifest design,
+the absence of this test is the single biggest gap.
+
+### X2. No test for the alphabetic-sort invariant linking `upload_layout.py:214` and `bag_commit.py:264` [P1]
+
+Both call `sorted(model.asset_metadata(...))`. The comment at
+`upload_layout.py:219-220` ("sorted to ensure deterministic
+directory order matching the regex") states the invariant. Nothing
+asserts that the two sites stay in sync. A unit test in
+`tests/asset/` constructing an asset table with three metadata
+columns out-of-order and confirming both
+`asset_table_upload_spec`'s regex and the bag-build path emit them
+in the same order would pin it.
+
+### X3. No test that `find_assets(asset_type="X")` is correctly filtered [P2]
+
+`tests/asset/test_asset.py:123-137` (`test_find_assets_by_type`)
+asserts `len(assets) >= 1` and `all("Model_File" in a.asset_types
+for a in assets)`. The first assertion is too weak (passes if
+*all* assets carry Model_File); the second is silently true if no
+assets are returned. Combine with a negative test: create an asset
+without Model_File and confirm it's excluded.
+
+### X4. No test for `Asset.add_asset_type` rejecting an unknown vocab term [P2]
+
+`tests/asset/test_asset.py:163-184` (`test_add_asset_type`) adds a
+new vocabulary term first (`vc.asset_type, "New_Type"`), then adds
+it. No negative test for the case where the term doesn't exist —
+which is the more common user error. The current code at
+`asset.py:243-263` doesn't validate the term; the catalog FK
+constraint fires. The test should pin the failure mode (catalog
+error class + message shape).
+
+### X5. No test for `Input_File`/`Output_File` auto-tagging at the asset layer [P2]
+
+The directional auto-tagging logic lives in
+`execution/execution.py:1820-1899`. The asset-side post-condition
+(an asset uploaded as Output ends up with both its content type
+*and* `Output_File` in `asset.asset_types`) is not asserted in
+`tests/asset/`. `test_asset.py:90` checks `"Model_File" in
+asset.asset_types` after upload but not the `"Output_File"` peer.
+
+---
+
+## Cross-module duplication candidates
+
+### Y1. `find_association(asset_table, "Asset_Type")` appears 5+ times [P2]
+
+`asset/asset.py:152`, `:253`, `:275`; `core/mixins/asset.py:220`,
+`:343`; `execution/execution.py:1845`; `execution/bag_commit.py:359`.
+Each site re-resolves the association table and `asset_fk`. A
+single helper on `DerivaModel` (`asset_type_association(table) →
+(assoc_table, fk_col)`) would centralize the pattern and let a
+future schema change (e.g., a renamed FK column) update one place.
+
+### Y2. `find_association(asset_table, "Execution")` appears 4+ times [P2]
+
+`core/mixins/asset.py:285`, `execution/execution.py:1826`,
+`execution/bag_commit.py:337`. Same pattern as Y1, same fix.
+
+### Y3. Two parallel "alphabetic-sort metadata columns" sites [P1]
+
+`core/upload_layout.py:214` (upload spec regex order) and
+`execution/bag_commit.py:264` (bag-build row emit). Both rely on
+`sorted(model.asset_metadata(table))`. A helper
+`model.asset_metadata_sorted(table)` (or a `@cached_property` on
+`Table`) would make the invariant explicit and let the two sites
+share a single source of sort order.
+
+### Y4. Asset-manifest construction in `Execution.asset_file_path` overlaps with `AssetFilePath.__init__` [P3]
+
+`execution/execution.py:1989-2014` constructs an `AssetEntry`,
+adds it to the manifest, constructs an `AssetFilePath` with the
+*same* values, then calls `_bind_manifest`. The two objects (the
+entry in the manifest and the in-memory `AssetFilePath`) carry
+redundant state. A factory method `AssetFilePath.create_and_register
+(manifest, ...)` would collapse the two-step into one.
+
+---
+
+## Recommended release-blockers
+
+For v1.37.1, the following are the minimum cuts before tag:
+
+- **C1** (`AssetSpecConfig` missing `asset_role`) — silent functional
+  gap in a documented hydra-zen surface.
+- **B1** (`_asset_record_class` leading-underscore re-exported) —
+  contract violation, cheap to fix (rename + `__all__` update).
+- **A1** (`list_feature_values` raises wrong exception type) — wrong
+  exception class in a stable API, cheap to fix.
+- **D1** (`MANIFEST_VERSION` never checked) — dead code or missing
+  migration trigger; pick one for the release.
+- **A2** (`asset.py` 3× duplication) — not strictly a release
+  blocker, but the cleanup ships with the same patch that lands A1
+  and a private helper makes A3's docstring fix a one-line touch.
+
+The P0 (C1) is genuinely user-visible; the P1s are pre-release
+hygiene that compounds badly if it ships into v1.37.x and a v1.38
+brings additional asset surface changes.

--- a/docs/audits/2026-05-22-engineer-audit-catalog.md
+++ b/docs/audits/2026-05-22-engineer-audit-catalog.md
@@ -1,0 +1,773 @@
+# Engineer audit — `catalog/` subsystem (v1.37.1, 2026-05-22)
+
+Reviewed `/Users/carl/GitHub/DerivaML/deriva-ml/src/deriva_ml/catalog/`
+(5 files, 1 952 LoC: `__init__.py` 74, `clone.py` 355,
+`clone_via_bag.py` 569, `localize.py` 643, `provenance.py` 311) and
+the test surface
+`/Users/carl/GitHub/DerivaML/deriva-ml/tests/catalog/` (6 files,
+1 546 LoC: 1 integration test module under `@pytest.mark.integration`,
+4 unit-test modules). Cross-workspace grep against
+`/Users/carl/GitHub/DerivaML/{deriva-mcp,deriva-mcp-core,deriva-ml-mcp,deriva-skills,deriva-ml-skills,deriva-ml-model-template}/`.
+
+Scope ground rules (per audit brief):
+
+- Test coverage of cloning (`clone.py` and `clone_via_bag.py`), the
+  bag-pipeline path, `localize_assets`, three-stage clone behaviour
+  the legacy surface still claims to provide, orphan strategies, and
+  dataset-version reinitialization.
+- Code duplication (orphan handling, FK helpers, dataset-version
+  recreation, alias creation).
+- Logic clarity (async-loop hoisting, orphan-strategy plumbing,
+  snapshot-id propagation).
+- Docstring completeness/accuracy (public functions documented,
+  examples, three-stage approach explained).
+- Legacy/historical concerns are out of scope (per brief).
+
+## Executive summary
+
+The active clone path (`clone_via_bag` → `CatalogBagBuilder` →
+`BagCatalogLoader`) is in good shape: well-documented, unit-tested
+for argument shape and policy merging, and exercised by three
+`-m integration` smoke tests. The wrappers and adjacent modules are
+where the risk lives:
+
+- **`localize_assets` is 350 LoC of asset-bytes movement with no
+  integration coverage and no per-asset error-recovery testing.**
+  Dry-run, helper purity (`_extract_hatrac_path`, `LocalizeResult`
+  defaults / round-trip) are tested. The actual fetch / push /
+  catalog-update / provenance-write loop has zero coverage. P0.
+- **`create_ml_workspace` claims a "three-stage approach" in its
+  module docstring** (`__init__.py`:7-12 of the legacy `clone.py`
+  doc and `CLAUDE.md`) **but the implementation is now a single
+  pipeline call.** The docstring still says "schema without FKs →
+  async data copy → FK application with orphan handling"; the body
+  is one `clone_via_bag(...)` invocation. P1 (false advertising).
+- **`_record_clone_provenance` and `_record_localize_provenance`
+  carry similar dataclass-update logic with slightly different
+  fallback rules.** Phase 1 writes a fresh `CloneDetails`; phase 2
+  reads-modifies-or-writes one. Neither has a test that exercises
+  the "phase 2 runs without phase 1" branch end-to-end. P2.
+- **The policy-merge `model_fields_set` predicate covers 4 of the
+  12 policy fields** (`vocab_export`, `terminal_tables`,
+  `dangling_fk_strategy`, `intentional_cycles`). The other 8 fields
+  (`schemas`, `exclude_schemas`, `exclude_tables`, `max_depth`,
+  `asset_mode`, `content_on_conflict`, `match_by_columns`,
+  `preserve_provenance`) get no clone-required defaults. Whether
+  that's intentional or accidental is undocumented. P2.
+- **The "dataset-version reinitialization" feature documented in
+  `create_ml_workspace`'s legacy parameter list** (and listed under
+  `CloneDetails.reinitialize_dataset_versions`) **is now a complete
+  no-op.** The legacy parameter is warned-and-ignored; the bag
+  pipeline does not re-seed dataset versions. No code path
+  re-initializes; nothing in tests reflects this. P1 (silent loss
+  of a documented feature).
+
+Severity mix targets: P0 — must address before release; P1 — should
+address; P2 — track for the next cycle; P3 — nit / cosmetic.
+
+---
+
+## 1. Test coverage
+
+### 1.1 `localize_assets` has no integration test (P0)
+
+- File: `tests/catalog/test_localize.py` (122 LoC)
+- Covered: `LocalizeResult` defaults + round-trip;
+  `_extract_hatrac_path` parsing variants.
+- Uncovered (the bulk of `localize.py`, 644 LoC):
+  - `localize_assets` happy path (fetch → push → URL update).
+  - `dry_run=True` branch and the early-return when
+    `not assets_to_localize`.
+  - Per-asset error handling — the inner `except Exception` at
+    `localize.py:367-371` swallows everything into
+    `result.errors`. No test asserts that one failure doesn't
+    abort the batch.
+  - The batch-update-then-fallback-to-individual-update logic at
+    `localize.py:374-391`. The fallback re-tries each row on
+    `table.update()` failure; nothing pins that "one bad row
+    doesn't lose the whole batch."
+  - `_record_localize_provenance` ("phase 2 with no phase 1" vs
+    "phase 2 over existing phase 1") branches.
+  - `_find_asset_table_path`: schema-known vs. schema-search
+    branches; "not found" returning the documented
+    `(None, None)` tuple **but the caller at
+    `localize.py:179-181` unpacks as `table_path, found_schema`
+    and only checks `table_path is None`**. Confirmed correct,
+    but no test guards the contract.
+  - URL-column auto-detection at `localize.py:198-201` (`URL` vs
+    `url`). Two production catalogs may legitimately differ;
+    no test pins either branch.
+  - The chunked-upload threshold logic (`file_size >
+    100 * 1024 * 1024`, `default_chunk_size = 50 MB`).
+    `localize.py:339-353` has three interacting predicates and
+    zero tests.
+
+Action: add at least the happy-path, dry-run, and one-failed-asset
+tests with mocked `HatracStore` + datapath update. The
+`_make_fake_catalog` helper in `test_provenance.py:147-158` is a
+model for the right level of mocking.
+
+### 1.2 `clone_via_bag` lacks tests for `_materialize_bag_dir`, `_materialize_bag_assets`, `_record_clone_provenance` (P1)
+
+- File: `tests/catalog/test_clone_via_bag.py` (666 LoC).
+- The wrapper-logic surface (`root_rid` → `RIDAnchor` mapping,
+  policy merge, credential lookup, nested-dataset expansion) is
+  thoroughly tested.
+- Uncovered helpers in `clone_via_bag.py`:
+  - `_materialize_bag_dir` (lines 89-128): zip-fallback path,
+    "neither directory nor zip exists" error path, and the
+    "extracted directory ambiguous" branch
+    (`len(extracted) != 1`) all have zero coverage.
+  - `_materialize_bag_assets` (lines 212-236): the
+    "skip when fetch.txt absent or empty" guard and the
+    `bdb.materialize(...)` call have zero coverage.
+  - `_record_clone_provenance` (lines 512-566): the orphan-stat
+    aggregation loop (`getattr(stats, "rows_skipped_orphan", 0)`),
+    the str-Enum coercion
+    (`str(policy.dangling_fk_strategy).split(".")[-1].lower()`),
+    and the broad `except Exception` guard are not tested.
+
+Action: small unit tests with a `MagicMock` `LoadReport` and a
+mock catalog suffice — the `set_catalog_provenance` boundary is
+already mockable.
+
+### 1.3 Orphan strategies (`FAIL`/`DELETE`/`NULLIFY`) have no
+behavioural test (P1)
+
+- The integration tests (`test_clone_via_bag_end_to_end_default_policy`,
+  `test_clone_via_bag_rows_only_skips_asset_uploads`,
+  `test_clone_via_bag_rid_anchor_scopes_walk`) all use the default
+  `DanglingFKStrategy.DELETE`. There is no test (unit or
+  integration) that:
+  - Verifies `FAIL` actually fails-fast when an orphan is reached.
+  - Verifies `NULLIFY` produces a row with the FK column set to
+    NULL on the destination.
+  - Verifies the aggregated orphan-stat counters
+    (`orphan_rows_removed`, `orphan_rows_nullified`) on the
+    written `CloneDetails` annotation reflect what happened.
+- `test_clone_via_bag_preserves_explicit_fail_strategy` (line 368)
+  pins **policy plumbing** (the merge doesn't override `FAIL`) but
+  not behaviour — it asserts on the policy passed to the mock,
+  not on a real load.
+
+Action: at least one integration test that constructs a slice with
+a known dangling FK (or mocks `BagCatalogLoader` to return a
+`LoadReport` with non-zero orphan counters) and asserts the
+provenance annotation reflects the result.
+
+### 1.4 Dataset-version reinitialization is documented but not
+implemented (P1)
+
+- `CloneDetails.reinitialize_dataset_versions` exists as a field
+  (`provenance.py:117`) and `create_ml_workspace` accepts the
+  parameter (`clone.py:111`).
+- The legacy parameter is silently ignored: `clone.py:209` passes
+  it to `_warn_about_legacy_params`, which emits a deprecation
+  warning **only if the caller passed a non-default value**. The
+  default is `True`, so a caller relying on the documented
+  behaviour gets a silent no-op.
+- No test verifies that a clone re-seeds `Dataset_Version` rows.
+  Bag-loaded `Dataset_Version` rows carry whatever values the
+  source had — including the source's catalog snapshot ID — which
+  may or may not be the right thing for the destination catalog.
+
+Action: either delete the field from `CloneDetails` and the
+parameter from `create_ml_workspace` (per workspace CLAUDE.md
+"No backwards-compat shims" rule) **or** wire up the actual
+re-seeding step and add an integration test. Picking the first
+option is consistent with the rest of the legacy-parameter cleanup.
+
+### 1.5 Bag-pipeline clone path has integration tests but no
+asset-upload coverage (P2)
+
+- `test_clone_via_bag_rows_only_skips_asset_uploads`
+  (`test_clone_via_bag_integration.py:165`) asserts
+  `total_attempts == 0` for `AssetMode.ROWS_ONLY`. There is no
+  symmetric test for `AssetMode.UPLOAD_IF_MISSING` or
+  `UPLOAD_FORCE` — i.e., the asset bytes actually reaching the
+  destination Hatrac. The `_materialize_bag_assets` step is
+  load-bearing for those modes and silently invoked.
+
+Action: add an integration test that clones with
+`UPLOAD_IF_MISSING`, then verifies one asset's bytes exist on
+the destination Hatrac (download → MD5 compare, or
+`head_obj` 200 OK).
+
+### 1.6 No test pins the `is_clone` predicate against `creation_method` enum form (P3)
+
+- `provenance.py:172-176` compares
+  `self.creation_method == CatalogCreationMethod.CLONE.value`
+  (against the string form) because the docstring claims
+  `use_enum_values=True`. But `VALIDATION_CONFIG`
+  (`core/validation.py`) does **not** set `use_enum_values=True`;
+  the model stores enum members. The current `==` works because
+  `CatalogCreationMethod` inherits from `str` so
+  `member == "clone"` is True. Tests at `test_provenance.py:72-95`
+  pass, but the predicate's `.value` access is misleading.
+- The docstring comment at `provenance.py:172-174` is wrong about
+  why the comparison works.
+
+Action: simplify to
+`self.creation_method == CatalogCreationMethod.CLONE` and update
+the comment. Lowest priority.
+
+### 1.7 Nested-dataset expansion tests use `MagicMock` plumbing, not real Datapath shape (P3)
+
+- `tests/catalog/test_clone_via_bag.py:562-609`
+  (`_make_mock_catalog_with_dataset_dataset_rows`) is 50 LoC of
+  bespoke mock setup that mimics the real datapath call chain
+  (`pb.schemas[...].tables[...].filter(...).entities().fetch()`).
+  This works but is brittle to refactors: changing the helper's
+  query shape silently breaks every test that uses the mock.
+- Action: extract a fixture, or document the call shape inline.
+  No urgent change required.
+
+---
+
+## 2. Code duplication
+
+### 2.1 Two `set_catalog_provenance` / `CloneDetails` write paths with subtle differences (P2)
+
+- `clone_via_bag.py:512-566` (`_record_clone_provenance`):
+  - Builds a fresh `CloneDetails` from policy + report.
+  - Sets `orphan_strategy=str(policy.dangling_fk_strategy).split(".")[-1].lower()`
+    and `asset_mode=str(policy.asset_mode).split(".")[-1].lower()`.
+  - Always calls `set_catalog_provenance(creation_method=CLONE,
+    clone_details=…)` — does **not** preserve the existing
+    `name`/`description`/`workflow_url`/`workflow_version`.
+- `localize.py:554-643` (`_record_localize_provenance`):
+  - Reads existing provenance first.
+  - If phase-1 details exist, `model_copy(update=…)` over them.
+  - If not, builds a fresh `CloneDetails` with phase-2-only fields.
+  - Explicitly preserves
+    `name`/`description`/`workflow_url`/`workflow_version` from
+    the existing annotation.
+
+The two paths handle the same provenance annotation; the second
+preserves descriptive fields the first wipes. A user who runs
+`set_catalog_provenance(name=…)` before `clone_via_bag` will lose
+the name when phase 1 writes; localize will then preserve
+whatever phase 1 wrote (i.e., still no name).
+
+Action: factor a helper `_merge_clone_details(existing,
+**updates)` so both phases use the same read-modify-write story
+and `name`/`description` survive both phases.
+
+### 2.2 Lower-case + dot-split enum stringification appears twice and is unnecessary (P3)
+
+- `clone_via_bag.py:550-551`:
+  ```python
+  orphan_strategy=str(policy.dangling_fk_strategy).split(".")[-1].lower(),
+  asset_mode=str(policy.asset_mode).split(".")[-1].lower(),
+  ```
+- Both enums (`DanglingFKStrategy`, `AssetMode`) inherit from
+  `StrEnum` (verified at audit time:
+  `DanglingFKStrategy.__mro__ = (..., StrEnum, str, ReprEnum, Enum, object)`).
+  `str(DanglingFKStrategy.DELETE) == "delete"`; no dot to split.
+- The two-step `split(".")[-1].lower()` is dead-defensive code
+  inherited from a pre-`StrEnum` shape (`"DanglingFKStrategy.DELETE"
+  → "DELETE" → "delete"`). It works coincidentally on `StrEnum`
+  because `str(...)` returns the value already.
+
+Action: replace with `policy.dangling_fk_strategy.value` /
+`policy.asset_mode.value`. Less code, less misleading.
+
+### 2.3 `_coerce_asset_mode` / `_coerce_orphan_strategy` are parallel
+string-mapping helpers with no remaining callers (P2)
+
+- `clone.py:276-296` and `clone.py:299-312` translate legacy
+  string spellings (`"refs"`, `"FULL"`, `"none"`, etc.) into the
+  new enum members. They are called only from
+  `create_ml_workspace` lines 243-244.
+- The only external caller of `create_ml_workspace` is
+  `deriva-mcp/src/deriva_mcp/tools/{catalog,background_tasks}.py`,
+  which is already broken on a non-string-related import
+  (`AssetCopyMode` doesn't exist; documented in the prior phase-3
+  audit). When deriva-mcp's cut-over completes (per workspace
+  CLAUDE.md), these coercers have no callers.
+- Per CLAUDE.md "No backwards-compat shims": these are textbook
+  backward-compat helpers.
+
+Action: tag for deletion in the next legacy-cleanup pass once
+deriva-mcp is retired. Not a v1.37.1 blocker.
+
+### 2.4 Two `from deriva_ml.catalog.provenance import …` import lists (P3)
+
+- `clone_via_bag.py:71-75` imports
+  `CatalogCreationMethod, CloneDetails, set_catalog_provenance`.
+- `localize.py:592-597` (inside `_record_localize_provenance`)
+  imports
+  `CatalogCreationMethod, CloneDetails, get_catalog_provenance,
+  set_catalog_provenance`.
+- The lazy import in `localize.py` is justified with "avoids a
+  circular reference" — but `provenance.py` does not import
+  anything from `localize.py` or `clone_via_bag.py`, so there is
+  no actual cycle. The lazy form costs a runtime import on every
+  call and obscures the dependency for static analysers.
+
+Action: hoist to module-level imports in `localize.py`. The
+"defensive against future cycles" comment can stay if you prefer,
+but the lazy form is unnecessary today.
+
+### 2.5 `_find_asset_table_path` and "search all schemas" pattern duplicate model traversal in `localize.py` (P3)
+
+- `localize.py:438-468` searches schemas one by one with a try /
+  `KeyError` loop. Functionally identical to a single
+  `for sname in pb.schemas: …` walk; the schema-known branch is
+  a separate try/except that returns early.
+- `DerivaML` already exposes `model_table(...)` /
+  `resolve_table(...)` helpers (per CLAUDE.md API-priority note);
+  using those would route through one cached lookup rather than
+  iterating `pb.schemas`.
+
+Action: refactor to a single lookup via the deriva-ml helper.
+Defer to next refactor wave.
+
+---
+
+## 3. Logic clarity
+
+### 3.1 Policy merge predicate covers 4 of 12 fields (P2)
+
+- `clone_via_bag.py:405-419` merges `vocab_export`,
+  `terminal_tables`, `dangling_fk_strategy`, `intentional_cycles`
+  with the `model_fields_set` predicate.
+- `FKTraversalPolicy` exposes 12 fields:
+  `schemas, exclude_schemas, exclude_tables, terminal_tables,
+   max_depth, vocab_export, asset_mode, dangling_fk_strategy,
+   content_on_conflict, match_by_columns, preserve_provenance,
+   intentional_cycles`.
+- For 8 fields, the caller's default-library-default is taken
+  silently — with no documentation that the merge is selective.
+  A caller who supplies `policy=FKTraversalPolicy()` (everything
+  defaulted) gets clone-friendly `vocab_export=FULL` and
+  `dangling_fk_strategy=DELETE` injected but library-default
+  `asset_mode=UPLOAD_IF_MISSING`. The asymmetry is surprising.
+
+Action: either (a) expand the merge to all clone-relevant fields,
+or (b) document the selective merge in the
+`clone_via_bag` docstring and the policy-merge inline comment
+(lines 386-404). Doing nothing is the worst option.
+
+### 3.2 `output_dir` defaults to a path under `Path.cwd()` with no overwrite semantics (P2)
+
+- `clone_via_bag.py:421-423`: when `output_dir=None`, the bag is
+  written under `Path.cwd() / f"clone-{src}-to-{dst}"`.
+- If the directory already exists from a previous run,
+  `CatalogBagBuilder` behaviour is undefined here (the docstring
+  says nothing). The clone may silently merge into a stale bag
+  or fail with an opaque error from deeper in `bdbag`.
+- No test exercises the "stale output_dir" case;
+  `test_clone_via_bag_default_output_dir` only verifies the path
+  derivation.
+
+Action: document the precondition (output_dir must be empty / not
+exist) in the docstring; consider raising a clear error when a
+non-empty directory is passed; add a unit test that confirms the
+error path.
+
+### 3.3 Nested-dataset BFS exception swallowing hides real failures (P2)
+
+- `clone_via_bag.py:189-199` catches `DataPathException`,
+  `KeyError`, `ConnectionError` and proceeds with the seed RID
+  set only.
+- The rationale ("catalog doesn't have nested-dataset
+  infrastructure") is right for `KeyError` on
+  `pb.schemas["deriva-ml"]`. It's questionable for
+  `DataPathException` (could be a transient query error, a
+  permission issue, or a schema typo — none of which should be
+  silently ignored) and `ConnectionError` (a transient transport
+  failure mid-BFS may produce a partial expansion that *looks*
+  complete to the rest of the pipeline).
+- The exception is logged at WARNING level, but the caller has
+  no programmatic signal that the expansion was truncated.
+  Downstream, the bag walker will likely produce dangling-FK
+  warnings; the connection between the two is non-obvious.
+
+Action: narrow to `KeyError` only for the "no nested-dataset
+infrastructure" case; let `DataPathException` / `ConnectionError`
+propagate. If the partial-expansion fallback must stay, return a
+sentinel or include a counter on `CloneViaBagResult` for
+"nested-expansion-truncated".
+
+### 3.4 `_record_clone_provenance`'s "best-effort" swallow is too wide (P2)
+
+- `clone_via_bag.py:561-566`:
+  ```python
+  except Exception as e:
+      logger.warning("clone_via_bag: failed to write provenance: %s", e)
+  ```
+- The except catches anything from the orphan-stat aggregation
+  loop (which calls `getattr` with defaults — safe) through the
+  `CloneDetails(...)` construction (Pydantic validation; should
+  not fail with correct input) and the
+  `set_catalog_provenance(...)` call (which is itself
+  best-effort).
+- Two of those failure modes are noise-suppression we want; the
+  third (CloneDetails validation) is a real bug we'd want to
+  surface as an error in dev.
+
+Action: narrow the except to the network-touching call only;
+let validation errors propagate.
+
+### 3.5 `localize_assets` records the function-parameter `source_hostname` as `asset_source_hostname` even in mixed-source slices (P1)
+
+- `localize.py:402` calls
+  `_record_localize_provenance(..., asset_source_hostname=source_hostname)`.
+- `source_hostname` is the **fallback for relative URLs**, not
+  the actual source of each asset. In a mixed-source slice
+  (where different assets came from different upstream hosts)
+  the annotation will read a single hostname that doesn't
+  describe the localization correctly.
+- Inside the loop, `assets_to_localize[*]["source_hostname"]`
+  carries the actual per-asset source. That information is
+  discarded by the time we write the annotation.
+
+Action: aggregate the actual per-asset source hostnames into a
+list (or `set`) on `LocalizeResult`, and write either the single
+hostname (when it's a single-source slice) or `None` + a
+log warning ("mixed-source slice; see audit log for details") on
+the annotation. Tag P1 because the provenance annotation is
+documented as durable observability of the phase-2 leg.
+
+### 3.6 `chunk_size if use_chunked else 0` is a confusing default (P3)
+
+- `localize.py:353` passes
+  `chunk_size=actual_chunk_size if use_chunked else 0` to
+  `local_hatrac.put_loc(...)`.
+- Passing `0` for `chunk_size` when `chunked=False` is dead
+  code — `HatracStore.put_loc` ignores `chunk_size` when
+  `chunked=False` per deriva-py's contract. Reading the line, a
+  reviewer naturally asks "what does chunk_size=0 mean?"
+- The "treat `chunk_size=0` from the caller as None" rule
+  (commented at lines 333-338) is also subtle: a user passing
+  `chunk_size=0` explicitly *might* mean "force non-chunked
+  upload", but is interpreted as "use default chunking".
+
+Action: pass `chunk_size=actual_chunk_size` unconditionally;
+let the `chunked` flag control behaviour. Update the docstring
+to clarify that `chunk_size=0` is the same as `chunk_size=None`.
+
+### 3.7 `_record_localize_provenance` reads `existing.clone_details is not None` but writes when it is `None` (P3)
+
+- `localize.py:601-628`: branch A reads existing
+  `clone_details`, copies fields; branch B writes a fresh
+  `CloneDetails` with empty `source_hostname=""` /
+  `source_catalog_id=""`.
+- Branch B's `source_hostname=""` is a structurally-invalid
+  `CloneDetails` value masquerading as valid (the type allows
+  empty strings, but the field is documented as the source
+  hostname — empty means "unknown"). A future reader who
+  filters provenance by source hostname will hit empty strings
+  and have to special-case them.
+
+Action: change branch B to use
+`asset_source_hostname or "unknown"` (or a similar sentinel),
+and document the "phase 2 without phase 1" semantics on
+`CloneDetails`.
+
+### 3.8 `is_clone` property comment is incorrect (P3)
+
+- `provenance.py:172-174`:
+  ```python
+  # use_enum_values=True stores the value, not the enum member,
+  # so compare against the string form.
+  return (
+      self.creation_method == CatalogCreationMethod.CLONE.value
+      and self.clone_details is not None
+  )
+  ```
+- `VALIDATION_CONFIG` (`core/validation.py`) does **not** set
+  `use_enum_values=True`. The comparison works because
+  `CatalogCreationMethod` is a `str`-inheriting `Enum`, so
+  `enum_member == "clone"` returns True. The comment is
+  misleading and the `.value` access is unnecessary.
+
+Action: simplify to `self.creation_method ==
+CatalogCreationMethod.CLONE`, fix the comment.
+
+### 3.9 `_extract_hatrac_path` accepts URLs with `/hatrac/` anywhere in the path (P2)
+
+- `localize.py:528-534`: any URL containing `/hatrac/` in its
+  path component returns the suffix from `/hatrac/`. This is
+  tested at `test_extract_hatrac_path_hatrac_in_middle_of_path`
+  (line 116) — i.e., the behaviour is **deliberate** but the
+  test name's "real-world prefixed URLs (e.g., reverse-proxy
+  paths)" rationale is thin: an actual reverse-proxy
+  configuration that strips a path prefix would not require the
+  client to send the un-stripped form.
+- More concerning: a deliberately-crafted URL like
+  `https://evil.example.org/some/hatrac/foo.bin` would parse to
+  a valid hatrac path and (since the source hostname is taken
+  from the URL netloc) get fetched from the attacker's server.
+  The threat is low (Hatrac is behind auth and the caller
+  supplies the URL anyway), but the loose parse contributes.
+
+Action: tighten to `path.startswith("/hatrac/")` only; or
+document the relaxed semantics as a deliberate quirk.
+
+### 3.10 Provenance `is_clone` doesn't verify `clone_details` is well-formed (P3)
+
+- `provenance.py:172-176`: the predicate only checks
+  `clone_details is not None`. A `CloneDetails(source_hostname="",
+  source_catalog_id="")` would return True.
+- See finding 3.7 — the empty-fallback CloneDetails is the
+  scenario where this matters.
+
+Action: strengthen to require non-empty
+`source_hostname` and `source_catalog_id`, or document the
+weakness.
+
+---
+
+## 4. Docstring completeness & accuracy
+
+### 4.1 `clone.py` docstring claims a three-stage pipeline that no longer exists (P1)
+
+- `clone.py:8-9`: "schema without FKs → async data copy → FK
+  application with orphan handling". The module-level docstring
+  truthfully says "The whole legacy implementation has been
+  removed in favor of `clone_via_bag`."
+- However, the `CLAUDE.md` for `deriva-ml` (Catalog Cloning
+  section, ~line 270) still reads: "Three-stage approach:
+  schema without FKs → async data copy → FK application with
+  orphan handling".
+- A new contributor reading the `CLAUDE.md` description will
+  expect to find the three-stage logic in `clone.py` and
+  discover it doesn't exist.
+
+Action: rewrite the `CLAUDE.md` "Catalog Cloning" subsection to
+describe the bag pipeline. Keep the historical note in
+`clone.py`'s module docstring; remove the parallel-but-stale
+description elsewhere.
+
+### 4.2 `create_ml_workspace` lists "Three-stage approach" properties as if they're still load-bearing (P1)
+
+- `clone.py:117-188`: the docstring mentions
+  `reinitialize_dataset_versions` and a bunch of legacy knobs
+  as parameters with semantics — without flagging that the
+  values are accepted-but-ignored. Yes, "Legacy parameters
+  (accepted, no-op, logged as warnings):" is at line 161, but
+  it's mid-docstring and easy to miss.
+- A user who reads the parameter table top-down will see
+  `reinitialize_dataset_versions: True` and assume the function
+  re-initializes versions. They will discover the no-op only
+  after running the clone and finding the destination's
+  `Dataset_Version` rows wrong.
+
+Action: move the "Legacy parameters" block to the top of the
+docstring (right under the one-line description), and mark each
+no-op parameter inline in the `Args:` block.
+
+### 4.3 `clone_via_bag` "Feature parity tracking" table mentions
+features that no longer have a "legacy parameter" counterpart (P3)
+
+- `clone_via_bag.py:27-50`: the table lists
+  `prune_hidden_fkeys`, `truncate_oversized`, `table_concurrency`,
+  `copy_annotations` as "Legacy-only" — these are the parameters
+  that `create_ml_workspace` accepts and ignores.
+- For someone reading `clone_via_bag` cold, the table is
+  confusing: it documents parameters of a *different* function
+  (the legacy `create_ml_workspace`). It belongs in `clone.py`'s
+  docstring, not here.
+
+Action: move the table into `clone.py:create_ml_workspace`'s
+docstring (or delete it; the table is also already half-stale).
+
+### 4.4 `localize_assets` docstring omits the "no provenance write
+on dry-run" behaviour (P2)
+
+- `localize.py:68-169`: the `Args:` block mentions
+  `dry_run: ... Provenance is not updated in dry-run.` This is
+  good. But the `Returns:` section does not explain that the
+  returned `LocalizeResult` in dry-run mode has
+  `assets_processed` populated as "would-process" count, not as
+  actual transfers.
+- A test author reading the docstring will reach for
+  `result.assets_processed > 0` as a success indicator and find
+  it true even in dry-run mode.
+
+Action: clarify in `Returns:`: "In dry-run mode,
+`assets_processed` reflects the count of assets that *would
+have been* localized; `localized_assets` is empty."
+
+### 4.5 `_record_clone_provenance` and `_record_localize_provenance`
+docstrings don't cross-reference each other (P3)
+
+- The two functions form a two-phase write protocol on the same
+  annotation. The phase-1 docstring
+  (`clone_via_bag.py:520-535`) mentions the phase-2 update
+  ("later updated by `localize_assets`") but says nothing about
+  preserving caller-set fields (`name`/`description`).
+- The phase-2 docstring (`localize.py:560-587`) does explain
+  the preservation behaviour but doesn't note the asymmetry
+  with phase-1 (which doesn't preserve them).
+- See finding 2.1 — the asymmetry should be fixed; either way,
+  the docstrings should note the contract.
+
+Action: align the docstrings, ideally by aligning the behaviour
+first.
+
+### 4.6 `CloneDetails.orphan_strategy` field type and value semantics undocumented (P2)
+
+- `provenance.py:107`: `orphan_strategy: str = "fail"`. The
+  string values are constrained to the lowercase enum-value
+  forms (`"fail"`, `"delete"`, `"nullify"`) but neither the
+  field comment nor the surrounding model docstring says so.
+- A future reader writing
+  `CloneDetails(source_hostname=…, orphan_strategy="DELETE")`
+  will get a structurally-valid object that fails to compare
+  against
+  `CatalogCreationMethod.CLONE.value`-style downstream code.
+
+Action: switch the type to a literal-string union or to
+`DanglingFKStrategy` (a `StrEnum` so it serializes correctly).
+The wire format stays compatible.
+
+### 4.7 `CatalogProvenance.created_at` is typed `str` (ISO8601) without explanation (P3)
+
+- `provenance.py:158`: `created_at: str`. The value is set to
+  `datetime.now(timezone.utc).isoformat()` in
+  `set_catalog_provenance` (line 240); a reader has to follow
+  the writer to learn the format.
+
+Action: type as `str` is fine (catalog annotation transport is
+JSON), but the field's docstring/Field description should say
+"ISO 8601 UTC".
+
+### 4.8 `OrphanStrategy` alias's docstring claims "value names match" but doesn't show the equivalence (P3)
+
+- `clone.py:78-82`: "Value names (`FAIL`, `DELETE`, `NULLIFY`)
+  match between the two; `OrphanStrategy.FAIL is
+  DanglingFKStrategy.FAIL`."
+- There is no test asserting that identity. A future change to
+  `deriva.bag.traversal.DanglingFKStrategy` (renaming a member,
+  changing the value form, adding a new member) would silently
+  break the alias claim. The closest assertion is
+  `test_intentional_fk_cycles_includes_dataset_dataset_version`
+  which doesn't touch the alias.
+
+Action: add a one-liner test
+`assert OrphanStrategy.FAIL is DanglingFKStrategy.FAIL` (and the
+two others). Or, when deriva-mcp retires, delete the alias.
+
+### 4.9 `clone_via_bag` Example doctest assertion has unrealistic value (P3)
+
+- `clone_via_bag.py:330`:
+  ```text
+  >>> result.load_report.total_rows_inserted  # doctest: +SKIP
+  12345
+  ```
+- The number 12345 is a placeholder. SKIPped, so it never runs;
+  but a reader unfamiliar with the codebase will wonder if it's
+  meaningful.
+
+Action: replace with a comment "# some positive number" or
+remove the assertion line.
+
+### 4.10 `_get_catalog_info` uses fragile `hasattr` duck-typing (P3)
+
+- `localize.py:419-424`:
+  ```python
+  if hasattr(catalog, "catalog") and hasattr(catalog, "host_name"):
+      ...
+  ```
+- The duck-typing has no test, and a future class that happens
+  to expose both attributes (e.g., a wrapper / mock) would route
+  through the wrong branch. The interface
+  `DerivaMLCatalogReader` exists for exactly this kind of
+  polymorphism (`CLAUDE.md` "Protocol Hierarchy").
+
+Action: switch to `isinstance(catalog, DerivaML)` (the runtime
+type) or add a protocol check; tag the function as accepting
+the union explicitly.
+
+---
+
+## 5. Cross-reference notes
+
+### 5.1 Workspace consumers of `catalog/` exports
+
+In-tree (`src/deriva_ml/`):
+
+- `core/base.py:1068`: `get_catalog_provenance` (read).
+- `__init__.py:78-94`: re-exports
+  `CatalogProvenance, CatalogCreationMethod, CloneDetails,
+  get_catalog_provenance, set_catalog_provenance`.
+- No in-tree caller of `clone_via_bag`, `create_ml_workspace`,
+  `localize_assets`, `OrphanStrategy`, or `CloneViaBagResult` /
+  `LocalizeResult`.
+
+Out-of-tree:
+
+- `deriva-ml-model-template/src/scripts/_cifar10_schema.py:44, 119`
+  uses `set_catalog_provenance`.
+- `deriva-mcp/src/deriva_mcp/tools/{catalog,background_tasks}.py`
+  imports `AssetCopyMode` (which doesn't exist), `OrphanStrategy`,
+  `create_ml_workspace`. **Already broken at runtime.** Per
+  workspace CLAUDE.md, deriva-mcp is being retired.
+
+The provenance API is the only catalog-package symbol with a
+working external consumer. Everything else in the `__all__` block
+(`OrphanStrategy`, `create_ml_workspace`, `clone_via_bag`,
+`CloneViaBagResult`, `localize_assets`, `LocalizeResult`) is
+internal-only at v1.37.1.
+
+### 5.2 `core/constants.INTENTIONAL_FK_CYCLES` is correctly wired everywhere (positive finding)
+
+- `tests/catalog/test_intentional_fk_cycles.py` is a thorough
+  cross-module wiring test (180 LoC, 6 tests).
+- Both `clone_via_bag.py:255` (legacy bag-builder) and
+  `clone_via_bag.py:383, 417` (clone_via_bag) wire it in.
+- Both branches of the policy-merge path also wire it (the
+  auto-build and the merge-into-caller-policy branches).
+- This is the cleanest part of the subsystem.
+
+### 5.3 Bag pipeline correctly preserves explicit FAIL strategy
+(positive finding)
+
+- `test_clone_via_bag_preserves_explicit_fail_strategy` (line
+  368) regression-tests audit §6.2 in the previous audit cycle:
+  a DBA passing `dangling_fk_strategy=FAIL` keeps the value
+  despite FAIL also being the library default. The
+  `model_fields_set` predicate is the right tool.
+- See finding 3.1 — this guarantee should extend to other
+  policy fields or be documented as deliberately scoped.
+
+---
+
+## 6. Totals
+
+- Total findings: **32**.
+- By severity:
+  - P0 — **1** (1.1 — `localize_assets` integration coverage).
+  - P1 — **6** (1.2, 1.3, 1.4, 3.5, 4.1, 4.2).
+  - P2 — **12** (1.5, 2.1, 2.3, 3.1, 3.2, 3.3, 3.4, 3.9, 4.4,
+    4.6).
+  - P3 — **13** (1.6, 1.7, 2.2, 2.4, 2.5, 3.6, 3.7, 3.8, 3.10,
+    4.3, 4.5, 4.7, 4.8, 4.9, 4.10).
+
+(Section 5 is observational notes, not findings.)
+
+## 7. Release decision
+
+Recommended action for v1.37.1:
+
+1. **Land at least one integration test for `localize_assets`
+   happy-path** (finding 1.1). The function ships in the public
+   `__init__.py` `__all__` and has zero coverage of its actual
+   work. Without this, "localize works" is folklore.
+2. **Either delete `reinitialize_dataset_versions` from
+   `CloneDetails` and `create_ml_workspace` or implement it**
+   (finding 1.4). Currently it's a documented feature that is a
+   silent no-op.
+3. **Update `CLAUDE.md`'s "Catalog Cloning" section** to
+   describe the bag pipeline rather than the deleted
+   three-stage clone (finding 4.1).
+4. Treat all P2 findings as v1.38 work; P3 as opportunistic
+   cleanup.
+
+The subsystem is **release-able** at P0=1 — the single P0 is a
+test-coverage gap on a feature that is already documented and
+shipped. Adding the test now (or marking the function clearly as
+"experimental, no integration coverage") closes the audit.

--- a/docs/audits/2026-05-22-engineer-audit-core.md
+++ b/docs/audits/2026-05-22-engineer-audit-core.md
@@ -1,0 +1,1089 @@
+# deriva-ml pre-release engineer audit (v1.37.1) — `core/`
+
+Reviewed the core subsystem under
+`/Users/carl/GitHub/DerivaML/deriva-ml/src/deriva_ml/core/` (21 modules
++ 11 mixins, ~10 800 LoC) and the corresponding test surface
+`/Users/carl/GitHub/DerivaML/deriva-ml/tests/core/` (20 files,
+~3 100 LoC) at the v1.37.1 release point. Cross-references against
+`src/deriva_ml/interfaces.py`, `src/deriva_ml/execution/`,
+`src/deriva_ml/dataset/`, and `src/deriva_ml/model/` confirm the in-
+tree consumers of the core surface. Severity scale: P0 (block release),
+P1 (must fix this release), P2 (next release), P3 (cleanup when
+convenient).
+
+## Summary
+
+Overall posture: **the foundation modules are good and the recently-
+refactored schema-cache machinery is excellent**. `exceptions.py`
+carries a well-organised hierarchy with consistent docstrings and
+structured attributes on every typed exception. `schema_cache.py` (218
+LoC) and its test suite (336 LoC) are a model of small, single-purpose
+design — atomic writes, concurrent-writer regression coverage, pin/
+unpin/status all exercised. `schema_diff.py` is pure-functional, well-
+documented, and has deterministic-ordering tests. `connection_mode.py`
+is 34 LoC and exercises every code path through `tests/core/
+test_connection_mode.py`.
+
+The weaker areas are:
+
+1. **`base.py` is 1 675 LoC of public API and the user's first contact
+   — and the docstrings have stale/wrong content in several places.**
+   `list_execution_dirs` and `get_storage_summary` use lowercase
+   `any` as a type hint (the builtin, not `typing.Any`). Several
+   docstring `Returns:` claims (chaise_url, cite) put concrete catalog
+   IDs that contradict the test fixture values. `catalog_snapshot`
+   constructs a new `DerivaML` without forwarding `working_dir`,
+   `cache_dir`, `mode`, `credential`, etc. — the returned instance
+   loses every non-default init kwarg.
+
+2. **`validation.py` (the public RID-validation surface) has zero
+   tests in `tests/core/`.** `validate_rids`, `validate_execution_
+   config`, and `ValidationResult` are exported and consumed via the
+   hydra-zen entry path; the only coverage is incidental via
+   `tests/dataset/test_validate_execution_configuration_unit.py` and
+   `tests/dataset/test_validate_specs_live.py`. The error-message
+   parsing at `validation.py:257` (`if "Invalid RIDs:" in error_msg`)
+   is string-coupled to `RidResolutionMixin.resolve_rids`'s message —
+   if either side changes, the validator silently degrades to
+   "RID validation failed: ..." for every bad RID.
+
+3. **`filespec.py:144` has a real bug.** Inside `create_filespecs`'s
+   inner `create_spec(file_path)`, the `length` field is computed as
+   `path.stat().st_size` — that's the *outer* `path` (the directory
+   the user passed in), not `file_path` (the file being processed).
+   When `create_filespecs` walks a directory, every produced FileSpec
+   carries the directory's stat-size, not its own. No test exercises
+   the multi-file `tmp_path` size invariant; the existing tests in
+   `tests/core/test_file.py` only assert filename and type-list.
+
+4. **The mixin layer's docstrings claim methods that don't exist or
+   that live in other mixins.** `WorkflowMixin` class docstring lists
+   `find_workflow_by_url` (actual: `lookup_workflow_by_url`) and
+   `list_workflow_executions` ("via FeatureMixin" — and indeed
+   `list_workflow_executions` is defined in `FeatureMixin`, not
+   `WorkflowMixin`). `VocabularyMixin.lookup_term`'s `Raises:` section
+   names `DerivaMLVocabularyException` — a class that has never
+   existed.
+
+5. **`logging_config.py` is configured by `DerivaML.__init__` but has
+   zero test coverage.** No test exercises `configure_logging`,
+   `is_hydra_initialized`, or `_apply_logger_overrides`. The
+   `get_logger` doctests work, but the side-effect-laden
+   `configure_logging` (sets levels on 4 deriva-py loggers, 4 hydra
+   loggers, and one deriva-ml logger; adds a handler conditionally)
+   is the actual surface that matters at `DerivaML.__init__:354`.
+
+6. **The exception hierarchy has drift between `exceptions.py.__all__`
+   and `definitions.py.__all__`.** `definitions.py` re-exports a
+   *subset* of exceptions and omits `DerivaMLFeatureNotFound`,
+   `DerivaMLOfflineError`, `DerivaMLStateInconsistency`,
+   `DerivaMLDirtyWorkflowError`, `NoAssociationException`,
+   `AmbiguousAssociationException`, `DerivaMLSchemaRefreshBlocked`,
+   `DerivaMLSchemaPinned`, `DerivaMLMaterializeLimitExceeded`, and
+   every `DerivaMLDenormalize*` class. Users following the documented
+   `from deriva_ml.core.definitions import ...` pattern (constants.py
+   docstring, definitions.py module header) cannot reach the typed
+   exceptions added since Phase 2.
+
+7. **Online-only operations have inconsistent exception types.**
+   `refresh_schema`/`diff_schema` raise `DerivaMLReadOnlyError` for the
+   "offline mode" guard at `base.py:555,707`; `create_execution`
+   raises `DerivaMLOfflineError` for the same condition (`execution.
+   py:170`). The dedicated `DerivaMLOfflineError` exists for this case;
+   `DerivaMLReadOnlyError` is overloaded.
+
+Counts: **51 findings** (1 P0, 9 P1, 25 P2, 16 P3) across the 21 core
+modules + 11 mixins, plus 7 cross-module coverage gaps and 5
+duplication candidates.
+
+---
+
+## `core/base.py` — DerivaML class (1 675 LoC)
+
+### B1. `list_execution_dirs` and `get_storage_summary` annotate return type with builtin `any` [P1]
+
+`base.py:1466`, `base.py:1589`. Both signatures use
+`-> list[dict[str, any]]` and `-> dict[str, any]` — `any` is Python's
+*builtin* `any()` function, not `typing.Any`. At runtime this is
+silently ignored by Python's type system, but `mypy`/`pyright` will
+flag it and the IDE autocompletion is wrong. Fix to `Any` (already
+imported via `from typing import Any` at line 20).
+
+### B2. `catalog_snapshot` drops every non-default kwarg [P1]
+
+`base.py:756-774`. The returned instance is built with
+`DerivaML(self.host_name, version_snapshot, logging_level=...,
+deriva_logging_level=...)`. Every other kwarg the user passed —
+`working_dir`, `cache_dir`, `domain_schemas`, `default_schema`,
+`s3_bucket`, `use_minid`, `credential`, `mode`, etc. — is silently
+re-defaulted. For a user doing `ml.catalog_snapshot(snap)`, the
+returned object has a different `working_dir` than `ml`, may have
+different `domain_schemas` (if auto-detection picks differently from
+the snapshot), and loses cached credentials. Either forward all
+kwargs (recommended) or document the contract that snapshot
+instances are bare.
+
+### B3. `__del__`'s catalog session check is correct but untested for the GC-ordering case [P2]
+
+`base.py:376-407`. The docstring says the abort is skipped when the
+catalog session may already be torn down. The tests at
+`test_del_no_abort_terminal.py` cover the status-filter logic but
+never exercise the actual GC-ordering torn-session crash that
+prompted the fix. A test that builds a real `DerivaML`, monkey-
+patches `self._execution.update_status` to assert the call is
+suppressed when `self.catalog._session is None`, would pin the
+guarantee.
+
+### B4. `cite()` swallows the `KeyError` cause [P2]
+
+`base.py:1040-1043`. The except clause raises a bare
+`DerivaMLException("Entity {e} does not have RID column")` for both
+`KeyError` (missing "RID" key) and the upstream `DerivaMLException`
+("Entity RID does not exist"). The first message string-interpolates
+the `KeyError` (so the user sees `Entity 'RID' does not have RID
+column` — odd phrasing); the second drops the original cause. Add
+`from e` and consider distinct messages.
+
+### B5. `cite()` doctest example mixes two output shapes [P3]
+
+`base.py:1015-1028`. The "Permanent citation (default)" example
+shows the catalog ID `1` in `https://deriva.org/id/1/...`, while
+the test harness in `tests/core/test_base.py::_CiteHarness` uses
+catalog_id `42`. The doctest is `# doctest: +SKIP` so the mismatch
+is harmless, but a user copy-pasting from the docstring will
+puzzle at the discrepancy.
+
+### B6. `download_dir` is a thin two-line method with a docstring three times its size [P3]
+
+`base.py:797-813`. The doctstring is fine; it's just a candidate
+for inlining at the few call sites (4 of them in
+`dataset/dataset.py`).
+
+### B7. `chaise_url` returns a string that the docstring claims is `'https://...'/schema:experiment_table'` but the test fixture produces `'https://deriva.example.org/chaise/recordset/#42@2026-01-01T12:00:00/...'` [P2]
+
+`base.py:963-993`. The docstring `Returns:` says the URL format is
+`https://{host}/chaise/recordset/#{catalog}/{schema}:{table}`, but
+the real branch at line 989 uses `self.catalog.get_server_uri()`
+which carries the snaptime when on a snapshot. The format the
+docstring documents is the *non-snapshot* case; the snapshot case
+isn't documented. Add the snapshot-form example or document the
+two-branch behavior.
+
+### B8. `_find_context_file` only searches up; no symlink resolution test [P3]
+
+`base.py:1649-1674`. The implementation uses `Path.resolve()` on
+the start dir, which follows symlinks. The unit tests
+(`tests/core/test_base.py::test_find_context_file_in_start_dir` and
+`_walks_parents`) only test the non-symlink case. A symlinked
+working directory pointing at a different drive would silently
+look up the wrong context file. Not high risk; document the
+behavior or add a symlink test.
+
+### B9. `pin_schema` online path swallows `cache.load()` exceptions silently if the cache file vanishes between `if cache.exists()` and `cache.load()` [P3]
+
+`base.py:636-654`. The check at the top of `pin_schema` calls
+`cache.load()` unconditionally to compare snapshot ids. If the
+cache file is deleted by a concurrent writer between `__init__`'s
+write and `pin_schema`'s read, `cache.load()` raises
+`FileNotFoundError`. The docstring claims `FileNotFoundError` is
+raised in that case, but the online branch ordering means the
+exception propagates *after* the pin would have applied for the
+offline path. Add a `try/except` consistent with `unpin_schema`'s
+"no-op if not pinned" semantics.
+
+### B10. `clear_cache` and `clean_execution_dirs` log via `self._logger` but no other base-class method does [P2]
+
+`base.py:1427, 1431, 1584`. The `_logger` attribute is set in
+`__init__` but only these three methods use it; everywhere else
+the module-level `logger = get_logger(__name__)` is used. Pick
+one; the dual-source pattern is the kind of thing that breaks
+when someone adds a new error path and consults the wrong logger
+namespace.
+
+---
+
+## `core/exceptions.py` — exception hierarchy (780 LoC)
+
+### E1. `definitions.py.__all__` omits 10+ exception classes [P1]
+
+`definitions.py:120-181`. The module re-exports only the legacy
+exception set and misses every new class added since Phase 2:
+`DerivaMLFeatureNotFound`, `DerivaMLOfflineError`,
+`DerivaMLStateInconsistency`, `DerivaMLDirtyWorkflowError`,
+`NoAssociationException`, `AmbiguousAssociationException`,
+`DerivaMLSchemaRefreshBlocked`, `DerivaMLSchemaPinned`,
+`DerivaMLMaterializeLimitExceeded`, `DerivaMLDenormalizeError` and
+all 5 subclasses. The module header recommends importing from
+`deriva_ml.core.definitions`, so users following that guidance can't
+reach the new classes. Either expand the re-export to match
+`exceptions.py.__all__` exactly, or delete the exception block in
+definitions.py and document `from deriva_ml.core.exceptions import
+...` as canonical.
+
+### E2. `core/__init__.py` exports only three exception classes [P2]
+
+`core/__init__.py:35,42-45`. Only `DerivaMLException`,
+`DerivaMLInvalidTerm`, `DerivaMLTableTypeError` are re-exported from
+`deriva_ml.core`. The package-level `deriva_ml.__init__` re-exports
+more, but the `deriva_ml.core` namespace under-promises. A user
+catching `from deriva_ml.core import DerivaMLNotFoundError` gets an
+`ImportError`. Either drop the partial set (force the longer
+qualified imports) or include the full hierarchy.
+
+### E3. `DerivaMLException._msg` private attribute is dead [P3]
+
+`exceptions.py:96, 105-107`. The base class stores `self._msg = msg`
+but no subclass and no caller in the codebase reads it. `super().
+__init__(msg)` already exposes the message via `str(exc)`. Either
+drop `_msg` or document it as a public alias.
+
+### E4. Most typed exceptions have docstring `Example:` blocks that all `+SKIP` doctest [P3]
+
+`exceptions.py:101, 122, 135, 151, 167, 183, 201, 220, 232, 250,
+269, ...`. Twenty-plus classes have raise-pattern examples that all
+skip doctest because they involve a fictional `ml` or `raise`. A
+handful — `DerivaMLMaterializeLimitExceeded` at line 379-384,
+`NoAssociationException` at line 451-461 — show how runnable
+examples can be written (attribute access on the raised exception).
+Convert the others to runnable form (construct the exception, check
+attributes), and only `+SKIP` the inline raises.
+
+### E5. `NoAssociationException` is documented as `DerivaMLNotFoundError` but its sibling `AmbiguousAssociationException` is `DerivaMLDataError` [P2]
+
+`exceptions.py:435-501`. The asymmetry is documented in
+`exceptions.py:9-25` and tested in `test_exceptions.py:39-77`, so
+the inheritance is intentional. But the inheritance pair
+("missing → NotFound, multiple → DataError") makes it impossible
+to catch both with a single typed `except`. Consider whether a
+shared `AssociationException` parent (extending `DerivaMLDataError`)
+would simplify the call-site catch in `find_association`'s callers.
+
+### E6. `DerivaMLStateInconsistency` has no test coverage [P2]
+
+`exceptions.py:415-432`, `tests/core/test_exceptions.py:17-24`.
+Only the inheritance is tested. The class docstring promises
+"enough information for a human to intervene" but doesn't define
+the message contract — no example of the actual SQLite-vs-catalog
+disagreement string that `state_machine.reconcile_with_catalog`
+emits. Add a positive-path test that exercises the real
+disagreement detector at `execution/state_machine.py` and
+confirms the typed exception is raised with the documented info.
+
+### E7. `DerivaMLDirtyWorkflowError` carries `self.path` but is constructed only from the path argument [P3]
+
+`exceptions.py:553-557`. The constructor signature is
+`__init__(self, path: str)`. The message includes the path; the
+attribute makes the path retrievable structurally. Fine — but the
+example in the docstring (line 549-551) uses only the message
+format, never demonstrating `.path` access. Document the structured
+attribute.
+
+---
+
+## `core/validation.py` — RID + config validation (427 LoC)
+
+### V1. Module is exported but has zero direct tests in `tests/core/` [P1]
+
+`validation.py:174-350` (`validate_rids`), `352-427`
+(`validate_execution_config`), `88-171` (`ValidationResult`). The
+old `tests/schema/test_validation.py` is deleted (only the `.pyc`
+remains). Coverage is now incidental through
+`tests/dataset/test_validate_execution_configuration_unit.py`. Add
+direct unit tests for:
+
+- `ValidationResult.merge` (no test exercises the `validated_rids`
+  merge case)
+- `ValidationResult.__repr__` with errors+warnings combinations
+  (covers the formatted output users see)
+- `validate_rids` with each of the five filter combinations
+  (`dataset_rids`/`asset_rids`/`workflow_rids`/`execution_rids`
+  /empty)
+
+### V2. `validate_rids` parses an error message string to detect invalid RIDs [P1]
+
+`validation.py:256-263`. The block
+
+```python
+error_msg = str(e)
+if "Invalid RIDs:" in error_msg:
+    for rid in all_rids:
+        if rid not in result.validated_rids:
+            ...
+            result.add_error(...)
+else:
+    result.add_error(f"RID validation failed: {e}")
+```
+
+is coupled to `RidResolutionMixin.resolve_rids`'s message at
+`rid_resolution.py:211` (`raise DerivaMLException(f"Invalid RIDs:
+{remaining_rids}")`). Any future refactor to the resolver — even a
+period change — silently breaks the per-RID error reporting and
+collapses every bad-RID case to one generic message. Either:
+
+1. Have `resolve_rids` raise a typed exception carrying the bad-RID
+   set as a structured attribute (`DerivaMLNotFoundError` subclass);
+   `validate_rids` then reads the attribute.
+2. Move the partial-failure logic into `resolve_rids` itself by
+   returning a result object instead of raising.
+
+### V3. `validate_execution_config` does duck-typed attribute access on `datasets`/`assets` [P2]
+
+`validation.py:391-410`. The function accepts dict, dataclass,
+`DatasetSpec`, `AssetSpec`, and bare strings. The `getattr(x,
+"rid", None) or (x.get("rid") if isinstance(x, dict) else None)`
+pattern obscures the contract — neither the parameter type
+annotation (`list[Any]`) nor the docstring tells the caller which
+shapes are accepted. Replace `list[Any]` with the actual union or
+add a Pydantic adapter.
+
+### V4. `ValidationResult.is_valid` defaults to `True`; `add_error` flips it [P3]
+
+`validation.py:121, 126-129`. Fine as a pattern, but tested only
+indirectly. Add a one-line direct test:
+`r = ValidationResult(); r.add_error("x"); assert r.is_valid is
+False`.
+
+### V5. `STRICT_VALIDATION_CONFIG` is exported but used nowhere in core/ [P3]
+
+`validation.py:61-66`. Search hits zero call sites in
+`src/deriva_ml/core/`. It's defensive infrastructure for future
+strict-validation needs; document the intent or drop it.
+
+---
+
+## `core/logging_config.py` — logging setup (221 LoC)
+
+### L1. `configure_logging` has no test coverage [P1]
+
+`logging_config.py:122-199`. The function is invoked by
+`DerivaML.__init__:354` and decides:
+
+- Whether to add a `StreamHandler` (only when not under Hydra and
+  no handler exists already)
+- Which 8 loggers (deriva-ml + hydra + deriva-py + bdbag + bagit)
+  to set levels on
+- Whether to call `basicConfig` (it explicitly doesn't)
+
+A test that monkeypatches `logging.getLogger` and asserts the
+resulting level-and-handler state for `(deriva_ml,)`, `(hydra*,)`,
+and `(deriva, bagit, bdbag)` separately under three runtime cases
+(no-hydra, hydra-initialized, custom handler) would pin the
+contract.
+
+### L2. `is_hydra_initialized` swallows `ImportError` and `Exception` [P2]
+
+`logging_config.py:72-77`. The `except (ImportError, Exception)`
+swallows every error from `GlobalHydra.instance().is_initialized()`.
+`Exception` already catches `ImportError`; the redundant catch
+makes the bare `Exception` swallow look like a typo. Replace with
+`except Exception:` and add a debug log for the failure.
+
+### L3. `get_logger` doctest at lines 107-113 is informative but doesn't test the `__name__`-prefix-stripping path [P3]
+
+`logging_config.py:114-119`. The form-3 path
+(`get_logger("deriva_ml.dataset")` returns
+`deriva_ml.dataset` unchanged) is doctested. The corresponding
+"already-prefixed *and* invalid (no `.` separator)" path —
+`get_logger("deriva_ml")` — is doctested. Add the
+short-suffix-with-dot edge case: `get_logger("a.b")` should
+become `deriva_ml.a.b` (the current implementation does this; just
+no test pins it).
+
+### L4. `DEFAULT_FORMAT`, `HYDRA_LOGGERS`, `DERIVA_LOGGERS` are module-level constants but absent from `__all__` [P3]
+
+`logging_config.py:38, 42-46, 49-54, 216-221`. They're public-shaped
+(uppercase, top-level), and a user customizing logging would
+plausibly want to import them. Add to `__all__` or rename with a
+leading underscore.
+
+### L5. `LOGGER_NAME` is exported from `__all__` but `get_logger.__doc__` is the canonical entry [P3]
+
+`logging_config.py:35, 215-221`. Minor — the constant doubles up
+documentation responsibility with the `get_logger` docstring. Pick
+one.
+
+---
+
+## `core/schema_cache.py` — workspace cache (218 LoC)
+
+### S1. `pin_status` raises `FileNotFoundError` when cache is missing — but `snapshot_id` returns `None` for the same condition [P2]
+
+`schema_cache.py:80-87, 194-218`. The asymmetry is intentional
+(snapshot lookup is "informational", pin_status is "authoritative")
+but is undocumented at the class level. Add a "Read API
+conventions" note to the class docstring.
+
+### S2. `_path` attribute is exposed by name only via `cache._path` in tests [P3]
+
+`schema_cache.py:74, schema_diff.py: uses cache._path indirectly`.
+Six tests in `test_schema_cache.py` reach for `cache._path` to
+plant or inspect the underlying file. The leading underscore says
+"private"; convert to a public `path` property or document the
+test-friendly access pattern.
+
+### S3. Pin/unpin operations don't log [P3]
+
+`schema_cache.py:155-192`. `refresh_schema` logs at INFO; pin and
+unpin don't. For audit-trail purposes — pin/unpin is exactly the
+sort of thing a reproducibility check would want logged — add a
+single INFO line per call.
+
+---
+
+## `core/schema_diff.py` — structural diff (321 LoC)
+
+### D1. `_compute_diff` only inspects tables inside schemas present in **both** payloads [P2]
+
+`schema_diff.py:246`. The `for schema_name in sorted(cached_names &
+live_names):` line means that tables inside a newly-added schema
+(reported via `added_schemas`) do not appear in `added_tables`.
+Symmetric for removed schemas. This is defensible (the added/removed
+*schema* implies its tables) but subtle — a user inspecting
+`diff.added_tables` will miss tables in added schemas. Document the
+behavior or expand the walk to enumerate tables of added schemas
+into `added_tables`.
+
+### D2. `_fkey_key` assumes all `referenced_columns` share `schema_name`/`table_name` [P3]
+
+`schema_diff.py:194-204`. The function reads `ref_cols_raw[0]
+["schema_name"]` to derive the referenced schema/table. ERMrest's
+data shape guarantees this (every FK references one table), but
+nothing in the code validates the invariant. If the catalog ever
+emits a malformed FK with a multi-table reference array, the
+`_fkey_key` silently picks the first entry. Add an `assert`.
+
+### D3. `SchemaDiff.render()` returns empty string for empty diffs [P3]
+
+`schema_diff.py:134-169, test_schema_diff.py:175-177`. The test
+asserts `empty.render() == "" or "no changes" in empty.render().
+lower()` — the `or` clause is a hedge against an implementation
+that doesn't exist. Tighten the test to `assert empty.render() ==
+""`.
+
+---
+
+## `core/config.py` — DerivaMLConfig (233 LoC)
+
+### C1. `init_working_dir` validator silently overwrites the user-provided `working_dir` [P1]
+
+`config.py:133-161`. The validator runs `compute_workdir(self.
+working_dir, ...)`, which appends `username/deriva-ml/hostname/
+catalog_id` to whatever path the user provided. A user who passes
+`working_dir="/tmp/wd"` ends up at `/tmp/wd/<user>/deriva-ml/<host>/
+<catalog>` and is not told. The same `working_dir` argument to
+`DerivaML.__init__` at `base.py:307-310` is honored as-is:
+
+```python
+if working_dir is not None:
+    self.working_dir = Path(working_dir).absolute()
+```
+
+So the same kwarg behaves differently depending on whether you go
+through the Pydantic config or the bare constructor. Pick one
+semantic. The bare-constructor behavior (use path as given) is the
+less surprising of the two; the Pydantic mutation behavior is
+hydra-specific path-organisation that should live in `compute_
+workdir` only, not in the validator.
+
+### C2. `init_working_dir` reads `HydraConfig.get().runtime.output_dir` unconditionally [P1]
+
+`config.py:151`. If the config is instantiated outside a Hydra
+run, this raises `ValueError: HydraConfig was not set`. The test
+suite hides this via `with patch("deriva_ml.core.config.
+HydraConfig")` (see `test_hydra_zen_config.py:64`). User code that
+constructs `DerivaMLConfig(hostname=..., catalog_id=...)` without
+a Hydra context (e.g., in a Jupyter notebook for ad-hoc config)
+hits the same `ValueError`. Wrap in a try/except and default to
+`None`, or document the Hydra-context prerequisite at the
+docstring.
+
+### C3. `compute_workdir`'s `working_dir` argument has surprising semantics [P2]
+
+`config.py:163-203`. If `working_dir` is *truthy*, the function
+appends `username/deriva-ml` to it; if falsy (`None` or empty
+string), it uses `~/.deriva-ml`. The truthy/falsy branching is
+fine, but the inserted `username` middle directory is documented
+as "to prevent conflicts between users" — yet no other code in
+the workspace honors this convention (e.g., `DerivaML.__init__`
+on the bare path). Either remove the `username` insertion (the
+catalog-id+hostname suffix already disambiguates) or apply it
+uniformly.
+
+### C4. `OmegaConf.register_new_resolver(..., replace=True)` at module import time [P2]
+
+`config.py:212`. The `replace=True` flag means importing
+`deriva_ml.core.config` silently overwrites any previously-
+registered `compute_workdir` resolver. Two concurrent importers
+(deriva-ml itself and a downstream project that registered its own
+resolver under the same name) silently lose information. Either
+drop `replace=True` and let the second importer get a clear
+`ValueError`, or namespace the resolver name.
+
+### C5. `store(HydraConf(...))` at module import time [P3]
+
+`config.py:217-230`. Importing `deriva_ml.core.config` registers
+Hydra config defaults *globally*. A user importing the module just
+to read the `DerivaMLConfig` class — for type-checking or
+validation purposes — also mutates the Hydra store. Move the side
+effect into a `configure_hydra()` function or guard with
+`if __name__ == ...` (not applicable here, but a flag like
+`DERIVA_ML_REGISTER_HYDRA` would let the user opt out).
+
+---
+
+## `core/filespec.py` — file metadata (190 LoC)
+
+### F1. `create_filespecs` length bug — uses outer `path.stat()`, not `file_path.stat()` [P0]
+
+`filespec.py:144`. Inside `create_spec(file_path)`:
+
+```python
+return FileSpec(
+    length=path.stat().st_size,  # <-- BUG: should be file_path.stat().st_size
+    md5=md5,
+    ...
+    url=file_path.as_posix(),
+    ...
+)
+```
+
+When the input `path` is a directory, `path.stat().st_size` returns
+the directory inode's size (typically 64-512 bytes) and every
+FileSpec produced from the directory walk gets that wrong size —
+not its own file's size. Single-file invocations are correct
+because `path == file_path` in that case. The test in
+`test_file.py::test_create_filespecs` doesn't assert the length
+field, so the bug has gone undetected. Fix to
+`file_path.stat().st_size` and add a regression test that creates
+two files of different sizes in a tmp dir and asserts both
+lengths.
+
+### F2. `create_filespecs` doesn't handle empty `file_types` argument cleanly [P3]
+
+`filespec.py:134-136, 142-149`. `file_types = file_types or []`
+then `file_types_fn = file_types if callable(file_types) else
+lambda _x: file_types`. The closure captures `file_types` (the
+mutated local), but if a caller passes `file_types=[]` explicitly
+(non-falsy after the `or`), the lambda returns `[]` and the `if
+"File" in type_list` check at line 149 produces `["File"]`. Fine,
+but the closure-vs-shadowing risk is real if the function is
+extended. Convert the static path to `lambda _x: list(file_types)`.
+
+### F3. `VocabularyTerm.__init__` pops `Name`/`name` and stores in `PrivateAttr` [P3]
+
+`ermrest.py:213-228`. The pattern works but is the kind of
+manual private-attr juggling Pydantic v2 added `model_validator`
+to replace. The `Name`/`Synonyms`/`Description` columns are
+catalog-system; consider exposing them as standard fields with
+`alias=` instead of `PrivateAttr`-via-`__init__`.
+
+---
+
+## `core/connection_mode.py` — mode enum (34 LoC)
+
+### CM1. The `__init__` of every `DerivaML` calls `ConnectionMode(mode)` to coerce [P3]
+
+`base.py:296, mixins/execution.py:163`. The coercion happens at the
+two real consumers; the module is otherwise standalone. Fine —
+flagging only because the spec §2.1 reference in the docstring
+points to a spec doc that isn't in-tree (it lives in
+`docs/design/...` or similar). A pointer to the actual doc in
+the module docstring would help future readers.
+
+---
+
+## `core/catalog_stub.py` — offline catalog stand-in (43 LoC)
+
+### CS1. `__getattr__` returns `AttributeError` for `_` names but the test only checks `__repr__`/`__str__` [P2]
+
+`catalog_stub.py:30-38`, `test_catalog_stub.py:30-43`. Line 36-37:
+
+```python
+if name.startswith("_"):
+    raise AttributeError(name)
+```
+
+The test exercises `repr(stub)` and `str(stub)` (which go through
+`__repr__`, not `__getattr__`). Add a positive test: `stub.
+_some_attr` should `raise AttributeError`, not
+`DerivaMLReadOnlyError`. Pin the dunder-vs-userattr contract.
+
+---
+
+## `core/async_helpers.py` — sync/async bridge (73 LoC)
+
+### A1. `run_async` has a runnable doctest but no proper test [P2]
+
+`async_helpers.py:35-73`. The module docstring example and the
+function doctest both demonstrate the happy path. Missing:
+
+- The `nest_asyncio.apply()` path (when a loop is already running).
+  This is the actual reason the module exists — Jupyter/papermill
+  compatibility.
+- The `Awaitable that raises` path, asserting the exception
+  surfaces unchanged.
+
+A test using `asyncio.new_event_loop()` and a coroutine that
+raises would exercise the loop-detection-and-fallback path.
+
+---
+
+## `core/upload_layout.py` — directory layout helpers (330 LoC)
+
+### UL1. `asset_table_upload_spec` calls `model.name_to_table(asset_table)` four times [P2]
+
+`upload_layout.py:215, 216, 226, 227`. The redundant assignments at
+226-227
+
+```python
+asset_table = model.name_to_table(asset_table)
+schema = model.name_to_table(asset_table).schema.name
+```
+
+are exact duplicates of lines 215-216 with no intervening mutation.
+Lines 226-227 should be deleted; both `asset_table` and `schema`
+are unchanged.
+
+### UL2. `NULL_SENTINEL` is module-level but only consumed by `asset/null_sentinel_processor.py` [P3]
+
+`upload_layout.py:67`. The constant is defined here as a
+convenience for the cross-module producer/consumer pair, but the
+production path (`bag_commit`) bypasses it (docstring: "does not
+need this sentinel"). Either drop the constant or move it to
+`asset/null_sentinel_processor.py` so the legacy/production path
+distinction is co-located with the consumer.
+
+### UL3. `DEFAULT_UPLOAD_TIMEOUT` at line 313 is not exported in `__all__` [P3]
+
+`upload_layout.py:90-102`. It's referenced via dotted import by
+upload code; either expose it via `__all__` or rename with a
+leading underscore.
+
+### UL4. `upload_root` mkdirs unconditionally on read [P2]
+
+`upload_layout.py:105-109`. Calling `upload_root(prefix)` always
+creates the `deriva-ml` directory under `prefix`. Read-side users
+that only want to *check* whether the upload root exists are
+forced to create it as a side effect. Consider an `exist_ok=True,
+parents=True, create=False` knob, or a separate `upload_root_
+path(prefix) -> Path` that doesn't mkdir.
+
+---
+
+## `core/mixins/path_builder.py` — path builder (164 LoC)
+
+### PB1. `_domain_path` returns annotation is `datapath.DataPath` but the body returns `pathBuilder().schemas[schema]` which is a `_Schema` wrapper [P3]
+
+`path_builder.py:77-98`. Minor type-annotation lie. Either correct
+the return type or drop the annotation; the lying annotation
+makes IDE autocompletion useless inside `_domain_path` users.
+
+### PB2. `get_table_as_dict` is a generator that wraps a non-generator `entities().fetch()` [P3]
+
+`path_builder.py:145-164`. The function `yield from`s the fetch
+result; the return type is `Iterable[dict[str, Any]]`. Combined
+with `get_table_as_dataframe`'s `list(self.get_table_as_dict(table))`
+through `rows_to_dataframe`, the generator yields twice. Fine —
+flagging only because the generator-ness is invisible to callers
+who think they're calling a fetch and getting a list.
+
+---
+
+## `core/mixins/rid_resolution.py` — RID resolution (213 LoC)
+
+### RR1. `resolve_rids` raises `DerivaMLException(f"Invalid RIDs: {remaining_rids}")` — should be a typed exception [P1]
+
+`rid_resolution.py:210-211`. The message-string coupling at
+`validation.py:257` (see V2) depends on this exact wording. The
+codebase has `DerivaMLNotFoundError` and a `DerivaMLInvalidTerm`-
+style pattern with structured attributes (the missing RIDs). A
+proper `DerivaMLNotFoundError` subclass — e.g.,
+`DerivaMLRidsNotFound(missing_rids: set[RID])` — would replace
+the string-parsing hack at the validation layer.
+
+### RR2. `BatchRidResult` is a `@dataclass` but is part of the public API [P2]
+
+`rid_resolution.py:40-54`. Per the CLAUDE.md guidance, user-facing
+return types should be Pydantic `BaseModel`, not `@dataclass`.
+`BatchRidResult` is returned from `resolve_rids` (a public
+method); callers may need to serialize it. Convert to a Pydantic
+model.
+
+### RR3. `resolve_rid` swallows `KeyError` and rewraps as `DerivaMLException("Invalid RID {rid}")` [P3]
+
+`rid_resolution.py:103-104`. Lossy — the original `KeyError`'s
+context is dropped. Add `from _e`.
+
+### RR4. `resolve_rids` returns empty dict for empty input; doctest shows the call pattern but no test asserts the empty-in / empty-out invariant [P3]
+
+`rid_resolution.py:155-157`, `tests/core/test_rid_resolution.py:
+50-54`. There *is* a test (`test_resolve_rids_empty`), so this is
+covered. Flagging that the test imports `test_ml` only to call
+`.resolve_rids([])`, which doesn't need a live catalog — the test
+could be a pure unit test against a `RidResolutionMixin`-only
+harness.
+
+---
+
+## `core/mixins/vocabulary.py` — vocabulary management (436 LoC)
+
+### VM1. `lookup_term` docstring claims `DerivaMLVocabularyException` is raised [P1]
+
+`vocabulary.py:217`. The class doesn't exist. The actual exception
+raised at line 235 is `DerivaMLException("The table {table} is
+not a controlled vocabulary")`. Fix the docstring to name
+`DerivaMLException` (or, better, add `DerivaMLTableTypeError` —
+see VM2).
+
+### VM2. Inconsistent exception type for "table is not a vocabulary" guard [P1]
+
+`vocabulary.py:160-161` (`add_term`), `vocabulary.py:234-235`
+(`lookup_term`), `vocabulary.py:327-328`
+(`list_vocabulary_terms`). `add_term` raises
+`DerivaMLTableTypeError("vocabulary", vocab_table.name)`; the
+other two raise the generic `DerivaMLException("The table ... is
+not a controlled vocabulary")`. Same condition, three call sites,
+two exception types. Pick one (`DerivaMLTableTypeError`) and use
+everywhere.
+
+### VM3. `_get_vocab_cache` lazily initializes `self._vocab_cache` [P3]
+
+`vocabulary.py:65-69`. `hasattr` check on `_vocab_cache` is
+fragile if a subclass `__slots__`-restricts. Initialize in a
+`_init_mixin_state` method called from `DerivaML.__init__`, or
+use a class-level sentinel.
+
+### VM4. `delete_term`'s association-count loop is O(N) over `vocab_table.find_associations()` × O(M) rows each [P2]
+
+`vocabulary.py:417-429`. Each iteration does a separate filtered
+fetch. For a vocabulary with many associations this is a 1+N
+pattern. Either batch with a single `pathBuilder` query joined
+across all association tables, or fetch only `RID` columns and
+shortcircuit on first match. Not urgent (delete is rare) but the
+same anti-pattern caused a perf bug in workflow types (see
+`workflow.py:62-79` for the fixed version).
+
+### VM5. `list_vocabulary_terms` raises generic `DerivaMLException` for non-vocab [P2]
+
+`vocabulary.py:327-328`. See VM2 — same condition, wrong typed
+exception.
+
+### VM6. `VocabCache` type alias is exported but used only inside this module [P3]
+
+`vocabulary.py:35, 40`. Either remove from `__all__` or document
+intended consumers.
+
+---
+
+## `core/mixins/workflow.py` — workflow management (409 LoC)
+
+### WF1. Class docstring claims `find_workflow_by_url` and `list_workflow_executions` [P1]
+
+`workflow.py:37-40`. The actual method is `lookup_workflow_by_url`;
+`list_workflow_executions` lives in `FeatureMixin`. Update the
+docstring class summary; either move `list_workflow_executions`
+to `WorkflowMixin` (its natural home) or stop documenting it in
+the wrong class.
+
+### WF2. No module-level logger; failures silently propagate [P2]
+
+`workflow.py:1-30`. Other mixins (`rid_resolution`, `execution`)
+have a module logger; this one doesn't. The `_add_workflow` catch-
+all at line 212 (`except Exception as e:`) re-raises as
+`DerivaMLException(f"Failed to insert workflow. Error: {error}")`
+without logging. Add a logger.
+
+### WF3. `_add_workflow` catches `Exception` and rewraps as `DerivaMLException` [P2]
+
+`workflow.py:187-215`. The bare-except + rewrap loses stack info
+that would be useful for debugging insertion failures. Either
+narrow to the catalog-specific exception classes or add `from e`.
+
+### WF4. `_add_workflow` uses `MLVocab.workflow_type` as a dict key (StrEnum → str coercion) [P3]
+
+`workflow.py:206-207`. The `{MLVocab.workflow_type: ...}` form
+relies on `StrEnum`'s `__eq__`/`__hash__` matching the string
+value. Works but flags as "use `.value` explicitly" for clarity
+and to match `assoc_path.filter(assoc_path.Workflow_Type == X)`
+style.
+
+---
+
+## `core/mixins/dataset.py` — dataset management (1 481 LoC)
+
+### DS1. `lookup_dataset` does a full table scan [P1]
+
+`dataset.py:177-185`. The implementation:
+
+```python
+return [ds for ds in self.find_datasets(deleted=deleted)
+        if ds.dataset_rid == dataset_rid][0]
+```
+
+This fetches **every** dataset row, builds `Dataset` objects for
+all of them, then Python-filters to the one wanted. On a catalog
+with hundreds of datasets this is O(N) network + O(N) Dataset
+construction per `lookup_dataset` call. The natural fix is a
+server-side filter:
+
+```python
+dataset_path = pb.schemas[...].tables["Dataset"]
+records = list(dataset_path.filter(dataset_path.RID == dataset_rid)
+              .entities().fetch())
+```
+
+`lookup_workflow` at `workflow.py:217-279` already uses this
+pattern; mirror it here.
+
+### DS2. `DatasetMixin` imports from `deriva_ml.config`, `deriva_ml.asset`, `deriva_ml.dataset` [P2]
+
+`dataset.py:20-44`. A "core" mixin shouldn't depend on five other
+top-level packages. The bootstrap/config-validation methods at
+`dataset.py:563-1097` (~530 LoC) belong in their own module
+(`deriva_ml.dataset.config_validation` or
+`deriva_ml.config.bootstrap_runner`), not in the `DerivaML` base
+class. Splitting the mixin would also halve the file size.
+
+### DS3. Mixin docstring lists 7 methods; the file defines 21 [P2]
+
+`dataset.py:75-83`. The class docstring claims 7 methods (`find_
+datasets`, `create_dataset`, ...). The file actually defines 21
+public methods including `validate_dataset_specs`,
+`validate_execution_configuration`, `validate_config_file`,
+`validate_config_directory`, `bootstrap_config`, `cache_dataset`,
+`estimate_bag_size`, `bag_info`, `estimate_denormalized_size`,
+`download_dataset_bag`. Update the docstring (and consider DS2).
+
+### DS4. `add_dataset_element_type` mutates the model and rebuilds workspace ORM under a `getattr(... "_workspace", None) is not None` guard [P2]
+
+`dataset.py:289-300`. The guard is defensive against the workspace
+not having been initialized; fine. But the comment block above
+(285-296) is 12 lines of explanation for what is effectively a
+"refresh the local ORM after a DDL change" operation. Extract to
+a named helper (`_refresh_workspace_orm_after_ddl()`) and inline-
+document the helper, not the call site.
+
+---
+
+## `core/mixins/execution.py` — execution management (1 253 LoC)
+
+### EX1. Module is 1 253 LoC with one mixin class — splits naturally [P2]
+
+`execution.py`. The file mixes:
+
+- Execution creation/resumption (`create_execution`,
+  `resume_execution`)
+- Registry queries (`list_executions`, `find_executions`,
+  `pending_summary`, `find_incomplete_executions`,
+  `gc_executions`)
+- Experiment queries (`lookup_experiment`, `find_experiments`)
+- Lineage queries (`lookup_lineage`, `_classify_rid`,
+  `_producer_of_dataset`, etc.)
+- Upload (`upload_pending`)
+
+Four distinct concerns, each ~250 LoC. Split into
+`execution_lifecycle.py`, `execution_registry.py`,
+`experiment_queries.py`, `lineage_queries.py`. Same gain as DS2.
+
+### EX2. `create_execution` raises `DerivaMLOfflineError`, but `refresh_schema` raises `DerivaMLReadOnlyError` for the same offline guard [P1]
+
+`execution.py:170, base.py:555, 707`. Pick one. The dedicated
+`DerivaMLOfflineError` (which extends `DerivaMLConfigurationError`)
+exists specifically for "online-only operation"; `DerivaMLReadOnly
+Error` is for "writes-on-read-only" (a different semantic).
+
+---
+
+## `core/mixins/feature.py` — feature management (647 LoC)
+
+### FT1. `fetch_table_features`, `list_feature_values`, `select_by_workflow` are tombstone shims [P1]
+
+`feature.py:525-565, 628-647`. Per the workspace CLAUDE.md rule
+"No backwards-compat shims — if something is unused, delete it,"
+these three methods that just `raise DerivaMLException("... has
+been retired")` should be deleted. Callers see a clean
+`AttributeError` from Python rather than a hand-rolled message;
+either is fine, and the message can live in the changelog.
+
+### FT2. `list_workflow_executions` lives in `FeatureMixin` [P2]
+
+`feature.py:566-626`. The method resolves workflows and queries
+executions — neither activity is feature-related. Move to
+`WorkflowMixin` or `ExecutionMixin`. The current placement is the
+historical artifact of the selector-factory pattern; the comment
+at line 574-577 hints at this.
+
+### FT3. No logger in this mixin [P3]
+
+`feature.py:1-30`. See WF2.
+
+---
+
+## `core/mixins/annotation.py` — Chaise annotation helpers (980 LoC)
+
+### AN1. Every public method has `@validate_call(config=VALIDATION_CONFIG)` [P3]
+
+`annotation.py` (16 decorators across the file). The annotation
+mixin is the only one that uniformly decorates every method.
+Other mixins decorate selectively. This is fine — annotations
+take user-supplied dicts that benefit from validation — but the
+inconsistency with the rest of the codebase is jarring. Either
+extend the pattern to the other mixins or note the rationale in
+the module docstring.
+
+### AN2. `STRICT_PREALLOCATED_RID_TAG` annotation tag is module-level [P3]
+
+`annotation.py:45`. The other annotation tags (DISPLAY_TAG, etc.)
+are also module-level — fine. The tag with `2026:` in its URI
+makes me wonder if it'll be stable across releases. Document the
+versioning policy.
+
+---
+
+## `core/mixins/file.py` — file management (268 LoC)
+
+### FL1. `add_files`'s last dataset is returned but the loop builds many [P2]
+
+`file.py:155-176`. The function creates one `Dataset` per
+directory level, then returns `dataset` (the last one built). The
+docstring says "Returns: Dataset that represents the newly added
+files" — but if the input spans multiple directories, the returned
+dataset only represents the *innermost* level. Either return the
+top-level dataset or return a list of all created datasets.
+
+### FL2. `add_files` re-builds `defined_types` per call [P3]
+
+`file.py:101-106`. The set-built-from-list-comprehension is
+recomputed on every `add_files` call. For a long-running script
+with many `add_files` invocations, vocabulary-list fetches
+dominate. Cache the result (with explicit invalidation on
+`add_term`).
+
+---
+
+## Cross-module observations
+
+### X1. Logger construction is inconsistent across the core/ subsystem [P2]
+
+- `core/base.py`, `core/mixins/rid_resolution.py`,
+  `core/mixins/execution.py`, `core/validation.py`: module logger
+  via `logger = get_logger(__name__)` (canonical).
+- `core/mixins/{annotation,asset,dataset,feature,file,
+  path_builder,vocabulary,workflow}.py`: no logger.
+- `dataset/restructure.py:63`: `logger = logging.getLogger(
+  __name__)` — direct stdlib bypass of `get_logger`.
+
+The canonical-vs-bypass split should be unified.
+
+### X2. `@validate_call` adoption is uneven [P2]
+
+26 decorators total. `annotation.py` has 16 (one per public
+method); `vocabulary.py` has 3; `feature.py` has 2 (on
+`feature_values` and `list_workflow_executions`); `dataset.py`
+has 1; `asset.py` has zero with a comment saying decorators were
+removed because Pydantic doesn't validate dataclass fields well
+(`asset.py:66-67`); `upload_layout.py` has 1. The "validate user
+input" guarantee is partial. Either commit to a uniform policy
+(decorator everywhere, or compose Pydantic models at the boundary
+and skip `@validate_call`) or document where the boundary is
+intentional.
+
+### X3. The "mode" guard pattern is duplicated across `refresh_schema`/`diff_schema`/`create_execution` [P3]
+
+`base.py:554-555, 706-707, execution.py:168-173`. Three nearly-
+identical "raise if mode is not online" guards. Extract to a
+decorator (`@require_online`) or a guard helper (`self._require_
+online("refresh_schema")`).
+
+### X4. `MLVocab` enum value is sometimes used as a string and sometimes via `.value` [P3]
+
+Throughout the mixins. `pathBuilder.schemas[ML_SCHEMA]` works
+because StrEnum auto-coerces; `{MLVocab.workflow_type: ...}` as a
+dict key works the same way. Inconsistency hurts readability —
+pick one (the `.value` form is the unambiguous one, but the bare
+form reads more cleanly). Document the convention.
+
+### X5. `Status` is gone but `enums.py` module docstring still claims it [P3]
+
+`enums.py:8`. The "Classes:" block lists `Status: Execution status
+values.` Phase 2 deleted the class (per comment at lines 67-71);
+the docstring summary lagged the change. Delete the line.
+
+### X6. Pure-Python tests prefer `_StorageHarness`/`_CiteHarness`-style minimal mocks, but live tests still build full `test_ml` instances for things that don't need them [P3]
+
+`test_storage_management.py`, `test_base.py::_CiteHarness` show
+the pattern: build a `SimpleNamespace`-shaped object exposing only
+the attributes the method under test reads. Apply the same
+pattern to `test_rid_resolution.py::test_resolve_rids_empty` (no
+catalog needed) and `test_catalog_annotations.py` tests where the
+assertion only inspects `annotations` dicts.
+
+### X7. The Async path in `async_helpers.py` is imported lazily but never tested in the lazy-import branch [P3]
+
+`async_helpers.py:67-72`. If `nest_asyncio` is *not* installed,
+the lazy import inside the if-loop branch raises `ImportError`.
+Document this as a graceful-degradation contract and add a
+package extra (`pip install deriva-ml[notebook]`).
+
+---
+
+## Tests that need to be added
+
+(consolidating the test gaps surfaced above)
+
+1. **`tests/core/test_validation.py`** — direct coverage for
+   `ValidationResult`, `validate_rids`, `validate_execution_config`.
+   See V1.
+2. **`tests/core/test_logging_config.py`** — `configure_logging`
+   side effects under no-Hydra / Hydra / custom-handler. See L1.
+3. **`tests/core/test_filespec.py`** — regression test for F1
+   (multi-file length bug), plus tests for `read_filespec` round-
+   trip and URL normalisation paths.
+4. **`tests/core/test_async_helpers.py`** — `run_async` with no
+   loop, with a running loop, and with a coroutine that raises.
+   See A1.
+5. **`tests/core/test_constants.py`** — pin the `rid_regex`
+   against expected positive/negative cases.
+6. **`tests/core/test_upload_layout.py`** — no test file exists.
+   `asset_table_upload_spec`, `bulk_upload_configuration`,
+   `manifest_path`, `table_path` all uncovered.
+7. **Module-level `__all__` audit** — a simple test that imports
+   each module and asserts every name in `__all__` resolves. The
+   `DerivaMLVocabularyException` ghost (VM1) would surface
+   immediately.
+
+---
+
+## Files touched
+
+- `src/deriva_ml/core/base.py` (1 675 LoC)
+- `src/deriva_ml/core/exceptions.py` (780 LoC)
+- `src/deriva_ml/core/validation.py` (427 LoC)
+- `src/deriva_ml/core/logging_config.py` (221 LoC)
+- `src/deriva_ml/core/schema_cache.py` (218 LoC)
+- `src/deriva_ml/core/schema_diff.py` (321 LoC)
+- `src/deriva_ml/core/config.py` (233 LoC)
+- `src/deriva_ml/core/definitions.py` (181 LoC)
+- `src/deriva_ml/core/enums.py` (182 LoC)
+- `src/deriva_ml/core/constants.py` (182 LoC)
+- `src/deriva_ml/core/ermrest.py` (325 LoC)
+- `src/deriva_ml/core/filespec.py` (190 LoC)
+- `src/deriva_ml/core/connection_mode.py` (34 LoC)
+- `src/deriva_ml/core/catalog_stub.py` (43 LoC)
+- `src/deriva_ml/core/async_helpers.py` (73 LoC)
+- `src/deriva_ml/core/upload_layout.py` (330 LoC)
+- `src/deriva_ml/core/sort.py` (100 LoC)
+- `src/deriva_ml/core/pd_utils.py` (39 LoC)
+- `src/deriva_ml/core/__init__.py` (67 LoC)
+- `src/deriva_ml/core/mixins/__init__.py` (42 LoC)
+- `src/deriva_ml/core/mixins/annotation.py` (980 LoC)
+- `src/deriva_ml/core/mixins/asset.py` (452 LoC)
+- `src/deriva_ml/core/mixins/dataset.py` (1 481 LoC)
+- `src/deriva_ml/core/mixins/execution.py` (1 253 LoC)
+- `src/deriva_ml/core/mixins/feature.py` (647 LoC)
+- `src/deriva_ml/core/mixins/file.py` (268 LoC)
+- `src/deriva_ml/core/mixins/path_builder.py` (164 LoC)
+- `src/deriva_ml/core/mixins/rid_resolution.py` (213 LoC)
+- `src/deriva_ml/core/mixins/vocabulary.py` (436 LoC)
+- `src/deriva_ml/core/mixins/workflow.py` (409 LoC)
+- `tests/core/` (20 files, ~3 100 LoC)

--- a/docs/audits/2026-05-22-engineer-audit-dataset.md
+++ b/docs/audits/2026-05-22-engineer-audit-dataset.md
@@ -1,0 +1,536 @@
+# Engineer audit — dataset/ subsystem (2026-05-22)
+
+Pre-release audit of `src/deriva_ml/dataset/` and its tests against
+release v1.37.1. Four lenses: test coverage, duplication, logic
+clarity, docstring quality.
+
+## Summary
+
+- 14 source modules audited (22k+ LoC counting tests).
+- 42 findings: **0 P0**, **6 P1**, **22 P2**, **14 P3**.
+- Top themes:
+  1. **Two correctness bugs in `Dataset.add_dataset_members` cycle check** — `set(self.dataset_rid)` produces character-set, not a singleton; recursion path is dead. P1.
+  2. **God-functions** in `Dataset.estimate_bag_size` (220 lines), `split_dataset` (590 lines), `restructure_assets` (~250 lines body), `get_dataset_minid` (220 lines). Each does I/O, planning, and result assembly in a single body. P1/P2.
+  3. **Parallel torch/tf adapters** — `_bag_element_is_asset`, `_build_row_lookup`, `_resolve_asset_path` are duplicated character-for-character across `torch_adapter.py` and `tf_adapter.py`. The selector-grouping in `Dataset.feature_values` / `DatasetBag.feature_values` is also parallel. P2.
+  4. **Retired-API shims** (`fetch_table_features`, `list_feature_values` on `DatasetBag`) violate the workspace "no backwards-compat shims" rule. P2.
+  5. **Test gaps** for public methods: `Dataset.to_markdown`, `Dataset.display_markdown`, `Dataset.get_chaise_url`, `DatasetBag.list_tables`, `DatasetBagBuilder.build_bag` (the heaviest method in the class). P2.
+
+---
+
+## Findings by module
+
+### src/deriva_ml/dataset/dataset.py
+
+#### [P1] `add_dataset_members` cycle check is structurally broken
+**Location:** `src/deriva_ml/dataset/dataset.py:1922-1933, 1965`
+**Issue:** Two bugs in `check_dataset_cycle`:
+
+1. `path = path or set(self.dataset_rid)` calls `set()` on a string,
+   producing `{"4", "H", "M"}` from RID `"4HM"` instead of the
+   intended `{"4HM"}` singleton. Cycle detection therefore false-
+   positives on any single-character match with the dataset RID's
+   characters and misses every real cycle.
+2. The `path` parameter is never recursively threaded — the only
+   call site (`check_dataset_cycle(rid_info.rid)`) supplies one
+   argument, so the second-arg branch is dead code; there's no
+   actual graph walk.
+
+The "Creating cycle of datasets is not allowed" path is effectively
+never hit on real inputs, and a cycle check with this shape was
+clearly never working correctly. The CLAUDE.md "RIDs are opaque:
+equality only" rule applies — `set(rid_string)` is parsing.
+
+**Evidence:**
+```python
+def check_dataset_cycle(member_rid, path=None):
+    path = path or set(self.dataset_rid)   # bug: char-set, not RID-set
+    return member_rid in path
+# Caller:
+if rid_info.table == self._dataset_table and check_dataset_cycle(rid_info.rid):
+    raise DerivaMLException("Creating cycle of datasets is not allowed")
+```
+
+**Suggested fix:** Either implement a real graph walk (traverse
+`list_dataset_children(recurse=True)` on each candidate Dataset
+member and reject if `self.dataset_rid` appears), or delete the
+nested helper and document that cycles must be prevented downstream.
+Add a regression test that nests A→B→A and asserts the raise.
+
+#### [P1] `_version_snapshot_catalog` has a dead `and str:` clause
+**Location:** `src/deriva_ml/dataset/dataset.py:2779`
+**Issue:** Truthiness check appends the literal `str` class to the
+condition. `str` is always truthy, so the clause is dead; the
+intended guard was presumably `isinstance(dataset_version, str) and
+dataset_version` (non-empty). Mostly benign — `DatasetVersion.parse("")`
+would raise — but it's a clear bug that signals the codepath wasn't
+exercised when written.
+
+**Evidence:**
+```python
+if isinstance(dataset_version, str) and str:
+    dataset_version = DatasetVersion.parse(dataset_version)
+```
+
+**Suggested fix:** `if isinstance(dataset_version, str) and dataset_version:`,
+or drop the second clause entirely.
+
+#### [P1] `Dataset.estimate_bag_size` is a 220-line god-function
+**Location:** `src/deriva_ml/dataset/dataset.py:2415-2633`
+**Issue:** Single method does (1) snapshot resolution, (2)
+async catalog construction with manual URL parsing, (3) URI-to-path
+extraction via a nested helper, (4) query-item list construction,
+(5) async query orchestration, (6) RID/length/sample
+post-processing, (7) per-table aggregation, (8) final dict
+assembly. Two nested helpers (`_extract_path`, `_run_query`,
+`_run_all_queries`) live inside the method.
+
+Tests rely entirely on integration-level fixtures
+(`test_estimate_bag_size.py` is 600 lines of demo-catalog
+exercises). The fine-grained steps — URI extraction, sample CSV
+estimation, asset/non-asset detection — are not unit-testable
+without standing up a live catalog.
+
+**Suggested fix:** Extract three helpers: `_build_estimate_queries(table_queries) -> list[_QueryItem]`, `_run_estimate_queries(catalog, items) -> tuple[rids_by_table, lengths_by_table, samples_by_table]`, `_assemble_estimate(...) -> dict`. The async machinery already lives behind `run_async`; pulling it out makes the orchestration testable with a mock catalog.
+
+#### [P1] `Dataset` has retired-API surface that should be deleted
+**Location:** `src/deriva_ml/dataset/dataset_bag.py:654-690`
+**Issue:** `DatasetBag.fetch_table_features` and
+`DatasetBag.list_feature_values` are stubs that raise with a
+"renamed to feature_values" message. Workspace `CLAUDE.md`:
+"No backwards-compat shims — if something is unused, delete it."
+There's an entire `tests/feature/test_retired_apis.py` keeping
+them alive. Same shape appears for `DerivaML.fetch_table_features`
+/ `list_feature_values` in `core/mixins/feature.py` and
+`Asset.list_feature_values` — but the dataset audit owns only the
+bag pair.
+
+**Suggested fix:** Delete both methods and the corresponding
+`test_retired_apis.py::test_bag_*` entries. Anyone still calling
+the old names will get the standard `AttributeError`, which is
+the workspace's documented stance.
+
+#### [P2] Dataset.list_workflow_executions is misleadingly named
+**Location:** `src/deriva_ml/dataset/dataset.py:629-660`
+**Issue:** The method's own docstring acknowledges: "Despite the name,
+the live Dataset implementation does **not** filter the returned
+execution list to executions whose outputs touch the dataset's
+member set — it returns every execution of the workflow." Meanwhile
+`DatasetBag.list_workflow_executions` *is* dataset-scoped. The two
+implementations of the same protocol method have divergent semantics
+that callers have to read the docstring to discover.
+
+**Suggested fix:** Either (a) implement the dataset-scoping filter
+in the live `Dataset` (preferred — symmetry with the bag), or
+(b) rename to `list_workflow_executions_unscoped` and add a
+scoped variant. Continuing to ship two methods with the same name
+and different semantics is a footgun.
+
+#### [P2] `feature_values` selector grouping is duplicated between Dataset and DatasetBag
+**Location:** `src/deriva_ml/dataset/dataset.py:591-604` and
+`src/deriva_ml/dataset/dataset_bag.py:637-652`
+**Issue:** Both implementations end with the identical pattern:
+group by target RID, call selector once per group, yield non-None
+choices. The grouping step is verbatim parallel code.
+
+**Suggested fix:** Move the selector-application loop into
+`deriva_ml.feature` (alongside `FeatureRecord.select_newest`) as a
+free function `apply_selector(records, target_col, selector)`.
+Both call sites become a one-liner. Reduces drift risk if
+selector semantics change.
+
+#### [P2] `add_dataset_types` redoes lookups already done by `add_dataset_type`
+**Location:** `src/deriva_ml/dataset/dataset.py:414-424`
+**Issue:** Loop calls `lookup_term` to get the term name, then
+`add_dataset_type` re-runs `lookup_term` internally. Double
+catalog round-trip per type.
+
+**Evidence:**
+```python
+for term in types_to_add:
+    if isinstance(term, VocabularyTerm):
+        term_name = term.name
+    else:
+        term_name = self._ml_instance.lookup_term(MLVocab.dataset_type, term).name
+    if term_name not in self.dataset_types:
+        self.add_dataset_type(term, _skip_version_increment=True)  # re-looks up
+        added_types.append(term_name)
+```
+
+**Suggested fix:** Resolve all terms once at the top, then call a
+shared internal `_add_dataset_type_unchecked(vocab_term, ...)` that
+takes a `VocabularyTerm` and skips the lookup.
+
+#### [P2] `_create_or_advance_dev_row` is a 120-line method that mixes lifecycle paths
+**Location:** `src/deriva_ml/dataset/dataset.py:1303-1421`
+**Issue:** Single method handles both create-new-dev-row and
+advance-existing-dev-row, with the branch determined inline at
+the top. Two distinct write paths with different conditional
+logic for RMT/Snapshot/Version share one body. The
+fault-injection comment on line 1418 also references the *wrong*
+exception message variable substitution — the f-string starts at
+`f"Concurrent modification of dev row {current_dev.version_rid} "`
+and then a regular string `"for dataset {self.dataset_rid}: ..."`
+follows it on lines 1417-1420 (`self.dataset_rid` is not
+interpolated).
+
+**Evidence (interpolation bug):**
+```python
+raise DerivaMLException(
+    f"Concurrent modification of dev row {current_dev.version_rid} "
+    "for dataset {self.dataset_rid}: another writer advanced the "  # not an f-string
+    "row between this call's read and write. Re-read the dataset "
+    "and retry if the new state is still what you intended."
+)
+```
+The literal text `{self.dataset_rid}` is shown to the user
+verbatim. Compare with the same message in `release()` (line 1043)
+which uses `f"... {self.dataset_rid}: ..."` correctly. P1
+candidate for the interpolation bug specifically — file as P2 since
+the user can still tell which dataset (the `version_rid` resolves
+it).
+
+**Suggested fix:** Split into `_insert_dev_row` and `_advance_dev_row`;
+share the concurrency-detection raise via a helper.
+
+#### [P2] `DatasetHistory` model docstring drifts from current attributes
+**Location:** `src/deriva_ml/dataset/aux_classes.py:204-235`
+**Issue:** Class docstring lists `dataset_version`, `dataset_rid`,
+`version_rid`, `minid`, `snapshot` but the actual model has
+`execution_rid`, `description`, `spec_hash` too. Critical detail:
+the docstring says "Catalog snapshot ID of when the version
+record was created" but doesn't mention that `snapshot` is
+`None` for dev rows — this is the load-bearing semantic from
+ADR-0003 and callers need to know it.
+
+**Suggested fix:** Add `execution_rid`, `description`, `spec_hash`
+to the Attributes list. Annotate `snapshot` with "None for dev
+rows; only released rows pin a snapshot."
+
+#### [P2] `Dataset.cache_denormalized` lacks `Raises:` and exception docs
+**Location:** `src/deriva_ml/dataset/dataset.py:1774-1849`
+**Issue:** Docstring documents Args/Returns/Example but no
+`Raises:` block. The denormalizer raises
+`DerivaMLDenormalizeUnrelatedAnchor` (referenced in arg
+description but not in `Raises:`), and the underlying paged
+client can raise on snapshot resolution failure. Mirrors the same
+gap in `get_denormalized_as_dataframe` / `get_denormalized_as_dict`.
+
+**Suggested fix:** Add `Raises:` with the documented exceptions
+(`DerivaMLDenormalizeUnrelatedAnchor`, `DerivaMLException`).
+
+#### [P2] `_increment_dataset_version` docs say "Internal" but it's the catalog-clone path
+**Location:** `src/deriva_ml/dataset/dataset.py:877-924`
+**Issue:** The docstring labels this "Internal helper preserved
+from the pre-dev-versioning model... Not for user-facing release
+work; use release() for that." The leading underscore in the name
+matches that. But the only caller is `catalog/clone.py`, which is
+a public surface. The leading-underscore convention typically
+means "package-private", which is correct here, but the docstring
+says "Internal" and `release()` is the user path — the boundary
+is fuzzy. Worth promoting to a public-named helper with a clear
+"clone-only" caveat, or moving it to `dataset.aux_classes` /
+`catalog.clone` to make ownership obvious.
+
+#### [P2] `release()` 120-line body could thin out
+**Location:** `src/deriva_ml/dataset/dataset.py:926-1049`
+**Issue:** Method does (1) dev-entry validation, (2) released-entry
+anchor lookup, (3) catalog snapshot stamp, (4) RMT-correlated
+update, (5) raise on contention. The `_create_or_advance_dev_row`
+helper already encapsulates a similar pattern but isn't reused —
+extract `_promote_dev_to_release(...)` symmetric with
+`_create_or_advance_dev_row` so the dev-vs-release lifecycle reads
+as parallel methods.
+
+#### [P3] `Dataset.to_markdown` / `display_markdown` / `get_chaise_url` have no tests
+**Location:** `src/deriva_ml/dataset/dataset.py:757-821`
+**Issue:** Three public methods with no test coverage. Each is
+small and pure (no catalog write) — easy to test with a fake
+`_ml_instance`.
+
+#### [P3] `Dataset.__init__` description arg is stored but `dataset_types` is fetched live
+**Location:** `src/deriva_ml/dataset/dataset.py:113-139`
+**Issue:** `description` is cached on the instance; `dataset_types`
+is a property that re-queries the catalog every access. The
+asymmetry isn't documented anywhere, and the description on the
+object can drift from the catalog (e.g. if another writer updates
+the Dataset row). Tests should at minimum acknowledge this.
+
+#### [P3] `_get_dataset_type_association_table` returns tuple but caller usually only uses second element
+**Location:** `src/deriva_ml/dataset/dataset.py:173-187`
+**Issue:** Returns `(atable_name, atable_path)`. Callers
+(`dataset_types`, `add_dataset_type`, `remove_dataset_type`) use only
+`atable_path`. The name is computed via `find_associations()[0].name`
+in case of multiple associations — but that pop-the-first behavior
+is suspect; if there are multiple Dataset_Type associations, the
+choice is arbitrary.
+
+#### [P3] `_estimate_csv_bytes` static helper has no test
+**Location:** `src/deriva_ml/dataset/dataset.py:2713-2749`
+**Issue:** Pure function — sample rows → estimated byte count.
+Could be unit-tested with synthetic rows. Currently exercised
+only through `estimate_bag_size` integration tests.
+
+### src/deriva_ml/dataset/dataset_bag.py
+
+#### [P1] `DatasetBag` re-implements selector + grouping rather than sharing with Dataset
+**Location:** `src/deriva_ml/dataset/dataset_bag.py:532-652`
+**Issue:** See dataset.py finding above — selector grouping is
+parallel. Bag also has extra logic (over-reach filtering,
+execution_rids Python-side filter, materialize_limit check) that
+makes the parallel less clean but the selector tail is identical.
+
+**Suggested fix:** Same — shared helper in `deriva_ml.feature`.
+
+#### [P2] Retired-API shims on DatasetBag
+**Location:** `src/deriva_ml/dataset/dataset_bag.py:654-690`
+**Issue:** Delete per workspace convention.
+
+#### [P2] `_dataset_table_view` SQL is opaque
+**Location:** `src/deriva_ml/dataset/dataset_bag.py:307-352`
+**Issue:** 45-line method builds a SQL UNION across all paths
+from Dataset to the target table by introspecting
+`self.model._schema_to_paths()`. The dataset RID list construction
+includes "all nested datasets" silently — there's no path filter
+to scope nested-dataset inclusion. Comments are sparse, and the
+method is consumed only by `restructure._get_reachable_assets`
+(restructure.py:200) — moving it to `restructure.py` as a private
+helper would tighten ownership.
+
+#### [P2] DatasetBag.list_tables has no tests, no Raises section
+**Location:** `src/deriva_ml/dataset/dataset_bag.py:221-230`
+**Issue:** Public method, undocumented exceptions, no tests in
+`tests/dataset/test_bag_api_coverage.py`.
+
+#### [P2] `as_torch_dataset` / `as_tf_dataset` docstrings are 130+ lines each
+**Location:** `src/deriva_ml/dataset/dataset_bag.py:1130-1302`,
+`1304-1483`
+**Issue:** The two docstrings are near-identical prose (target
+arity, missing policy, RID-last contract) — drift risk is high.
+The `as_torch_dataset` Returns section and the `as_tf_dataset`
+Returns section describe the same shape contract twice.
+
+**Suggested fix:** Either accept the duplication and add a
+docstring-style invariant test (test that both methods'
+parameters and Args texts share the matching prose), or extract
+the shared sections into a module-level constant referenced by
+both. Given how big they are, a shared "design contract" link
+in each docstring plus per-method specifics would be cleaner.
+
+#### [P3] DatasetBag fetches execution_rid at init time, not lazily
+**Location:** `src/deriva_ml/dataset/dataset_bag.py:151-153`
+**Issue:** `self.execution_rid = execution_rid or (self._catalog._get_dataset_execution(self.dataset_rid) or {}).get("Execution")` runs an unconditional SQLite query at `__init__`, accessing a private method on the catalog (`_get_dataset_execution`). Lazy property would avoid the cost when callers don't read it.
+
+#### [P3] `current_version` property docstring claims immutability but doesn't enforce
+**Location:** `src/deriva_ml/dataset/dataset_bag.py:181-192`
+**Issue:** "Unlike the live Dataset class, this value is immutable" — `self._current_version` is set in `__init__` but a writer could `bag._current_version = ...`. Add `@property` setter that raises, or document the convention more honestly.
+
+### src/deriva_ml/dataset/aux_classes.py
+
+#### [P2] `DatasetHistory` model fields don't all appear in docstring
+**Location:** `src/deriva_ml/dataset/aux_classes.py:204-215`
+**Issue:** See above.
+
+#### [P3] `DatasetVersion.parse` re-runs `Version.__init__` redundantly
+**Location:** `src/deriva_ml/dataset/aux_classes.py:138-165`
+**Issue:** `Version(version)` parses; then a new `cls` instance has `Version.__init__(instance, str(v))` called on it (re-parses). Could `__new__` and copy `__dict__` directly. Minor perf, but the two-parse round-trip is a code smell.
+
+#### [P3] `DatasetMinid.dataset_snapshot` docstring missing
+**Location:** `src/deriva_ml/dataset/aux_classes.py:268-276`
+**Issue:** Computed-field property has only an inline comment ("`version_rid` is `{rid}` or `{rid}@{snapshot}`") — no docstring. Same for `dataset_rid` at line 262-266.
+
+### src/deriva_ml/dataset/bag_builder.py
+
+#### [P2] `DatasetBagBuilder.build_bag` has no direct unit/integration test
+**Location:** `src/deriva_ml/dataset/bag_builder.py:240-334`
+**Issue:** The heaviest method in the class (95 lines), responsible for the snapshot-aware CatalogBagBuilder dance and zip-path recovery. `tests/dataset/test_bag_builder.py` only covers spec generation, annotations, aggregate queries, and policy. The `_SnapshotAwareCatalogBagBuilder._run_export` override and the timeout-restoration `try/finally` are entirely uncovered.
+
+**Suggested fix:** Add at least one test that calls `build_bag` against a small demo dataset and asserts (a) returned path is a `.zip` that exists, (b) bag name is `Dataset_{rid}`, (c) timeout restoration happens on exception.
+
+#### [P2] `_dataset_nesting_depth` is computed but only annotation flow uses it
+**Location:** `src/deriva_ml/dataset/bag_builder.py:686-717`
+**Issue:** Method exists and is documented but isn't called anywhere in `bag_builder.py` or under `src/deriva_ml/`. Likely dead.
+
+**Evidence:**
+```bash
+$ grep -rn "_dataset_nesting_depth" src/deriva_ml/
+# only the definition matches
+```
+
+**Suggested fix:** Delete unless an external skill uses it. Per workspace rule "if something is unused, delete it."
+
+#### [P3] `_SnapshotAwareCatalogBagBuilder` is documented as workaround for upstream #114 — should track resolution
+**Location:** `src/deriva_ml/dataset/bag_builder.py:71-119`
+**Issue:** Inline note "See issue #114" — track upstream so this can be retired when the upstream fix lands.
+
+#### [P3] `anchors_for` walks descendants twice
+**Location:** `src/deriva_ml/dataset/bag_builder.py:723-754`
+**Issue:** `_iter_descendant_rids` walks; later `_exclude_empty_associations` also walks descendants (`rids_to_scan`). Both walks are full traversals via `list_dataset_children`. Cache the descendant set per build call.
+
+### src/deriva_ml/dataset/bag_cache.py
+
+#### [P3] `CacheStatus.cached_incomplete` aliased but never tested
+**Location:** `src/deriva_ml/dataset/bag_cache.py:67-71`
+**Issue:** Back-compat alias for `cached_holey`. No test exercises the alias (only the canonical value). If it's a load-bearing back-compat surface, pin a test; otherwise delete per workspace convention.
+
+#### [P3] `BagCache._is_fully_materialized` is a static method but reaches via class
+**Location:** `src/deriva_ml/dataset/bag_cache.py:174-206`
+**Issue:** Called as `BagCache._is_fully_materialized(bag_path)` from `bag_download.py:657`. Promote to a module-level free function (since it has no class state) — easier to test, easier to import.
+
+### src/deriva_ml/dataset/bag_download.py
+
+#### [P1] `get_dataset_minid` is a 220-line monolith
+**Location:** `src/deriva_ml/dataset/bag_download.py:389-605`
+**Issue:** Single function does (a) version-record resolution, (b) spec hash computation, (c) Tier-1 cache lookup, (d) Tier-2 MINID branch, (e) Tier-3 client-side bag branch, (f) DatasetMinid construction with shared snapshot-vs-None RID guard repeated twice (lines 531, 599). The three-tier comment headers help reading but the cyclomatic complexity is high.
+
+**Suggested fix:** Extract `_resolve_version_record`, `_tier1_local_cache_lookup`, `_tier2_minid_path`, `_tier3_client_path`, and `_build_dataset_minid(rid, snapshot, version, location, checksum)` helper for the duplicated RID-vs-snapshot construction.
+
+#### [P2] `create_dataset_minid` `spec` arg is "vestigial on the non-MINID arm"
+**Location:** `src/deriva_ml/dataset/bag_download.py:340-352`
+**Issue:** The comment at 343-352 explicitly says the spec parameter is unused on the `use_minid=False` branch ("CatalogBagBuilder recomputes its own spec from the same anchors/policy"). Carrying a parameter that's silently ignored on one branch is a footgun.
+
+**Suggested fix:** Either pass the precomputed spec into `build_bag` so both branches honor it, or drop `spec` from this function's signature on the `use_minid=False` path (route through a different helper).
+
+#### [P2] `fetch_minid_metadata` `dataset` arg is unused
+**Location:** `src/deriva_ml/dataset/bag_download.py:101-119`
+**Issue:** `del dataset` on line 116. The parameter is kept "for future logging / auth context" per the inline comment. Per workspace "no over-engineering" rule, drop it; re-add when actually needed.
+
+#### [P3] `download_dataset_minid` mixes three source types with no dispatch helper
+**Location:** `src/deriva_ml/dataset/bag_download.py:184-194`
+**Issue:** Three `if/elif/else` branches choose archive source by sniffing `minid.bag_url` (`use_minid`, `file://`, else). The dispatch is fine but each branch contributes to a method that's already 130 lines; extract `_fetch_archive(minid, use_minid, tmp_dir) -> Path` to keep this method focused on cache placement.
+
+### src/deriva_ml/dataset/restructure.py
+
+#### [P1] `restructure_assets` is a 500-line function (with docstring)
+**Location:** `src/deriva_ml/dataset/restructure.py:250-746`
+**Issue:** Pure function but its body (post-docstring) is still ~250 lines covering: input validation, asset-table detection, type-path map, asset-to-dataset map, feature/column target classification, per-asset processing with branch on `missing` policy, file placement (symlink/copy/transform).
+
+**Suggested fix:** Extract `_resolve_grouping_path(asset, targets, ..., missing)`, `_place_asset(source, target_path, file_transformer, use_symlinks)`. The current shape works but is hard to navigate.
+
+#### [P2] Asset source-path fallback to `_catalog._database_model.bag_path` is private-API reach
+**Location:** `src/deriva_ml/dataset/restructure.py:611-614`
+**Issue:** `bag._catalog._database_model.bag_path` — reaching through two private attributes on the catalog. The bag already exposes `bag.path` (per dataset_bag.py:195). Use that.
+
+**Evidence:**
+```python
+try:
+    bag_root = Path(bag._catalog._database_model.bag_path)
+    source_path = bag_root / "data" / "asset" / asset.get("RID", "") / asset_table / Path(filename).name
+except AttributeError:
+    pass  # catalog doesn't have _database_model (e.g. in tests)
+```
+
+**Suggested fix:** Replace with `bag_root = bag.path`. The `try/except AttributeError` becomes unnecessary.
+
+#### [P2] `_default_dir_name_from_target` skip-cols set is hardcoded
+**Location:** `src/deriva_ml/dataset/restructure.py:104-105`
+**Issue:** `_skip_cols = {"RID", "RCT", "RMT", "RCB", "RMB", "Feature_Name", "Execution"}` — the catalog's system columns are listed in
+`deriva_ml.core.definitions.SYSTEM_COLUMNS` or similar; duplicating
+the set here means it drifts if Deriva adds another (e.g. a future
+`RVT` or system tag). Pull from the canonical constant.
+
+#### [P3] `_get_reachable_assets` dict-conversion is fragile
+**Location:** `src/deriva_ml/dataset/restructure.py:220-221`
+**Issue:** `rows = [dict(row._mapping) for row in result]` — accesses
+SQLAlchemy's private `_mapping`. Use `.mappings().all()` instead
+(public API; same shape).
+
+### src/deriva_ml/dataset/split.py
+
+#### [P1] `split_dataset` is a 590-line function
+**Location:** `src/deriva_ml/dataset/split.py:482-1069`
+**Issue:** Single function does validation, member listing, size resolution, denormalization, partition computation, dry-run early return, vocab provisioning, dataset hierarchy creation, member assignment, and result construction. The bulk (200 lines) is the docstring; the body is ~250 lines and contains seven inline log-info calls, a 5-section commented-block structure, and a nested loop for member batching.
+
+**Suggested fix:** Extract `_compute_partitions(source_ds, ...) -> (partition_rids, strategy_desc)` and `_create_split_hierarchy(exe, source_dataset_rid, partition_rids, ...) -> SplitResult`. The dry-run path returns before the hierarchy creation, so the split is clean.
+
+#### [P2] `split_dataset` CLI `main()` is 320 lines
+**Location:** `src/deriva_ml/dataset/split.py:1077-1402`
+**Issue:** Argparse setup (170 lines), dry-run vs real-run branching, two large duplicated parameter blocks (the same `split_dataset` call appears twice with `dry_run=True` and `dry_run=False`), and print formatting.
+
+**Suggested fix:** Build kwargs dict once, pass `dry_run=args.dry_run` through it. Halves the body.
+
+#### [P2] `stratified_split` three-way path hardcodes "Testing"/"Training"/"Validation" partition names
+**Location:** `src/deriva_ml/dataset/split.py:338-364`
+**Issue:** The three-way branch accesses `partition_sizes["Testing"]` directly by string. Two-way path keys by ordered list. Inconsistency makes it harder to extend (e.g. four-way splits). At minimum document the keying convention; ideally use the same key-by-list pattern in both branches.
+
+#### [P2] `_resolve_sizes` raises `ValueError` but type hints don't say so
+**Location:** `src/deriva_ml/dataset/split.py:374-438`
+**Issue:** Function raises on negative/zero sizes and on totals exceeding the dataset. Docstring documents Args/Returns/Raises correctly, but the more general issue is that the validation happens during normal execution, not at the `validate_call` boundary. Consider a Pydantic model for the partition spec so the validation surface is one named class.
+
+#### [P3] `_ensure_dataset_types` silently swallows errors
+**Location:** `src/deriva_ml/dataset/split.py:472-474`
+**Issue:** `if "already exists" not in str(e).lower(): logger.warning(...)` — string-matching on the exception message is brittle. Use exception type instead, or catch a specific `DerivaMLException` subclass.
+
+### src/deriva_ml/dataset/torch_adapter.py and tf_adapter.py
+
+#### [P2] Adapter helpers `_bag_element_is_asset`, `_build_row_lookup`, `_resolve_asset_path` duplicated character-for-character
+**Location:** `src/deriva_ml/dataset/torch_adapter.py:160-195` and
+`src/deriva_ml/dataset/tf_adapter.py:185-220`
+**Issue:** Three helpers (35 lines per file) are verbatim identical
+across the two adapter modules. Validation block (element_type in
+bag, asset-table sample_loader check) and target-resolution
+(`_resolve_targets` + RID-list construction) are also duplicated.
+
+**Suggested fix:** Move helpers and the validation block into
+`deriva_ml.dataset.target_resolution` (already shared) or a new
+sibling `adapter_common.py`. Each adapter becomes ~30 lines of
+framework-specific dataset construction.
+
+#### [P3] Both adapters catch `Exception` in `_bag_element_is_asset`
+**Location:** `src/deriva_ml/dataset/torch_adapter.py:167, 173` and same in tf_adapter
+**Issue:** Broad `except Exception` silently swallows. Narrow to `(AttributeError, KeyError)` (already listed alongside) and let other exceptions propagate.
+
+### src/deriva_ml/dataset/bag_feature_cache.py
+
+#### [P2] `_ensure_cache_populated` parameter `feat` lacks type annotation and `record_class: type`
+**Location:** `src/deriva_ml/dataset/bag_feature_cache.py:121-180`
+**Issue:** `feat` is untyped, `record_class: type` is overly broad. The actual types are `Feature` and `type[FeatureRecord]`. Add them.
+
+#### [P3] Cache table stores everything as TEXT — type round-tripping relies on Pydantic
+**Location:** `src/deriva_ml/dataset/bag_feature_cache.py:159-163`
+**Issue:** Comment "Store everything as TEXT; Pydantic reifies types at FeatureRecord construction time" — fine, but if a feature column has e.g. JSON-stringified array values, the SQLite layer would store the str representation and Pydantic would re-parse. Document the constraint that all FeatureRecord field types must accept str-deserialization, or pin a regression test.
+
+### src/deriva_ml/dataset/target_resolution.py
+
+(No findings — module is well-scoped, single-purpose, well-documented, and tested via `tests/dataset/test_target_resolution.py`.)
+
+### src/deriva_ml/dataset/validation.py
+
+#### [P3] Validation models duplicate the dual-track shape across Dataset/Asset/Workflow
+**Location:** `src/deriva_ml/dataset/validation.py:71-150`
+**Issue:** `DatasetSpecResult`, `AssetSpecResult`, `WorkflowSpecResult` all carry `valid: bool`, `reasons: list[...]`, `actual_table: str | None`. A base class would tighten the contract. Low-priority — current shape works.
+
+### src/deriva_ml/dataset/__init__.py
+
+(No findings — minimal re-exports, correctly documented.)
+
+---
+
+## Test coverage gaps (cross-module)
+
+1. **`Dataset.to_markdown` / `Dataset.display_markdown` / `Dataset.get_chaise_url`** — no tests.
+2. **`DatasetBag.list_tables`** — no tests in `test_bag_api_coverage.py`.
+3. **`DatasetBagBuilder.build_bag`** — no direct test (only spec/annotation/aggregate-query coverage).
+4. **`Dataset._estimate_csv_bytes`** — pure helper, only exercised through end-to-end `estimate_bag_size` tests.
+5. **`BagCache.cached_incomplete`** alias — no test exercises the back-compat alias.
+6. **`Dataset.list_workflow_executions`** unscoped semantic — no test asserts that it returns all executions (not just dataset-scoped ones). Risk: future drift toward scoped semantics goes undetected.
+7. **`test_prefetch_is_alias_for_cache`** — tests `cache()` (not `prefetch()`); since `prefetch` doesn't exist, the test is meaningless. Either delete the test or implement `prefetch()` as an alias.
+8. **`add_dataset_members` cycle path** — no test catches the broken `set(self.dataset_rid)` bug; covered with a real A→B→A cycle test.
+9. **`_create_or_advance_dev_row` concurrent-write race** — error path is documented but no test injects an RMT mismatch. Add with a model-side fixture that mutates the row between `dataset_history()` and the update call.
+10. **Snapshot-suffix preservation in `_SnapshotAwareCatalogBagBuilder._run_export`** — overrides upstream for issue #114 but no regression test pins the snapshot suffix on the export URL.
+
+## Duplication candidates (cross-module)
+
+1. **`feature_values` selector + grouping pattern** — `dataset.py:591-604` and `dataset_bag.py:637-652`. Extract to `deriva_ml.feature`.
+2. **`_bag_element_is_asset`, `_build_row_lookup`, `_resolve_asset_path`** — `torch_adapter.py:160-195` and `tf_adapter.py:185-220` are verbatim parallel.
+3. **`DatasetMinid` construction with conditional snapshot suffix** — `bag_download.py:531-537` and `bag_download.py:599-605`. Extract to `_build_dataset_minid(...)`.
+4. **`as_torch_dataset` / `as_tf_dataset` docstring prose** — same target-arity, missing-policy, RID-last contract repeated. Extract to module docstring or shared constant.
+5. **Retired-API shim shape** — `DatasetBag.fetch_table_features` / `list_feature_values` repeat the same pattern as the DerivaML / Asset retired pairs. Delete all three per workspace convention.
+
+---
+
+## Severity tag legend
+
+- **P0** — blocks release.
+- **P1** — should-fix this cycle. Correctness bugs or extraction needed for sustainable maintenance.
+- **P2** — nice-to-have. Real findings but the system functions correctly today.
+- **P3** — note-only. Style/clarity nudges.

--- a/docs/audits/2026-05-22-engineer-audit-execution.md
+++ b/docs/audits/2026-05-22-engineer-audit-execution.md
@@ -1,0 +1,816 @@
+# Engineer audit — execution/ subsystem (2026-05-22)
+
+Release target: **v1.37.1**
+Scope: `src/deriva_ml/execution/*.py` (21 modules, ~9,451 LOC) and
+`tests/execution/*.py` (34 files, ~10,668 LOC).
+
+## Summary
+
+- **21 modules audited** (8 large: execution.py 2,676 LOC; runner.py
+  720; bag_commit.py 761; base_config.py 698; workflow.py 706;
+  execution_record.py 688; state_machine.py 626; state_store.py 420).
+- **65 findings: 1 P0, 24 P1, 31 P2, 9 P3.**
+- Top themes:
+  1. **`execution.py` is a god module (2,676 LOC, ~30 public/protected
+     methods on one class).** Asset-tagging, lifecycle transitions, asset
+     download, dataset attach, feature staging, hierarchy, and cleanup
+     all live in one place. Heaviest method (`_update_asset_execution_table`)
+     mixes Input/Output branches over 130 lines with documented
+     dead Output-path. Split candidates exist in `bag_commit.py` and
+     `execution_record.py` patterns.
+  2. **Real bug in dirty-tree detection (`Workflow._github_url`).** The
+     check `"M " in result.stdout.strip()` misses every case where the
+     change is unstaged (` M`), both-modified (`MM`), renamed (`R `),
+     deleted (`D `), or untracked (`??`), and falsely flags clean
+     files whenever any unrelated file in the repo has a staged
+     modification. Combined with `cwd=executable_path.parent` rather
+     than the repo root, dirty-detection is unreliable. This silently
+     allows provenance-violating runs through. Tests only exercise the
+     happy path (`# modified` → modified-not-staged → ` M`); they
+     pass today only because the test fixture stages-then-modifies in
+     a way that doesn't reproduce the substring.
+  3. **Duplicate `list_input_datasets` / `list_assets` between
+     `Execution` and `ExecutionRecord`.** Both walk the same catalog
+     tables with the same Producer filter and the same try/except.
+     `Execution`'s "fallback for dry_run" branch can never fire (a
+     dry-run execution is created with `_execution_record=None`, so the
+     delegate path uses the fallback unconditionally) — but the
+     `_execution_record` guard implies otherwise.
+  4. **Docstring-style inconsistency in `runner.py`** (NumPy section
+     headers `Parameters / ----------` inside an otherwise Google-style
+     codebase — CLAUDE.md mandates Google). Affects readability and
+     tooling that parses doctrings.
+  5. **`_update_asset_execution_table` Output branch is dead in
+     production.** All Output assets now flow through
+     `bag_commit._add_asset_rows_to_bag`. The Output branch only runs
+     from tests (`test_asset_role_auto_tag.py`). Tests preserve a code
+     path the production pipeline no longer exercises — risks divergence
+     between bag-commit reality and the tested behaviour.
+
+## Findings by module
+
+### src/deriva_ml/execution/workflow.py
+
+#### [P0] Dirty-tree detection is wrong — silently accepts dirty workflows
+**Location:** `src/deriva_ml/execution/workflow.py:627-637`
+**Issue:** Two compounding bugs in `_github_url`:
+1. `is_dirty = bool("M " in result.stdout.strip())` matches only the
+   first-column-`M` staged-modified status. `git status --porcelain`
+   emits ` M` (unstaged modify), `MM` (both), `??` (untracked), `D ` /
+   ` D`, `R ` (rename), `A ` (added), etc. None of these set
+   `is_dirty=True`, so a user editing a workflow file and saving (but
+   not staging) will have provenance recorded with the LAST-COMMITTED
+   checksum — defeating the entire dirty-workflow guard.
+2. `cwd=executable_path.parent` plus `--porcelain` (no path argument)
+   walks the whole repo. A clean workflow file in a repo with any
+   staged modification elsewhere will be flagged dirty (false positive).
+**Evidence:**
+```python
+result = subprocess.run(
+    ["git", "status", "--porcelain"],
+    cwd=executable_path.parent,
+    capture_output=True, text=True, check=False,
+)
+is_dirty = bool("M " in result.stdout.strip())
+```
+**Suggested fix:** Scope to the file and check the porcelain line's
+first two columns properly. The robust form is `git status --porcelain
+-- <relative-path>` and treat any non-empty output as dirty:
+```python
+result = subprocess.run(
+    ["git", "status", "--porcelain", "--", str(executable_path)],
+    cwd=repo_root, capture_output=True, text=True, check=False,
+)
+is_dirty = bool(result.stdout.strip())
+```
+Add tests for ` M`, `MM`, `??`, `D `, and the "clean file in dirty
+repo" case. This is the only P0 in the audit and warrants a hold-and-fix
+before tagging v1.37.1.
+
+#### [P1] Triple-quoted "docstring" mid-function is a stray comment, not a docstring
+**Location:** `src/deriva_ml/execution/workflow.py:639`
+**Issue:** The line `"""Get SHA-1 hash of latest commit of the file in
+the repository"""` sits inside `_github_url`, not at function head, and
+behaves as a no-op string expression that the bytecode evaluator
+discards. Looks like a misplaced docstring; should be `# Get SHA-1 ...`.
+**Suggested fix:** Convert to a regular `#` comment. Trivial.
+
+#### [P1] `_github_url` has no error handling for `git remote get-url` exit code
+**Location:** `src/deriva_ml/execution/workflow.py:612-621`
+**Issue:** `subprocess.run([... "git", "remote", "get-url", "origin"])` is
+called without `check=True`. If `origin` doesn't exist, `result.stdout`
+is empty and `github_url` becomes `""`. The `except CalledProcessError`
+clause is unreachable without `check=True`. Returned URL silently looks
+like `/blob/<sha>/relative/path.py` (no host) and gets recorded as
+provenance.
+**Suggested fix:** Either add `check=True` (so the except clause fires)
+or test `result.returncode` explicitly. Same pattern fix applies to the
+`git log` block at line 641.
+
+#### [P1] `get_url_and_checksum` raises on non-git directories even when `allow_dirty=True`
+**Location:** `src/deriva_ml/execution/workflow.py:472-480`
+**Issue:** The "Not executing in a Git repository" guard fires before
+`allow_dirty` is consulted. A dry-run / one-off script run from
+outside a checkout cannot benefit from `DERIVA_ML_ALLOW_DIRTY=true`.
+Combined with the `DERIVA_ML_DRY_RUN=true` env flag flowing into
+`allow_dirty=True` in the model validator, the intent ("allow dirty
+provenance") is broken at the precondition stage.
+**Suggested fix:** Bypass the git-presence check when `allow_dirty` is
+True; emit a warning instead and leave URL/checksum empty.
+
+#### [P2] `_check_nbstrip_status` is defined but never called
+**Location:** `src/deriva_ml/execution/workflow.py:540-556`
+**Issue:** Static method appears unreferenced inside this module and is
+not exported. Dead code per CLAUDE "no backwards-compat shims" rule.
+**Suggested fix:** Delete or wire into `_github_url` for `.ipynb`
+files.
+
+#### [P2] `get_dynamic_version` raises `RuntimeError`, not a `DerivaML*` exception
+**Location:** `src/deriva_ml/execution/workflow.py:697-700`
+**Issue:** Departs from the documented hierarchy
+(`DerivaMLConfigurationError`/`DerivaMLException`). Callers can't catch
+this with the project's exception umbrella.
+**Suggested fix:** Wrap as `DerivaMLConfigurationError("setuptools_scm
+is not available")`.
+
+#### [P3] `__setattr__` validator does heavy work on every assignment
+**Location:** `src/deriva_ml/execution/workflow.py:136-175`
+**Issue:** For each `workflow.description = ...` assignment, the
+override checks `__pydantic_private__`, dispatches to
+`_update_description_in_catalog`, then re-enters Pydantic. Fine for
+intentional updates, but the same path triggers for internal
+re-assignment paths (e.g. `setup_url_checksum` mutating `self.url`
+inside a model validator — guarded only by the `_ml_instance is not
+None` test). Document the invariant in the class docstring.
+
+### src/deriva_ml/execution/execution.py
+
+#### [P1] God class — Execution carries 30+ methods and 2,676 LOC
+**Location:** entire file
+**Issue:** One class manages lifecycle transitions (`__enter__`,
+`__exit__`, `execution_start`, `execution_stop`, `abort`,
+`update_status`), asset download (`download_asset`,
+`_initialize_execution`), asset upload (`upload_execution_outputs`,
+`_bag_commit_upload`, `_update_asset_execution_table`,
+`_set_asset_descriptions`), asset staging (`asset_file_path`,
+`metrics_file`), feature staging (`add_features`), dataset attach
+(`download_dataset_bag`, `create_dataset`, `add_files`,
+`list_input_datasets`), hierarchy (`add_nested_execution`, `is_nested`,
+`is_parent`), and cleanup (`_clean_folder_contents`). Cognitive load is
+high and changes ripple. Suggest extracting `AssetUploadPipeline` /
+`AssetStaging` mixins, leaving lifecycle on `Execution`.
+**Suggested fix:** Phase out by extracting the asset-staging and
+upload methods into `execution/asset_upload.py` (mirroring the
+`bag_commit.py` extraction pattern). Not a blocker for v1.37.1; ledger
+for the next minor.
+
+#### [P1] `_update_asset_execution_table` Output branch is dead in production
+**Location:** `src/deriva_ml/execution/execution.py:1864-1899` (Output
+branch); only call site at line 1462 always passes `asset_role="Input"`.
+**Issue:** The Output flow now lives in
+`bag_commit._add_asset_rows_to_bag` (which writes
+`{Asset}_Execution` + `{Asset}_Asset_Type` rows during bag build —
+explicitly noted in `bag_commit.py:322-326`). Only tests still call
+`_update_asset_execution_table` with `asset_role="Output"`
+(`test_asset_role_auto_tag.py`). The tests are pinning a code path
+that production no longer exercises — silent risk of bag-commit
+diverging from the tested behavior.
+**Evidence:**
+```python
+# execution.py:1462 (only production caller)
+self._update_asset_execution_table(
+    {f"{asset_table.schema.name}/{asset_table.name}": [asset_path]},
+    asset_role="Input",  # always Input here
+)
+```
+**Suggested fix:** Either (a) drop the Output branch from
+`_update_asset_execution_table` and rewrite the auto-tag tests to
+exercise `bag_commit._add_asset_rows_to_bag` directly, or (b) keep the
+branch but route the bag-commit Output path through it as the single
+source of truth. Option (a) is the smaller change and aligns with the
+documented "bag is now authoritative" stance.
+
+#### [P1] `asset_file_path` falsy-`asset_types` bug — empty list collapses to asset_name
+**Location:** `src/deriva_ml/execution/execution.py:1950`
+**Issue:** `asset_types = asset_types or kwargs.pop("Asset_Type", None)
+or asset_name`. If the user explicitly passes `asset_types=[]` to
+register an asset with no content tags, the empty list is falsy and the
+code substitutes `asset_name` (the table name as a tag) which then
+triggers a `lookup_term` on a name that may not exist in
+`Asset_Type` vocabulary. The user's intent ("no tags") becomes "guess
+a tag from the table name."
+**Suggested fix:** Use `if asset_types is None:` instead of `or` so an
+explicit empty list is honored. Add a test:
+`asset_file_path(..., asset_types=[])` should not call `lookup_term`.
+
+#### [P1] `_initialize_execution` mixes init-side-effects with download work
+**Location:** `src/deriva_ml/execution/execution.py:654-772`
+**Issue:** 118-line method does (1) dataset materialization,
+(2) `Dataset_Execution` association inserts, (3) batched asset
+download, (4) per-asset destination-dir construction, (5) configuration
+JSON serialization, (6) uv.lock attachment, (7) Hydra config asset
+registration, (8) runtime-env snapshot, (9) the first
+`_bag_commit_upload`. Each step has its own failure mode but they
+share one log message ("Initialize status finished.") and one
+exception umbrella (`DerivaMLException`). Hard to reason about
+recovery — which steps already succeeded if upload at step 9 raises?
+**Suggested fix:** Split into `_materialize_datasets()`,
+`_download_inputs()`, `_register_init_metadata()`, and
+`_upload_init_assets()` private helpers. Each one log-bracketed and
+individually catchable.
+
+#### [P1] `Execution.__init__` performs catalog inserts before SQLite registry write — partial-failure window
+**Location:** `src/deriva_ml/execution/execution.py:378-482`
+**Issue:** The catalog `Execution.insert` (line 378) happens BEFORE
+the SQLite registry insert (line 449). If the SQLite write raises
+(disk full, schema mismatch), the catalog row exists but the workspace
+has no record. The `except Exception` at line 468 logs and re-raises,
+but the orphaned catalog row stays. The error message says "Execution
+can be recovered via ml.lookup_execution(rid) + manual adoption" — but
+that path requires implementing manual adoption, which is not a documented
+public API.
+**Suggested fix:** Either (a) insert SQLite first (so a catalog
+failure can be retried without orphan), or (b) document and ship the
+adopt-orphan path that the error message references.
+
+#### [P1] `from_registry` skips workflow lookup, leaving `workflow_rid=None`
+**Location:** `src/deriva_ml/execution/execution.py:484-524`
+**Issue:** `from_registry` minimally hydrates an Execution for
+`resume_execution`, but sets `instance.workflow_rid = None` (line 523)
+without loading it from SQLite (the registry row carries it). Any
+downstream code that relies on `execution.workflow_rid` (e.g.,
+`add_workflow_executions` linkage during nested-execution attach) will
+see None on a resumed execution.
+**Evidence:**
+```python
+instance.workflow_rid = None  # never repopulated from store.get_execution
+```
+**Suggested fix:** Populate from the SQLite row in `from_registry`:
+`instance.workflow_rid = store.get_execution(rid)["workflow_rid"]`.
+
+#### [P2] `_clean_folder_contents` has duplicate retry logic with magic constants
+**Location:** `src/deriva_ml/execution/execution.py:1721-1764`
+**Issue:** Inline `MAX_RETRIES = 3`, `RETRY_DELAY = 1`, and a nested
+`remove_with_retry` closure. Same retry pattern appears in
+`asset/manifest.py` and `catalog/clone.py`. Magic constants live in
+each call site rather than `core/constants.py`.
+**Suggested fix:** Move to a `core/file_utils.py` retry helper. Not a
+blocker.
+
+#### [P2] `download_asset` cache code has two `expected_md5 = asset_record.get("MD5")` lookups
+**Location:** `src/deriva_ml/execution/execution.py:1399, 1404, 1430`
+**Issue:** `expected_md5` is fetched once at line 1399, then re-fetched
+as `asset_record.get("MD5")` at line 1404 (`if use_cache: md5 =
+expected_md5`) and again at line 1430. Three lookups, two locals
+(`md5` and `expected_md5`) holding the same value. Reads cleaner with
+one local.
+**Suggested fix:** Use `expected_md5` throughout; drop the `md5` local.
+
+#### [P2] Inconsistent logger usage (`logger`, `self._logger`, `logging`)
+**Location:** `src/deriva_ml/execution/execution.py:208, 474, 549, 673,
+685, 772, 1229, 1272, 1417, 1441, 1646, 1659, 1668, 1683, 1714, 1745,
+1764, 2505, 2567, 2575`
+**Issue:** Three different logger handles in one file:
+- `logger` (module-level, line 90)
+- `self._logger` (instance handle from `ml_object._logger`)
+- `logging.warning(...)` / `logging.error(...)` (root logger calls)
+The module-level `logger` is `get_logger(__name__)` (deriva_ml.*),
+while `logging.error` bypasses that and lands on the root logger.
+Inconsistent observability and filter behavior.
+**Suggested fix:** Use module-level `logger` everywhere; remove the
+`self._logger` indirection.
+
+#### [P2] `Execution.execute()` is a sugar method that doesn't add value
+**Location:** `src/deriva_ml/execution/execution.py:2141-2158`
+**Issue:** Returns `self`. Docstring says "use as `with exe.execute()
+as e:`". Same semantics as `with exe as e:`. Adds a method the user
+must know about without buying anything.
+**Suggested fix:** Either delete (and update docs to use bare
+`with exe:`) or document the legacy-compat rationale.
+
+#### [P2] `list_input_datasets` dry-run fallback is unreachable
+**Location:** `src/deriva_ml/execution/execution.py:2174-2191`
+**Issue:** The check `if self._execution_record is not None: return
+self._execution_record.list_input_datasets()` delegates the persistent
+path. The "Fallback for dry_run mode" branch below requires
+`_execution_record is None`, but dry-run executions also have
+`_dry_run=True` and never insert into `Dataset_Execution` (per
+`_initialize_execution` line 679-682). The fallback queries
+`Dataset_Execution` for an execution_rid that's never been written —
+returning an empty list. The fallback is dead code in practice.
+**Suggested fix:** Either remove the fallback (raising
+`DerivaMLException("not available in dry-run")` like `is_nested()` /
+`is_parent()`) or fix the gap by populating
+`Dataset_Execution` in dry-run.
+
+#### [P2] `list_assets` swallows lookup failures with bare `except Exception: pass`
+**Location:** `src/deriva_ml/execution/execution.py:2218-2226`
+**Issue:** The dry-run fallback iterates `Execution_Asset_Execution`,
+calls `lookup_asset(r["Execution_Asset"])`, and swallows every
+exception with `pass`. Hides real bugs (e.g., a typo in the column
+name); user sees an empty list and assumes "no assets" when the lookup
+is just broken.
+**Suggested fix:** Log at `WARNING` with the swallowed exception. The
+`ExecutionRecord.list_assets` (line 660-661) does it correctly with
+`logger.debug`; mirror that.
+
+#### [P3] `asset_file_path` accepts arbitrary `**kwargs` as metadata — silent typos
+**Location:** `src/deriva_ml/execution/execution.py:1911, 1963`
+**Issue:** `**kwargs` are merged into `metadata_dict` without
+column-name validation. A typo like `Lenght=12345` silently lands in
+the asset's metadata column dict and gets dropped by the asset_table
+filter later (or rejected at insert time with a confusing message).
+**Suggested fix:** Validate kwargs against
+`self._model.asset_metadata(asset_name)` before merging; raise
+`DerivaMLValidationError` on unknown columns.
+
+#### [P3] `__str__` and `__repr__` both define output but `__str__` doesn't include status
+**Location:** `src/deriva_ml/execution/execution.py:2410-2419`
+**Issue:** `__str__` lists working_dir, execution_rid, workflow_rid,
+asset_paths, configuration — no status. `__repr__` includes status.
+Calling `print(exe)` is less informative than `repr(exe)`.
+**Suggested fix:** Either include `status` in `__str__` or have
+`__str__` delegate to `__repr__`.
+
+### src/deriva_ml/execution/execution_record.py
+
+#### [P1] `list_assets` is a quadratic schema walk with bare `except Exception`
+**Location:** `src/deriva_ml/execution/execution_record.py:609-664`
+**Issue:** For each schema (domain + ml), iterates every table and
+filters by `endswith("_Execution")`. For a 200-table catalog that's
+400 catalog touches per call. Plus the inner try/except swallows every
+filter-and-fetch error at `logger.debug`. A real catalog connectivity
+problem becomes "execution has no assets." Same anti-pattern as
+`Execution.list_assets` (see above).
+**Suggested fix:** Index association tables once (per ml_instance
+lifetime) into `self._ml_instance._asset_execution_tables` and iterate
+that. Drop the bare-except to surface real errors.
+
+#### [P1] Duplicate `list_input_datasets` / `list_assets` between Execution and ExecutionRecord
+**Location:** `execution.py:2160-2227` vs `execution_record.py:568-664`
+**Issue:** Both classes implement the same Producer-filter walk
+(`Dataset_Execution` filter then `_producer_of_dataset` exclusion).
+Even the error message style differs ("ExecutionRecord is not bound to
+a catalog" vs "Execution has no bound ExecutionRecord"). Two places to
+keep in sync.
+**Suggested fix:** Move the implementation into a free function
+`lineage._list_input_datasets(ml, execution_rid)` and have both classes
+call it. Removes ~60 lines.
+
+#### [P2] Pydantic `_workflow` PrivateAttr violates the project's "user-facing → BaseModel field" rule
+**Location:** `src/deriva_ml/execution/execution_record.py:131-141`
+**Issue:** CLAUDE.md ("Class idiom choice — Pydantic vs `@dataclass`")
+says user-facing fields should be Pydantic fields with validation, not
+PrivateAttr-backed properties. `_workflow`, `_status`, `_description`
+are user-visible (read via `record.workflow`, set via
+`record.description = ...`) but bypass Pydantic validation entirely.
+The catalog setter is in `__setattr__`-like wrappers instead.
+**Suggested fix:** Restructure so `workflow`, `status`, `description`
+are real Pydantic fields with `@field_validator` for catalog write-back.
+Matches the audit's "single serialization story" rationale.
+
+#### [P2] `ExecutionRecord.__init__` overrides Pydantic's auto-init for no clear reason
+**Location:** `src/deriva_ml/execution/execution_record.py:143-185`
+**Issue:** Hand-rolled `__init__` that calls `super().__init__(...)`
+with a partial kwargs set then manually sets `_workflow`, `_status`,
+etc. Pydantic v2 supports `PrivateAttr(default=...)` initialization
+through the constructor; the manual override is redundant.
+**Suggested fix:** Use Pydantic v2's `model_post_init` hook, or fold
+the private-attr initialization into a `@model_validator(mode="after")`.
+
+#### [P2] `is_nested()` / `is_parent()` materialize the full iterator just to count
+**Location:** `src/deriva_ml/execution/execution_record.py:337-359`
+**Issue:** `return len(list(self.list_execution_parents())) > 0` walks
+every parent (recursively if there's a cycle) just to ask "does at
+least one parent exist?" Use the iterator and short-circuit.
+**Suggested fix:** `return next(iter(self.list_execution_parents()),
+None) is not None`.
+
+### src/deriva_ml/execution/runner.py
+
+#### [P1] Docstrings use NumPy style, project mandates Google style
+**Location:** `src/deriva_ml/execution/runner.py:380-450, 633-707`
+**Issue:** Sections like `Parameters\n----------\n` and `Examples\n--------\n`
+are NumPy-style. CLAUDE.md ("Docstrings: Google style") requires
+`Args:` / `Returns:` / `Raises:` / `Example:`. The mismatch breaks
+mkdocstrings parsing if the project enforces Google in its mkdocs
+config (the module docstring uses RST `:class:` directives too — also
+non-Google).
+**Suggested fix:** Convert `run_model` and `create_model_config`
+docstrings to Google sections. Roughly 80 lines of docstring rewrite.
+
+#### [P1] `_complete_parent_execution` catches and warns on every exception, no test coverage for failure
+**Location:** `src/deriva_ml/execution/runner.py:259-263`
+**Issue:** `except Exception as e: logging.warning(...)`. Atexit runs
+in a teardown context; a swallowed upload failure means the user
+loses their multirun parent. Only the dry-run-skip path
+(`test_dry_run_placeholder_does_not_warn`) is tested. No coverage for
+"parent upload raises mid-atexit" — and no observability beyond a
+single WARN line.
+**Suggested fix:** At minimum, log the exception with stack
+(`logger.exception("...")`) instead of formatting `{e}`. Better: write
+the failure to the workspace so `ml.find_incomplete_executions()`
+surfaces it on next run.
+
+#### [P1] `MultirunState` uses a class with class-level mutable defaults instead of an instance
+**Location:** `src/deriva_ml/execution/runner.py:175-198`
+**Issue:** `parent_execution_rid: str | None = None` etc. are
+class-level attributes, but `_multirun_state = MultirunState()` is a
+module-level singleton. Subclassing or instantiating elsewhere would
+silently share state through the class. Should be an instance or a
+plain `@dataclass`.
+**Suggested fix:** `@dataclass` with default factory, or move the
+state to module-level globals. The current shape misleads.
+
+#### [P2] Global singleton state across all multirun calls — concurrency hazard
+**Location:** `src/deriva_ml/execution/runner.py:198, 451`
+**Issue:** `_multirun_state` is module-global; a single Python process
+running two multirun sweeps concurrently (via subprocess or asyncio)
+shares parent-execution state. The atexit hook compounds: register
+once, runs once, even if multiple multiruns happen in sequence in a
+notebook.
+**Suggested fix:** Document the single-process-single-sweep invariant
+explicitly. Long-term, scope state by Hydra job name.
+
+#### [P2] `_resolve_model_source` swallows `(TypeError, OSError)` silently
+**Location:** `src/deriva_ml/execution/runner.py:362-364`
+**Issue:** When source-resolution fails, the workflow URL stays at the
+CLI entry point and the user has no signal. Especially relevant for
+`deriva-ml-run` users — they expect the workflow URL to reflect the
+model file, and `_resolve_model_source` is the only path that fixes
+it.
+**Suggested fix:** Log at `WARNING` when resolution fails, naming the
+config.
+
+#### [P2] `run_model` is 270 lines with 13 sectional comments — split it
+**Location:** `src/deriva_ml/execution/runner.py:369-630`
+**Issue:** One function does Hydra-logging-reset, ML-instance
+construction, RID validation, workflow URL correction, multirun parent
+creation, choices capture, execution config build, parent linking, the
+actual `callable_config(...)` call, and the upload. Sections are
+visually separated by `# ----` banners, but the same 13 sections could
+be 5 helper functions.
+**Suggested fix:** Extract `_connect_ml`, `_correct_workflow_url`,
+`_capture_choices`, `_run_callable_in_execution`, `_upload_outputs`
+helpers.
+
+#### [P3] `Returns -------\nNone` docstring sections will not render
+**Location:** `src/deriva_ml/execution/runner.py:432-435`
+**Issue:** Even in NumPy style, "Returns" should describe the return
+value semantics. Saying `None` literally is fine, but pair with the
+side-effects line.
+
+### src/deriva_ml/execution/bag_commit.py
+
+#### [P1] `_add_asset_rows_to_bag` and `_add_staged_feature_rows_to_bag` each lease RIDs in a separate batch
+**Location:** `bag_commit.py:337-339, 363-372, 490-491`
+**Issue:** Three separate `post_lease_batch` calls per commit (one for
+asset_execution_assoc, one for asset_type rows, one for feature rows).
+Each is a serialized round trip. For a 1,000-asset commit with 3 types
+each + features, that's 3 sequential POSTs that could be one batch
+(or one POST per logical group, properly amortized).
+**Suggested fix:** Either batch into one `post_lease_batch` with
+typed-token-prefix-routing, or accept the multi-batch cost and
+document it.
+
+#### [P1] `_add_staged_feature_rows_to_bag` silently skips rows on lookup failure
+**Location:** `bag_commit.py:444-452`
+**Issue:** When `ml.lookup_feature(target_table, feature_name)` raises,
+the entire feature group is skipped with `continue` and a `logger.error`.
+The user's staged feature records vanish from this commit. They stay
+"pending" in SQLite (no `mark_feature_records_failed`), so the next
+commit re-tries — which will fail the same way. Silent loss of work
+that needs operator intervention to discover.
+**Suggested fix:** Call `mark_feature_records_failed` for the group so
+the user sees the failure via `pending_summary()`.
+
+#### [P2] `match_by_columns` construction walks every table in every schema
+**Location:** `bag_commit.py:561-576`
+**Issue:** Nested `for schema in model.schemas: for table in
+model.schemas[schema].tables.values():` iterates the full model on
+every load. Cheap for small catalogs, but a deriva-py model can carry
+hundreds of tables.
+**Suggested fix:** Cache on the model object (or compute once per
+DerivaML instance lifetime).
+
+#### [P2] `_read_asset_type_map` ignores duplicate filename writes
+**Location:** `bag_commit.py:725-760`
+**Issue:** Iterates JSONL lines and calls `out.update(json.loads(line))`.
+If two lines carry the same filename with different type lists, the
+later one wins silently. Should at least log when a filename is
+overwritten.
+**Suggested fix:** Detect collision and union or warn.
+
+#### [P3] `total_assets` denominator silently zeroes when manifest is empty
+**Location:** `bag_commit.py:195-196`
+**Issue:** `total_assets = sum(len(es) for es in by_table.values())`.
+When empty, progress callback's `100.0 * staged_so_far / total_assets`
+would be `0/0`. Code guards with `if total_assets > 0`, but the user
+sees no `Staging` events for a feature-only commit. Document that
+behavior, or emit a single "no assets" event.
+
+### src/deriva_ml/execution/state_machine.py
+
+#### [P1] `transition` writes SQLite preemptively with `sync_pending=True` even on success
+**Location:** `state_machine.py:264-295`
+**Issue:** The flow is: (1) write SQLite with `sync_pending=True`, (2) PUT
+catalog, (3) write SQLite again to clear `sync_pending`. Two SQLite
+writes per online transition. The doc-comment explains the rationale
+(crash safety), but the cost is a 2× write amplification for every
+status change. For a fast happy path (Created → Running → Stopped →
+Pending_Upload → Uploaded), that's 8 SQLite writes per execution. WAL
+mode amortizes, but 8× fsync is still real.
+**Suggested fix:** Use a savepoint or single-transaction-with-deferred-flush
+pattern: write the row optimistically with `sync_pending=False`, do
+the catalog PUT, on failure set `sync_pending=True`. Trade-off
+documented in spec §2.2 but worth re-checking against actual fsync
+cost.
+
+#### [P2] `reconcile_with_catalog` doesn't cover `Stopped ↔ {Uploaded, Pending_Upload}` disagreements
+**Location:** `state_machine.py:424-439` (`_DISAGREEMENT_RULES`)
+**Issue:** The rule table covers 8 pairs but misses several plausible
+ones: `(Stopped, Uploaded)`, `(Stopped, Pending_Upload)`, `(Pending_Upload,
+Aborted)`. These fall into the "unexpected" else branch (line 570) and
+raise `DerivaMLStateInconsistency` — but the user's recourse is to
+manually edit SQLite. Common case for resuming a workspace from a
+catalog where another process has advanced the execution.
+**Suggested fix:** Extend `_DISAGREEMENT_RULES` to "adopt" the catalog
+state in these cases.
+
+#### [P3] `validate_transition` example renders as `assert <value> is None`
+**Location:** `state_machine.py:156-161`
+**Issue:** Docstring shows `>>> validate_transition(...)` with the
+comment "returns None, no raise". This is pure-Python and runs as
+doctest — but the call requires `ExecutionStatus` to be in the local
+namespace. Without conftest.py wiring it, the doctest collects and
+fails on `ExecutionStatus` not being defined.
+**Verification needed:** Run `uv run pytest --collect-only --doctest-modules
+src/deriva_ml/execution/state_machine.py` and confirm.
+**Suggested fix:** Mark the example `# doctest: +SKIP` or expose
+`ExecutionStatus` in `src/deriva_ml/conftest.py`.
+
+### src/deriva_ml/execution/state_store.py
+
+#### [P1] `pending_summary_rows`, `count_pending_by_kind`, `count_pending_rows` are no-op stubs
+**Location:** `state_store.py:336-399`
+**Issue:** Three reader methods always return zero/empty
+("retired in Phase 3 cleanup"). Production code paths still call them
+(``Execution.pending_summary``, ``find_executions``,
+``__repr__`` pending suffix). Documented, but live as silent
+zero-truthers. Any caller expecting "what's pending in this execution"
+gets a misleading "nothing pending" when there genuinely is staged
+work in the asset manifest (`pending_assets`).
+**Evidence:** `ml.pending_summary()` and `exe.pending_summary()` both
+return empty PendingSummary objects in production today, regardless of
+manifest state.
+**Suggested fix:** Either (a) implement against the asset manifest
+(`AssetManifest.pending_assets()` is the real source of pending data),
+or (b) delete the stubs and update the callers to query the manifest
+directly. Option (a) restores the documented surface.
+
+#### [P2] `update_execution` accepts arbitrary `**fields` then validates against column set
+**Location:** `state_store.py:258-286`
+**Issue:** Runtime KeyError check is fine, but a typed signature
+(`**fields: object`) gives no IDE hint about valid kwargs. A typed
+TypedDict overload would catch typos statically.
+**Suggested fix:** Define `class ExecutionFields(TypedDict, total=False):
+status: ExecutionStatus; error: str | None; ...` and overload.
+
+#### [P3] `delete_execution` doesn't return whether a row was deleted
+**Location:** `state_store.py:403-420`
+**Issue:** Silent no-op when rid doesn't exist. Caller has to call
+`get_execution` before to know whether the delete actually fired.
+**Suggested fix:** Return `bool` (whether a row was deleted).
+
+### src/deriva_ml/execution/execution_configuration.py
+
+#### [P2] `validate_assets` `else` branch fabricates an AssetSpec from `str(v)`
+**Location:** `execution_configuration.py:113-114`
+**Issue:** "Unknown type — try string coercion" is too lenient. A
+mistaken `None` becomes `AssetSpec(rid="None")` which is later
+"resolved" against the catalog and raises a confusing not-found error.
+**Suggested fix:** Raise `DerivaMLValidationError` listing the
+unsupported type instead.
+
+#### [P3] `argv` default uses `Field(default_factory=lambda: sys.argv)` — captures import-time argv
+**Location:** `execution_configuration.py:82`
+**Issue:** `default_factory` is called at instance construction (correct),
+but `sys.argv` at construction time may not match the argv of the
+process that originally launched the execution (e.g., a notebook
+kernel restart). The semantic is "the argv that created this
+ExecutionConfiguration object" rather than "the argv that started the
+job."
+**Suggested fix:** Document the semantics explicitly.
+
+### src/deriva_ml/execution/find_caller.py
+
+#### [P2] `_top_user_frame` walks the entire stack twice
+**Location:** `find_caller.py:111-189`
+**Issue:** The function records `last_user_frame` and "keeps going back
+to find an even higher one." Then `_get_calling_module` calls it
+twice (line 292 and line 306), each walking the full stack. For deep
+notebooks this is measurable.
+**Suggested fix:** Cache the result for the lifetime of one
+`_get_calling_module` invocation.
+
+#### [P2] `_get_notebook_path` queries Jupyter Server API with `timeout=3`
+**Location:** `find_caller.py:239`
+**Issue:** A non-responsive Jupyter server blocks workflow construction
+for 3 seconds × N servers. In a notebook session this is hit on every
+`create_workflow`/`create_execution` call.
+**Suggested fix:** Cache the resolved notebook path per process. The
+mapping `(kernel_id) → notebook_path` is stable for the lifetime of the
+kernel.
+
+### src/deriva_ml/execution/base_config.py
+
+#### [P2] `_captured_hydra_output_dir` is a module-global mutable
+**Location:** `base_config.py:61, 264-266, 527`
+**Issue:** Captures Hydra's output dir at `get_notebook_configuration`
+call time, then `run_notebook` reads it. Two notebooks running
+concurrently in the same process (Jupyter Lab kernels in the same
+host?) would share-state-and-clobber. Stack-trace recoverable but a
+multi-tenant footgun.
+**Suggested fix:** Return the path from `get_notebook_configuration`
+explicitly as a second tuple element; remove the module global.
+
+#### [P2] `load_configs` "experiments must load last" rule is undocumented invariant
+**Location:** `base_config.py:425-428`
+**Issue:** Magic name "experiments" is special-cased without
+explanation. Future devs adding a config module won't know why.
+**Suggested fix:** Document the dependency direction explicitly in the
+function's `Note:` block (it's noted at the end, but the *why* isn't).
+
+### src/deriva_ml/execution/environment.py
+
+#### [P2] `get_os_info["environ"]` captures every environment variable verbatim
+**Location:** `environment.py:171`
+**Issue:** Includes secrets-bearing variables like
+`AWS_SECRET_ACCESS_KEY`, `DERIVA_CLIENT_AUTH_TOKEN`, etc. The captured
+snapshot gets uploaded as an Execution_Metadata asset. Anyone with
+catalog read access to the asset table can extract these.
+**Evidence:** No allow/deny-list applied.
+**Suggested fix:** Filter against an explicit allow-list or redact
+keys matching common secret-name patterns (`*_TOKEN`, `*_KEY`,
+`*_SECRET`, `*_PASSWORD`). This is a confidentiality issue but not
+P0 because access to the asset already implies catalog read which
+is itself privileged.
+
+### Test coverage gaps (cross-module)
+
+#### [P1] Zero tests for `multirun_config.py` public surface
+**Location:** `src/deriva_ml/execution/multirun_config.py` (153 LOC)
+**Issue:** None of `multirun_config()`, `get_multirun_config()`,
+`list_multirun_configs()`, `get_all_multirun_configs()`, or
+`MultirunSpec` are exercised by any test. They're public symbols
+re-exported in `__init__.py`. A typo or re-architecting would land
+silently.
+**Suggested fix:** Add `tests/execution/test_multirun_config.py`
+covering register/lookup/list/get-all and registry isolation.
+
+#### [P1] Zero tests for `environment.py` helpers
+**Location:** `src/deriva_ml/execution/environment.py` (237 LOC)
+**Issue:** `get_execution_environment`, `get_loaded_modules`,
+`get_platform_info`, `get_os_info`, `get_umask`, `get_sys_info` are all
+untested. They run on every execution (saved as a metadata asset). A
+platform-specific edge case (e.g., `os.getlogin()` raising on a
+container with no login session) would crash every execution.
+**Suggested fix:** At least smoke tests that the dict has the
+documented keys and serializes to JSON.
+
+#### [P1] `Execution.metrics_file`, `database_catalog`, and `catalog` property paths untested
+**Location:** `src/deriva_ml/execution/execution.py:1025-1070, 2016-2091`
+**Issue:** No tests for `metrics_file()` (the convenience metric
+write path), `database_catalog` property (returns DerivaMLBagView for
+downloaded bags), or `catalog` property.
+**Suggested fix:** Unit tests with the existing `basic_execution`
+fixture pattern.
+
+#### [P1] `from_registry` classmethod not directly tested
+**Location:** `src/deriva_ml/execution/execution.py:484-524`
+**Issue:** Only exercised indirectly through `resume_execution` calls
+in `test_execution_registry.py`. The classmethod itself — minimum-init
+construction, the explicit `workflow_rid=None` assignment, the
+absent `_execution_record` — isn't asserted.
+**Suggested fix:** Test that the constructed instance answers
+`status` (via read-through) and raises on `is_nested()` /
+`is_parent()` (the documented dry-run failure modes).
+
+#### [P2] `lineage.py` Pydantic models tested at the lookup layer, not as standalone shapes
+**Location:** `src/deriva_ml/execution/lineage.py`
+**Issue:** `LineageResult`, `LineageNode`, `RootDescriptor`,
+`WorkflowSummary`, etc. are exposed publicly (re-exported from
+`__init__.py`) for downstream MCP consumers. No direct
+schema/serialization tests for the model boundary —
+`test_lookup_lineage_unit.py` exercises them via the lookup path but
+doesn't pin the JSON shape.
+**Suggested fix:** Add `test_lineage_models.py` with `.model_dump()` /
+`.model_validate_json()` round-trip tests.
+
+#### [P2] `_clean_folder_contents` retry path not tested
+**Location:** `src/deriva_ml/execution/execution.py:1721-1764`
+**Issue:** The retry-on-PermissionError logic (for Windows compat) is
+never triggered in tests. A regression that turns retries off would
+go unnoticed.
+**Suggested fix:** Mock `Path.unlink` to raise PermissionError once,
+then succeed; assert retry count.
+
+#### [P2] `DescribedList` runtime behavior covered via `test_ast_walker`, but `with_description` not directly tested
+**Location:** `src/deriva_ml/execution/base_config.py:580-698`
+**Issue:** Only consumer is `tests/config/test_ast_walker.py` (which
+runs at the AST level). No test verifies that `instantiate(
+with_description([...]))` actually produces a `DescribedList` with the
+expected `.description` attribute.
+**Suggested fix:** Add `test_with_description_instantiates.py` with a
+hydra-zen instantiate round-trip.
+
+### Duplication candidates (cross-module)
+
+#### [P1] `_update_description_in_catalog` / `_update_status_in_catalog` duplicated across Workflow, ExecutionRecord
+**Location:** `workflow.py:201-219`, `execution_record.py:282-314`
+**Issue:** Both classes implement near-identical `pathBuilder().schemas
+[ml_schema].<Table>.update([{"RID": ..., "<Col>": ...}])` helpers.
+Pattern is "look up the path, update one column on one RID." Could be
+a shared `_catalog_set_column(ml, schema, table, rid, column, value)`
+helper.
+
+#### [P1] `pathBuilder().schemas[ml_schema].Execution_Execution` query for parent/child appears 4× across the codebase
+**Location:** `execution.py:2358-2368`, `execution_record.py:412-447,
+500-535`
+**Issue:** Same "filter `Execution_Execution` on parent/child, fetch
+related Execution rows, instantiate ExecutionRecord" walked 4 times.
+Each has minor variations (recurse flag, visited set, RID kwarg).
+**Suggested fix:** Extract `lineage._walk_execution_hierarchy(ml,
+rid, direction)` (direction = "children" or "parents") with the
+recursion / visited tracking centralized.
+
+#### [P2] `_check_writable_catalog` duplicated between Workflow and ExecutionRecord
+**Location:** `workflow.py:177-199`, `execution_record.py:256-280`
+**Issue:** Same `ErmrestSnapshot` isinstance check + same RID-presence
+check + same exception message format. The only difference is the
+"operation" string interpolation.
+**Suggested fix:** Move to a free function
+`_assert_writable_catalog(catalog, rid, operation)` in
+`execution_record.py` or `core/checks.py`. Both classes import it.
+
+#### [P2] `update_status` implementation pattern duplicated 3×
+**Location:** `execution.py:1189-1243`, `execution_snapshot.py:199-251`,
+`execution_record.py:316-335`
+**Issue:** Three classes implement `update_status` differently:
+- `Execution.update_status` goes through the state machine.
+- `ExecutionRecord.update_status` goes through
+  `_update_status_in_catalog` (catalog-only, no state machine).
+- `ExecutionSnapshot.update_status` goes through the state machine.
+The mismatch: `ExecutionRecord` skips state-machine validation, so
+`record.update_status(ExecutionStatus.Failed)` from any starting
+status will succeed without `ALLOWED_TRANSITIONS` enforcement.
+**Suggested fix:** Either (a) route ExecutionRecord through the state
+machine (preferred — consistent validation), or (b) document the
+"no state-machine guard" intent and add a warning to the docstring.
+
+#### [P2] `_format_duration` is a module-private but its logic is duplicated by `transition` callers
+**Location:** `execution.py:110-138`
+**Issue:** `execution_start` / `execution_stop` / `__exit__` /
+`upload_execution_outputs` all call `_format_duration` — five sites.
+The state machine sees only the formatted string. Could move the
+formatting INTO the state machine's `extra_fields` post-processing so
+callers pass `{stop_time: dt}` and the state machine derives
+`duration`.
+**Suggested fix:** Centralize in `state_machine.transition` once the
+read-through pattern stabilizes.
+
+#### [P2] `lookup_term(MLVocab.asset_role, ...)` called repeatedly across asset paths
+**Location:** `execution.py:1812, 1953`, `bag_commit.py:168`
+**Issue:** `Output` / `Input` / individual asset-type lookups happen
+on every asset operation. Each is a small catalog GET. Could be cached
+once on the ml_instance.
+**Suggested fix:** Memoize `lookup_term` results per
+`(vocab, term)` pair on the ml_instance for the session lifetime.
+
+#### [P3] Two identical `from datetime import timezone` local imports inside `Execution`
+**Location:** `execution.py:127, 426, 1270, 1317, 1560, 2499`
+**Issue:** Six in-function local imports of the same name. Pulled
+locally to avoid potential import-time circulars, but the module
+already imports `from datetime import datetime` at top level — the
+`timezone` import could join it without breaking anything.
+**Suggested fix:** Lift to top-level import.
+
+## Top action items for v1.37.1 hold-gate
+
+1. **P0 fix:** `Workflow._github_url` dirty-detection — replace the
+   substring check with proper file-scoped porcelain parsing. Add
+   tests for ` M`, `MM`, `??`, `D `, untracked, and the
+   "clean file in dirty repo" false positive case.
+2. **P1 backports worth doing pre-release** (cheap, contained):
+   - `asset_file_path` `or asset_name` falsy-asset_types bug (one
+     line + one test).
+   - `_initialize_execution` setting `instance.workflow_rid = None`
+     in `from_registry` (one line + one test).
+   - Mid-function triple-quoted string at workflow.py:639 (one line).
+3. **Defer to v1.38.x:**
+   - God-class refactor of `Execution`.
+   - `runner.py` Google-style docstring conversion.
+   - `_update_asset_execution_table` dead-Output-branch removal.
+   - State-store pending-summary stubs replaced with manifest-backed
+     readers.
+   - `multirun_config` and `environment` test gaps.

--- a/docs/audits/2026-05-22-engineer-audit-feature.md
+++ b/docs/audits/2026-05-22-engineer-audit-feature.md
@@ -1,0 +1,324 @@
+# Engineer audit — feature subsystem (v1.37.1)
+
+**Date:** 2026-05-22
+**Scope:**
+
+- `src/deriva_ml/feature.py` — `Feature`, `FeatureRecord`, selectors
+- `src/deriva_ml/core/mixins/feature.py` — `FeatureMixin` (CRUD + reads)
+- `src/deriva_ml/dataset/dataset.py` — `Dataset.feature_values`, `Dataset.find_features`, `Dataset.lookup_feature`
+- `src/deriva_ml/dataset/dataset_bag.py` — `DatasetBag.feature_values`, `DatasetBag.find_features`, `DatasetBag.lookup_feature`, `DatasetBag.list_workflow_executions`
+- `src/deriva_ml/dataset/bag_feature_cache.py` — bag denormalization read path
+- `src/deriva_ml/model/catalog.py` — `DerivaModel.find_features`, `DerivaModel.lookup_feature`
+- `src/deriva_ml/model/deriva_ml_bag_view.py` — bag-view `find_features`
+- `tests/feature/` — entire test directory
+
+## Summary
+
+Smaller, recently-refactored subsystem with reasonably tight test coverage of the unit-level
+selector contract and the three-container symmetry suite. Two real correctness issues stand
+out:
+
+- **P0 — `DatasetBag.find_features(None)` will return duplicate `Feature` objects** because it
+  bypasses the dedup logic the catalog model added for the no-arg branch.
+- **P1 — `FeatureRecord.select_majority_vote(column=None)` indexes a `set`** when auto-detecting
+  the single term column, which raises `TypeError` instead of returning a record. No test covers
+  the auto-detect happy path, so this latent bug isn't caught.
+
+The rest is largely polish: three parallel implementations of the
+"group-by-target-RID-then-apply-selector" pattern, a few docstring/annotation inconsistencies,
+and several coverage gaps around the multi-target dedup story, edge cases of the selectors, and
+the FK-walk classification in `Feature.__init__`.
+
+Total findings: **21** (3 × P0, 7 × P1, 8 × P2, 3 × P3).
+
+---
+
+## Findings by module
+
+### `src/deriva_ml/feature.py`
+
+#### F-1 [P1] `select_majority_vote(column=None)` auto-detect indexes a set
+`feature.py:354-355`
+```python
+if len(record_cls.feature.term_columns) == 1:
+    col = record_cls.feature.term_columns[0].name
+```
+`Feature.term_columns` is a `set[Column]` (constructed via a set comprehension in
+`Feature.__init__` at line 552). Subscripting a set raises `TypeError`. The only existing test
+that exercises `column=None` (`test_select_majority_vote_raises_without_column_when_no_metadata`)
+hits the *no* metadata branch and never reaches line 355, so this is uncovered. Replace with
+`next(iter(record_cls.feature.term_columns)).name` (or sort by name for deterministic output).
+
+#### F-2 [P2] `select_majority_vote._selector` IndexErrors on empty `records`
+`feature.py:352` (`record_cls = type(records[0])`) and `feature.py:368`
+(`max_count = max(counts.values())`). Both `records[0]` and `max(empty)` raise on
+`records == []`. Other selectors return `None` for empty input (see
+`test_select_by_workflow_returns_none_on_empty_records`,
+`test_select_by_execution_returns_none_on_empty_records`); `select_majority_vote` silently
+breaks the symmetry. Guard at the top with `if not records: return None` and update the return
+annotation to `FeatureRecord | None`.
+
+#### F-3 [P2] `map_type` return-type annotation drops `bool`
+`feature.py:596` annotates the return as
+`UnionType | Type[str] | Type[int] | Type[float]`, but line 628 returns `bool`. Docstring
+line 611 says "str for all other types" but `bool` is a distinct branch. Add `Type[bool]` to
+the annotation and correct the docstring.
+
+#### F-4 [P3] Class-docstring header lists `select_by_execution` as classmethod
+`feature.py:21` describes `select_by_execution(execution_rid)` next to
+`select_by_workflow(workflow, *, container)`, but the implementation at line 132 is
+`@staticmethod`. The asymmetry is harmless but visible — `select_by_execution` should either be
+a classmethod for consistency with `select_by_workflow` / `select_majority_vote`, or the docs
+shouldn't suggest classmethod symmetry.
+
+#### F-5 [P2] `Feature._model` is an internal attribute with no leading underscore in `__init__` docstring
+`feature.py:523` stores `self._model = model`. The `__init__` Args block uses `model` (no
+underscore) and the rest of the class doesn't otherwise touch `_model` — it's used inside
+`__init__` only. The instance attribute can be dropped entirely (assign into a local, drop the
+`self._model = model` line). Saves one strong reference per Feature.
+
+#### F-6 [P1] No test exercises FK classification (`asset_columns` / `term_columns` / `value_columns`) on a real `Feature` from the catalog
+The classification logic at `feature.py:546-558` is the heart of `Feature.__init__`. Existing
+tests only assert *counts* on demo features (`test_create_feature`,
+`test_create_feature_with_non_asset_table_raises`) without ever inspecting which specific
+columns landed in which bucket, and `TestFeatureRecord.test_feature_record_column_methods` uses
+fully mocked columns that never run `Feature.__init__`. Add a test that:
+1. Creates a feature with a known mix of asset/term/value/metadata columns.
+2. Inspects each bucket by column name (not just `len`).
+3. Verifies the structural FKs (`Execution`, `Feature_Name`, target table FK) are NOT in any
+   bucket — this is the `assoc_fkeys` subtraction the comment at line 537 warns against.
+
+---
+
+### `src/deriva_ml/core/mixins/feature.py`
+
+#### F-7 [P1] `select_by_workflow` docstring example passes a `Workflow` object where the signature requires `str`
+`core/mixins/feature.py:459-460`:
+```python
+>>> workflow = ml.lookup_workflow("Glaucoma_Training_v2")  # doctest: +SKIP
+>>> sel = FeatureRecord.select_by_workflow(workflow, container=ml)  # doctest: +SKIP
+```
+`FeatureRecord.select_by_workflow(workflow: str, ...)` calls
+`container.list_workflow_executions(workflow)` which is `@validate_call`'d to `str` — passing
+the `Workflow` object would fail Pydantic validation. The example is misleading. Use either
+`"Glaucoma_Training_v2"` directly (Workflow_Type name) or `workflow.rid`. The same correction
+applies to the module-header example in `feature.py:21` if it's ever materialized.
+
+#### F-8 [P1] `feature_values` and `Dataset.feature_values` and `DatasetBag.feature_values` each re-implement the same group-by-RID-and-apply-selector pattern
+Three near-identical blocks:
+- `core/mixins/feature.py:513-523`
+- `dataset/dataset.py:594-604`
+- `dataset/dataset_bag.py:641-652`
+
+```python
+grouped: dict[str, list[FeatureRecord]] = defaultdict(list)
+for rec in records:
+    target_rid = getattr(rec, target_col, None)
+    if target_rid is not None:
+        grouped[target_rid].append(rec)
+for group in grouped.values():
+    chosen = selector(group)
+    if chosen is not None:
+        yield chosen
+```
+Extract once into a module-level helper (e.g. `feature._reduce_with_selector(records, target_col,
+selector)`), then call from all three sites. Three places drift independently as more selector
+options accumulate. The bag's import of `defaultdict` at line 591 inside the method (lazy) and
+the dataset's at the top (eager) is an existing inconsistency that hints at this duplication
+being intentional but unaudited.
+
+#### F-9 [P2] `delete_feature` swallows underlying failures behind `False`
+`core/mixins/feature.py:269-277`:
+```python
+try:
+    feature = next(f for f in self.model.find_features(table) if f.feature_name == feature_name)
+    feature.feature_table.drop()
+    return True
+except StopIteration:
+    return False
+```
+Only `StopIteration` from the `next(...)` becomes `False`. Any catalog-side error during
+`feature.feature_table.drop()` propagates — fine in principle, but the docstring's
+`Raises: DerivaMLException` says "If deletion fails due to constraints or permissions" which
+implies wrapped errors. Either: (a) wrap the drop in a try-except that converts to
+`DerivaMLException` with the table name in context, or (b) reword the docstring to admit that
+non-existence is `False` and any other failure is the raw underlying exception (deriva-py's
+`HTTPError` etc.).
+
+#### F-10 [P2] `find_features` return-type drift: `Iterable` in `interfaces.py`, `list` in mixin
+`interfaces.py:215` declares `find_features(...) -> Iterable[Feature]` (and the same for
+Dataset / DatasetBag in interfaces.py:763), but `core/mixins/feature.py:328` and `:355` return
+`list[Feature]`. `DatasetBag.find_features` is a generator (yields), so it really is an
+`Iterable` — meaning callers cannot assume `len(...)` or random-access on the result.
+`tests/feature/test_features.py:221` does `len(list(subject_features)) + len(list(image_features))`,
+which works defensively but the rest of the codebase consumes via comprehension — the
+inconsistency hasn't bitten yet. Either pin the protocol to `list` (and make the bag eager) or
+pin all three to `Iterable` and stop returning a `list` in the mixin. Picking `Iterable` keeps
+the bag streaming.
+
+#### F-11 [P2] `lookup_feature` not-found type is documented inconsistently across containers
+- `mixins/feature.py:316-317`: `Raises: DerivaMLFeatureNotFound`
+- `dataset/dataset.py:621`: `Raises: DerivaMLException` (parent class)
+- `dataset/dataset_bag.py:709`: `Raises: DerivaMLException`
+- `model/catalog.py:664-666` (actual implementation): raises `DerivaMLFeatureNotFound`
+
+All three containers delegate to the same `model.lookup_feature`, so they all raise the same
+exception. Pin the docstrings to `DerivaMLFeatureNotFound` everywhere (sibling of
+`DerivaMLException`, so existing `except DerivaMLException` callers still work) — otherwise
+users writing precise `except` blocks against the bag/dataset surface won't know they can use
+the narrower type.
+
+#### F-12 [P3] `list_workflow_executions` docstring claims "Entries are unique by construction"
+`mixins/feature.py:578-579`. True today (each execution runs one workflow), but the live
+`Dataset.list_workflow_executions` pass-through (`dataset.py:629`) explicitly documents that
+dataset scoping is deferred. If the dataset path is ever changed to union per-member-execution
+contributions, uniqueness could break. The "unique by construction" claim is a load-bearing
+invariant for `select_by_workflow`'s `set(...)` conversion — pin it with a regression test
+asserting `len(rids) == len(set(rids))` on a multi-execution workflow. Test
+`test_list_workflow_executions_returns_matching_rids` at `test_features.py:498` does assert
+uniqueness, so this is well-covered for the catalog path; the dataset/bag paths are not.
+
+---
+
+### `src/deriva_ml/dataset/dataset.py`
+
+#### F-13 [P1] `Dataset.feature_values` documents `materialize_limit` as forwarding to the upstream, but the upstream's check fires on the **unfiltered** row count
+`dataset/dataset.py:579-589`: the dataset filters `raw_in_scope` after fetching from
+`self._ml_instance.feature_values(...)`. If `materialize_limit=N` and the feature has 10N rows
+in the catalog but only N/2 dataset members, the upstream raises *before* the dataset filter
+even sees the rows. The docstring (lines 545-548) says "forwarded to `DerivaML.feature_values`;
+raises `DerivaMLMaterializeLimitExceeded` if exceeded" — accurate, but a user reading
+"materialize_limit caps the number of rows" naturally expects the post-filter count to be the
+gate. Clarify the docstring: the cap applies to the **catalog query**, not the
+dataset-filtered result.
+
+---
+
+### `src/deriva_ml/dataset/dataset_bag.py`
+
+#### F-14 [P0] `DatasetBag.find_features(None)` returns duplicate `Feature` objects
+`dataset/dataset_bag.py:522-530`:
+```python
+if table is None:
+    for schema in sorted(self.model.schemas):
+        for t in sorted(self.model.schemas[schema].tables):
+            yield from self.model.find_features(t)
+    return
+yield from self.model.find_features(table)
+```
+This deliberately walks every table and calls the `table-specific` branch of
+`model.find_features`, which **does not** apply the dedup logic that the no-arg branch added
+(`catalog.py:603-645`). Each feature association is reachable from multiple FK targets (target
+table, `Execution`, `Feature_Name` vocab, every term vocab the feature references), so a feature
+on `Image` with two term columns produces ~4 duplicate `Feature` objects from the bag walk.
+
+This is the same bug `docs/bugs/2026-05-19-find-features-duplicates.md` calls out for the
+catalog path; the bag path was not similarly fixed. Replace the no-arg branch with a single
+call to `self.model.find_features(None)` (which the bag-view model inherits from `DerivaModel`),
+or apply the same `seen_feature_tables` dedup inline.
+
+#### F-15 [P0] No regression test covers `DatasetBag.find_features(None)`
+The catalog's dedup test (`test_features.py:198-216`) only exercises `ml_instance.find_features()`.
+The three-container symmetry suite (`test_feature_values.py:379-383`) always calls
+`find_features(target_table)` with a specific table, so the bag's no-arg branch is uncovered.
+Add a `test_bag_find_features_no_arg_dedups` test that asserts uniqueness on
+`bag.find_features()` and matches the catalog's invariants in `test_find_features`.
+
+#### F-16 [P2] `DatasetBag.feature_values` materialize_limit semantics differ from the catalog
+`dataset/dataset_bag.py:629-635` checks the limit *after* fetching from the bag cache and
+applying the in-bag target/execution filters (lines 614-624). The catalog backend checks
+*before* record construction (`mixins/feature.py:497-501`). For symmetric API expectations this
+should fire before filtering, or the docstring (line 562-565: "mainly for API parity") should
+be more explicit that the bag enforces the cap on the **post-filter** count, not the source
+row count.
+
+#### F-17 [P2] `DatasetBag.feature_values` swallows `Exception` when probing `get_table_contents(target_col)`
+`dataset/dataset_bag.py:607-613`:
+```python
+try:
+    target_rids = {r["RID"] for r in self.model.get_table_contents(target_col)}
+except Exception:
+    target_rids = None
+```
+Bare `except Exception` is over-broad. The comment claims "If the target table is missing from
+the bag entirely, fall through with the unfiltered set" — but a `KeyError` / `DerivaMLTableNotFound`
+is the only legitimate signal here. Tighten to the specific exception class so genuine bag-IO
+failures (sqlite locked, corrupt row) aren't silently masked as "target table missing".
+
+#### F-18 [P2] `BagFeatureCache._ensure_cache_populated` does not handle a partially-populated cache
+`dataset/bag_feature_cache.py:140-180`: the existence check at line 141 returns the existing
+cache table. If a prior call crashed midway through the insert loop at lines 173-177, the next
+caller sees the partially-populated table and silently returns short data. Bags are immutable
+*after* materialization, but the cache is built on demand inside the running process. Either
+build inside a single `BEGIN ... COMMIT` (so a crash leaves the table empty and the existence
+check fails) or write a sentinel row that the existence check inspects.
+
+---
+
+### `src/deriva_ml/dataset/bag_feature_cache.py`
+
+#### F-19 [P3] Cache table column types are uniformly `Text`
+`bag_feature_cache.py:160-163` stores every field as `Text` ("Pydantic reifies types at
+FeatureRecord construction time"). This is fine but loses SQL-side filtering capability — a
+future enhancement that lets `bag.feature_values` push `execution_rids` into a SQL `WHERE`
+clause (instead of the Python-side filter at `dataset_bag.py:620-624`) would benefit from a
+properly-typed `Execution` column. Not blocking for v1.37.1; flag for the cache-design review.
+
+---
+
+### Tests (`tests/feature/`)
+
+#### F-20 [P1] `select_majority_vote` test coverage misses the auto-detect happy path
+`tests/feature/test_select_majority_vote.py` covers (a) explicit-column, (b) no-metadata raise,
+and (c) explicit-overrides-auto-detect. Missing:
+1. Auto-detect from a real `feature_record_class()` with **exactly one** term column —
+   exercises `feature.py:354-355` (the set-indexing bug F-1).
+2. Auto-detect raise when the feature has **multiple** term columns —
+   exercises `feature.py:356-361`.
+3. Empty `records` input — exercises F-2.
+
+#### F-21 [P2] `test_feature_record_column_methods` uses mocks rather than a real `Feature`
+`tests/feature/test_features.py:60-90` builds the `FeatureRecord.feature` attribute from
+`mocker.Mock()` objects. This pins the classmethod *call-through* (does `cls.feature_columns()`
+return `cls.feature.feature_columns`?) but not the *construction* — the actual classification
+into `asset_columns` / `term_columns` / `value_columns` is never exercised by this test. See
+F-6 — the same gap applies in two layers (Feature construction and classmethod readback).
+
+#### F-22 [P3] `test_create_feature` (`test_features.py:106-129`) doesn't assert `value_columns` count for `image_quality_feature`
+Line 129 stops after `feature_columns()`. Add `assert len(image_quality_feature.value_columns()) == 0`
+for parity with the other two assertions in the same test.
+
+---
+
+## Cross-module coverage gaps
+
+| Gap | P |
+|-----|---|
+| `DatasetBag.find_features(None)` dedup (F-14/F-15) | P0 |
+| `Feature.__init__` FK classification — no test inspects which specific columns land in `asset_columns` / `term_columns` / `value_columns` from a real catalog Feature (F-6, F-21) | P1 |
+| `select_majority_vote` auto-detect happy path + multi-term raise (F-20) | P1 |
+| Empty-records behavior of `select_majority_vote` (F-2) | P2 |
+| `materialize_limit` interaction with `Dataset.feature_values`'s post-fetch member filter — no test verifies what the cap counts (F-13) | P2 |
+| `Dataset.list_workflow_executions` uniqueness invariant (F-12) | P3 |
+
+## Cross-module duplication candidates
+
+| Sites | Pattern | P |
+|-------|---------|---|
+| `mixins/feature.py:513-523`, `dataset/dataset.py:594-604`, `dataset/dataset_bag.py:641-652` | Group-by-target-RID + apply-selector + drop-None survivors (F-8) | P1 |
+| `mixins/feature.py:482-483`, `dataset/dataset.py:579-589`, `dataset/dataset_bag.py:620-624` | `execution_rids` empty-list short-circuit + non-empty filter | P2 |
+| `dataset/dataset_bag.py:489-530` walking schemas/tables manually vs `catalog.py:625-645` dedup walk — both want "every feature in the model" (F-14) | P0 |
+| `mixins/feature.py:560-626` (catalog `list_workflow_executions`) and `dataset/dataset_bag.py:720-781` (bag `list_workflow_executions`) — same two-phase RID-then-type resolution implemented twice against different storage layers | P3 |
+
+## Notes
+
+- `delete_feature_term` does not exist in this codebase. The audit prompt mentioned it; the
+  closest is `VocabularyMixin.delete_term` (`mixins/vocabulary.py:395`), which is out of scope
+  for this audit.
+- `add_features` on `DerivaML` is intentionally retired (raises with pointer to
+  `exe.add_features`). Tests in `test_retired_apis.py` pin the retirement contract; nothing to
+  flag.
+- The selector docstrings are otherwise in good shape and the unit-test coverage for the pure-
+  Python selectors (`select_newest`, `select_first`, `select_latest`, `select_by_execution`,
+  `select_by_workflow`) is solid — the None-on-no-match contract is pinned in three places
+  (test_select_by_execution.py, test_select_by_workflow.py, conftest of the symmetry suite).

--- a/docs/audits/2026-05-22-engineer-audit-model.md
+++ b/docs/audits/2026-05-22-engineer-audit-model.md
@@ -1,0 +1,586 @@
+# Engineer audit — model subsystem (v1.37.1)
+
+**Date:** 2026-05-22
+**Scope:**
+
+- `src/deriva_ml/model/__init__.py` — re-exports + lazy loaders
+- `src/deriva_ml/model/annotations.py` — annotation builders (public API for `deriva-skills`)
+- `src/deriva_ml/model/catalog.py` — `DerivaModel` (introspection, `find_features`, `is_*`, `from_cached`, …)
+- `src/deriva_ml/model/database.py` — `DatabaseModel` (bag-backed deriva-ml database)
+- `src/deriva_ml/model/denormalize_planner.py` — `DenormalizePlanner` (~1840 LoC, Rule 2/5/6 enforcement)
+- `src/deriva_ml/model/deriva_ml_bag_view.py` — read-only catalog view over a bag
+- `tests/model/` — entire directory (`test_annotations.py`, `test_asset_metadata_columns.py`, `test_data_sources.py`, `test_database.py`, `test_derivamodel_from_cached.py`, `test_exceptions.py`, `test_find_association.py`, `test_fk_orderer.py`, `test_handles.py`, `test_is_asset.py`, `test_models.py`)
+
+## Summary
+
+The largest subsystem in `src/` (~6 800 LoC counting tests), and the one with the
+most variance in code quality between files. The four files differ in
+character: `annotations.py` is a clean public-API builder library with
+strong coverage; `catalog.py` is the well-documented but coverage-poor
+introspection layer most of `core/mixins/` reaches through; `denormalize_planner.py`
+is a ~1800 LoC algorithm subsystem with rigorous docstrings but only
+indirect test coverage routed through `tests/local_db/` and
+`tests/dataset/`; and `deriva_ml_bag_view.py` is a thin protocol-shaped
+view layer whose own write-refuses are completely uncovered.
+
+The headline issues are coverage gaps and duplication, not correctness
+bugs. The `tests/model/` directory has zero direct tests for
+`DatabaseModel`, `DenormalizePlanner` (as a class), most of
+`DerivaMLBagView`, and the majority of `DerivaModel`'s read methods —
+all the integration-style verification lives in adjacent test
+directories (`tests/local_db/`, `tests/dataset/`, `tests/feature/`).
+`test_models.py` is a 7-line empty stub. The annotation builders have a
+strong external-consumer-contract test suite that pins the
+deriva-skills surface, which is the right pattern to copy for the
+other model files.
+
+Three real liabilities stand out:
+
+- **P1 — `_build_join_tree` raises bare `DerivaMLException` while its
+  sibling `_prepare_wide_table` raises the typed
+  `DerivaMLDenormalizeAmbiguousPath`** for the same conceptual error.
+- **P1 — `DatabaseModel.dataset_version` and `rid_lookup` raise bare
+  `DerivaMLException`** where `DerivaMLDatasetNotFound` is available.
+- **P1 — `tests/model/test_data_sources.py` and `tests/model/test_fk_orderer.py`
+  belong upstream** in `deriva.bag` — they test `BagDataSource` and
+  `ForeignKeyOrderer` which both live in `deriva.bag.sources` /
+  `deriva.bag.loader`, not in `deriva_ml/model/`. They drag ~520 LoC of
+  test code into the wrong directory.
+
+The rest is polish: ~6 docstring/annotation drifts, ~8 duplication
+spots in the annotation builders' `to_dict()` and in the planner's
+predicate plumbing, a couple of dead-code spots
+(`_system_schemas`, `TAG_SOURCE_DEFINITIONS`, the `WWW` magic schema),
+and substantial coverage gaps in the `DerivaModel` introspection
+methods that `core/mixins/` depends on.
+
+Total findings: **45** (0 × P0, 15 × P1, 22 × P2, 8 × P3).
+
+---
+
+## Findings by module
+
+### `src/deriva_ml/model/__init__.py`
+
+#### M-1 [P3] `__all__` advertises lazy names but the only consumer path is direct import
+`__init__.py:55-93` lists `"DatabaseModel"` and `"DerivaMLBagView"` in
+`__all__`, supported by `__getattr__` at lines 96-106. Every consumer in
+the workspace (`dataset/dataset.py:72`, `execution/execution.py:88`,
+`tests/model/test_database.py:7`, `tests/dataset/test_download.py:14`)
+imports from the concrete module — `from deriva_ml.model.database
+import DatabaseModel` — not from the package root. The lazy machinery
+exists but no caller uses it. Either delete `__getattr__` and drop the
+two names from `__all__`, or document an intended consumer.
+
+### `src/deriva_ml/model/annotations.py`
+
+#### M-2 [P2] `AnnotationBuilder.to_dict` raises `NotImplementedError` but is never invoked polymorphically
+`annotations.py:282-294` declares an `AnnotationBuilder` base class with
+abstract `tag` and `to_dict()`. Five subclasses inherit
+(`Display`, `VisibleColumns`, `VisibleForeignKeys`, `TableDisplay`,
+`ColumnDisplay`). The only code that consults `AnnotationBuilder` as a
+type is the test suite's `EXPORTED_BUILDERS` tuple
+(`test_annotations.py:509`). The base class buys no polymorphism in
+production. Either delete it (subclasses don't need to inherit;
+they're tagged via class-level `tag = TAG_*`) or make it an actual
+`Protocol`/`ABC` and have `apply_annotations()` accept the protocol.
+
+#### M-3 [P2] `TAG_SOURCE_DEFINITIONS` is defined but never used or exported
+`annotations.py:274` defines
+`TAG_SOURCE_DEFINITIONS = "tag:isrd.isi.edu,2019:source-definitions"`.
+It is not referenced anywhere in `src/`, `tests/`, or in the cross-workspace
+grep (`deriva-mcp`, `deriva-skills`, `deriva-ml-skills`, `deriva-ml-mcp`,
+`deriva-mcp-core`, `deriva-ml-model-template`). Delete.
+
+#### M-4 [P2] 18 `to_dict()` methods all follow the same "if not None, copy" pattern
+The pattern (`Display`, `NameStyle`, `PseudoColumn`, `PseudoColumnDisplay`,
+`TableDisplayOptions`, `ColumnDisplayOptions`, `PreFormat`, `Facet`,
+`FacetRange`, ...) repeats 18 times in identical form:
+```python
+def to_dict(self) -> dict[str, Any]:
+    result = {}
+    if self.field1 is not None:
+        result["field1"] = self.field1
+    if self.field2 is not None:
+        result["field2"] = self.field2.value  # enum
+    ...
+```
+A single helper `_dataclass_to_dict(self, *, exclude_none=True, enum_value=True)`
+on a shared base would shrink these to one line each and stop the next
+contributor having to remember to wire up the optional-field skip on
+every new field added to a dataclass. Worth doing because the
+annotations module is public-API and changes here propagate to
+deriva-skills.
+
+#### M-5 [P2] `Facet`, `FacetList`, `PseudoColumn`, `SortKey`, `FacetRange`, etc. don't inherit from `AnnotationBuilder`
+`annotations.py:606-729 ("PseudoColumn")`, `annotations.py:1170-1242 ("Facet")`,
+`annotations.py:1245-1264 ("FacetList")`, `annotations.py:1141-1167
+("FacetRange")`, `annotations.py:428-448 ("SortKey")`,
+`annotations.py:485-522 ("OutboundFK"/"InboundFK")`. These all carry
+their own `to_dict()` but no `.tag` because they're **inside**
+annotations, not top-level annotations. This is correct, but the
+contrast with the `AnnotationBuilder`-bearing five is uncommented and
+will read as missing-inheritance to the next reader. Either add a
+one-line comment block separating "tagged annotations" from "helpers
+embedded inside annotations", or unify the base class (see M-2).
+
+#### M-6 [P3] `VisibleColumns._contexts` is a single-leading-underscore "internal" but documented for direct user access
+`annotations.py:816` declares `_contexts: dict[str, list[ColumnEntry] | str]
+= field(default_factory=dict)`. The class docstring at
+`annotations.py:806-811` explicitly tells users to write to it directly
+for faceted search:
+```
+>>> facets = FacetList()
+>>> facets.add(Facet(source="Status", open=True))
+>>> vc._contexts["filter"] = facets.to_dict()
+```
+A leading-underscore name that's also a documented public-API knob is a
+contradictory signal. Either expose `vc.filter(...)` as a first-class
+method (it would mirror `compact`/`detailed`/`entry`) or rename
+`_contexts` to `contexts`.
+
+#### M-7 [P2] `Display(name="X", markdown_name="Y")` test uses bare `pytest.raises(ValueError)`, not the typed exception path
+`test_annotations.py:59-62` asserts `ValueError` is raised when both
+`name` and `markdown_name` are passed to `Display`. The check at
+`annotations.py:400-402` is `raise ValueError(...)`. This is fine, but
+it's inconsistent with the rest of the codebase where typed
+`DerivaMLValidationError` subclasses are the convention. Annotation
+builders deliberately use `ValueError` because they're public-API
+helpers and `ValueError` is the Pythonic signal for "bad combination of
+args" — but document this in the class docstring so the choice is
+explicit. Currently it reads as an oversight.
+
+#### M-8 [P3] `Facet.choices: list[Any]` loses type information
+`annotations.py:1199` declares `choices: list[Any] | None = None`. The
+field accepts text choices in practice
+(`Facet(source="Status", choices=["Active", "Inactive"])`). Narrow to
+`list[str | int | float | bool | None] | None` so the schema is
+self-documenting and IDE autocomplete works in deriva-skills.
+
+#### M-9 [P3] `Facet.array_options: dict[str, Any]` is a structured config typed as a free-form dict
+`annotations.py:696` (`PseudoColumn.array_options`) declares
+`dict[str, Any] | None = None`. The valid sub-keys are
+`max_length: int` and `order: list[SortKey]`. A nested dataclass
+(`ArrayOptions`) would let IDE autocomplete catch typos here too.
+Same pattern as M-8.
+
+### `src/deriva_ml/model/catalog.py`
+
+#### M-10 [P1] `asset_metadata_columns` uses raw `str | Table` while every sibling uses `TableInput`
+`catalog.py:702` reads `def asset_metadata_columns(self, table: str | Table)`
+while 10 sibling methods (`name_to_table`, `is_vocabulary`, `vocab_columns`,
+`is_association`, `find_association`, `is_asset`, `find_features`,
+`lookup_feature`, `asset_metadata`) all type as `TableInput`. The
+type alias exists at `catalog.py:69` precisely for consistency. Drop
+the inline form.
+
+#### M-11 [P1] `DerivaModel.__init__` builds `self._system_schemas` and never reads it
+`catalog.py:113` sets
+`self._system_schemas = frozenset(SYSTEM_SCHEMAS | {ml_schema})`.
+Cross-workspace grep finds zero readers (only this write line). Dead
+code from an earlier refactor — `is_system_schema` delegates to
+`_is_system_schema(schema_name, self.ml_schema)` in
+`core/definitions.py` instead. Delete.
+
+#### M-12 [P2] `name_to_table` hard-codes `"WWW"` as a search-path schema
+`catalog.py:387-388`:
+```python
+# Search domain schemas (sorted for deterministic order), then ML schema, then WWW
+search_order = [*sorted(self.domain_schemas), self.ml_schema, "WWW"]
+```
+The `"WWW"` schema is a Deriva convention for web-content tables, not a
+`deriva-ml` concept. The hard-coded magic constant should at minimum
+live in `core/definitions.py` next to `SYSTEM_SCHEMAS`, with a comment
+explaining why `WWW` is searched (the rest of the function uses
+`domain_schemas` + `ml_schema`, both configured per-instance). If
+`WWW` is just legacy support for a single deployment, justify it in a
+comment; otherwise extract.
+
+#### M-13 [P1] `find_features` (no-arg branch) has subtle dedup logic but no `tests/model/` test
+`catalog.py:603-645`. The cross-schema dedup at 628-644 (the fix for
+the 2026-05-19 duplicate-features bug — see the in-line comment block)
+is correctness-critical and lives entirely in this single function.
+`tests/model/` does not exercise it; the regression test
+(`docs/bugs/2026-05-19-find-features-duplicates.md`) is referenced in
+the comment but the actual regression-pinning test lives at
+`tests/feature/test_features.py:419-425` (4 lines: a happy-path assertion
+that `Health` appears in the result). Nothing pins the dedup behavior
+when the same association is reachable through three schemas. Add a
+unit test in `tests/model/test_catalog.py` (new file) that constructs
+the exact triangle described in the comment and asserts that
+`find_features(None)` returns a single Feature.
+
+#### M-14 [P1] `get_schema_description` has zero unit tests but is consumed by `deriva-mcp`
+`catalog.py:242-349` defines a substantial JSON-shape method that
+populates `is_vocabulary`, `is_asset`, `is_association`, FK info, and
+optionally `features`. Cross-workspace grep confirms it is called by
+`deriva-mcp/src/deriva_mcp/resources.py:445`,
+`deriva-mcp/src/deriva_mcp/rag/helpers.py:88`,
+`deriva-mcp/src/deriva_mcp/tools/rag.py:416`,
+`deriva-mcp/src/deriva_mcp/rag/__init__.py:478`, plus four test files
+that mock its return value. So this is a **shape contract**.
+`tests/model/` has zero direct tests of this method. Any change to
+the returned shape silently breaks the legacy MCP. Pin the shape with
+a snapshot test that constructs a small catalog and asserts on the
+returned dict keys + nested structure.
+
+#### M-15 [P1] `is_dataset_rid` has no direct unit test
+`catalog.py:752-784`. Used at 7 call sites in `core/mixins/dataset.py`
+and `dataset/dataset.py`. The function has a non-obvious branch around
+`deleted=True`/`False` and `Deleted` column reading
+(`return not list(rid_info.datapath.entities().fetch())[0]["Deleted"]`).
+The KeyError → `DerivaMLException` translation at 776-777 also has no
+coverage. Add unit tests for the three branches: live RID, deleted
+RID with `deleted=False`, deleted RID with `deleted=True`, and invalid
+RID.
+
+#### M-16 [P2] `refresh_model` has no docstring and no direct unit test
+`catalog.py:234-235`. Two-line method; the docstring would describe
+"re-fetch the catalog model from the server, replacing
+`self.model`." Used at `core/base.py:867` and 5 sites in
+`tests/dataset/`. Add docstring + one test that mutates the catalog
+out-of-band, calls `refresh_model`, and asserts the change is visible.
+
+#### M-17 [P2] `chaise_config` property has no docstring beyond "Return the chaise configuration"
+`catalog.py:238-240`. The one-line docstring is fine for trivial
+properties but `chaise_config` is the head-of-line knob for catalog UI
+configuration and the doctest example would be runnable
+(`>>> ml.model.chaise_config["navbarBrandText"]`).
+
+#### M-18 [P2] `apply()` `CatalogStub` refusal is tested only implicitly
+`catalog.py:727-750`. The offline-mode refusal at 746-749 is a
+correctness-critical guard against silent schema changes. No test in
+`tests/model/` constructs an offline DerivaModel and asserts the
+`DerivaMLReadOnlyError`. Add one.
+
+#### M-19 [P1] `is_association` return-type annotation is `bool | set[str] | int` but the docstring says "True/False" for the common path
+`catalog.py:453`: `def is_association(...) -> bool | set[str] | int`.
+The Args block discusses `unqualified=True`'s side effect on the
+return type but the call sites (`catalog.py:338`,
+`core/mixins/dataset.py`, etc.) treat it as `bool`. Splitting into
+`is_association(...) -> bool` (with a narrower contract) and
+`association_details(...) -> set[str] | int | None` would let the
+common path stop wrapping the return in `bool(...)` like
+`get_schema_description` does at `catalog.py:338`.
+
+#### M-20 [P2] `_define_association` is a private method documented as internal but accessed from tests
+`catalog.py:898-949`. The method has a substantial docstring and a
+real responsibility (vocab-aware FK key resolution) but the leading
+underscore signals "do not consume." `tests/model/test_find_association.py:76,111`
+reach into it directly. Either expose it (`define_association`) so
+test calls stop reading like internal hackery, or document explicitly
+in the docstring that it's "test-only internal" — which it isn't
+(zero non-test callers cross-workspace, but the implementation looks
+load-bearing).
+
+#### M-21 [P2] `find_assets` and `find_vocabularies` lack `Example:` blocks
+`catalog.py:551-562`. Two of the most-used introspection methods. Add
+`Example:` blocks (skipped — `# doctest: +SKIP`) for symmetry with
+`find_features`.
+
+#### M-22 [P3] `from_cached` docstring shows `catalog=CatalogStub()` only in the prose, not as a runnable doctest
+`catalog.py:141-193`. The minimal-schema-dict path is exercised by
+`test_derivamodel_from_cached.py:13-23` but the docstring example
+shows no callable form. Add a doctest equivalent (the test pattern
+fits inline: `>>> schema_dict = {"schemas": {...}, ...}; >>> model =
+DerivaModel.from_cached(schema_dict, catalog=CatalogStub())`).
+
+### `src/deriva_ml/model/database.py`
+
+#### M-23 [P1] `dataset_version` and `rid_lookup` raise bare `DerivaMLException`
+`database.py:193`: `raise DerivaMLException(f"Dataset RID {rid} is not in this bag")`
+`database.py:217`: `raise DerivaMLException(f"Dataset {dataset_rid} not found in this bag")`
+The codebase ships `DerivaMLDatasetNotFound` (`core/exceptions.py:239`)
+exactly for this case. Inheritance preserves the legacy catch path
+but the typed subclass surfaces the dataset RID via the structured
+field — the same pattern issue #180 / commit a1f8e22 applied to
+`find_association`. Convert both raises to `DerivaMLDatasetNotFound(rid)`.
+
+#### M-24 [P1] `DatabaseModel.dataset_version` and `rid_lookup` are tested only indirectly through bag downloads
+`database.py:178-217`. Both methods are public — `dataset_version()` is
+in the public interface and `rid_lookup` is called from
+`deriva_ml_bag_view.py:137,368`. No `tests/model/test_database.py`
+function tests either directly. Their unit-testability is high (build
+a `DatabaseModel` from a fixture bag), so the absence is a coverage
+gap rather than a hard limitation.
+
+#### M-25 [P2] Module-level `logger` and instance `self._logger` are both defined
+`database.py:42`: `logger = get_logger(__name__)` (module-level)
+`database.py:94`: `self._logger = get_logger(__name__)` (instance)
+`database.py:141,145`: only `self._logger` is called. The module-level
+`logger` is dead. Pick one (instance is needless because both share
+`__name__`); delete the other.
+
+#### M-26 [P2] `_build_bag_rids` "highest version wins" semantics are uncovered
+`database.py:151-176`. The "keep highest version" rule at lines
+175-176 (`if rid not in self.bag_rids or version > self.bag_rids[rid]`)
+is a behavior contract for nested datasets — a downloaded bag can
+contain multiple historical versions of nested datasets, and this
+method picks one per RID. No test pins this behavior. The
+`test_table_versions` test in `test_database.py:145-194` exercises bag
+version-change semantics end-to-end but the specific "two versions of
+the same RID in the same bag" case isn't constructed.
+
+### `src/deriva_ml/model/denormalize_planner.py`
+
+#### M-27 [P1] `_build_join_tree` raises bare `DerivaMLException` for an ambiguous path; sibling raises the typed exception
+`denormalize_planner.py:1548-1551`:
+```python
+raise DerivaMLException(
+    f"Ambiguous path between {element_name} and {target}: "
+    f"found {len(unique)} FK paths:\n" + ...
+)
+```
+The Rule 6 ambiguity at the top level (`_prepare_wide_table` →
+`_find_path_ambiguities`) raises the typed
+`DerivaMLDenormalizeAmbiguousPath`
+(`denormalize_planner.py:1692`). The path here in `_build_join_tree`
+is logically the same failure mode — multiple FK paths between two
+tables that the caller didn't disambiguate — but it surfaces as a
+bare exception. Convert to `DerivaMLDenormalizeAmbiguousPath(element_name, target, paths, suggested_intermediates)`.
+
+#### M-28 [P2] `valid_schemas = self.model.domain_schemas | {self.model.ml_schema}` is recomputed three times
+`denormalize_planner.py:517, 575, 666`. Same expression, same value
+within a single call. Extract to a `_valid_schemas` cached property
+on the planner. Bonus: makes the schema-membership rule one named
+thing instead of a phrase repeated by hand.
+
+#### M-29 [P2] `domain_fks = [fk for fk in fks if fk.pk_table.name not in ("ERMrest_Client", "ERMrest_Group")]` is duplicated
+`denormalize_planner.py:378` (in `_is_topological_association`)
+`denormalize_planner.py:443` (in `_is_feature_association`)
+Both predicates need to ignore the system FKs to `ERMrest_Client` /
+`ERMrest_Group`. Extract a helper:
+```python
+def _domain_fks(self, tbl) -> list:
+    return [fk for fk in tbl.foreign_keys if fk.pk_table.name not in _SYSTEM_FK_TARGETS]
+```
+The two predicates also share the `try/except: return False` wrap (a
+defensive pattern that should be documented or eliminated — see M-31).
+
+#### M-30 [P1] `_is_topological_association` and `_is_feature_association` swallow all exceptions
+`denormalize_planner.py:373-381, 438-452`:
+```python
+try:
+    tbl = name_or_table if hasattr(name_or_table, "foreign_keys") else self.model.name_to_table(name_or_table)
+    fks = list(tbl.foreign_keys)
+    ...
+    return len(domain_fks) == 2
+except Exception:
+    return False
+```
+The bare `except Exception: return False` masks real bugs (e.g. a
+typo'd table name silently returns False instead of `DerivaMLException`).
+The hot path is `name_to_table(name_or_table)` which raises
+`DerivaMLException` if the name is unknown — catching only that
+specific exception would preserve the "missing table is not an
+association" semantics without hiding real errors.
+
+#### M-31 [P2] Rule 2 (sink-finding) docstring claims "exactly one sink" but `_find_sinks` returns 0+
+`denormalize_planner.py:953-1004`. The docstring at 982-985 says
+"Normally exactly one. Multiple sinks → caller should raise
+`DerivaMLDenormalizeMultiLeaf`. Zero sinks → cycle, caller should
+raise `DerivaMLDenormalizeNoSink`." The method itself returns the
+sorted list and lets `_determine_row_per` enforce the cardinality.
+That's fine in code but the docstring reads as if the method enforces
+it. Reword to "Sink table names (cardinality not enforced — see
+`_determine_row_per` for Rule 2 enforcement)."
+
+#### M-32 [P1] `DenormalizePlanner` itself has no direct unit tests; all coverage is indirect via `tests/local_db/`
+`denormalize_planner.py` is ~1840 LoC of Rule 2/5/6 logic. The class
+is consumed via `DerivaModel._planner` and tested at:
+
+- `tests/local_db/test_planner_rules.py` — exercises `_find_sinks`,
+  `_determine_row_per`, `_find_path_ambiguities`, `_prepare_wide_table`,
+  `_is_topological_association`, `_is_feature_association` against a
+  populated catalog
+- `tests/dataset/test_schema_paths.py` — exercises `_schema_to_paths`
+- `tests/dataset/test_denormalize.py:333` — one direct call
+- `tests/dataset/test_composite_fk_denormalize.py:176` — one direct call
+
+No file inside `tests/model/` mentions `_planner` or `DenormalizePlanner`.
+Moving the planner-rules tests into `tests/model/test_denormalize_planner.py`
+(or symlinking) would put the tests next to the code. At minimum,
+add a `tests/model/test_planner.py` smoke test that constructs a
+`DenormalizePlanner` directly (not via the lazy property) to pin the
+1-arg constructor contract.
+
+#### M-33 [P2] `_outbound_reachable` vs `_outbound_reachable_strict` distinction is essential but not tested in isolation
+`denormalize_planner.py:586-694, 696-778`. The split between the two
+primitives is the difference between Rule 5/2's enforcement
+(directional fan-out — strict) and Denormalizer's anchor-classification
+(connectivity probe — non-strict). The docstrings explain this at
+length (75 lines combined). No test pins the divergence with a
+ground-truth example like "bridge case (Image ← feature-assoc →
+Image_Classification): `_outbound_reachable` returns
+`{Image_Classification}`, `_outbound_reachable_strict` returns
+`set()`." A 10-line test would lock in the rule that future
+contributors won't accidentally unify.
+
+#### M-34 [P2] Recursive `_schema_to_paths` has no `max_depth` default but the docstring at 816 implies one
+`denormalize_planner.py:786, 829-842`. Signature: `max_depth: int | None
+= None`. The docstring at line 816 reads "Use to protect against
+pathological schemas with deep chains." A real catalog can have
+20+ levels of FK chains in pathological cases. The cycle-detection
+at line 890-893 catches simple cycles via `if child in path`. With
+`max_depth=None` and a complex schema, the recursion can still blow
+up. Set a default like `max_depth=20`; document the choice.
+
+#### M-35 [P3] `_DEFAULT_SKIP_TABLES` is module-level frozenset; should be a class attribute
+`denormalize_planner.py:294`. Currently a module-level
+`_DEFAULT_SKIP_TABLES = frozenset({"Dataset_Dataset", "Execution"})`.
+Subclasses or alternate planners can't customize. Promote to a
+class attribute on `DenormalizePlanner`.
+
+### `src/deriva_ml/model/deriva_ml_bag_view.py`
+
+#### M-36 [P1] Write-operation refusals (`create_dataset`, `pathBuilder`, `catalog_snapshot`) have zero coverage
+`deriva_ml_bag_view.py:316-352`. Three methods that exist purely to
+raise `DerivaMLException` and document the bag-is-read-only contract.
+No test asserts the refusal. Trivial to add — fixture bag,
+construct `DerivaMLBagView`, call each, expect the exception. Without
+this coverage, a future change that silently makes one succeed (e.g.
+delegates to `_database_model` by accident) ships unnoticed.
+
+#### M-37 [P2] `lookup_term` has a slow-path comment that says "scan for synonyms" but the slow path also matches `Name`
+`deriva_ml_bag_view.py:218-239`. The fast path (218-229) does
+`WHERE Name = term_name`. The slow path (231-239) iterates rows and
+checks `term_name in term.get("Synonyms", [])` — but the loop also
+iterates over the `Name` column without a name-match check on the
+slow-path side. If the fast path missed a row (e.g. because the
+`Name` column was cased differently than expected), the slow path
+would miss it too. Worth a comment that says explicitly "slow path
+ONLY catches synonym matches; name matches are owned by the fast
+path."
+
+#### M-38 [P2] `find_datasets` and `lookup_dataset` are tested only indirectly via `compare_catalogs`
+`deriva_ml_bag_view.py:118-190`. `tests/model/test_database.py` is the
+only file that touches these and it uses them as helpers in a larger
+catalog-comparison flow. No direct test asserts the shape of
+`find_datasets`'s return (e.g. that a bag with one dataset returns a
+single `DatasetBag` with the expected RID, description, dataset_types).
+
+#### M-39 [P2] `_get_dataset_execution` returns `None` for missing-RID but raises nothing for the bag-rids miss
+`deriva_ml_bag_view.py:243-271`. The function pattern is "if version
+is None → return None; else SQL select and return dict-or-None". A
+miss inside `bag_rids` returns `None`; a miss in the
+`Dataset_Version` SQL query also returns `None`. Callers can't
+distinguish the two failure modes. Either a single typed-exception path
+or a `Result`-shaped return would help.
+
+### Tests (`tests/model/`)
+
+#### M-40 [P1] `tests/model/test_data_sources.py` tests `deriva.bag.sources.BagDataSource` — it does not belong in `tests/model/`
+`test_data_sources.py:12`: `from deriva.bag.sources import BagDataSource`.
+The file is 141 LoC of `BagDataSource` tests (multi-CSV handling, nested
+dataset CSVs, etc.). `BagDataSource` is upstream in `deriva.bag` and
+has nothing to do with `deriva_ml/model/`. These tests should live in
+`deriva.bag`'s test suite. Move (or, if the upstream coverage is
+sufficient, delete).
+
+#### M-41 [P1] `tests/model/test_fk_orderer.py` tests `deriva.bag.loader.ForeignKeyOrderer` — same issue
+`test_fk_orderer.py:14`: `from deriva.bag.loader import ForeignKeyOrderer`.
+The file is 373 LoC of `ForeignKeyOrderer` tests (topological sort,
+cycle handling, etc.). Same dispatch as M-40 — move upstream or
+delete. Together with `test_data_sources.py` that's ~520 LoC of
+test code in the wrong directory.
+
+#### M-42 [P3] `tests/model/test_models.py` is a 7-line empty class
+`test_models.py:7`: `class TestCatalogModel: pass`. Empty stub.
+Either populate (with the catalog tests M-13/M-14/M-15/M-19 ask for)
+or delete.
+
+#### M-43 [P2] `test_database.py::TestDataBaseModel` test class name uses non-standard case
+`test_database.py:16`: `class TestDataBaseModel`. The convention is
+`TestDatabaseModel` (matching the class under test). Trivial rename.
+
+#### M-44 [P1] No tests for `DerivaMLBagView.resolve_rid`
+`deriva_ml_bag_view.py:353-369`. The method is part of the
+`DerivaMLCatalog` protocol surface that the bag view implements. No
+test exercises it. The contract `{"RID": rid, "version": version}` is
+not pinned.
+
+#### M-45 [P3] `test_annotations.py::TestExternalConsumerContract` only covers 5 of the ~10 builders
+`test_annotations.py:509-515`. `EXPORTED_BUILDERS` lists `Display`,
+`VisibleColumns`, `VisibleForeignKeys`, `TableDisplay`, `ColumnDisplay`.
+The annotation module also exports `PseudoColumn`, `Facet`,
+`FacetList`, `PreFormat`, `SortKey`, `InboundFK`, `OutboundFK`,
+`NameStyle`, `TableDisplayOptions`, `ColumnDisplayOptions`,
+`PseudoColumnDisplay`, `FacetRange`. The contract test ("class has
+`.tag`, instance has `.to_dict()`") doesn't apply to all of these
+(no `.tag` on `PseudoColumn`, etc.) but the JSON-roundtrip check
+should. Add a second contract test that exercises every exported
+helper's `to_dict()`.
+
+## Cross-module coverage gaps
+
+The `tests/model/` directory **has no direct tests for**:
+
+- `DatabaseModel` (all `tests/model/test_database.py` flows are
+  `DerivaMLBagView`-routed integration tests; `DatabaseModel`'s own
+  surface — `dataset_version`, `rid_lookup`, `_build_bag_rids` — is
+  uncovered as a unit)
+- `DenormalizePlanner` as a class (tested indirectly via
+  `tests/local_db/test_planner_rules.py` and friends)
+- `DerivaModel` methods: `is_dataset_rid`, `get_schema_description`,
+  `refresh_model`, `apply` offline-mode refusal, `find_assets`,
+  `find_vocabularies`, `is_association` (no live test — only
+  mock-based), `vocab_columns`, `lookup_feature`
+- `DerivaMLBagView` write-refusals (`create_dataset`, `pathBuilder`,
+  `catalog_snapshot`), `resolve_rid`, `lookup_term` (one assertion in
+  `tests/dataset/test_download.py`)
+- `__getattr__` lazy-import paths in `model/__init__.py`
+
+The annotation builders are well-covered. The catalog / database /
+bag-view / planner surfaces lean on neighboring test directories
+(`tests/local_db/`, `tests/dataset/`, `tests/feature/`,
+`tests/schema/`) for indirect coverage. The collateral damage:
+moving `model/` files becomes harder because the tests that pin their
+behavior live elsewhere.
+
+## Cross-module duplication candidates
+
+- **18 × `to_dict()` "if not None: copy" pattern** in `annotations.py`
+  (M-4). Extracting a single helper would cut ~120 LoC and make
+  field-addition mechanical.
+- **`valid_schemas = domain_schemas | {ml_schema}`** in
+  `denormalize_planner.py` (M-28).
+- **`domain_fks = [fk for fk in fks if fk.pk_table.name not in
+  ("ERMrest_Client", "ERMrest_Group")]`** in two predicate methods of
+  `denormalize_planner.py` (M-29).
+- **`try: ... self.model.name_to_table(name_or_table) ...; except
+  Exception: return False`** in two predicate methods (M-30).
+- **`__getattr__`-style model delegation** appears once in
+  `catalog.py:351` and once implicitly via `BagDatabase`. Not
+  duplicated per se, but the interaction with `BagDatabase.schemas`
+  (instance-attribute, blocks `@property`) is documented in a comment
+  rather than enforced — a regression could re-add the property and
+  silently break `DatabaseModel`.
+
+## Notes
+
+- `annotations.py` is the cleanest file in the subsystem and the right
+  template for the rest: it has a strong public-API surface, the
+  `TestExternalConsumerContract` test (`test_annotations.py:483-602`)
+  pins the deriva-skills contract end-to-end, and the module docstring
+  is genuinely useful as documentation. The dedup opportunities (M-4)
+  are the largest single LoC reduction available in the subsystem but
+  the current code is correct and the duplication is **mechanical, not
+  semantic** — refactor before adding new annotation tags, not as a
+  P0.
+- `denormalize_planner.py` has the best in-file documentation in the
+  whole codebase (the module docstring at 1-197, then per-method
+  docstrings averaging 30 lines). Coverage routing it through
+  `tests/local_db/` is acceptable in principle (the planner is private
+  to the denormalization subsystem) but a few direct tests in
+  `tests/model/` would make the boundary explicit.
+- The `deriva-skills/use-annotation-builders` external contract is
+  load-bearing (confirmed via cross-workspace grep at
+  `deriva-skills/.../use-annotation-builders/{SKILL.md,references/builder-api.md}`).
+  Any rename or signature change in `annotations.py` is a breaking
+  change for that skill.
+- `from_cached` and `CatalogStub` form the offline-mode entry point
+  used by `core/base.py` lines 466, 502, 594, 864. The single test in
+  `test_derivamodel_from_cached.py` confirms it works with a minimal
+  schema dict, but the apply-refusal path
+  (`catalog.py:746-749`) — the one that prevents accidental schema
+  changes in offline mode — has zero coverage (M-18).

--- a/docs/audits/2026-05-22-engineer-audit-schema.md
+++ b/docs/audits/2026-05-22-engineer-audit-schema.md
@@ -1,0 +1,719 @@
+# Engineer Audit — schema/ Subsystem (v1.37.1, 2026-05-22)
+
+## Scope and method
+
+Reviewed:
+
+- `src/deriva_ml/schema/__init__.py` (8 LoC)
+- `src/deriva_ml/schema/create_schema.py` (660 LoC)
+- `src/deriva_ml/schema/annotations.py` (629 LoC)
+- `src/deriva_ml/schema/policy.json` (81 LoC)
+- `tests/schema/test_acl_application.py`, `test_annotations.py`,
+  `test_cascade_behavior.py`, `test_policy.py`,
+  `test_seeded_vocab_terms.py`, `test_vocab_fk_convention.py`
+
+External consumers (grep `from deriva_ml.schema` across `src/`):
+
+- `src/deriva_ml/demo_catalog.py` — uses `create_ml_catalog`
+- `src/deriva_ml/core/base.py:1126` — uses `catalog_annotation`
+- `src/deriva_ml/core/mixins/asset.py:30` — uses `asset_annotation`
+- `src/deriva_ml/schema/create_schema.py:35` — uses
+  `asset_annotation`, `generate_annotation`
+
+Recent context: PR #186 (`ecd140a3`) — fixed ACL-ordering bug in
+`create_ml_catalog` so `acl_config` runs **after**
+`create_ml_schema`. New `tests/schema/test_acl_application.py`
+guards that ordering.
+
+Severity:
+**P0** (release-blocker) / **P1** (must-fix before release) /
+**P2** (should-fix soon) / **P3** (nice-to-have).
+
+---
+
+## Executive summary
+
+The subsystem is in a **shipworthy** state for v1.37.1. The
+load-bearing entry points (`create_ml_catalog`,
+`create_ml_schema`, `asset_annotation`, `build_navbar_menu`,
+`initialize_ml_schema`) all carry recent test coverage, and PR
+#186 closed the most consequential bug (ACL ordering). The
+findings below are mostly correctness-near-misses and
+documentation drift — no P0 blockers.
+
+The single most important pattern uncovered: **`generate_annotation`
+hard-codes the literal string `"deriva-ml"` in seven places while
+also accepting a `schema` parameter** (F-01). Callers who pass a
+non-default schema name get a half-rewritten annotation set that
+references both the supplied schema and the literal — Chaise will
+silently render broken FK pseudo-columns. This is a latent
+correctness bug for anyone who tries to use the documented
+`schema_name=` parameter on `create_ml_schema`.
+
+Themes:
+
+1. **Hard-coded schema names** (F-01, F-02, F-03) — `schema_name`
+   parameter is partially honored.
+2. **Doc / signature drift** (F-04, F-05, F-06, F-07) —
+   `asset_annotation` claims to return a dict; `generate_annotation`
+   has no docstring; `model` parameter is unused.
+3. **Non-deterministic emitted JSON** (F-08) — `asset_metadata`
+   set iteration leaks into Chaise annotations.
+4. **Internal table-builder helpers are exposed via module
+   namespace but undocumented** (F-09 — F-12).
+5. **No unit tests for `asset_annotation` / `generate_annotation`**
+   (F-13, F-14) — the only coverage is indirect through full
+   catalog integration tests.
+6. **`use_hatrac` parameter accepted but ignored** (F-15) — silent
+   `File` vs `Execution_Asset` divergence.
+7. **CASCADE warning is clear but doesn't surface the bag-pipeline
+   carve-out at the call site** (F-16, F-17).
+8. **Schema-cache freshness contract is invisible from the
+   subsystem** (F-18) — `create_ml_schema` rebuilds the catalog
+   model but the in-process `SchemaCache` (in `core/`) is never
+   touched. Acceptable, but worth a comment.
+9. **Hidden test gaps for the FK-naming convention used by
+   `asset_annotation`** (F-19) — annotation string-formula values
+   like `f"{asset_name}_Asset_Type_{asset_name}_fkey"` aren't
+   verified to match what `define_association` actually emits.
+
+Total findings: **27** (P0: 0, P1: 5, P2: 13, P3: 9).
+
+---
+
+## Findings
+
+### F-01 — `generate_annotation` hard-codes `"deriva-ml"` despite `schema` parameter (P1, correctness)
+
+`src/deriva_ml/schema/annotations.py:361,506,517,520,530,546,552`
+
+```python
+def generate_annotation(model: Model, schema: str) -> dict:
+    ...
+    dataset_annotation = {
+        deriva_tags.visible_columns: {
+            "*": [
+                ...
+                {
+                    "source": [
+                        {"outbound": ["deriva-ml", "Dataset_Version_fkey"]},  # ← literal
+                        ...
+```
+
+Seven occurrences inside `dataset_annotation` reference the literal
+`"deriva-ml"` instead of the `schema` parameter. The rest of the
+function (`workflow_annotation`, `execution_annotation`,
+`dataset_version_annotation`) correctly uses the parameter. A user
+who passes `schema_name="my_ml"` to `create_ml_schema` will get a
+`Dataset` table whose `visible_columns` annotation references
+`"deriva-ml"` FKs that don't exist in their schema — Chaise will
+silently render the column as missing.
+
+**Action**: replace the seven literals with the `schema` parameter.
+
+### F-02 — `catalog_annotation` hard-codes `"deriva-ml"` in `chaise_config.defaultTable` (P2, correctness)
+
+`src/deriva_ml/schema/annotations.py:232`
+
+```python
+"defaultTable": {"table": "Dataset", "schema": "deriva-ml"},
+```
+
+Same shape as F-01 but inside the Chaise top-level config. A
+non-default `schema_name` will mean the Chaise landing page
+points at a non-existent schema. Acceptable to defer if
+non-default `schema_name` is in practice unused, but the
+`schema_name` parameter is part of `create_ml_schema`'s
+documented signature, so the contract is broken.
+
+**Action**: thread the schema name through `catalog_annotation`
+(or pull it from `model.ml_schema`).
+
+### F-03 — `create_ml_schema` honors `schema_name` partially (P2, correctness)
+
+`src/deriva_ml/schema/create_schema.py:313-410`
+
+The function takes `schema_name: str = "deriva-ml"`. It correctly
+uses the parameter to look up / drop the schema (line 335) and to
+create vocabulary tables. But it calls `generate_annotation(model,
+schema_name)` which itself contains literal `"deriva-ml"` (F-01).
+And at line 410, `initialize_ml_schema(model, schema_name)` passes
+the name through correctly.
+
+So `create_ml_schema` partly honors `schema_name`. The contract
+needs either (a) the literals fixed (F-01, F-02), or (b) the
+parameter removed and the literal `"deriva-ml"` documented as
+the only supported value.
+
+**Action**: pick a direction. The cheap path is fixing the
+literals.
+
+### F-04 — `asset_annotation` docstring says "Returns a dictionary" but returns `None` (P1, doc)
+
+`src/deriva_ml/schema/annotations.py:247-358`
+
+```python
+def asset_annotation(asset_table: Table):
+    """Generate annotations for an asset table.
+
+    Args:
+        asset_table: The Table object representing the asset table.
+
+    Returns:
+        A dictionary containing the annotations for the asset table.
+    """
+```
+
+The function mutates `asset_table.annotations` in-place and calls
+`asset_table.schema.model.apply()`. It has **no `return`
+statement** — returns `None`. The "Returns" docstring section is
+wrong.
+
+**Action**: rewrite the docstring to describe the mutation and
+the `apply()` side effect; drop the `Returns` block (or replace
+with `Returns: None`).
+
+### F-05 — `generate_annotation` has no docstring at all (P1, doc)
+
+`src/deriva_ml/schema/annotations.py:361`
+
+```python
+def generate_annotation(model: Model, schema: str) -> dict:
+    workflow_annotation = {
+```
+
+The function is part of the module-level `__all__` (line 623), so
+it's a public API. Workspace convention (CLAUDE.md) requires a
+Google-style docstring with `Args/Returns/Raises/Example`.
+
+**Action**: add a Google-style docstring; document the five keys
+of the returned dict (`workflow_annotation`, `dataset_annotation`,
+`execution_annotation`, `schema_annotation`,
+`dataset_version_annotation`).
+
+### F-06 — `generate_annotation`'s `model` parameter is unused (P2, dead code)
+
+`src/deriva_ml/schema/annotations.py:361`
+
+```python
+def generate_annotation(model: Model, schema: str) -> dict:
+```
+
+`model` is declared but never referenced inside the function body.
+Either the function intended to introspect the model (e.g., to
+discover features) or the parameter is dead. The call site
+(`create_schema.py:340`) passes `generate_annotation(model,
+schema_name)`, so removing the parameter is a public-API change.
+
+**Action**: either (a) remove the parameter and update the one
+call site, or (b) use the parameter (e.g., to drive
+`navbarMenu`-style discovery) and document it.
+
+### F-07 — `create_dataset_table` has no docstring (P1, doc)
+
+`src/deriva_ml/schema/create_schema.py:40-82`
+
+The neighboring `create_execution_table`, `create_workflow_table`,
+`create_asset_table`, and `define_table_dataset_version` all have
+Google-style docstrings; `create_dataset_table` is the only
+sibling with none. Given the function creates four tables
+(Dataset, Dataset_Type, Dataset_Type association, Dataset_Version,
+Dataset_Dataset for nested, Dataset_Execution) the parameter
+documentation is non-trivial.
+
+**Action**: add a Google-style docstring listing the side-effect
+graph (which tables get created, which FK edges get added).
+
+### F-08 — `asset_annotation` iterates a `set` for `visible_columns` ordering (P1, correctness — non-determinism)
+
+`src/deriva_ml/schema/annotations.py:259, 307, 321`
+
+```python
+asset_metadata = {c.name for c in asset_table.columns} - DerivaAssetColumns
+...
+"*": [
+    ...
+] + [fkey_column(c) for c in asset_metadata],   # ← set iteration
+"detailed": [
+    ...
+] + [fkey_column(c) for c in asset_metadata],   # ← set iteration
+```
+
+`asset_metadata` is a **set**, so its iteration order is
+implementation-defined. The resulting Chaise `visible_columns`
+order will jitter run-to-run on rebuilds and is not
+byte-reproducible across catalog instances created from the same
+source. This in turn breaks downstream diffs of catalog
+annotations.
+
+This is the same family of bug as the asset-manifest ordering bug
+documented in CLAUDE.md ("Metadata directory order must match
+`sorted(metadata_columns)` — both `asset_table_upload_spec()` and
+`_build_upload_staging()` sort alphabetically").
+
+**Action**: replace both list comprehensions with `[fkey_column(c)
+for c in sorted(asset_metadata)]`.
+
+### F-09 — Internal table-builder helpers (`create_dataset_table` etc.) are not in `__all__` but are reachable via attribute access (P2, API surface)
+
+`src/deriva_ml/schema/create_schema.py:655-659`
+
+```python
+__all__ = [
+    "create_ml_catalog",
+    "create_ml_schema",
+    "initialize_ml_schema",
+]
+```
+
+`create_dataset_table`, `create_execution_table`,
+`create_workflow_table`, `create_asset_table`,
+`define_table_dataset_version` are all module-level and reachable
+as `deriva_ml.schema.create_schema.create_dataset_table`. They
+have no `_` prefix so the static analyzer treats them as public,
+but `__all__` excludes them. A wildcard import gets only the three
+listed — which is correct — but an explicit
+`from deriva_ml.schema.create_schema import create_dataset_table`
+works and is a hidden surface contract.
+
+**Action**: prefix with `_` (recommended — they're build-time
+helpers), **or** add them to `__all__` and give them docstrings
+that reflect "internal but exposed".
+
+### F-10 — `asset_annotation`'s FK-name string-formula is a fragile contract (P2, correctness)
+
+`src/deriva_ml/schema/annotations.py:276-289`
+
+```python
+asset_type_source = {
+    "source": [
+        {"inbound": [schema, f"{asset_name}_Asset_Type_{asset_name}_fkey"]},
+        {"outbound": [schema, f"{asset_name}_Asset_Type_Asset_Type_fkey"]},
+        "RID",
+    ],
+    "markdown_name": "Asset Types",
+}
+```
+
+These FK-constraint names are constructed by `Table.define_association`
+inside deriva-py. The exact format (`<assoc>_<column>_fkey`) is a
+deriva-py convention, not a deriva-ml-controlled name. If deriva-py
+ever changes the synthesized constraint-name template, this
+annotation breaks silently — Chaise will render no asset-types
+column.
+
+There is no test that asserts these names actually match the FK
+constraints emitted by `define_association`.
+
+**Action**: at minimum, add an integration assertion that the
+generated table has a FK constraint matching
+`f"{asset_name}_Asset_Type_{asset_name}_fkey"`. Better: pull the
+name from `asset_table.foreign_keys[…].name` rather than
+formatting a string.
+
+### F-11 — `create_asset_table.use_hatrac` parameter is accepted and silently ignored (P1, correctness)
+
+`src/deriva_ml/schema/create_schema.py:222-249`
+
+```python
+def create_asset_table(
+    schema: Schema,
+    asset_name: str,
+    execution_table: Table,
+    asset_type_table: Table,
+    asset_role_table: Table,
+    use_hatrac: bool = True,
+) -> Table:
+    ...
+    asset_table = schema.create_table(
+        AssetTableDef(
+            schema_name=schema.name,
+            name=asset_name,
+            hatrac_template="/hatrac/metadata/{{MD5}}.{{Filename}}",
+        )
+    )
+```
+
+The `use_hatrac` parameter is documented in the docstring
+("Whether to use Hatrac for file storage") but the function body
+**never references it**. The `File` table is created at line 392
+with `use_hatrac=False`, but it gets the same `hatrac_template`
+as `Execution_Metadata` and `Execution_Asset`. So the `File` table
+is wired up identically to a Hatrac-backed asset.
+
+This is either (a) the parameter is dead and the `File` table's
+"not managed by Hatrac" semantic is implemented elsewhere, or
+(b) the parameter was supposed to switch off the `hatrac_template`
+and someone forgot to wire it up.
+
+**Action**: investigate. If the `File` table actually doesn't go
+through Hatrac at runtime, the parameter is misleading and should
+either be removed or actually drive behavior. The seeded term
+`{"Name": "File", "Description": "A file that is not managed by
+Hatrac"}` (create_schema.py:476) reinforces that the semantic was
+intended.
+
+### F-12 — `define_table_dataset_version` and similar helpers leak schema-name string-coupling (P2, design)
+
+`src/deriva_ml/schema/create_schema.py:85-150`
+
+`define_table_dataset_version(sname, …)` takes the schema name as
+a string parameter and builds FK definitions that reference
+`sname` for `Dataset` and `Execution` tables. The function is
+called from `create_dataset_table` (line 72), which itself takes a
+`Schema` object. There's a layered API gap: the caller has the
+Schema, the inner function takes a string.
+
+This isn't load-bearing, but it makes the helper hard to reuse —
+you can't pass it a `Schema` directly.
+
+**Action**: change the signature to `define_table_dataset_version(schema: Schema, …)` and use `schema.name` internally,
+mirroring `create_execution_table(schema, …)`.
+
+### F-13 — No unit test for `asset_annotation` (P1, coverage)
+
+`tests/schema/` has no test file covering `asset_annotation`. The
+only coverage is indirect, via `test_acl_application.py` which
+exercises full catalog creation (and so runs `asset_annotation`
+as a side effect of `create_ml_schema`). A change that broke the
+annotation shape (e.g., dropped a key from `visible_columns`)
+would not be caught.
+
+The function is straightforward to test against a mock `Table`
+(no live catalog needed) — same pattern as
+`test_annotations.py::build_navbar_menu`.
+
+**Action**: add `tests/schema/test_asset_annotation.py` with at
+least:
+- annotation dict shape (top-level keys);
+- presence of the `asset_type_source` inbound/outbound triple;
+- deterministic ordering (covers F-08);
+- file-preview annotation gets applied to the URL column.
+
+### F-14 — No unit test for `generate_annotation` (P1, coverage)
+
+Same shape as F-13. `generate_annotation` produces the dict that
+`create_ml_schema` passes to four `create_*_table` helpers; it
+has no test. Adding a test would catch the F-01 literal-vs-parameter
+bug as a regression.
+
+**Action**: add `tests/schema/test_generate_annotation.py`
+checking the five-key shape and that **no** value contains the
+literal `"deriva-ml"` when called with `schema="not-deriva-ml"`.
+
+### F-15 — `policy.json` schema is not documented anywhere in the subsystem (P2, doc)
+
+`src/deriva_ml/schema/policy.json` is bundled with the package and
+shelled out to `deriva.config.acl_config`. Its structure
+(`groups`, `acl_definitions`, `acl_bindings`, `catalog_acl`,
+`schema_acls`, `table_acls`) is partially documented in
+`tests/schema/test_policy.py` (which asserts the invariants) but
+there's no narrative in the module docstring, no README, no link
+from `create_ml_catalog`'s docstring to the file format. A future
+maintainer rewriting the file has no reference.
+
+**Action**: add a brief `policy.json` schema explainer to
+`create_ml_catalog`'s docstring (or a sibling
+`schema/policy.md`) covering: the four group-resolution levels,
+the `read_only` / `self_serve` ACL definitions, the
+`row_owner_guard` binding, and the negative-lookahead pattern
+that targets non-public schemas.
+
+### F-16 — CASCADE warning is present but not surfaced to callers programmatically (P2, safety)
+
+`src/deriva_ml/schema/create_schema.py:336`
+
+```python
+if model.schemas.get(schema_name):
+    logger.warning(f"Dropping existing schema '{schema_name}' with CASCADE")
+    model.schemas[schema_name].drop(cascade=True)
+```
+
+The CASCADE drop fires after a `logger.warning(...)` only. A
+caller can't intercept this (no callback, no confirmation
+parameter, no exception that requires `force=True`). Compare to
+`refresh_schema` in `core/base.py:510-571`, which refuses to drop
+work without `force=True`.
+
+The CLAUDE.md note ("never call `create_ml_schema` on a catalog
+that already has data in `deriva-ml`") signals that the contract
+is "callers don't actually do this." But the safer pattern would
+be to require an explicit `force_drop=True`.
+
+**Action**: add `force_drop: bool = False` and raise
+`DerivaMLConfigurationError` when the schema exists and
+`force_drop` is False. (The clone path already avoids this code
+path per the docstring at line 322.)
+
+### F-17 — `create_ml_schema` docstring mentions bag-pipeline carve-out but doesn't link to the bag loader (P3, doc)
+
+`src/deriva_ml/schema/create_schema.py:322-326`
+
+The docstring says the bag-pipeline clone path "does not call
+this function — it loads catalog content via
+`BagCatalogLoader` instead." Useful, but no module path is given.
+A reader chasing the carve-out has to grep.
+
+**Action**: add a fully-qualified reference, e.g.,
+`:class:\`deriva_ml.catalog.bag_catalog_loader.BagCatalogLoader\``.
+
+### F-18 — Schema-cache freshness: `create_ml_schema` doesn't touch the in-process `SchemaCache` (P2, design clarity)
+
+`src/deriva_ml/schema/create_schema.py` doesn't import or invoke
+the `core.schema_cache.SchemaCache`. In practice this is fine
+because `create_ml_schema` is called either before a `DerivaML`
+instance exists or via `create_ml_catalog` (which then constructs
+the instance). But for ad-hoc REPL workflows where a user does:
+
+```python
+ml = DerivaML(host, catalog_id)
+create_ml_schema(ml.catalog)   # destructive
+ml.find_datasets()             # stale schema-cache, may crash
+```
+
+…the schema-cache will be stale and there is no contract
+documenting it.
+
+**Action**: at minimum, add a note to `create_ml_schema`'s
+docstring that callers with an existing `DerivaML` instance
+should call `ml.refresh_schema(force=True)` afterward. (No code
+change needed — the function lives below the cache layer.)
+
+### F-19 — `test_vocab_fk_convention.py` proves Name-targeted FKs, but doesn't prove `asset_annotation`'s formula matches (P2, coverage)
+
+`tests/schema/test_vocab_fk_convention.py` walks the catalog and
+asserts that every FK targeting a vocab table references `Name`.
+Excellent invariant. But `asset_annotation` builds string
+references like `f"{asset_name}_Asset_Type_{asset_name}_fkey"`
+which is the **synthesized constraint name**, not the FK target.
+A test that crafts the same formula and looks it up against the
+live catalog's FK constraint names would close F-10.
+
+**Action**: extend `test_vocab_fk_convention.py` (or add a
+sibling) to assert that every FK-string-formula in
+`asset_annotation`'s output resolves to a real constraint on the
+created table.
+
+### F-20 — Parallel asset-table creation is repeated three times with copy-paste (P2, dup)
+
+`src/deriva_ml/schema/create_schema.py:375-407`
+
+```python
+create_asset_table(schema, MLTable.execution_metadata,
+    execution_table, asset_type_table, asset_role_table)
+create_asset_table(schema, MLTable.execution_asset,
+    execution_table, asset_type_table, asset_role_table)
+file_table = create_asset_table(schema, MLTable.file,
+    execution_table, asset_type_table, asset_role_table,
+    use_hatrac=False)
+```
+
+Three near-identical calls. The `File` table differs only by
+`use_hatrac=False` (which itself is broken per F-15) and the
+follow-up `Table.define_association(Dataset, File)` at lines
+401-407.
+
+Acceptable as-is (only three sites), but a `for asset_name in
+(MLTable.execution_metadata, MLTable.execution_asset, MLTable.file):`
+loop would be tidier.
+
+**Action**: optional refactor. Low priority unless touched.
+
+### F-21 — `generate_annotation` has parallel `workflow_annotation` / `dataset_annotation` / `execution_annotation` blocks that don't share structure (P3, dup)
+
+`src/deriva_ml/schema/annotations.py:362-619`
+
+Each of the four returned annotation dicts has its own
+hand-written `visible_columns: { "*": [...], "detailed": [...],
+"filter": { "and": [...] } }` block. The `RCB/RMB` pseudo-columns
+and the "Created By" / "Modified By" filter entries appear in
+multiple blocks. Extracting a `_audit_columns(schema, table)`
+helper would cut ~80 lines and ensure the four tables share the
+same audit-column display.
+
+**Action**: optional refactor; would also make F-01 easier
+because the helper would naturally take the schema parameter.
+
+### F-22 — `_ensure_terms` helper inside `initialize_ml_schema` is good; could be promoted (P3, design)
+
+`src/deriva_ml/schema/create_schema.py:449-455`
+
+```python
+def _ensure_terms(table_name: str, terms: list[dict]) -> None:
+    """Insert terms that don't already exist in a vocabulary table."""
+    table = pb.tables[table_name]
+    existing = {row["Name"] for row in table.entities()}
+    missing = [t for t in terms if t["Name"] not in existing]
+    if missing:
+        table.insert(missing, defaults={"ID", "URI"})
+```
+
+Useful pattern; defined as a nested closure so it can't be reused.
+The CLAUDE.md mentions a `find_associations` / `add_term`
+elsewhere — promoting `_ensure_terms` to a module-level helper
+would let other vocab-seeding code reuse it.
+
+**Action**: optional. If there's no second caller, leave it.
+
+### F-23 — Five seeded asset types have descriptions that mix metadata structure with content (P3, content drift)
+
+`src/deriva_ml/schema/create_schema.py:460-484`
+
+Asset_Type seed descriptions:
+- `"Execution_Config"`: "Configuration File for execution metadata"
+- `"Execution_Metadata"`: "Information about the execution environment"
+
+vs.
+
+- `"Hydra_Config"`: "Hydra YAML configuration file (config.yaml,
+  overrides.yaml, hydra.yaml)" — names specific filenames
+- `"Metrics_File"`: "Training-metric log file (typically JSONL,
+  one record per evaluation point — epoch, step, or eval cycle)"
+
+The format is inconsistent: some descriptions are pure semantic
+("Information about the X"), others enumerate filename
+conventions, others document format ("typically JSONL"). Chaise
+will display these verbatim in the vocabulary picker. A
+consumer-facing description style guide would help.
+
+**Action**: cosmetic; reconcile descriptions to one of (a)
+"What is this term for?" (semantic), or (b) "What concrete
+artifacts carry this term?" (operational). Currently mixed.
+
+### F-24 — `initialize_ml_schema` docstring is excellent but has no `Example:` block (P3, doc)
+
+`src/deriva_ml/schema/create_schema.py:413-444`
+
+The function carries the strongest docstring in the subsystem
+(documents the platform-vs-domain principle, names anti-examples
+that the test suite then pins). It lacks an `Example:` block
+showing the typical invocation, which is a workspace convention.
+
+**Action**: add an `Example:` block (probably `# doctest: +SKIP`
+since it requires a live catalog).
+
+### F-25 — `create_ml_catalog` shells out to a sub-Python; surface the cleanup contract (P2, safety)
+
+`src/deriva_ml/schema/create_schema.py:618-641`
+
+```python
+try:
+    subprocess.run(
+        [sys.executable, "-m", "deriva.config.acl_config", ...],
+        check=True, capture_output=True, text=True,
+    )
+except subprocess.CalledProcessError as e:
+    raise DerivaMLConfigurationError(
+        f"Failed to apply ACL policy to catalog {catalog.catalog_id} ..."
+    ) from e
+```
+
+If `acl_config` fails, the catalog **already exists** (it was
+created by `server.create_ermrest_catalog()` at line 590 and the
+schema was created at line 601). The exception is raised but the
+half-configured catalog leaks. Compare to the `catalog_alias`
+branch (line 644) — if alias creation fails, same problem.
+
+A `try/except/delete_ermrest_catalog(really=True)/raise`
+wrapper would prevent the leak.
+
+**Action**: wrap the `acl_config` subprocess and the alias-creation
+call in a single try block that calls
+`catalog.delete_ermrest_catalog(really=True)` on failure before
+re-raising. The test fixtures already do this — the production
+helper should too.
+
+### F-26 — `policy.json` group `eye-ai` is bundled with the deriva-ml package (P3, design)
+
+`src/deriva_ml/schema/policy.json:6,9-14`
+
+```json
+"eye-ai": ["https://auth.globus.org/d38e6f4d-..."],
+...
+"project-writers":  ["isrd-systems", "eye-ai"],
+"project-curators": ["isrd-systems", "local-admin", "eye-ai"],
+"project-users":    ["isrd-systems", "local-admin", "eye-ai"],
+```
+
+The bundled policy hard-codes an `eye-ai` group reference. Every
+deriva-ml catalog created via `create_ml_catalog` thus implicitly
+grants the eye-ai Globus group write/curate access on every
+non-public schema. This is reasonable for ISI but bleeds project
+identity into a platform-level default.
+
+**Action**: either (a) document this in `policy.json`'s
+neighborhood, or (b) factor the project-specific groups out into
+a per-project policy file overlay.
+
+### F-27 — `Workflow.URL` column is typed `ermrest_uri` but Chaise display uses raw markdown (P3, cosmetic)
+
+`src/deriva_ml/schema/create_schema.py:289`
+`src/deriva_ml/schema/annotations.py:389-392`
+
+`Workflow.URL` is declared `BuiltinType.ermrest_uri` (a
+deriva-specific type that Chaise renders as a clickable link).
+The `detailed` view in `workflow_annotation` overrides this with
+a custom markdown template:
+
+```python
+{
+    "display": {"markdown_pattern": "[{{{URL}}}]({{{URL}}})"},
+    "markdown_name": "URL",
+},
+```
+
+This is redundant with the `ermrest_uri` type — Chaise will
+already render the column as a link. The custom template only
+exists for the "detailed" view; the "*" view doesn't have it.
+Inconsistent.
+
+**Action**: either drop the custom `markdown_pattern` (let
+`ermrest_uri` do its job) or apply it to both views.
+
+---
+
+## Coverage map
+
+| Function / asset | Public? | Unit test | Integration test |
+|---|---|---|---|
+| `create_ml_catalog` | yes (`__all__`) | — | `test_acl_application.py`, `test_vocab_fk_convention.py`, `test_cascade_behavior.py` |
+| `create_ml_schema` | yes (`__all__`) | — | `test_cascade_behavior.py` |
+| `initialize_ml_schema` | yes (`__all__`) | `test_seeded_vocab_terms.py` (source-introspection) | indirect |
+| `create_dataset_table` | exposed | — | indirect |
+| `create_execution_table` | exposed | — | indirect |
+| `create_workflow_table` | exposed | — | indirect |
+| `create_asset_table` | exposed | — | indirect |
+| `define_table_dataset_version` | exposed | — | indirect |
+| `asset_annotation` | yes (`__all__`) | **none** (F-13) | indirect |
+| `catalog_annotation` | yes (`__all__`) | — | `tests/core/test_catalog_annotations.py` |
+| `build_navbar_menu` | yes (`__all__`) | `test_annotations.py` | — |
+| `generate_annotation` | yes (`__all__`) | **none** (F-14) | indirect |
+| `policy.json` | (resource) | `test_policy.py` (structural) | `test_acl_application.py` |
+
+---
+
+## Recommendation for v1.37.1
+
+**Ship as-is.** No P0. The five P1 items (F-01, F-04, F-05, F-07,
+F-08, F-11, F-13, F-14) are correctness-near-misses and doc
+issues; none change observable schema or break a working install.
+Recommend follow-up PRs:
+
+1. **F-01 + F-08 in one PR** — they're the only two findings that
+   change emitted catalog state, and both fixes are small.
+2. **F-04 + F-05 + F-07 in a docs-only PR** — pure docstring
+   patches.
+3. **F-11 + F-13 + F-14 in a coverage PR** — investigate
+   `use_hatrac`, add unit tests for the two untested public
+   annotation functions.
+4. **F-25 in a safety PR** — catalog-cleanup wrapper around the
+   `acl_config` shell-out.
+
+Defer P2/P3 to a non-release window.
+
+---
+
+## Totals
+
+- **Findings:** 27 (P0: 0, P1: 7, P2: 13, P3: 7)
+- **File:** `/Users/carl/GitHub/DerivaML/deriva-ml/docs/audits/2026-05-22-engineer-audit-schema.md`

--- a/docs/audits/2026-05-22-writer-audit.md
+++ b/docs/audits/2026-05-22-writer-audit.md
@@ -1,0 +1,450 @@
+# Technical-writer audit (2026-05-22)
+
+Pre-release documentation audit of deriva-ml v1.37.x. Scope, lenses, and severity tags as defined in the audit brief.
+
+## Summary
+
+- **Public-API symbols audited:** ~80 (DerivaML class methods, DerivaMLConfig, ExecutionConfiguration, Execution lifecycle methods, Dataset, DatasetBag, FeatureRecord and its selectors, AssetSpec/AssetSpecConfig, DatasetSpec/DatasetSpecConfig, Workflow, top-level exceptions, and all annotation-builder classes in `deriva_ml.model`).
+- **Doc pages audited:** 38 (`docs/index.md`, 3 getting-started stubs, 9 user-guide pages, 4 configuration pages, 14 api-reference pages, 7 concepts stubs, 3 workflows stubs, `docs/cli-reference.md`, `docs/architecture.md`, `docs/release-notes.md`, `docs/reference/`).
+- **Findings:** 56 total — **9 P0**, **20 P1**, **20 P2**, **7 P3**.
+- **Top themes (in priority order):**
+  1. **Reference rot**: the api-reference tree has at least one entry pointing at a module that does not exist (`upload.md` → `deriva_ml.dataset.upload`), the docs nav buries entry points (`DerivaMLConfig`, `AssetSpec`, `AssetSpecConfig`, `FeatureRecord`, annotation builders) under `DerivaML` or omits them entirely.
+  2. **Stale code examples**: at least three high-traffic snippets in `docs/user-guide/datasets.md`, `docs/configuration/overview.md`, and `docs/user-guide/executions.md` call APIs with signatures that no longer exist (`split_dataset(ml, rid, test_size=...)` is missing the now-required `execution` arg; `DerivaMLConfig(check_auth=True)` cites a field that no longer exists; `AssetFilePath.set_metadata(key, value)` is documented but the class only exposes a `metadata` property + `set_asset_types`).
+  3. **Getting-started is missing**: `docs/getting-started/{install,quick-start,project-setup}.md` are HTML meta-refresh redirects to the template repo. A first-time reader landing on the site has zero in-site walkthrough — they get bounced out of the docs to a separate GitHub repo before they can copy a single line of working code.
+  4. **Doc tree shape**: 14 redirect-only pages (`concepts/`, `workflows/`, `cli-reference.md`, three `getting-started/`) live in the tree but are not in `mkdocs.yml`'s nav. They render as bare HTML if a Google result links to them. Decision needed — delete them, or restore real content.
+  5. **Public-API symbols without runnable `Example:` blocks**: most annotation builders (`TableDisplayOptions`, `ColumnDisplayOptions`, `PreFormat`, `Facet`, `FacetRange`, `InboundFK`/`OutboundFK`, `Aggregate`, `TemplateEngine`, `ArrayUxMode`, `FacetUxMode`), most exception classes, and `DatasetHistory` / `DatasetMinid` carry attribute-style docstrings without an `Example:` block, even though they are user-facing per CLAUDE.md.
+  6. **Release notes are 3+ releases out of date** (last entry `Version 1.34.0`; current release `v1.37.4`).
+
+## Top-level entry-point review
+
+### `DerivaML` class — `src/deriva_ml/core/base.py`
+
+- **Class-level docstring** (lines 97–135): strong. Documents the verb-naming convention (`find_*` vs `list_*`), lists attributes, and gives a runnable `# doctest: +SKIP` example. The convention block is one of the best concept-in-docstring entries in the codebase. **No findings.**
+- **`__init__`** (lines 237–290): full Google docstring with all kwargs, but **no `Example:` block** despite the class being the canonical user-facing entry point. P2.
+- **`from_context`** (lines 192–235): good prose; uses `Example::` (sphinx-rst directive) instead of Google `Example:` style. Inconsistent with the rest of the file. P3.
+- **`apply_catalog_annotations`** (lines 1078–1132): thorough; one of the best docstrings in the codebase. **No findings.**
+- **`refresh_schema`**, **`pin_schema`**, **`unpin_schema`**, **`pin_status`**, **`diff_schema`**: excellent — every method documents its mode-branched behavior, its raises, and its caller obligations. **No findings.**
+- **`chaise_url`** (lines 963–985): Example block uses heading `Examples:` (plural) — Google style is `Example:` (singular). Same for `cite` (lines 995–1043), `create_vocabulary` (lines 1134–1170), `create_table` (lines 1192–1300), `add_term` (mixin), `clear_cache`. The mkdocstrings handler accepts either, but the rest of the codebase uses singular `Example:`. Inconsistency. P3.
+- **`create_table`** docstring (lines 1192–1300): runs to ~108 lines of `Example:` markup. Useful, but mostly duplicates what's in `concepts/`-era docs. Could be split or shortened. P3.
+- **`mode`** property (lines 776–789): minimal `Example:` (`ml.mode is ConnectionMode.online`) — pure-Python example would need a constructed instance, so the example doesn't actually run as a doctest. Not marked `# doctest: +SKIP`. P2.
+- **`download_dir`** (lines 797–813): no `# doctest: +SKIP` on the catalog-dependent example (`cache_dir = ml.download_dir(cached=True)`) — example uses an undefined `ml`. If `--doctest-modules` runs against this it will fail. P1.
+
+### `DerivaMLConfig` — `src/deriva_ml/core/config.py`
+
+- **Class docstring** (lines 71–114): comprehensive attribute table, runnable `Example:`. **No findings.**
+- **`compute_workdir`** (lines 163–203): doctest example `>>> DerivaMLConfig.compute_workdir('/shared/data', '52', 'ml.example.org')` is expected output uses literal `username` — but the method calls `getpass.getuser()` at runtime. The example doctest would FAIL for any non-`username` user. P0 — this WILL break `pytest --doctest-modules` on any developer machine. Either skip with `# doctest: +SKIP` or convert to a no-output assertion.
+
+### `ExecutionConfiguration` — `src/deriva_ml/execution/execution_configuration.py`
+
+- **Class docstring** (lines 39–76): excellent — describes every attribute, including the mixed RID-string/AssetSpec coercion. **No findings.**
+- **`validate_assets`** validator (lines 87–115): docstring describes the four input shapes correctly. **No findings.**
+- **`load_configuration`** (lines 117–141): good. **No findings.**
+
+### `Execution` — `src/deriva_ml/execution/execution.py`
+
+- **Class docstring** (lines 220–266): the example documents the "upload AFTER the context manager exits" rule clearly. **No findings.**
+- **`__init__`** (lines 269–311): solid. **No findings.**
+- **`download_dataset_bag`** (lines 1163–1188): the example is fine but the **returned-value description** ("DatasetBag with `path`, `rid`, `minid`") is wrong — `DatasetBag` exposes `path`, `dataset_rid`, `current_version` (no `rid`, no top-level `minid` field). P1.
+- **`update_status`** (lines 1189–1244): example `exe.update_status(ExecutionStatus.Running)` — but `update_status(status)` without an `error` is valid only on terminal-state attempts where error is ignored. Fine. **No findings.**
+- **`execution_start`/`execution_stop`** (lines 1245–1344): mention "execution_stop()" inside the `execution_start()` example, which is a good cross-link. **No findings.**
+- **`upload_execution_outputs`** (lines 1469–1505): solid. **No findings.**
+- **`add_features`** (lines 1072–1160): excellent prose ("Provenance requirement" callout); example is runnable as `# doctest: +SKIP`. **No findings.**
+- **`asset_file_path`** (lines 1902–2014): missing `Example:` block entirely (every other public mutating method has one). P1.
+- **`metrics_file`** (lines 2016–2091): excellent. The `MLAsset.execution_metadata.value` pure-Python doctest actually runs — exemplary. **No findings.**
+- **`abort`** (lines 2585–2616): solid. **No findings.**
+- **`pending_summary`** / **`upload_outputs`** (lines 2618–2676): solid. **No findings.**
+
+### `AssetSpec`, `AssetSpecConfig`, `AssetFilePath` — `src/deriva_ml/asset/aux_classes.py`
+
+- **`AssetSpec`** (lines 153–176): the doctest examples are pure-Python and *will run* during collection — but `AssetSpec(rid="3JSE")` is not asserted (no expected output). `RID` validation lives in `core.definitions`; if the regex allows `"3JSE"` the test passes silently. P3 (cosmetic — preferred Google form: `>>> AssetSpec(rid="3JSE").cache` `False`).
+- **`AssetSpecConfig`** (lines 187–202): example uses `from hydra_zen import store` — pure-Python but marked `# doctest: +SKIP`. **No findings.**
+- **`AssetFilePath`** (lines 28–150): no class-level `Example:` shows `set_asset_types()`; the constructor docstring is fine. The `metadata` getter/setter docstrings (lines 88–122) document the semantics well. **No findings on existence**, but see the `executions.md` issue below — user-guide docs claim a `set_metadata(key, value)` method exists; it does not. P0 (in docs/, not in src/).
+
+### `DatasetSpec`, `DatasetSpecConfig` — `src/deriva_ml/dataset/aux_classes.py`
+
+- **`DatasetSpec`** (lines 304–394): docstring opens with `"Represent a dataset_table in an execution configuration dataset_table list"` — typo / placeholder leak from a refactor. P2.
+- **`DatasetSpec.version`** field type is `DatasetVersion | conlist(...) | tuple[...] | str` but the docstring just says "The version of the dataset. Should follow semantic versioning." — doesn't mention that lists/tuples/dicts/strings are all accepted via `version_field_validator`. P2.
+- **`DatasetVersion`** / **`VersionPart`** (lines 28–202): exemplary. Pure-Python doctests, clear rationale. **No findings.**
+- **`DatasetHistory`** (lines 204–235): no `Example:` block, attribute-style only. P2.
+- **`DatasetMinid`** (lines 238–301): no `Example:` block, no description of when an instance is actually constructed (it's a parser for the MINID landing-page JSON). P2.
+- **`DatasetSpecConfig`** (lines 398–425): no `Example:` block. Compared to `AssetSpecConfig` (lines 187–202) — `AssetSpecConfig` has one, `DatasetSpecConfig` does not. P2.
+
+### `Dataset` — `src/deriva_ml/dataset/dataset.py`
+
+- **Class docstring** (lines 75–110): excellent. **No findings.**
+- **`Dataset.__init__`** (lines 112–139): solid. **No findings.**
+- **`dataset_types` property** (lines 189–211): two-line `Example:` is opaque (`>>> types = dataset.dataset_types` `>>> print(types)`) — doesn't say what the output looks like. P3.
+- **`create_dataset`** static method (lines 213–292): excellent. **No findings.**
+- **`release`**, **`is_dirty`**, **`release_diff`**, **`compare_versions`**, **`mark_dev`** — pin-quality writing on dev/released semantics. **No findings.**
+- **`add_dataset_members`** (lines 1852+): inspected, well-documented. **No findings.**
+- **`download_dataset_bag`** (lines 2320+): **docstring says `fetch_concurrency` defaults to 8 but the signature is `fetch_concurrency: int = 1`**. Found at file lines 2327 and 2353. P0 — direct contradiction between signature and docstring.
+
+### `DatasetBag` — `src/deriva_ml/dataset/dataset_bag.py`
+
+- **Class docstring** (lines 65–112): excellent. **No findings.**
+- **`as_torch_dataset`** / **`as_tf_dataset`** (lines 1130–1485): exhaustive — long but warranted given the framework adapter shape. **No findings.**
+- **`restructure_assets`** (line 1485+): inspected. **No findings.**
+- **`current_version`** property (lines 181–192): no `Example:`. P3.
+
+### `FeatureRecord` — `src/deriva_ml/feature.py`
+
+- **Module docstring** (lines 1–33): excellent — names every selector helper. **No findings.**
+- **Class docstring** (lines 49–95): explains attributes, provenance, multi-annotator selector pattern. **No findings.**
+- **`select_newest`**, **`select_first`**, **`select_latest`** (lines 107–311): documented with runnable code in `Example:` blocks but the inline code is shown inside RST `::` literal blocks instead of doctest-style `>>>`. Mkdocstrings rendering is fine; the missing `>>>` means these are NOT picked up by `--doctest-modules`. Acceptable but inconsistent. P3.
+- **`select_by_execution`**, **`select_by_workflow`** (lines 131–269): excellent — "None return semantics" callout is exactly what a user needs. **No findings.**
+- **`select_majority_vote`** (lines 313–373): solid. **No findings.**
+
+### `Workflow` — `src/deriva_ml/execution/workflow.py`
+
+- **Class docstring** (lines 41–105): good — covers catalog binding, write-back, deduplication. **No findings.**
+
+### Annotation builders — `src/deriva_ml/model/annotations.py`
+
+Per CLAUDE.md, this is documented public API consumed by the `deriva-skills/use-annotation-builders` skill. Per-class assessment:
+
+- **`Display`** (lines 336–420): excellent. Multiple runnable examples. **No findings.**
+- **`NameStyle`** (lines 302–333): one runnable example. **No findings.**
+- **`SortKey`** (lines 428–448): example block `>>> SortKey("Name")  # Ascending` has no expected output — doctest passes silently. P3.
+- **`InboundFK`**, **`OutboundFK`** (lines 456–559): good runnable examples. **No findings.**
+- **`PseudoColumnDisplay`** (lines 562–599): no `Example:`. P2.
+- **`PseudoColumn`** (lines 606–730): exhaustive — multiple `Example:` blocks for outbound, inbound, multi-hop, display formatting, array aggregate. **No findings.**
+- **`VisibleColumns`** (lines 741–862): excellent. **No findings.**
+- **`VisibleForeignKeys`** (lines 874–911): minimal but adequate. **No findings.**
+- **`TableDisplayOptions`** (lines 920–969): no `Example:`. P2.
+- **`TableDisplay`** (lines 973–1021): adequate. **No findings.**
+- **`PreFormat`** (lines 1030–1051): no `Example:`. P2.
+- **`ColumnDisplayOptions`** (lines 1055–1085): no `Example:`. P2.
+- **`ColumnDisplay`** (lines 1087–1140): no `Example:` block. P2.
+- **`Facet`**, **`FacetList`**, **`FacetRange`** (lines 1142+): inspected; minimal docstrings without `Example:` blocks. P2.
+- **`TemplateEngine`**, **`Aggregate`**, **`ArrayUxMode`**, **`FacetUxMode`** enums (lines 139–280): inspected; member-style docstrings without examples of *use*. P2.
+- **`AnnotationBuilder`** base (lines 282–294): documents only the abstract contract. **No findings.**
+- **`fk_constraint` helper**: referenced in `VisibleColumns` examples but its own docstring not surfaced in this audit. P3.
+
+## Findings by area
+
+### Docstrings: src/
+
+#### [P0] `DerivaMLConfig.compute_workdir` doctest example is non-runnable
+**Location:** `src/deriva_ml/core/config.py:186-191`
+**Issue:** The docstring shows a `>>> DerivaMLConfig.compute_workdir('/shared/data', '52', 'ml.example.org')` example with literal expected output `PosixPath('/shared/data/username/deriva-ml/ml.example.org/52')`. The method internally calls `getpass.getuser()`, so the expected `username` portion will differ on every machine. Per CLAUDE.md, pure-Python examples run for real during pytest collection — this one will FAIL.
+**Quote:** `>>> DerivaMLConfig.compute_workdir('/shared/data', '52', 'ml.example.org')` / `PosixPath('/shared/data/username/deriva-ml/ml.example.org/52')`
+**Suggested fix:** Either (a) mark both example lines `# doctest: +SKIP`, or (b) convert to a no-output assertion like `>>> str(DerivaMLConfig.compute_workdir('/x', '52', 'h.example.org')).endswith('/h.example.org/52')` `True`.
+
+#### [P0] `Dataset.download_dataset_bag` docstring contradicts signature on `fetch_concurrency` default
+**Location:** `src/deriva_ml/dataset/dataset.py:2327` (signature) vs `dataset.py:2353` (docstring)
+**Issue:** Signature is `fetch_concurrency: int = 1` but the `Args:` block says `"Defaults to 8."` — direct contradiction.
+**Quote (signature):** `fetch_concurrency: int = 1`
+**Quote (docstring):** `"fetch_concurrency: Maximum number of concurrent file downloads during materialization. Defaults to 8."`
+**Suggested fix:** Decide which is correct and align the other. (The `DatasetSpec.fetch_concurrency` in `aux_classes.py` defaults to `8`, so the docstring intent appears to be 8 — the signature looks like a regression.)
+
+#### [P1] `Execution.download_dataset_bag` documents return fields that don't exist
+**Location:** `src/deriva_ml/execution/execution.py:1174-1178`
+**Issue:** Returns block lists `path`, `rid`, `minid` — but `DatasetBag` exposes `path`, `dataset_rid`, `current_version`, etc. There is no top-level `rid` attribute and no `minid` attribute on a `DatasetBag`.
+**Quote:** `"DatasetBag: Object containing: - path: Local filesystem path to downloaded dataset - rid: Dataset's Resource Identifier - minid: Dataset's Minimal Viable Identifier"`
+**Suggested fix:** Replace with `bag.path`, `bag.dataset_rid`, `bag.current_version` to match the actual public surface (and mirror the more-correct docstring on `Dataset.download_dataset_bag`).
+
+#### [P1] `Execution.asset_file_path` is missing a usage `Example:` block
+**Location:** `src/deriva_ml/execution/execution.py:1902-1942`
+**Issue:** This is the canonical method for registering output files. The class-level docstring and every other major mutating method on `Execution` (`add_features`, `metrics_file`, `upload_execution_outputs`, `download_dataset_bag`, `download_asset`) has an `Example:` block. `asset_file_path` doesn't.
+**Quote:** Ends with `"Raises:" ... "DerivaMLValidationError: If asset_types contains invalid terms."` — no `Example:`.
+**Suggested fix:** Add a runnable `# doctest: +SKIP` example covering at least (a) new-file mode (`path = exe.asset_file_path("Model", "model.pt"); path.write_bytes(...)`) and (b) the `metadata=AssetRecord(...)` form, since that's the recommended path.
+
+#### [P1] `DerivaML.download_dir` example uses an undefined `ml` and is not skipped
+**Location:** `src/deriva_ml/core/base.py:808-811`
+**Issue:** The `Example:` block reads `>>> cache_dir = ml.download_dir(cached=True)` with no `# doctest: +SKIP`. Per CLAUDE.md, catalog-dependent examples MUST carry `+SKIP`. The references to `ml` would fail under `--doctest-modules`.
+**Quote:** `>>> cache_dir = ml.download_dir(cached=True)` / `>>> work_dir = ml.download_dir(cached=False)`
+**Suggested fix:** Add `# doctest: +SKIP` to both lines.
+
+#### [P1] `DerivaML._get_session_config` example is not skipped
+**Location:** `src/deriva_ml/core/base.py:727-729`
+**Issue:** `>>> config = DerivaML._get_session_config()` — this *should* run (it's a `@staticmethod` with no catalog requirement), but `>>> print(config['retry_read']) # 8` has the expected output `8` written as a *comment* not as a doctest expected line. So either the doctest is wrong, or it's not actually being run. The intent is unclear from the source.
+**Quote:** `>>> print(config['retry_read']) # 8`
+**Suggested fix:** Convert to standard doctest form: `>>> config['retry_read']` `8`.
+
+#### [P1] `DatasetSpec` class docstring leads with a typo / placeholder
+**Location:** `src/deriva_ml/dataset/aux_classes.py:304-317`
+**Issue:** Opens with `"Represent a dataset_table in an execution configuration dataset_table list"` — "dataset_table" looks like an unfinished refactor (the class is `DatasetSpec`, not `DatasetTable`).
+**Quote:** `"Represent a dataset_table in an execution configuration dataset_table list"`
+**Suggested fix:** Rewrite to `"Specification for a dataset input to an execution configuration."` to match the `AssetSpec` style.
+
+#### [P2] `DatasetSpec.version` docstring understates the accepted types
+**Location:** `src/deriva_ml/dataset/aux_classes.py:317`
+**Issue:** Field type is `DatasetVersion | conlist(int, 3) | tuple[int,int,int] | str` and the `version_field_validator` accepts dicts, lists, tuples, strings, and `DatasetVersion`. The `Attributes:` block reduces this to `"version (DatasetVersion): The version of the dataset. Should follow semantic versioning."` — readers won't know they can pass `"1.2.3"`, `[1, 2, 3]`, or `(1, 2, 3)`.
+**Quote:** `"version (DatasetVersion): The version of the dataset. Should follow semantic versioning."`
+**Suggested fix:** Mention all accepted forms with one-liner examples per accepted type.
+
+#### [P2] `DerivaML.__init__` has no `Example:` block
+**Location:** `src/deriva_ml/core/base.py:237-290`
+**Issue:** Every kwarg is documented but there is no runnable `Example:` showing the constructor with common kwarg combos (`hostname` + `catalog_id`; `working_dir=`; `mode=ConnectionMode.offline`).
+**Suggested fix:** Add three small `# doctest: +SKIP` example invocations.
+
+#### [P2] Several annotation-builder helpers lack `Example:` blocks
+**Locations:**
+- `PseudoColumnDisplay` — `src/deriva_ml/model/annotations.py:562-599`
+- `TableDisplayOptions` — `src/deriva_ml/model/annotations.py:920-969`
+- `PreFormat` — `src/deriva_ml/model/annotations.py:1030-1051`
+- `ColumnDisplayOptions` — `src/deriva_ml/model/annotations.py:1055-1085`
+- `ColumnDisplay` — `src/deriva_ml/model/annotations.py:1087-1140`
+- `Facet`, `FacetList`, `FacetRange` — `src/deriva_ml/model/annotations.py:1142+`
+- Enums `TemplateEngine`, `Aggregate`, `ArrayUxMode`, `FacetUxMode`
+
+**Issue:** Per CLAUDE.md `model/annotations.py` is consumed externally by the `deriva-skills/use-annotation-builders` skill. The skill's authors and end-users need to see runnable examples for each surface, not just an attribute table.
+**Suggested fix:** Each builder should carry at least one minimum-viable `>>>` example showing how to instantiate it and pass it to a parent builder (e.g., `ColumnDisplay().detailed(ColumnDisplayOptions(pre_format=PreFormat(format="%.2f")))`).
+
+#### [P2] `DatasetHistory`, `DatasetMinid` lack `Example:` blocks
+**Location:** `src/deriva_ml/dataset/aux_classes.py:204-301`
+**Issue:** Both are user-facing return types (`Dataset.dataset_history()` returns `list[DatasetHistory]`; `DatasetMinid` surfaces in MINID-creation flows). Neither has an `Example:` block; readers landing on these from the API reference get only an attribute table.
+**Suggested fix:** Add a `# doctest: +SKIP` example for each showing the typical access pattern.
+
+#### [P2] `DatasetSpecConfig` lacks `Example:` block (asymmetric with `AssetSpecConfig`)
+**Location:** `src/deriva_ml/dataset/aux_classes.py:398-425`
+**Issue:** `AssetSpecConfig` (lines 187–202) has a clear hydra-zen `store()` example. `DatasetSpecConfig` does not, even though it's the more common configuration in real projects.
+**Suggested fix:** Add an `Example:` block paralleling `AssetSpecConfig`'s.
+
+#### [P2] `DerivaML.cache_table`, `DerivaML._cache_features` use sphinx-style `Example::` not Google `Example:`
+**Location:** `src/deriva_ml/core/base.py:874-901`, `:903-961`
+**Issue:** `Example::` is the docutils/sphinx literal-block convention; the rest of the codebase consistently uses Google's `Example:` heading followed by `>>>` lines. Mixed convention.
+**Suggested fix:** Convert to `Example:` + `>>>` style consistently across the file.
+
+#### [P3] `SortKey`, `AssetSpec` examples have no expected-output lines
+**Locations:** `src/deriva_ml/model/annotations.py:437-438`, `src/deriva_ml/asset/aux_classes.py:167-169`
+**Issue:** Examples like `>>> SortKey("Name")  # Ascending` and `>>> spec = AssetSpec(rid="3JSE")` lack expected-output assertions. They run but assert nothing.
+**Suggested fix:** Add an assertion line (`>>> SortKey("Name").column` `'Name'`).
+
+#### [P3] Inconsistent `Example:` vs `Examples:` heading
+**Locations:** `core/base.py:978-985, 1015-1028, 1156-1169, 1226-1299, 1385-1393, 1446-1449`, plus most mixin files.
+**Issue:** Google style is singular `Example:`. Some methods use `Examples:`. mkdocstrings handles both, but readers see two visual treatments.
+**Suggested fix:** Normalize to `Example:` across the codebase (search/replace).
+
+#### [P3] `Dataset.dataset_types` example is opaque
+**Location:** `src/deriva_ml/dataset/dataset.py:203-205`
+**Issue:** `>>> types = dataset.dataset_types` `>>> print(types)` shows no expected output. Reader has no idea what's printed.
+**Suggested fix:** Add a representative expected output line like `['TrainingSet', 'Labeled']`.
+
+### docs/user-guide/
+
+#### [P0] `docs/user-guide/datasets.md` calls `split_dataset` with a stale signature
+**Location:** `docs/user-guide/datasets.md:289-330` (multiple examples)
+**Issue:** Every `split_dataset` example in the user guide uses the form `split_dataset(ml, source_dataset_rid, test_size=0.2, seed=42)`. The current signature in `src/deriva_ml/dataset/split.py:482` requires an `execution` parameter as the third positional argument: `split_dataset(ml, source_dataset_rid, execution, *, test_size=0.2, ...)`. Every copy-paste from this page raises `TypeError: split_dataset() missing 1 required positional argument: 'execution'`.
+**Quote:** `result = split_dataset(ml, source_dataset_rid, test_size=0.2, seed=42)`
+**Suggested fix:** Update all four examples (lines 290, 304, 322, 342, 361) to include an `execution=exe` arg, wrapped in an `ml.create_execution(...)` context manager. Note also that the *module docstring* at `src/deriva_ml/dataset/split.py:26-87` has the correct shape — the docs page just diverged from it.
+
+#### [P0] `docs/configuration/overview.md` documents a `check_auth` field that does not exist on `DerivaMLConfig`
+**Location:** `docs/configuration/overview.md:46-66`
+**Issue:** The example shows `check_auth=True` and the field table lists `check_auth | bool | True | Verify authentication on connect`. There is no `check_auth` field in `src/deriva_ml/core/config.py` (and a grep across `core/` finds no occurrences). Code copied from this snippet will fail Pydantic validation immediately.
+**Quote:** `check_auth=True, # Verify authentication`
+**Suggested fix:** Remove `check_auth=True` from the example and the corresponding row from the parameter table. If the intent was something else (mode? credential?), document the real field.
+
+#### [P0] `docs/user-guide/executions.md` documents an `AssetFilePath.set_metadata()` method that does not exist
+**Location:** `docs/user-guide/executions.md:108-143`
+**Issue:** The page contains two mentions of `.set_metadata()`: `"if you plan to update its metadata via .set_metadata() or .set_asset_types()"` and `path.set_metadata("Acquisition_Time", "14:30:00")  # update after registration`. The class (`src/deriva_ml/asset/aux_classes.py:28-150`) only exposes a `metadata` property (read/write) plus `set_asset_types()`. There is no `set_metadata()` method.
+**Quote:** `path.set_metadata("Acquisition_Time", "14:30:00")  # update after registration`
+**Suggested fix:** Replace with `path.metadata = {...}` (full-dict replacement via the property setter) — and document the underlying behavior (the setter accepts a dict or an `AssetRecord` and overwrites the entire metadata dict; there is no per-key incremental update).
+
+#### [P0] `docs/getting-started/{install,quick-start,project-setup}.md` are HTML redirects, not docs
+**Location:** all three files in `docs/getting-started/`
+**Issue:** Each is an HTML meta-refresh redirecting to `https://github.com/informatics-isi-edu/deriva-ml-model-template`. A first-time visitor to https://informatics-isi-edu.github.io/deriva-ml hitting "Quick start" gets bounced out of the docs site to a separate GitHub repo. The mkdocs nav doesn't surface getting-started at all (`mkdocs.yml` nav skips it entirely), so the existence of these files is invisible to most readers — but anyone with a stale bookmark or Google result hits these stubs.
+**Quote:** `<meta http-equiv="refresh" content="0; url=https://github.com/informatics-isi-edu/deriva-ml-model-template">`
+**Suggested fix:** Either (a) delete the three files (they're not in nav and the redirect is silent), or (b) restore minimal getting-started content so the first-time reader has a path through the docs site itself. Option (b) is strongly preferred — the `docs/index.md` "Starting a new project" section already points to the template repo, so an in-site walkthrough adds value rather than duplicating.
+
+#### [P0] `docs/api-reference/upload.md` references a non-existent module
+**Location:** `docs/api-reference/upload.md`
+**Issue:** Page body is `::: deriva_ml.dataset.upload` — but `src/deriva_ml/dataset/` contains no `upload.py`. The `mkdocstrings` directive will either render an empty page or fail the build.
+**Quote:** `::: deriva_ml.dataset.upload`
+**Suggested fix:** Either point to `deriva_ml.cli.upload` (the actual upload CLI module under `src/deriva_ml/cli/upload.py`), or delete the file and its nav entry (`mkdocs.yml:81`). Note: the nav entry's label is "Upload"; the CLI's job is different from "asset upload during executions," so check the intent before silently re-pointing.
+
+#### [P0] `docs/release-notes.md` is 3+ releases stale
+**Location:** `docs/release-notes.md`
+**Issue:** Latest entry is `Version 1.34.0`. Current release per `git tag` is `v1.37.4`. Releases 1.35, 1.36, 1.37, and 1.37.1–1.37.4 are not documented. Recent merged PRs (#177, #178, #179, #180, #181, #184, #185) include user-visible changes — execution staging directory move, asset overwrite warning, find_association typed exceptions — none of which appear in release notes.
+**Suggested fix:** Backfill 1.35–1.37.4. This is a hard pre-release blocker — release notes are the standard signal for "should I upgrade?"
+
+#### [P1] `mkdocs.yml` nav omits 14 doc pages that exist on disk
+**Location:** `mkdocs.yml`
+**Issue:** The following exist as `.md` files but are not in the nav, so they're either dead pages (rendering as orphans if linked to) or undeclared content:
+- `docs/getting-started/install.md`, `quick-start.md`, `project-setup.md` (redirects)
+- `docs/concepts/*.md` (7 redirects)
+- `docs/workflows/*.md` (3 redirects)
+- `docs/cli-reference.md` (redirect)
+- `docs/architecture.md` (real content — but not in nav!)
+- `docs/reference/README.md`, `docs/reference/schema.md` (real content — schema is canonical per `reference/README.md`)
+
+**Suggested fix:** Delete the redirect-only files; add `architecture.md` and `reference/schema.md` to the nav (the latter is described as the "Authoritative description of the deriva-ml schema" — first-class content). If the redirects are kept for legacy URL preservation, document the policy in a comment in `mkdocs.yml`.
+
+#### [P1] `mkdocs.yml` does not surface `DerivaMLConfig`, `AssetSpec/AssetSpecConfig`, `DatasetSpec/DatasetSpecConfig`, or `MLAsset/MLVocab` enums in API Reference
+**Location:** `mkdocs.yml:62-81`
+**Issue:** The `API Reference` section exposes `DerivaML` (`deriva_ml_base.md`), `DerivaModel`, `Dataset`, `DatasetBag`, `Dataset Splitting`, `Dataset Auxiliary Classes`, `Execution`, `ExecutionConfiguration`, `Workflow`, `Lineage`, `Feature`, `Definitions & Types`, `Exceptions`, `Upload`. Missing: `DerivaMLConfig`, the `AssetSpec`/`AssetSpecConfig` pair as a discoverable page, and (most importantly) the annotation builders in `deriva_ml.model.annotations` are buried inside `deriva_model.md` (`::: deriva_ml.model`) rather than getting their own first-class API-reference page.
+**Suggested fix:** Add `api-reference/config.md` (`::: deriva_ml.core.config`), `api-reference/asset.md` (`::: deriva_ml.asset.aux_classes`), and `api-reference/annotations.md` (`::: deriva_ml.model.annotations`) — the last is particularly important because CLAUDE.md pins it as a public API consumed by the `deriva-skills` Claude Code skill.
+
+#### [P1] `docs/api-reference/exceptions.md` is a single `:::` directive — no overview of the hierarchy
+**Location:** `docs/api-reference/exceptions.md`
+**Issue:** Page body is just `::: deriva_ml.core.exceptions`. The exception hierarchy described in `CLAUDE.md` is a useful map (`DerivaMLException → DerivaMLConfigurationError → DerivaMLSchemaError, ...`), but readers landing on this page get an alphabetical class dump without that tree.
+**Suggested fix:** Add the hierarchy diagram from `CLAUDE.md` ("Exception Hierarchy" section) as introductory prose above the mkdocstrings directive.
+
+#### [P1] `docs/api-reference/execution.md` uses `::: deriva_ml.execution` with no overview
+**Location:** `docs/api-reference/execution.md`
+**Issue:** Single-line body `::: deriva_ml.execution` will render the entire submodule (Execution, Workflow, ExecutionConfiguration, BaseConfig, lineage types, multirun_config, runner, lineage, ...) on one page — but the `execution_configuration.md`, `workflow.md`, `lineage.md` pages already point to specific submodules. Either this page duplicates them, or it's incoherent. The TOC will be enormous.
+**Suggested fix:** Either narrow this page to `::: deriva_ml.execution.execution` (just the `Execution` class) or restructure to make this page a true table-of-contents / overview that links to the per-class pages.
+
+#### [P1] `docs/api-reference/deriva_ml_base.md` typo
+**Location:** `docs/api-reference/deriva_ml_base.md:4`
+**Issue:** Typo `"These methods assume tha tthe catalog"` — "tha tthe" with a space inside the word.
+**Quote:** `"These methods assume tha tthe catalog contains a 'deriva-ml' and a domain schema."`
+**Suggested fix:** Fix to `"These methods assume that the catalog ..."`.
+
+#### [P1] `docs/api-reference/deriva_ml_base.md` mentions Execution Asset table that no longer exists by that name
+**Location:** `docs/api-reference/deriva_ml_base.md:17-18`
+**Issue:** Lists `Execution Asset` and `Execution Metadata` as ML schema entities. Per `MLAsset` enum in `core/definitions.py`, the catalog tables are `Execution_Asset` and `Execution_Metadata` (underscore-separated). The prose form ("Execution Asset", "Execution Metadata" with space) is fine for English but might mislead readers searching the catalog. Minor.
+**Suggested fix:** Either use the canonical `Execution_Asset` form or add "(`Execution_Asset` in the catalog)" parenthetical for searchability.
+
+#### [P1] `docs/concepts/`, `docs/workflows/`, `docs/cli-reference.md` are 11 HTML redirects with no nav presence
+**Location:** all files in `docs/concepts/`, `docs/workflows/`, plus `docs/cli-reference.md`
+**Issue:** Same shape as the getting-started redirects. Old URLs from prior versions of these docs are preserved as redirects, but neither the redirect targets nor the redirect itself is in the nav. If a search-engine result or external link points to e.g. `/concepts/datasets/`, the user lands on a bare HTML page with no navigation, no header, no styling — just a plain refresh tag.
+**Quote (example):** `<meta http-equiv="refresh" content="0; url=../user-guide/datasets.md">`
+**Suggested fix:** Either (a) delete all 11 files (the redirects do bounce, but the experience is broken), or (b) use a proper mkdocs redirect plugin like `mkdocs-redirects` so the redirect happens server-side and the user lands on a real docs page.
+
+#### [P1] `docs/user-guide/datasets.md` references `ml.add_term(MLVocab.dataset_type, ...)` without showing the `MLVocab` import
+**Location:** `docs/user-guide/datasets.md:52, 62-68`
+**Issue:** `ml.add_term(MLVocab.dataset_type, "TrainingSet", ...)` appears in a "Notes" callout AND in the next code block, but the `from deriva_ml import MLVocab` import only appears at line 61 (inside the second usage). A reader skimming the callout sees `MLVocab.dataset_type` with no idea where to import it from.
+**Suggested fix:** Add a one-line `from deriva_ml import MLVocab` to the first occurrence, or pull the import up to the chapter's overall setup snippet.
+
+#### [P1] `docs/user-guide/executions.md` references a `DatasetSpec(version=None)` default that doesn't match the code
+**Location:** `docs/user-guide/executions.md:42-47`
+**Issue:** The table says `version | str | None | Specific version to use (default: current)`. The class signature in `src/deriva_ml/dataset/aux_classes.py:319-320` makes `version` **required** (no default) and accepts `DatasetVersion | conlist | tuple | str`. Constructing `DatasetSpec(rid="...")` without a version fails validation.
+**Quote:** `| version | str | None | Specific version to use (default: current) |`
+**Suggested fix:** Update the table to reflect that `version` is required and document the four accepted types.
+
+#### [P1] `docs/configuration/overview.md` shows `domain_schemas='my_domain'` (singular string) and elsewhere shows `domain_schemas={'my_domain'}` (set)
+**Location:** `docs/configuration/overview.md:26-27, 50, 61`
+**Issue:** The example shows `domain_schemas='my_domain'` (a string), but the field type is `str | set[str] | None`. Both forms are legal — but mixing them across examples in the same page without explanation confuses readers.
+**Suggested fix:** Pick one form for the page, or add a single sentence: "`domain_schemas` accepts a single name (string) or a set of names. Use a set when working with catalogs that expose multiple domain schemas."
+
+#### [P1] `docs/user-guide/exploring.md` claims `ml.find_executions(status=...)` accepts an `ExecutionStatus` enum directly
+**Location:** `docs/user-guide/exploring.md:122-128`
+**Issue:** `uploaded = list(ml.find_executions(status=ExecutionStatus.Uploaded))` — confirm this works. Cross-check with `core/mixins/execution.py`. If the actual filter signature takes a string, the example will fail.
+**Suggested fix:** Verify the signature; if the kwarg requires a string, either change the call or document the conversion (`status="Uploaded"` or `status=ExecutionStatus.Uploaded.value`).
+
+#### [P1] `docs/user-guide/reproducibility.md` references an asset_type `"Execution_Config"` for `uv.lock`
+**Location:** `docs/user-guide/reproducibility.md:18`
+**Issue:** Row in the table says `Execution_Config | uv.lock | Python dependency lockfile from the project root, recording exact package versions`. Confirm against `ExecMetadataType` enum members. If the enum uses a different name (e.g. `Lock_File`), the reader has no way to query the asset later.
+**Suggested fix:** Verify against `src/deriva_ml/core/definitions.py` `ExecMetadataType` and align.
+
+#### [P2] `docs/index.md` "When to use deriva-ml" is excellent but never reached from nav
+**Location:** `docs/index.md`
+**Issue:** The "Strong fit" / "Weaker fit" discussion is one of the best onboarding signals in the docs. But the nav opens directly to "Exploring a catalog" via the User Guide. New readers may never see this content.
+**Suggested fix:** Either add a prominent "Read this first" call-out at the top of `user-guide/exploring.md`, or restructure the nav so `index.md` is a clearly-labeled landing page distinct from chapter 1.
+
+#### [P2] `docs/user-guide/exploring.md` references `Chapter 4` and `Chapter 7` by number, but the nav uses titles
+**Location:** `docs/user-guide/exploring.md:236-241`, similar in `datasets.md:543-550`, `features.md`
+**Issue:** Internal cross-references use ad-hoc chapter numbers ("Chapter 1", "Chapter 7"), but the nav titles them by topic ("Exploring a catalog", "Reproducibility"). Numbers get out of sync when chapters are added/removed.
+**Suggested fix:** Use the chapter titles directly: `[Exploring a catalog](exploring.md)`, `[Reproducibility](reproducibility.md)`. mkdocs-autorefs picks up titles automatically.
+
+#### [P2] `docs/user-guide/executions.md` "Execution status lifecycle" mermaid diagram and `ExecutionStatus` enum are not cross-linked
+**Location:** `docs/user-guide/executions.md:270-288`
+**Issue:** The mermaid diagram shows the states; the table below documents them. Neither links to `execution.state_store.ExecutionStatus` in the API reference, so readers wanting the canonical enum can't navigate there.
+**Suggested fix:** Add an "API reference: `ExecutionStatus`" link to the section's "See also" footer, pointing to whichever api-reference page hosts the enum.
+
+#### [P2] `docs/configuration/overview.md` `DatasetSpecConfig` example uses field `timeout=[10, 1800]` (list) instead of the `tuple` form in the `DatasetSpec` model
+**Location:** `docs/configuration/overview.md:91-93`
+**Issue:** `DatasetSpec.timeout` is typed `tuple[int, int] | None`. `DatasetSpecConfig.timeout` is `list[int] | None`. Reader might expect either form to work in both contexts.
+**Suggested fix:** Add a one-line note: "`DatasetSpec` (Python) accepts a tuple; `DatasetSpecConfig` (hydra-zen) uses a list because hydra serialization doesn't support tuples. Both produce the same effective config."
+
+#### [P2] `docs/concepts/`, `docs/workflows/`, `docs/cli-reference.md` redirects don't tell mkdocs they should be excluded from build
+**Location:** `mkdocs.yml`
+**Issue:** mkdocs builds all `.md` files under `docs/` by default. The 14 redirect-only pages get compiled and shipped, just without nav. Build output is bloated.
+**Suggested fix:** Either delete the files or set `not_in_nav` / `exclude_from_search` configuration. mkdocs-material supports per-page `not_in_nav` in front matter.
+
+#### [P2] `docs/user-guide/sharing.md` is in nav but not in scope of this audit — flag for review
+**Location:** `mkdocs.yml:48`, `docs/user-guide/sharing.md`
+**Issue:** Not reviewed in this pass due to time. Flag for a follow-up audit — it appears in nav as Chapter 6 (Sharing and collaboration) but I did not validate its code examples or cross-references against current API.
+**Suggested fix:** Run the same pass on `sharing.md` before release.
+
+#### [P2] `docs/architecture.md` is large, current, and not in nav
+**Location:** `docs/architecture.md`, `mkdocs.yml`
+**Issue:** A 300+ line mermaid-rich architecture overview exists but is not surfaced in the nav. Readers who want a system-level view (especially those evaluating deriva-ml for adoption) will not find it.
+**Suggested fix:** Add to nav, possibly as "About → Architecture" or as a top-level "Architecture" link.
+
+#### [P2] `docs/user-guide/features.md` `create_feature` signature in "Notes" doesn't match the actual signature
+**Location:** `docs/user-guide/features.md:113-114`
+**Issue:** Notes block says `create_feature(target_table, feature_name, terms=None, assets=None, metadata=None, optional=None, comment="", update_navbar=True)`. Check this against `src/deriva_ml/core/mixins/feature.py:63` to confirm parameter order. The user-guide claims `terms`, `assets`, `metadata`, `optional` — confirm all four are accepted and in this order.
+
+#### [P2] `docs/user-guide/datasets.md` mentions `DatasetSpec` import without showing `from deriva_ml.dataset.aux_classes import DatasetSpec`
+**Location:** `docs/user-guide/datasets.md:438, 467-468, 485, 490`
+**Issue:** Several code blocks use `DatasetSpec(...)` without showing the import. Some blocks have the import; others don't. Inconsistent.
+**Suggested fix:** Add `from deriva_ml.dataset.aux_classes import DatasetSpec` (or, equivalently, `from deriva_ml.dataset import DatasetSpec`) to every snippet that uses it, or note that subsequent snippets reuse imports from earlier in the page.
+
+#### [P2] `docs/user-guide/hydra-zen.md` line 53 imports `AssetSpecConfig` from `deriva_ml.asset`
+**Location:** `docs/user-guide/hydra-zen.md:53`
+**Issue:** Table cell says `from deriva_ml.asset import AssetSpecConfig`. Verified to work — `asset/__init__.py` re-exports it. But other docs (`docs/configuration/overview.md`, README content) might import from `deriva_ml.asset.aux_classes` directly. Pick one canonical import path and document it.
+**Suggested fix:** Pick `from deriva_ml.asset import AssetSpecConfig` (the shorter path) as canonical and update everywhere.
+
+#### [P3] `docs/api-reference/lineage.md` cross-references `deriva_ml_base.md` for `lookup_lineage` but mkdocstrings inheritance might already include it
+**Location:** `docs/api-reference/lineage.md:11-14`
+**Issue:** `"The method itself is documented on the DerivaML class: [DerivaML — lookup_lineage](deriva_ml_base.md)"` — the link target is the page, not the specific anchor. Readers click through to the entire 1600-line DerivaML page and have to ctrl-F.
+**Suggested fix:** Use the anchor: `(deriva_ml_base.md#deriva_ml.core.base.DerivaML.lookup_lineage)`.
+
+#### [P3] `docs/index.md` "ERD" image alt text could be more descriptive
+**Location:** `docs/index.md:27`
+**Issue:** `![ERD](assets/ERD.png)` — alt text is just "ERD", which is meaningless to screen readers.
+**Suggested fix:** Change to `![Entity-relationship diagram showing Dataset, Workflow, Execution, and Feature_Name tables in the deriva-ml schema](assets/ERD.png)`.
+
+#### [P3] `docs/user-guide/datasets.md` mentions `MINID` but doesn't link to a definition
+**Location:** `docs/user-guide/datasets.md:522`
+**Issue:** First mention of MINID is `"To create a MINID (a persistent, citable identifier) for a shared bag"` with a forward reference to Chapter 6. Good — but no link, just text.
+**Suggested fix:** `"To create a [MINID](sharing.md#minids) (a persistent, citable identifier) ..."`.
+
+#### [P3] `docs/release-notes.md` is in nav root, not under a "Release" group
+**Location:** `mkdocs.yml:82`
+**Issue:** Singleton top-level entry. Consider grouping with "About" / "Project info" if other singletons are added.
+
+### docs/getting-started/ + cross-references
+
+#### [P0] User has no in-site walkthrough of "install → connect → first command"
+**Location:** `docs/getting-started/*.md`, `docs/index.md`, `docs/user-guide/exploring.md`
+**Issue:** Aggregate finding — covered by the per-page P0s above. Worth surfacing separately: the docs site has no `pip install deriva-ml` instruction visible in the nav. The reader is bounced to the template repo before they can install the library.
+**Suggested fix:** Add a real `getting-started/install.md` (in-site, in nav) with the `uv add deriva-ml` / `pip install deriva-ml` snippet, a one-line `deriva-auth` instruction, and a "next: Exploring a catalog" call to action.
+
+### Cross-cutting
+
+#### [P2] `core/__init__.py` docstring at line 16 example uses `DerivaML('deriva.example.org', 'my_catalog')` — string for catalog_id
+**Location:** `src/deriva_ml/core/__init__.py:16-18`
+**Issue:** Other examples use `catalog_id='42'` (numeric-looking string). Mixed conventions in examples — sometimes name, sometimes number, sometimes int. The `catalog_id: str | int` field type accepts both, but consistency aids skim-readability.
+**Suggested fix:** Pick one form for examples (numeric string `'42'` is most common across the codebase) and use it consistently.
+
+#### [P2] No mention of `mode=ConnectionMode.offline` in user-facing docs
+**Location:** Nowhere in `docs/user-guide/`.
+**Issue:** Offline mode is a documented feature on `DerivaML.__init__` (`base.py:285-289`) and gets a dedicated `Working offline` chapter (`offline.md`). But the offline-mode constructor pattern (`ml = DerivaML(..., mode=ConnectionMode.offline)`) is not in any user-guide page I audited.
+**Suggested fix:** Add a "How to work in offline mode" section to `offline.md` showing the constructor pattern, or cross-reference from `exploring.md`.
+
+#### [P3] CLAUDE.md mentions `cli-reference.md` exists and is current; the file in the repo is a redirect
+**Location:** `docs/cli-reference.md`, brief
+**Issue:** The brief lists `docs/cli-reference.md` as in-scope and asks "current?" — it's a redirect stub. So either the brief is stale or the file was deleted recently.
+**Suggested fix:** Decide whether `cli-reference.md` should be revived (the `deriva-ml-run` / `deriva-ml-run-notebook` reference is currently buried inside `docs/user-guide/executions.md` lines 388–460). A dedicated CLI reference page accessible from nav would be more discoverable.
+
+## Coverage gaps (cross-cutting)
+
+These are areas where either docs exist without code, or code exists without docs.
+
+1. **`DerivaML.from_context()`** (`base.py:192-235`) has a thorough docstring but is not mentioned in any user-guide page. It's the documented entry point for Claude-generated scripts — should appear in `exploring.md` or `hydra-zen.md` as the canonical pattern for "I'm working in a context the MCP server set up."
+2. **`DerivaML.cache_table()` / `_cache_features()` / `workspace` property** (`base.py:874-961`) — the "local caching" UX is documented in source but has no user-guide chapter. There's a `Workspace` concept buried in the source — should be documented as a discoverable feature.
+3. **`DerivaML.pin_schema` / `unpin_schema` / `pin_status` / `diff_schema`** are thoroughly documented in source (`base.py:603-713`) but have no user-guide coverage. These are diagnostic / advanced-user surfaces and probably deserve a "Working with schema cache" section.
+4. **`DerivaML.clear_cache` / `get_cache_size` / `list_execution_dirs` / `clean_execution_dirs` / `get_storage_summary`** (`base.py:1368-1622`) — local-disk management methods. No user-guide doc. These are useful day-to-day commands and worth a "Managing local storage" section.
+5. **Annotation builders** have docstrings in `model/annotations.py` and a `concepts/annotations.md` redirect to `features.md` — but `features.md` doesn't actually cover annotation builders (it covers feature definitions). True annotation-builder docs only exist in the docstrings. The `deriva-skills` Claude Code skill is documented as the consumer per CLAUDE.md — but for human readers, there is no user-guide tour of `Display`, `VisibleColumns`, `TableDisplay`. Either (a) add a chapter (P1 for a thorough surface, P2 if the skill consumer is the primary audience), or (b) explicitly link to `deriva-skills` docs from the API-reference page.
+6. **`AssetRecord`** is exported from `deriva_ml.asset.__init__` and referenced in docstrings (`Execution.asset_file_path` mentions `AssetRecord`) but is not in the api-reference nav at all and not in the main `deriva_ml.__init__` exports.
+7. **`Workflow`** has an api-reference page (`api-reference/workflow.md`) but no user-guide chapter section. Workflow creation appears inline in `executions.md` (`ml.create_workflow(...)`) but the model itself (catalog write-back, deduplication, URL detection) isn't explained anywhere in the user guide.
+8. **`MultirunSpec` and `multirun_config`** are exported from `deriva_ml.execution.__init__` but the `configuration/experiments.md` page covers experiments without making the `multirun_config` shape explicit. Reader sees it referenced via `deriva-ml-run --multirun` but the underlying spec is not introduced.
+9. **`DerivaMLBagView`** is mentioned in `dataset_bag.py` docstrings as "use DerivaMLBagView for catalog-level operations" but there is no docs page for it. Its mention in `dataset_bag.py:87` is a dead-end for any reader.
+10. **The `core/exceptions.py` hierarchy** — CLAUDE.md lays this out cleanly, and `exceptions.md` should reproduce it. The hierarchy is not in user-facing docs except as docstrings.
+
+## Recommendations
+
+In priority order for the v1.37.x release cycle:
+
+1. **Fix the four P0 broken-code-example issues** (`split_dataset`, `check_auth`, `set_metadata`, `compute_workdir` doctest). These actively mislead readers; every one will produce a TypeError or AttributeError on the first paste. ETA: half a day across all four.
+2. **Fix the api-reference `upload.md` dead reference** — either re-point to `deriva_ml.cli.upload` or delete. Even a 404 in a published docs site is a bad signal. ETA: 10 minutes.
+3. **Write release notes for 1.35–1.37.4.** Use `git log v1.34.0..v1.37.4 --oneline` and the merged PRs as input. This is what release-day readers expect to see first. ETA: 1–2 hours.
+4. **Decide and act on the 14 redirect-only pages** (`getting-started/`, `concepts/`, `workflows/`, `cli-reference.md`). Recommend: install `mkdocs-redirects` plugin, declare redirects there, delete the HTML-stub files. ETA: 1–2 hours including testing.
+5. **Add real getting-started content.** At minimum a single `getting-started/install.md` with `pip install deriva-ml`, the `deriva-auth` step, and a `DerivaML(hostname=..., catalog_id=...)` first-call. Put it in the nav. The current "bounce to template repo" experience loses readers who just want to evaluate the library. ETA: half a day.
+6. **Restructure `mkdocs.yml` nav** to add: `DerivaMLConfig` page, dedicated `Annotation Builders` page (`api-reference/annotations.md`), `architecture.md`, `reference/schema.md`. Fix the `Upload` entry. ETA: 1–2 hours.
+7. **Backfill the `Example:` blocks** on the user-facing annotation builders (`TableDisplayOptions`, `PreFormat`, `ColumnDisplayOptions`, `ColumnDisplay`, the `Facet*` family, `PseudoColumnDisplay`) — these are pinned as public API by CLAUDE.md but lack the runnable examples that CLAUDE.md mandates for public APIs. ETA: 1 day.
+
+Lower priority (post-release cycle): the P2 / P3 normalization items (singular `Example:`, internal cross-link anchors, alt-text), the coverage-gap items (workspace docs, schema-pin docs, multirun docs). These are real but don't block release.


### PR DESCRIPTION
## Summary

Lands the nine audit reports from the 2026-05-22 pre-release pass — durable receipts for both fix-pack PRs (already-merged #193 and the upcoming docs P0 PR).

Eight engineer audits (one per subsystem: dataset, execution, feature, asset, catalog, schema, model, core) plus one technical-writer audit covering public-API docstrings and the user-facing docs tree.

**Totals:** 382 findings across the nine reports.

| Audit | P0 | P1 | Total |
|---|---|---|---|
| schema (eng) | 0 | 7 | 27 |
| feature (eng) | 3 | 7 | 21 |
| catalog (eng) | 1 | 6 | 32 |
| asset (eng) | 1 | 10 | 43 |
| dataset (eng) | 0 | 6 | 42 |
| execution (eng) | 1 | 24 | 65 |
| model (eng) | 0 | 15 | 45 |
| core (eng) | 1 | 9 | 51 |
| writer | 9 | 20 | 56 |
| **Total** | **16** | **104** | **382** |

## What's in here

Nine markdown reports under \`docs/audits/2026-05-22-*-audit-*.md\`. Each report:

- Severity-tagged findings (P0 release-blocker → P3 note-only).
- file:line anchored with code snippet quotes — actionable without re-running the audit.
- Per-module structure plus cross-module sections (coverage gaps, duplication candidates).

## How this PR fits the release plan

- PR #193 (merged → v1.37.5) resolved the 6 correctness P0s plus the catalog coverage-gap P0.
- The 9 documentation P0s are the input for fix-pack 2 (next PR).
- The 95 P1s + 263 P2/P3s are the v1.38 backlog input.

These reports are the durable record of which findings were generated, which were picked up, and which remain open. Diffing future audits against this baseline shows whether the rot rate is going up or down.

## Test plan

- [x] Documentation-only PR; no code change. No tests to run.
- [x] Markdown lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)