### PR TITLE
chore(dataset): P1 sweep — 2 correctness bugs + 1 cleanup

### DIFF
--- a/src/deriva_ml/dataset/dataset.py
+++ b/src/deriva_ml/dataset/dataset.py
@@ -1930,18 +1930,41 @@ class Dataset:
         """
         description = description or "Updated dataset via add_dataset_members"
 
-        def check_dataset_cycle(member_rid, path=None):
+        # Lazily compute the set of RIDs that would form a cycle if
+        # added as a member of this dataset: self.dataset_rid plus
+        # every descendant dataset's RID. ``list_dataset_children``
+        # already walks the descendant tree with built-in cycle
+        # protection, so we lean on it rather than re-implementing
+        # the walk here.
+        #
+        # The lazy ``_cycle_rids`` cell avoids paying the cost of
+        # the descendant walk when no Dataset-RID members are being
+        # added (the common case — most callers add ``Image`` or
+        # ``Subject`` rows, not nested datasets).
+        _cycle_rids_cache: set[RID] | None = None
+
+        def _get_cycle_rids() -> set[RID]:
+            nonlocal _cycle_rids_cache
+            if _cycle_rids_cache is None:
+                _cycle_rids_cache = {self.dataset_rid} | {
+                    child.dataset_rid
+                    for child in self.list_dataset_children(recurse=True)
+                }
+            return _cycle_rids_cache
+
+        def check_dataset_cycle(member_rid: RID) -> bool:
+            """True if adding ``member_rid`` as a nested dataset would form a cycle.
+
+            A cycle forms when ``member_rid`` is either this dataset
+            itself (direct self-reference) or one of its transitive
+            descendants. Pre-fix, this check did ``set(self.dataset_rid)``
+            on a string and matched on individual characters, which
+            could never detect a real cycle (RIDs are multi-character
+            strings, not single characters). See the workspace
+            CLAUDE.md "RIDs are opaque: equality only" rule —
+            ``set(rid_string)`` is parsing.
             """
-
-            Args:
-              member_rid:
-              path: (Default value = None)
-
-            Returns:
-
-            """
-            path = path or set(self.dataset_rid)
-            return member_rid in path
+            return member_rid in _get_cycle_rids()
 
         if validate:
             existing_rids = set(m["RID"] for ms in self.list_dataset_members().values() for m in ms)

--- a/src/deriva_ml/dataset/dataset.py
+++ b/src/deriva_ml/dataset/dataset.py
@@ -2810,7 +2810,12 @@ class Dataset:
         Returns:
             DerivaMLCatalog: Either a snapshot-bound catalog or the current catalog.
         """
-        if isinstance(dataset_version, str) and str:
+        # Empty-string ``dataset_version`` must skip the parse —
+        # ``DatasetVersion.parse("")`` raises. The original
+        # ``and str`` clause was a typo: ``str`` is the class and
+        # always truthy, so it never guarded anything. The intent
+        # is ``and dataset_version`` (non-empty string).
+        if isinstance(dataset_version, str) and dataset_version:
             dataset_version = DatasetVersion.parse(dataset_version)
         if dataset_version:
             return self._ml_instance.catalog_snapshot(self._version_snapshot_catalog_id(dataset_version))

--- a/src/deriva_ml/dataset/dataset_bag.py
+++ b/src/deriva_ml/dataset/dataset_bag.py
@@ -656,44 +656,6 @@ class DatasetBag:
             if chosen is not None:
                 yield chosen
 
-    def fetch_table_features(self, *args: Any, **kwargs: Any) -> None:
-        """Retired — use ``feature_values(table, name)`` or ``Denormalizer``.
-
-        ``DatasetBag.fetch_table_features`` has been removed. To read
-        feature values for a single feature, use :meth:`feature_values`::
-
-            for rec in bag.feature_values("Image", "Quality"):
-                ...
-
-        For wide-table denormalization across multiple features, use the
-        ``Denormalizer`` subsystem.
-
-        Raises:
-            DerivaMLException: Always. Points at the replacement API.
-        """
-        raise DerivaMLException(
-            "DatasetBag.fetch_table_features() has been retired. "
-            "Use feature_values(table, feature_name) to read a single feature, "
-            "or Denormalizer for multi-feature wide tables."
-        )
-
-    def list_feature_values(self, *args: Any, **kwargs: Any) -> None:
-        """Retired — renamed to :meth:`feature_values`.
-
-        ``DatasetBag.list_feature_values`` has been removed; use
-        :meth:`feature_values` (identical signature) instead::
-
-            for rec in bag.feature_values("Image", "Quality"):
-                ...
-
-        Raises:
-            DerivaMLException: Always. Points at the replacement API.
-        """
-        raise DerivaMLException(
-            "DatasetBag.list_feature_values() has been retired and renamed. "
-            "Use feature_values(table, feature_name, selector=...) instead."
-        )
-
     def lookup_feature(self, table: str | Table, feature_name: str) -> Feature:
         """Look up a feature definition from bag metadata — works fully offline.
 

--- a/tests/dataset/test_datasets.py
+++ b/tests/dataset/test_datasets.py
@@ -4,6 +4,8 @@ Tests for dataset functionality.
 
 from pprint import pformat
 
+import pytest
+
 try:
     from icecream import ic
 except ImportError:
@@ -16,6 +18,7 @@ from deriva_ml import (
     MLVocab,
     TableDefinition,
 )
+from deriva_ml.core.exceptions import DerivaMLException
 from deriva_ml.dataset.aux_classes import DatasetSpec
 from deriva_ml.dataset.bag_builder import DatasetBagBuilder
 from deriva_ml.demo_catalog import DatasetDescription
@@ -413,3 +416,67 @@ class TestDataset:
         execution_rids = {exe.execution_rid for exe in executions}
         assert execution1.execution_rid in execution_rids
         assert execution2.execution_rid in execution_rids
+
+    def test_add_dataset_members_rejects_self_reference_cycle(self, dataset_test, tmp_path):
+        """Adding a dataset as a member of itself raises a cycle exception.
+
+        Regression test for ``add_dataset_members``'s
+        ``check_dataset_cycle``. Pre-fix the check did
+        ``set(self.dataset_rid)`` on a multi-character string,
+        producing a character-set (e.g. ``{"4", "H", "M"}`` from
+        ``"4HM"``). The check could never detect a real
+        Dataset-RID cycle. Self-reference is the minimum-viable
+        cycle case; this test exercises it.
+        """
+        dset_description = dataset_test.dataset_description
+        parent = dset_description.dataset
+
+        with pytest.raises(DerivaMLException, match=r"cycle"):
+            parent.add_dataset_members(
+                members=[parent.dataset_rid],
+                description="self-reference must be refused",
+            )
+
+    def test_add_dataset_members_rejects_descendant_cycle(self, dataset_test, tmp_path):
+        """Adding a transitive descendant (grandchild) as a nested member raises.
+
+        Stricter than self-reference: the rebuilt cycle check
+        walks ``list_dataset_children(recurse=True)`` to gather
+        the full descendant set, so adding any RID already in
+        the subtree — not just a direct child — forms a cycle.
+
+        The demo fixture's outer dataset has grandchildren
+        (``double_nested → [training, testing] → [dataset, dataset]``).
+        We pick one of the grandchildren — not a direct member
+        of the outer, so the existing-member guard doesn't fire
+        first; the cycle guard is what catches the request.
+
+        Pre-fix this scenario passed silently because the cycle
+        check was the broken character-set match. Post-fix it
+        raises ``DerivaMLException`` with a cycle message.
+        """
+        dset_description = dataset_test.dataset_description
+        parent = dset_description.dataset
+
+        # Direct children (not useful — they're already members,
+        # so the existing-member guard would fire before the
+        # cycle guard).
+        direct_children_rids = {
+            child.dataset_rid for child in parent.list_dataset_children()
+        }
+        # All descendants (recursive).
+        all_descendants = parent.list_dataset_children(recurse=True)
+        # Grandchildren = descendants minus direct children.
+        grandchildren = [
+            d for d in all_descendants if d.dataset_rid not in direct_children_rids
+        ]
+        if not grandchildren:
+            pytest.skip("Fixture has no grandchild datasets to exercise the cycle path.")
+
+        grandchild_rid = grandchildren[0].dataset_rid
+
+        with pytest.raises(DerivaMLException, match=r"cycle"):
+            parent.add_dataset_members(
+                members=[grandchild_rid],
+                description="grandchild descendant must be refused as cycle",
+            )

--- a/tests/feature/test_retired_apis.py
+++ b/tests/feature/test_retired_apis.py
@@ -49,15 +49,23 @@ def test_ml_select_by_workflow_no_longer_exists(test_ml) -> None:
 
 # Bag-side retirements — use the materialized_bag_with_feature fixture from
 # tests/dataset/conftest.py (visible via pytest conftest discovery).
+#
+# These mirror the ml-side cleanup: the two ``DatasetBag`` tombstones
+# (``fetch_table_features``, ``list_feature_values``) were deleted outright
+# in the dataset/ P1 sweep. Callers now see a clean ``AttributeError``;
+# the replacement guidance lives in the changelog, not in a method body
+# that exists solely to raise.
 
 
-def test_bag_fetch_table_features_raises(materialized_bag_with_feature) -> None:
+def test_bag_fetch_table_features_no_longer_exists(materialized_bag_with_feature) -> None:
+    """The retired shim is gone; Python raises AttributeError."""
     bag = materialized_bag_with_feature.bag
-    with pytest.raises(DerivaMLException, match=r"feature_values|Denormalizer"):
+    with pytest.raises(AttributeError, match=r"fetch_table_features"):
         bag.fetch_table_features("Image")
 
 
-def test_bag_list_feature_values_raises(materialized_bag_with_feature) -> None:
+def test_bag_list_feature_values_no_longer_exists(materialized_bag_with_feature) -> None:
+    """The retired shim is gone; Python raises AttributeError."""
     bag = materialized_bag_with_feature.bag
-    with pytest.raises(DerivaMLException, match=r"feature_values"):
+    with pytest.raises(AttributeError, match=r"list_feature_values"):
         bag.list_feature_values("Image", "x")


### PR DESCRIPTION
## Summary

Fourth subsystem in the post-1.37.6 P1 sweep. Closes 3 of the 6 P1s in \`docs/audits/2026-05-22-engineer-audit-dataset.md\`. Three commits:

| Commit | Audit ID | Theme |
|---|---|---|
| 1 | (cycle check) | Correctness — \`add_dataset_members\` cycle check was structurally broken; rebuilt on a real graph walk |
| 2 | (typo) | Correctness — \`_version_snapshot_catalog\` had a dead \`and str:\` clause (always truthy); fixed to \`and dataset_version\` |
| 3 | (tombstones) | Cleanup — deleted \`DatasetBag.fetch_table_features\` and \`DatasetBag.list_feature_values\` retired stubs |

## Notable changes

### Cycle-check fix (real correctness bug)

The ``add_dataset_members`` cycle check did ``set(self.dataset_rid)`` on a multi-character RID string, producing a CHARACTER set (e.g. ``{"4", "H", "M"}`` from ``"4HM"``) instead of the intended singleton ``{"4HM"}``. The check could never detect a real Dataset-RID cycle. A user calling ``parent.add_dataset_members([parent.dataset_rid])`` silently created a Dataset_Dataset row pointing at itself.

Fix leverages the already-existing ``list_dataset_children(recurse=True)`` (which has its own cycle-protected graph walk) to compute the cycle-rid set lazily — callers adding non-Dataset members (the common case) don't pay the cost.

Two regression tests:
- ``test_add_dataset_members_rejects_self_reference_cycle`` — minimum-viable case.
- ``test_add_dataset_members_rejects_descendant_cycle`` — descendant (grandchild) chosen specifically to skip past the existing-member guard.

Both fail against pre-fix code (the cycle guard never fires); both pass post-fix.

### Tombstone cleanup

Matches the core/ P1 sweep precedent (PR #196) — same "no backwards-compat shims" rule, same flip-from-DerivaMLException-to-AttributeError pattern on the tests.

## Deferred to follow-up refactor PRs

Four god-function extractions and one selector-dedup are real refactors (~5–10 hours of careful work each). Splitting them out so the small correctness fixes here can ship fast:

| Audit ID | What | Why deferred |
|---|---|---|
| \`estimate_bag_size\` (220 LoC) | Extract 3 helpers (build queries, run queries, assemble result) | Refactor + async machinery + integration-test churn |
| \`get_dataset_minid\` (220 LoC) | Extract 4 tier helpers + shared MINID-builder | Refactor across the 3-tier cache logic |
| \`restructure_assets\` (~250 LoC body) | Extract \`_resolve_grouping_path\`, \`_place_asset\` | Pure-function refactor but big blast radius |
| \`split_dataset\` (~250 LoC body) | Extract \`_compute_partitions\` + \`_create_split_hierarchy\` | Two large helpers, four call paths to migrate |
| \`DatasetBag\` selector dedup | Joins the F-8 dedup backlog from the feature audit | Shared helper across 3 modules |

## Test plan

- [x] \`uv run pytest tests/dataset/test_datasets.py tests/feature/test_retired_apis.py -v\` — 19 passed (live catalog at \`DERIVA_HOST=localhost\`).
- [x] Cycle-check regression tests verified to fail against pre-fix code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)