### PR TITLE
chore(feature): P1 sweep — 3 audit findings (docstrings + FK-classification coverage)

### DIFF
--- a/src/deriva_ml/core/mixins/feature.py
+++ b/src/deriva_ml/core/mixins/feature.py
@@ -454,10 +454,21 @@ class FeatureMixin:
                 ... ):
                 ...     print(f"{rec.Image}: {rec.Glaucoma} (by {rec.Execution})")
 
-            Filter by a specific workflow — works identically on a downloaded bag::
+            Filter by a specific workflow — works identically on a downloaded bag.
+            ``select_by_workflow`` takes a ``str`` (Workflow_Type name or
+            Workflow RID); the underlying ``list_workflow_executions``
+            call is ``@validate_call``'d to ``str`` and will reject a
+            ``Workflow`` object outright::
 
+                >>> # By Workflow_Type name (the common case):
+                >>> sel = FeatureRecord.select_by_workflow(  # doctest: +SKIP
+                ...     "Glaucoma_Training_v2", container=ml,
+                ... )
+                >>> # ... or by Workflow RID, when you need a specific run:
                 >>> workflow = ml.lookup_workflow("Glaucoma_Training_v2")  # doctest: +SKIP
-                >>> sel = FeatureRecord.select_by_workflow(workflow, container=ml)  # doctest: +SKIP
+                >>> sel = FeatureRecord.select_by_workflow(  # doctest: +SKIP
+                ...     workflow.rid, container=ml,
+                ... )
                 >>> labels = [r.Glaucoma for r in ml.feature_values(  # doctest: +SKIP
                 ...     "Image", "Glaucoma", selector=sel,
                 ... )]

--- a/src/deriva_ml/dataset/dataset.py
+++ b/src/deriva_ml/dataset/dataset.py
@@ -546,6 +546,17 @@ class Dataset:
                 ``DerivaML.feature_values``; raises
                 ``DerivaMLMaterializeLimitExceeded`` if exceeded.
                 Default ``None`` preserves unbounded behavior.
+
+                **The cap applies to the catalog query, not to the
+                dataset-filtered result.** ``Dataset.feature_values``
+                fetches every feature row from the catalog first, then
+                drops rows whose target RID isn't a dataset member.
+                A feature with ``10*N`` catalog rows where only ``N/2``
+                belong to this dataset will trip the limit at ``N``
+                even though the post-filter yield would be small.
+                To bound the dataset-scope output instead, leave
+                ``materialize_limit`` unset and consume the iterator
+                with ``itertools.islice``.
             execution_rids: Optional filter forwarded to the upstream
                 catalog query. When set, only feature rows whose
                 ``Execution`` value is in this list are materialized.

--- a/tests/feature/test_features.py
+++ b/tests/feature/test_features.py
@@ -128,6 +128,107 @@ class TestFeatures:
         assert len(image_quality_feature.term_columns()) == 1
         assert len(image_quality_feature.feature_columns()) == 1
 
+    def test_feature_init_classifies_columns_by_name_not_just_count(self, dataset_test, tmp_path):
+        """Inspect ``Feature.__init__``'s FK-classification by column name.
+
+        The existing ``test_create_feature`` only checks bucket
+        sizes. Bucket *contents* are uncovered: a regression that
+        swapped two columns between buckets (e.g. accidentally
+        put the structural ``Execution`` FK in ``value_columns``)
+        would pass that test while breaking selectors and asset
+        upload.
+
+        This test pins the classification by name:
+
+        1. Each known feature column lands in the named bucket.
+        2. The three structural FKs (``Execution``, ``Feature_Name``,
+           the target-table FK) are NOT in any of
+           ``asset_columns`` / ``term_columns`` / ``value_columns``.
+           See ``Feature.__init__``'s ``assoc_fkeys`` subtraction at
+           ``feature.py:546-558``.
+
+        Uses the demo catalog's three features (Health on Subject,
+        BoundingBox on Image, Quality on Image). Coverage gap from
+        audit P1 F-6.
+        """
+        ml_instance = DerivaML(
+            dataset_test.catalog.hostname,
+            dataset_test.catalog.catalog_id,
+            working_dir=tmp_path,
+            use_minid=False,
+        )
+
+        # --- Subject.Health: one term column, one value column,
+        # zero asset columns. The term column is the controlled-
+        # vocab FK ``SubjectHealth``; the value column is the
+        # int2 ``Scale`` metadata column (see demo_catalog.py's
+        # ``create_feature("Subject", "Health", terms=...,
+        # metadata=[ColumnDefinition("Scale", ...)])`` call).
+        health = next(
+            f for f in ml_instance.model.find_features("Subject")
+            if f.feature_name == "Health"
+        )
+        term_names = {c.name for c in health.term_columns}
+        value_names = {c.name for c in health.value_columns}
+        asset_names = {c.name for c in health.asset_columns}
+        assert term_names == {"SubjectHealth"}, (
+            f"Subject.Health.term_columns: expected {{'SubjectHealth'}}, "
+            f"got {term_names}."
+        )
+        assert value_names == {"Scale"}, (
+            f"Subject.Health.value_columns: expected {{'Scale'}}, "
+            f"got {value_names}."
+        )
+        assert asset_names == set()
+
+        # --- Image.BoundingBox: one asset column (the box-mask file),
+        # zero terms, zero plain values.
+        bbox = next(
+            f for f in ml_instance.model.find_features("Image")
+            if f.feature_name == "BoundingBox"
+        )
+        asset_names = {c.name for c in bbox.asset_columns}
+        assert len(asset_names) == 1, (
+            f"Image.BoundingBox.asset_columns: expected exactly one column; "
+            f"got {asset_names}."
+        )
+        assert {c.name for c in bbox.term_columns} == set()
+        assert {c.name for c in bbox.value_columns} == set()
+
+        # --- Image.Quality: one term column (the ImageQuality vocab FK),
+        # zero asset/value.
+        quality = next(
+            f for f in ml_instance.model.find_features("Image")
+            if f.feature_name == "Quality"
+        )
+        term_names = {c.name for c in quality.term_columns}
+        assert term_names == {"ImageQuality"}, (
+            f"Image.Quality.term_columns: expected {{'ImageQuality'}}, "
+            f"got {term_names}."
+        )
+        assert {c.name for c in quality.asset_columns} == set()
+        assert {c.name for c in quality.value_columns} == set()
+
+        # --- Structural FKs must not appear in ANY bucket.
+        # ``Feature.__init__`` subtracts them via ``assoc_fkeys``;
+        # this pin guards against a regression that drops the
+        # subtraction.
+        STRUCTURAL = {"Execution", "Feature_Name"}
+        for feat, target_fk in [(health, "Subject"), (bbox, "Image"), (quality, "Image")]:
+            all_buckets = (
+                {c.name for c in feat.asset_columns}
+                | {c.name for c in feat.term_columns}
+                | {c.name for c in feat.value_columns}
+            )
+            leaked = (STRUCTURAL | {target_fk}) & all_buckets
+            assert not leaked, (
+                f"{feat.target_table.name}.{feat.feature_name}: structural "
+                f"FK columns leaked into a classification bucket: {leaked}. "
+                f"Feature.__init__'s ``assoc_fkeys`` subtraction must "
+                f"remove every column whose FK constraint is part of the "
+                f"association table's primary key."
+            )
+
     def test_create_feature_with_non_asset_table_raises(self, test_ml):
         """create_feature surfaces the bad table name in the error.
 


### PR DESCRIPTION
## Summary

Second subsystem in the post-1.37.6 P1 sweep. Closes 3 of the 7 P1 findings in \`docs/audits/2026-05-22-engineer-audit-feature.md\`. Three small commits:

| Commit | Audit ID | What |
|---|---|---|
| 1 | F-7 | \`select_by_workflow\` docstring example was passing a \`Workflow\` object where the signature requires \`str\` — fixed example, named the constraint inline |
| 2 | F-13 | \`Dataset.feature_values\` \`materialize_limit\` cap applies to the catalog query, not the dataset-filtered result — added a clarifying paragraph + an \`itertools.islice\` pointer |
| 3 | F-6 | New live-catalog test pins \`Feature.__init__\` FK classification by column *name* (existing test only asserted counts) |

## Already-done audit P1s (not in this PR)

| ID | Where it landed |
|---|---|
| F-1 (\`select_majority_vote(column=None)\` indexes a set) | PR #193 |
| F-20 (auto-detect happy-path coverage) | PR #193 |
| F-14 / F-15 (\`DatasetBag.find_features(None)\` duplicates + missing test) | PR #193 (the P0s) |

## Deferred to a separate refactor PR

**F-8**: the group-by-target-RID + apply-selector + drop-None loop is duplicated across three modules (\`mixins/feature.py\`, \`dataset/dataset.py\`, \`dataset_bag.py\`). Extracting to a shared helper is a 3-file refactor with non-trivial blast radius — keeping it out of this scoped P1 sweep so the docstring/test fixes here can land cleanly. Tracking as the next PR after this merges.

## Test plan

- [x] \`uv run pytest tests/feature/ -v\` — 82 passed (live catalog at \`DERIVA_HOST=localhost\`).
- [x] The new \`test_feature_init_classifies_columns_by_name_not_just_count\` exercises Subject.Health (term + value), Image.BoundingBox (asset), Image.Quality (term) — covers all three demo-feature shapes plus the \`assoc_fkeys\` subtraction guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)