### PR TITLE
chore(catalog): P1 sweep — 6 audit findings (docs + correctness + coverage)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -306,13 +306,17 @@ Import from: `from deriva_ml.interfaces import ...`
 
 ## Catalog Cloning
 
-**`create_ml_workspace`** (`src/deriva_ml/catalog/clone.py`): Creates partial catalog clones:
-- Three-stage approach: schema without FKs → async data copy → FK application with orphan handling
-- Export annotation parsing for guided table discovery
-- Orphan strategies: FAIL, DELETE, NULLIFY for incoherent row-level policies
-- Dataset version reinitialization with proper catalog snapshots
+**`clone_via_bag`** (`src/deriva_ml/catalog/clone_via_bag.py`): The current catalog-clone path. Builds a BDBag from the source catalog (using the export pipeline + an explicit traversal policy), then loads the bag into a schema-ready destination catalog via deriva-py's `BagCatalogLoader`. The legacy three-stage approach (schema without FKs → async data copy → FK application) was retired in v1.36.0 in favor of this single-call pipeline.
 
-**`localize_assets`** (`src/deriva_ml/catalog/localize.py`): Copies assets from source to local Hatrac after cloning with `asset_mode=REFERENCES`.
+Key parameters:
+- `root_rid` — anchor for the bag's content slice. Translated to a `RIDAnchor` and merged with the policy's existing anchors.
+- `policy` — `FKTraversalPolicy` controlling traversal scope and per-table behaviour. The caller's policy is merged with deriva-ml defaults (vocab export FULL, terminal tables {Execution, Workflow}, dangling FK strategy DELETE) — caller-provided non-default values win.
+- `asset_mode` — `AssetMode.UPLOAD` (default) copies asset bytes into the destination Hatrac; `AssetMode.ROWS_ONLY` skips asset upload (rows are still inserted with their source-Hatrac URLs); `AssetMode.REFERENCES` preserves source URLs for later localization.
+- `dangling_fk_strategy` — `FAIL` (refuse), `DELETE` (drop the row), or `NULLIFY` (set the FK column NULL).
+
+**`create_ml_workspace`** (`src/deriva_ml/catalog/clone.py`): Legacy wrapper preserved for callers that haven't migrated. Routes to `clone_via_bag` under the hood; several historical parameters (e.g., `reinitialize_dataset_versions`, `prune_hidden_fkeys`, `truncate_oversized`, `table_concurrency`, `copy_annotations`) are accepted-but-ignored and logged as deprecation warnings. New code should call `clone_via_bag` directly.
+
+**`localize_assets`** (`src/deriva_ml/catalog/localize.py`): Phase-2 leg of the split-phase clone. After a `clone_via_bag(asset_mode=REFERENCES)` (or `ROWS_ONLY`) leaves the destination with source-Hatrac URLs, `localize_assets` copies the bytes server-to-server (download from source, upload to dest) and rewrites the catalog rows to point at the destination Hatrac. Records phase-2 stats on the catalog provenance annotation.
 
 ### create_ml_schema CASCADE Warning
 

--- a/src/deriva_ml/catalog/clone.py
+++ b/src/deriva_ml/catalog/clone.py
@@ -119,7 +119,20 @@ def create_ml_workspace(
     Reimplementation of the legacy clone surface on top of the
     bag pipeline (ADR-0006). The parameter list matches the
     pre-migration signature for back-compat, but several knobs
-    are no longer load-bearing — see "Legacy parameters" below.
+    are no longer load-bearing.
+
+    **⚠ Legacy parameters (accepted, no-op, logged as warnings)**:
+    these belonged to the bespoke three-stage clone that was
+    retired in v1.36.0 and have no direct equivalents in the
+    bag pipeline. They're accepted so existing call-sites don't
+    error; explicit non-default values trigger a deprecation
+    warning. Each one is also marked inline below in the
+    ``Args:`` block with ``[NO-OP]``. The full set:
+    ``prune_hidden_fkeys``, ``truncate_oversized``,
+    ``reinitialize_dataset_versions``, ``table_concurrency``,
+    ``progress_callback``, ``copy_annotations``,
+    ``copy_policy``, ``add_ml_schema``, ``alias``,
+    ``include_associations``, ``include_vocabularies``.
 
     Args:
         source_hostname: Hostname of the source ERMrest server.
@@ -131,25 +144,43 @@ def create_ml_workspace(
             non-empty, treated as ``policy.schemas``. Each entry
             is parsed as ``"schema:table"`` and the schema name
             extracted.
+        include_associations: **[NO-OP]** Legacy; ignored.
+        include_vocabularies: **[NO-OP]** Legacy; ignored.
         exclude_objects: ``"schema:table"`` entries to exclude.
             Mapped to ``policy.exclude_tables``.
         exclude_schemas: Schemas to skip during the walk. Merged
             into ``policy.exclude_schemas``.
         dest_hostname: Destination hostname. Defaults to
             ``source_hostname`` (same-server clone).
+        alias: **[NO-OP]** Legacy; ignored.
+        add_ml_schema: **[NO-OP]** Legacy; ignored.
+        asset_mode: An :class:`AssetMode` value. Legacy string
+            spellings ``"refs"``/``"REFERENCES"`` map to
+            ``ROWS_ONLY`` and ``"full"``/``"FULL"`` maps to
+            ``UPLOAD_IF_MISSING`` via :func:`_coerce_asset_mode`.
+        copy_annotations: **[NO-OP]** Legacy; ignored.
+        copy_policy: **[NO-OP]** Legacy; ignored.
+        source_credential: Optional credential dict for the
+            source server. ``None`` triggers :func:`get_credential`
+            on ``source_hostname``.
+        dest_credential: Optional credential dict for the
+            destination server. ``None`` triggers
+            :func:`get_credential` on the destination hostname.
+        orphan_strategy: Maps to :attr:`FKTraversalPolicy.dangling_fk_strategy`.
+        prune_hidden_fkeys: **[NO-OP]** Legacy; ignored.
+        truncate_oversized: **[NO-OP]** Legacy; ignored.
+        reinitialize_dataset_versions: **[NO-OP]** Legacy;
+            ignored. The bag-pipeline clone preserves source-
+            catalog ``Dataset_Version`` rows verbatim. If you
+            need destination-snapshot re-seeding, do it
+            explicitly after the clone returns.
+        table_concurrency: **[NO-OP]** Legacy; ignored.
+        progress_callback: **[NO-OP]** Legacy; ignored.
         dest_catalog_id: Destination catalog ID. **Required** for
             the bag pipeline — the new path does not create the
             destination catalog. Use deriva-py's
             :meth:`DerivaServer.create_ermrest_catalog` separately
             if you need to materialize one.
-        asset_mode: An :class:`AssetMode` value. Legacy string
-            spellings ``"refs"``/``"REFERENCES"`` map to
-            ``ROWS_ONLY`` and ``"full"``/``"FULL"`` maps to
-            ``UPLOAD_IF_MISSING`` via :func:`_coerce_asset_mode`.
-        orphan_strategy: Maps to :attr:`FKTraversalPolicy.dangling_fk_strategy`.
-        source_credential, dest_credential: Optional credential
-            dicts. ``None`` triggers :func:`get_credential` on
-            the relevant hostname.
         output_dir: Where the intermediate bag lives. Defaults to
             ``./clone-{source_catalog_id}-to-{dest_catalog_id}/``.
 
@@ -157,17 +188,6 @@ def create_ml_workspace(
         :class:`~deriva_ml.catalog.clone_via_bag.CloneViaBagResult`
         from the underlying ``clone_via_bag`` call. **Not** the
         old ``CloneCatalogResult`` — that class no longer exists.
-
-    Legacy parameters (accepted, no-op, logged as warnings):
-        ``prune_hidden_fkeys``, ``truncate_oversized``,
-        ``reinitialize_dataset_versions``, ``table_concurrency``,
-        ``progress_callback``, ``copy_annotations``,
-        ``copy_policy``, ``add_ml_schema``, ``alias``,
-        ``include_associations``, ``include_vocabularies``.
-        These belonged to the bespoke three-stage clone and have
-        no direct equivalents in the bag pipeline. They're
-        accepted so existing call-sites don't error; explicit
-        non-default values trigger a deprecation warning.
 
     Raises:
         ValueError: If ``dest_catalog_id`` is not supplied (the

--- a/src/deriva_ml/catalog/localize.py
+++ b/src/deriva_ml/catalog/localize.py
@@ -44,6 +44,17 @@ class LocalizeResult(BaseModel):
         errors: List of error messages for failed assets.
         localized_assets: List of (RID, old_url, new_url) tuples for
             successfully localized assets.
+        source_hostnames: Set of hostnames the localized assets were
+            moved *from*. Populated per-asset as each localization
+            succeeds. Used by ``_record_localize_provenance`` to
+            decide what to write to the ``asset_source_hostname``
+            field: a single hostname when the slice was uniform-
+            sourced, or ``None`` (plus a log warning) when the
+            slice was mixed-source. Pre-fix, the provenance
+            annotation always carried the caller's
+            ``source_hostname`` parameter — which only describes
+            the fallback hostname for relative URLs, not the
+            actual source of each asset.
     """
 
     model_config = VALIDATION_CONFIG
@@ -53,6 +64,7 @@ class LocalizeResult(BaseModel):
     assets_failed: int = 0
     errors: list[str] = Field(default_factory=list)
     localized_assets: list[tuple[str, str, str]] = Field(default_factory=list)
+    source_hostnames: set[str] = Field(default_factory=set)
 
 
 def localize_assets(
@@ -359,6 +371,13 @@ def localize_assets(
                 logger.info("Localized asset %s: %s -> %s", rid, current_url, new_url)
                 result.assets_processed += 1
                 result.localized_assets.append((rid, current_url, new_url))
+                # Record the per-asset source for the provenance
+                # annotation. We aggregate into a set rather than
+                # writing the caller's ``source_hostname`` parameter
+                # (which is only the fallback for relative URLs)
+                # so a mixed-source slice is observable downstream.
+                if asset_src_host:
+                    result.source_hostnames.add(asset_src_host)
 
                 # Clean up scratch file
                 if local_file.exists():
@@ -396,10 +415,35 @@ def localize_assets(
     # clone_via_bag step wrote phase-1 provenance; we mutate it
     # rather than replace.
     if not dry_run:
+        # Resolve the source hostname based on what the per-asset
+        # walk actually observed, not the caller's
+        # ``source_hostname`` parameter (which is only the fallback
+        # used when the asset URL is relative). A uniform-sourced
+        # slice writes the single hostname; a mixed-source slice
+        # writes ``None`` + emits a warning so the annotation
+        # doesn't lie about which hostname the assets came from.
+        if len(result.source_hostnames) == 1:
+            resolved_source_hostname: str | None = next(iter(result.source_hostnames))
+        elif len(result.source_hostnames) > 1:
+            logger.warning(
+                "Mixed-source slice: assets came from %d distinct "
+                "hostnames %s; provenance annotation will record "
+                "asset_source_hostname=None.",
+                len(result.source_hostnames),
+                sorted(result.source_hostnames),
+            )
+            resolved_source_hostname = None
+        else:
+            # No assets actually localized (everything was
+            # skipped or failed). Fall back to the caller's
+            # ``source_hostname`` parameter so the annotation
+            # still carries useful context.
+            resolved_source_hostname = source_hostname
+
         _record_localize_provenance(
             ermrest_catalog,
             result=result,
-            asset_source_hostname=source_hostname,
+            asset_source_hostname=resolved_source_hostname,
         )
 
     return result

--- a/src/deriva_ml/catalog/provenance.py
+++ b/src/deriva_ml/catalog/provenance.py
@@ -114,7 +114,12 @@ class CloneDetails(BaseModel):
     add_ml_schema: bool = False
     copy_annotations: bool = True
     copy_policy: bool = True
-    reinitialize_dataset_versions: bool = True
+    # ``reinitialize_dataset_versions`` was a legacy field that
+    # was never populated. Deleted in the catalog/ P1 sweep
+    # (audit P1 1.4); ``create_ml_workspace`` still accepts the
+    # legacy kwarg of the same name as an accepted-but-ignored
+    # parameter, but the CloneDetails annotation no longer
+    # carries the field.
     rows_copied: int = 0
     rows_skipped: int = 0
     skipped_rids: list[str] = Field(default_factory=list)

--- a/tests/catalog/test_clone_via_bag.py
+++ b/tests/catalog/test_clone_via_bag.py
@@ -664,3 +664,161 @@ def test_expand_nested_dataset_anchors_no_children() -> None:
     anchors = [RIDAnchor(table="Dataset", rids=["L"])]
     expanded = _expand_nested_dataset_anchors(anchors, catalog)
     assert set(expanded[0].rids) == {"L"}
+
+
+# ---------------------------------------------------------------------------
+# Orphan-strategy behavioural coverage (audit P1 1.3)
+# ---------------------------------------------------------------------------
+#
+# Pre-fix, the orphan strategies (FAIL/DELETE/NULLIFY) had no
+# behavioural test: existing integration tests all use the DELETE
+# default, and ``test_clone_via_bag_preserves_explicit_fail_strategy``
+# pins only the policy-merge plumbing (the merged policy reaching
+# the builder). No test verified that non-zero orphan counters
+# from a real load actually surface on the destination's
+# provenance annotation.
+#
+# These tests close that gap by mocking ``BagCatalogLoader.run()``
+# to return a synthesized ``LoadReport`` with non-zero orphan
+# counters under each strategy, then asserting the
+# ``set_catalog_provenance`` call carries the expected
+# ``orphan_strategy`` + aggregated counters.
+
+
+def _make_load_report_with_orphans(
+    *,
+    total_rows: int,
+    rows_skipped_orphan: int = 0,
+    rows_nullified_orphan: int = 0,
+) -> MagicMock:
+    """Build a LoadReport-shaped mock with synthesized orphan counters.
+
+    The provenance writer reads ``total_rows_inserted`` and
+    iterates ``table_stats.values()`` summing
+    ``rows_skipped_orphan`` and ``rows_nullified_orphan``. We
+    pack everything into a single synthetic table stat for
+    simplicity.
+    """
+    report = MagicMock()
+    report.total_rows_inserted = total_rows
+    table_stat = MagicMock(spec=[])
+    table_stat.rows_skipped_orphan = rows_skipped_orphan
+    table_stat.rows_nullified_orphan = rows_nullified_orphan
+    report.table_stats = {"my_schema.SomeTable": table_stat}
+    return report
+
+
+def test_clone_via_bag_delete_strategy_surfaces_orphan_count_on_provenance(
+    tmp_path: Path,
+) -> None:
+    """``DanglingFKStrategy.DELETE`` + orphan rows → annotation reflects the count.
+
+    A clone whose load step drops orphan rows (because the FK
+    target was excluded from the slice, e.g.) must record the
+    aggregated count on the destination's provenance annotation.
+    A reader inspecting the catalog later sees "rows_copied=N,
+    orphan_rows_removed=K" and knows the clone was lossy under
+    the DELETE strategy.
+    """
+    fake_bag_path = tmp_path / "fake-bag"
+    fake_bag_path.mkdir()
+
+    fake_report = _make_load_report_with_orphans(
+        total_rows=100, rows_skipped_orphan=7
+    )
+
+    user_policy = FKTraversalPolicy(
+        dangling_fk_strategy=DanglingFKStrategy.DELETE,
+    )
+
+    with (
+        patch("deriva_ml.catalog.clone_via_bag.DerivaServer"),
+        patch(
+            "deriva_ml.catalog.clone_via_bag.get_credential",
+            return_value={},
+        ),
+        patch(
+            "deriva_ml.catalog.clone_via_bag.CatalogBagBuilder"
+        ) as MockBuilder,
+        patch(
+            "deriva_ml.catalog.clone_via_bag.BagCatalogLoader"
+        ) as MockLoader,
+        patch(
+            "deriva_ml.catalog.clone_via_bag.set_catalog_provenance"
+        ) as MockSetProv,
+    ):
+        MockBuilder.return_value.build.return_value = fake_bag_path
+        loader = MagicMock()
+        loader.run.return_value = fake_report
+        MockLoader.return_value.__enter__.return_value = loader
+
+        clone_via_bag(
+            source_hostname="src.example.org",
+            source_catalog_id="1",
+            dest_hostname="dst.example.org",
+            dest_catalog_id="42",
+            root_rid="ABC",
+            policy=user_policy,
+            output_dir=tmp_path,
+        )
+
+        MockSetProv.assert_called_once()
+        clone_details = MockSetProv.call_args.kwargs["clone_details"]
+        assert clone_details.orphan_strategy == "delete"
+        assert clone_details.orphan_rows_removed == 7
+        assert clone_details.orphan_rows_nullified == 0
+        assert clone_details.rows_copied == 100
+
+
+def test_clone_via_bag_nullify_strategy_surfaces_orphan_count_on_provenance(
+    tmp_path: Path,
+) -> None:
+    """``DanglingFKStrategy.NULLIFY`` + nullified rows → annotation reflects the count."""
+    fake_bag_path = tmp_path / "fake-bag"
+    fake_bag_path.mkdir()
+
+    fake_report = _make_load_report_with_orphans(
+        total_rows=50, rows_nullified_orphan=4
+    )
+
+    user_policy = FKTraversalPolicy(
+        dangling_fk_strategy=DanglingFKStrategy.NULLIFY,
+    )
+
+    with (
+        patch("deriva_ml.catalog.clone_via_bag.DerivaServer"),
+        patch(
+            "deriva_ml.catalog.clone_via_bag.get_credential",
+            return_value={},
+        ),
+        patch(
+            "deriva_ml.catalog.clone_via_bag.CatalogBagBuilder"
+        ) as MockBuilder,
+        patch(
+            "deriva_ml.catalog.clone_via_bag.BagCatalogLoader"
+        ) as MockLoader,
+        patch(
+            "deriva_ml.catalog.clone_via_bag.set_catalog_provenance"
+        ) as MockSetProv,
+    ):
+        MockBuilder.return_value.build.return_value = fake_bag_path
+        loader = MagicMock()
+        loader.run.return_value = fake_report
+        MockLoader.return_value.__enter__.return_value = loader
+
+        clone_via_bag(
+            source_hostname="src.example.org",
+            source_catalog_id="1",
+            dest_hostname="dst.example.org",
+            dest_catalog_id="42",
+            root_rid="ABC",
+            policy=user_policy,
+            output_dir=tmp_path,
+        )
+
+        MockSetProv.assert_called_once()
+        clone_details = MockSetProv.call_args.kwargs["clone_details"]
+        assert clone_details.orphan_strategy == "nullify"
+        assert clone_details.orphan_rows_nullified == 4
+        assert clone_details.orphan_rows_removed == 0
+        assert clone_details.rows_copied == 50

--- a/tests/catalog/test_clone_via_bag_helpers.py
+++ b/tests/catalog/test_clone_via_bag_helpers.py
@@ -1,0 +1,297 @@
+"""Unit tests for the three internal helpers in ``clone_via_bag.py``.
+
+Closes audit P1 1.2: ``_materialize_bag_dir``, ``_materialize_bag_assets``,
+and ``_record_clone_provenance`` had zero direct coverage. The
+existing ``tests/catalog/test_clone_via_bag.py`` covers the wrapper-
+level surface (policy merge, anchor expansion, credential lookup,
+nested-dataset expansion) but every uncovered branch in these
+three helpers (zip fallback, ambiguous extraction, missing
+fetch.txt, the orphan-stat aggregation loop, the orphan-strategy
+str-Enum coercion, the broad-except provenance guard) is unit-
+testable with a small filesystem + a ``MagicMock`` LoadReport.
+
+Pure-Python tests; no live catalog required.
+"""
+
+from __future__ import annotations
+
+import zipfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from deriva.bag.traversal import AssetMode, DanglingFKStrategy, FKTraversalPolicy
+
+from deriva_ml.catalog.clone_via_bag import (
+    _materialize_bag_assets,
+    _materialize_bag_dir,
+    _record_clone_provenance,
+)
+
+
+# ---------------------------------------------------------------------------
+# _materialize_bag_dir
+# ---------------------------------------------------------------------------
+
+
+class TestMaterializeBagDir:
+    """Exercise every branch of ``_materialize_bag_dir``.
+
+    The function decides between three outcomes:
+      * Bag directory already exists on disk → return it as-is.
+      * Bag directory absent but a sibling ``.zip`` exists → extract
+        the zip and return the unpacked directory.
+      * Neither exists, OR extraction yields an ambiguous set of
+        candidate directories → raise ``FileNotFoundError``.
+
+    All three were previously uncovered.
+    """
+
+    def test_returns_directory_when_already_unpacked(self, tmp_path: Path):
+        """If the bag directory exists on disk, the function is a no-op."""
+        bag = tmp_path / "my-bag"
+        bag.mkdir()
+        (bag / "bagit.txt").touch()  # token bag marker
+        result = _materialize_bag_dir(bag)
+        assert result == bag
+
+    def test_extracts_zip_when_directory_missing(self, tmp_path: Path):
+        """If only ``{bag}.zip`` exists, extract and return the unpacked dir.
+
+        ``CatalogBagBuilder`` hard-codes ``bag_archiver=zip`` and
+        removes the unpacked directory after archiving, so the
+        bag-pipeline arrives at this helper expecting it to recover
+        from the zip.
+        """
+        bag = tmp_path / "my-bag"  # directory will not exist
+        # Build a ``{bag}.zip`` that holds a single top-level dir
+        # matching ``bag.name`` — the canonical bdbag layout.
+        zip_path = bag.with_suffix(".zip")
+        with zipfile.ZipFile(zip_path, "w") as zf:
+            # bdbag emits one top-level dir + nested files.
+            zf.writestr(f"{bag.name}/bagit.txt", "BagIt-Version: 1.0\n")
+            zf.writestr(f"{bag.name}/data/.keep", "")
+
+        result = _materialize_bag_dir(bag)
+        assert result == bag
+        assert (bag / "bagit.txt").exists()
+
+    def test_raises_when_neither_directory_nor_zip_exists(self, tmp_path: Path):
+        """Both directory and zip absent → ``FileNotFoundError`` (loud)."""
+        missing = tmp_path / "does-not-exist"
+        with pytest.raises(FileNotFoundError, match=r"Bag missing.*no.*fallback"):
+            _materialize_bag_dir(missing)
+
+    def test_raises_when_zip_yields_ambiguous_candidates(self, tmp_path: Path):
+        """A zip that produces multiple top-level dirs has no clear bag.
+
+        bdbag's contract is one top-level dir per zip; a violation
+        of that means we can't pick which one is the bag, so we
+        refuse rather than guess. This branch was uncovered before
+        — a regression that loosens the heuristic (e.g., to "pick
+        the first one") would silently load arbitrary contents.
+        """
+        bag = tmp_path / "my-bag"  # not pre-extracted
+        zip_path = bag.with_suffix(".zip")
+        # Build a zip with TWO top-level dirs, neither named
+        # ``my-bag``. The extraction will leave both behind in
+        # ``tmp_path`` and the helper can't pick one.
+        with zipfile.ZipFile(zip_path, "w") as zf:
+            zf.writestr("first-dir/bagit.txt", "")
+            zf.writestr("second-dir/bagit.txt", "")
+        with pytest.raises(FileNotFoundError, match=r"Could not locate bag directory"):
+            _materialize_bag_dir(bag)
+
+
+# ---------------------------------------------------------------------------
+# _materialize_bag_assets
+# ---------------------------------------------------------------------------
+
+
+class TestMaterializeBagAssets:
+    """Exercise the skip-vs-materialize guard in ``_materialize_bag_assets``.
+
+    The function short-circuits when ``fetch.txt`` is absent or
+    empty. Otherwise it calls ``bdb.materialize(bag_path)``. Both
+    branches were uncovered before.
+    """
+
+    def test_skips_when_fetch_txt_absent(self, tmp_path: Path):
+        """No ``fetch.txt`` → no-op (no import of ``bdb``)."""
+        bag = tmp_path / "my-bag"
+        bag.mkdir()
+        # No fetch.txt at all. The helper should return without
+        # importing or calling ``bdb.materialize``.
+        with patch("bdbag.bdbag_api.materialize") as mock_materialize:
+            _materialize_bag_assets(bag)
+        mock_materialize.assert_not_called()
+
+    def test_skips_when_fetch_txt_empty(self, tmp_path: Path):
+        """Empty ``fetch.txt`` → no-op.
+
+        A zero-byte ``fetch.txt`` is the bdbag convention for
+        "no remote payloads to fetch"; the helper must not call
+        ``bdb.materialize`` (which would otherwise do a wasted
+        roundtrip).
+        """
+        bag = tmp_path / "my-bag"
+        bag.mkdir()
+        (bag / "fetch.txt").touch()  # zero-byte
+        with patch("bdbag.bdbag_api.materialize") as mock_materialize:
+            _materialize_bag_assets(bag)
+        mock_materialize.assert_not_called()
+
+    def test_calls_materialize_when_fetch_txt_has_entries(self, tmp_path: Path):
+        """Non-empty ``fetch.txt`` → ``bdb.materialize(bag_path)`` is called."""
+        bag = tmp_path / "my-bag"
+        bag.mkdir()
+        # Non-empty fetch.txt — one line is enough.
+        (bag / "fetch.txt").write_text(
+            "https://example.org/hatrac/x\t1024\tdata/asset/x.bin\n"
+        )
+        with patch("bdbag.bdbag_api.materialize") as mock_materialize:
+            _materialize_bag_assets(bag)
+        mock_materialize.assert_called_once_with(str(bag))
+
+
+# ---------------------------------------------------------------------------
+# _record_clone_provenance
+# ---------------------------------------------------------------------------
+
+
+def _make_load_report(
+    *,
+    total_rows: int = 100,
+    per_table_orphans: dict[str, dict[str, int]] | None = None,
+) -> MagicMock:
+    """Build a minimal LoadReport-shaped mock.
+
+    The helper reads:
+      - ``report.total_rows_inserted`` (an int)
+      - ``report.table_stats`` — a dict from table-name to a
+        per-table stats object that ``getattr`` reads for
+        ``rows_skipped_orphan`` and ``rows_nullified_orphan``
+        (both default to 0 when absent).
+    """
+    report = MagicMock()
+    report.total_rows_inserted = total_rows
+    table_stats: dict[str, MagicMock] = {}
+    for table_name, counts in (per_table_orphans or {}).items():
+        ts = MagicMock(spec=[])  # spec=[] so getattr defaults work
+        for key, value in counts.items():
+            setattr(ts, key, value)
+        table_stats[table_name] = ts
+    report.table_stats = table_stats
+    return report
+
+
+class TestRecordCloneProvenance:
+    """Exercise ``_record_clone_provenance`` against mock catalogs + reports.
+
+    The helper does three things:
+      1. Aggregates orphan counters across tables.
+      2. Coerces the policy's str-Enums (``dangling_fk_strategy``,
+         ``asset_mode``) into the lowercase suffix.
+      3. Calls ``set_catalog_provenance`` with a built ``CloneDetails``.
+
+    Each branch was uncovered before.
+    """
+
+    def test_aggregates_orphan_stats_across_tables(self):
+        """Per-table orphan counters are summed."""
+        report = _make_load_report(
+            total_rows=200,
+            per_table_orphans={
+                "Image": {"rows_skipped_orphan": 5, "rows_nullified_orphan": 0},
+                "Subject": {"rows_skipped_orphan": 3, "rows_nullified_orphan": 2},
+                "Observation": {"rows_skipped_orphan": 0, "rows_nullified_orphan": 7},
+            },
+        )
+        policy = FKTraversalPolicy(
+            dangling_fk_strategy=DanglingFKStrategy.NULLIFY,
+            asset_mode=AssetMode.ROWS_ONLY,
+        )
+        dest_catalog = MagicMock()
+
+        with patch(
+            "deriva_ml.catalog.clone_via_bag.set_catalog_provenance"
+        ) as mock_set:
+            _record_clone_provenance(
+                dest_catalog=dest_catalog,
+                source_hostname="src.example.org",
+                source_catalog_id="42",
+                policy=policy,
+                report=report,
+            )
+
+        mock_set.assert_called_once()
+        clone_details = mock_set.call_args.kwargs["clone_details"]
+        assert clone_details.rows_copied == 200
+        assert clone_details.orphan_rows_removed == 5 + 3 + 0
+        assert clone_details.orphan_rows_nullified == 0 + 2 + 7
+
+    def test_str_enum_coercion_uses_lowercase_suffix(self):
+        """Policy str-Enums are coerced to the lowercase suffix.
+
+        ``DanglingFKStrategy.NULLIFY`` → ``"nullify"``;
+        ``AssetMode.UPLOAD_IF_MISSING`` → ``"upload_if_missing"``.
+        Pre-fix this was uncovered; a regression in
+        ``str(policy.X).split(".")[-1].lower()`` would silently
+        write the full ``"DanglingFKStrategy.NULLIFY"`` string
+        into the annotation.
+        """
+        report = _make_load_report(total_rows=10)
+        policy = FKTraversalPolicy(
+            dangling_fk_strategy=DanglingFKStrategy.NULLIFY,
+            asset_mode=AssetMode.UPLOAD_IF_MISSING,
+        )
+        dest_catalog = MagicMock()
+
+        with patch(
+            "deriva_ml.catalog.clone_via_bag.set_catalog_provenance"
+        ) as mock_set:
+            _record_clone_provenance(
+                dest_catalog=dest_catalog,
+                source_hostname="src.example.org",
+                source_catalog_id="42",
+                policy=policy,
+                report=report,
+            )
+
+        clone_details = mock_set.call_args.kwargs["clone_details"]
+        assert clone_details.orphan_strategy == "nullify"
+        assert clone_details.asset_mode == "upload_if_missing"
+
+    def test_swallows_unexpected_report_shape(self):
+        """A report missing attributes does not abort the clone.
+
+        The helper's broad ``except Exception`` is the safety net
+        for "set_catalog_provenance failed" / "LoadReport shape
+        regressed" — provenance writes are best-effort and must
+        not break a successful clone. Pre-fix the broad-except
+        branch was untested.
+        """
+        broken_report = MagicMock()
+        # No total_rows_inserted, no table_stats — getattr falls
+        # through; the explicit attribute reads raise AttributeError.
+        del broken_report.table_stats
+        del broken_report.total_rows_inserted
+
+        policy = FKTraversalPolicy()
+        dest_catalog = MagicMock()
+
+        # The function should not raise — it logs and continues.
+        with patch(
+            "deriva_ml.catalog.clone_via_bag.set_catalog_provenance"
+        ) as mock_set:
+            _record_clone_provenance(
+                dest_catalog=dest_catalog,
+                source_hostname="src.example.org",
+                source_catalog_id="42",
+                policy=policy,
+                report=broken_report,
+            )
+
+        # The set call never happened (we crashed before getting
+        # to it) — which is fine, the helper swallowed the error.
+        mock_set.assert_not_called()

--- a/tests/catalog/test_localize.py
+++ b/tests/catalog/test_localize.py
@@ -28,6 +28,27 @@ def test_localize_result_defaults() -> None:
     assert result.assets_failed == 0
     assert result.errors == []
     assert result.localized_assets == []
+    assert result.source_hostnames == set()
+
+
+def test_localize_result_source_hostnames_accumulate_per_asset() -> None:
+    """``source_hostnames`` accumulates the per-asset source hostnames.
+
+    Pre-fix, ``_record_localize_provenance`` was called with the
+    caller's ``source_hostname`` parameter — only the fallback
+    used for relative URLs — and silently wrote a single
+    hostname even on mixed-source slices. The aggregated set
+    on ``LocalizeResult`` is the per-asset truth that
+    ``localize_assets`` now feeds to provenance.
+    """
+    result = LocalizeResult()
+    result.source_hostnames.add("source-a.example.org")
+    result.source_hostnames.add("source-b.example.org")
+    result.source_hostnames.add("source-a.example.org")  # duplicate, set absorbs
+    assert result.source_hostnames == {
+        "source-a.example.org",
+        "source-b.example.org",
+    }
 
 
 def test_localize_result_round_trip() -> None:
@@ -40,6 +61,7 @@ def test_localize_result_round_trip() -> None:
         localized_assets=[
             ("1-ABC", "https://src/hatrac/x", "https://dst/hatrac/y"),
         ],
+        source_hostnames={"source-a.example.org", "source-b.example.org"},
     )
     dumped = original.model_dump(mode="json")
     restored = LocalizeResult.model_validate(dumped)


### PR DESCRIPTION
## Summary

Fifth subsystem in the post-1.37.6 P1 sweep. Closes all 6 P1s in \`docs/audits/2026-05-22-engineer-audit-catalog.md\`. Three themed commits:

| Commit | Audit IDs | Theme |
|---|---|---|
| 1 | 4.1, 4.2 | Docs rot — CLAUDE.md "Catalog Cloning" rewritten on the bag pipeline; \`create_ml_workspace\` docstring restructured with \`[NO-OP]\` markers on every legacy parameter |
| 2 | 1.4, 3.5 | Correctness — per-asset source hostname tracked on \`LocalizeResult\`; dead \`CloneDetails.reinitialize_dataset_versions\` field deleted |
| 3 | 1.2, 1.3 | Coverage — 10 new unit tests for the three internal helpers in \`clone_via_bag.py\`; 2 new tests for orphan-strategy behaviour |

## Notable changes

### Per-asset source-hostname tracking (3.5)

Pre-fix, \`_record_localize_provenance\` was called with the caller's \`source_hostname\` parameter — only the **fallback** for relative URLs, not the actual source of each asset. In a mixed-source slice (different assets from different upstream hosts), the catalog provenance annotation reported a single hostname that didn't describe the localization correctly.

Fix: \`LocalizeResult\` gains a \`source_hostnames: set[str]\` field; the per-asset loop adds each \`asset_src_host\` to it on successful localization. Before writing the annotation, \`localize_assets\` resolves the hostname based on what was actually observed:
- Single hostname → write it.
- Multiple hostnames → write \`None\` + emit a WARNING log naming the count and sorted list.
- Empty set (nothing localized) → fall back to the caller's parameter.

### \`reinitialize_dataset_versions\` dead-field deletion (1.4)

\`CloneDetails.reinitialize_dataset_versions\` was a boolean declared on the provenance dataclass but never written by any code path. Pure dead surface. Deleted the field; the legacy parameter on \`create_ml_workspace\` is kept as-is (audit P1 4.2's docstring restructure already marks it \`[NO-OP]\`).

### CLAUDE.md catalog-cloning rewrite (4.1)

The "Three-stage approach" description still in CLAUDE.md was retired in v1.36.0. A new contributor reading it would expect logic in \`clone.py\` that doesn't exist. Rewrote the subsection to lead with \`clone_via_bag\` as the canonical entry point, document its key parameters, and frame \`create_ml_workspace\` accurately as a legacy wrapper.

### Helper-test coverage (1.2)

Three internal helpers (\`_materialize_bag_dir\`, \`_materialize_bag_assets\`, \`_record_clone_provenance\`) had zero direct coverage. New \`tests/catalog/test_clone_via_bag_helpers.py\` (10 tests) exercises every branch: zip-fallback extraction, ambiguous-extraction error, the fetch.txt skip-vs-materialize guard, orphan-stat aggregation, str-Enum coercion, and the broad-except provenance guard.

### Orphan-strategy behavioural coverage (1.3)

Existing integration tests all use the default DELETE strategy; the existing FAIL test pinned policy-merge plumbing only, not behaviour. Added two new tests that mock \`BagCatalogLoader.run()\` to return synthesized LoadReports with non-zero \`rows_skipped_orphan\` / \`rows_nullified_orphan\` counters, then assert the \`set_catalog_provenance\` call carries the expected aggregated counts.

## Test plan

- [x] \`uv run pytest tests/catalog/\` — 68 passed (live catalog at \`DERIVA_HOST=localhost\`).
- [x] \`tests/catalog/test_clone_via_bag.py + test_clone_via_bag_helpers.py + test_localize.py\` — 40 passed (pure-Python unit tests, no DERIVA_HOST needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)