### PR TITLE
chore(execution): P1 sweep (part 1) — 9 audit findings (correctness + coverage)

### DIFF
--- a/src/deriva_ml/execution/execution.py
+++ b/src/deriva_ml/execution/execution.py
@@ -520,7 +520,23 @@ class Execution:
         # self.uploaded_assets intentionally not set — they are all
         # read-through properties backed by SQLite / the asset manifest.
         instance._execution_record = None
+        # Pull ``workflow_rid`` from the registry row. The SQLite
+        # row carries it (see ``state_store.executions.workflow_rid``);
+        # leaving it None silently breaks downstream code that
+        # relies on ``execution.workflow_rid`` (notably
+        # ``add_workflow_executions`` linkage during nested-execution
+        # attach). Best-effort: if the registry lookup fails or
+        # returns None, leave it None — but we try.
         instance.workflow_rid = None
+        try:
+            row = ml_object.workspace.execution_state_store().get_execution(execution_rid)
+            if row is not None:
+                instance.workflow_rid = row.get("workflow_rid")
+        except Exception:
+            # The registry read can fail in odd offline-mode tests
+            # or partially-initialized fixtures; preserve the
+            # legacy ``None`` rather than refuse to construct.
+            pass
         return instance
 
     def _save_runtime_environment(self):
@@ -1946,8 +1962,16 @@ class Execution:
         asset_table = self._model.name_to_table(asset_name)
         schema = asset_table.schema.name
 
-        # Validate and normalize asset types
-        asset_types = asset_types or kwargs.pop("Asset_Type", None) or asset_name
+        # Validate and normalize asset types. Use ``is None`` rather
+        # than ``or`` so an explicit ``asset_types=[]`` (the user
+        # saying "no content tags") is honored as-is — the previous
+        # ``or`` chain collapsed an empty list to ``asset_name`` and
+        # then ``lookup_term`` would fail on the table name. The
+        # legacy ``Asset_Type`` kwarg keeps its fallback role.
+        if asset_types is None:
+            asset_types = kwargs.pop("Asset_Type", None)
+            if asset_types is None:
+                asset_types = asset_name
         asset_types = [asset_types] if isinstance(asset_types, str) else asset_types
         for t in asset_types:
             self._ml_object.lookup_term(MLVocab.asset_type, t)

--- a/src/deriva_ml/execution/runner.py
+++ b/src/deriva_ml/execution/runner.py
@@ -143,6 +143,7 @@ See Also
 from __future__ import annotations
 
 import atexit
+import dataclasses
 import inspect
 import logging
 from pathlib import Path
@@ -172,12 +173,20 @@ T = TypeVar("T", bound="DerivaML")
 # =============================================================================
 
 
+@dataclasses.dataclass
 class MultirunState:
     """Manages state for multirun (sweep) executions.
 
     In multirun mode, we create a parent execution that groups all the
     individual sweep jobs. This class holds the shared state needed to
     coordinate between jobs.
+
+    A ``@dataclass`` (instance fields) rather than the previous
+    plain class with class-level defaults — the latter pattern
+    silently shared state through the class object if anyone
+    instantiated a second ``MultirunState`` or subclassed it.
+    The module-level singleton ``_multirun_state`` is the
+    documented usage, so instance-level fields match intent.
 
     Attributes:
         parent_execution_rid: RID of the parent execution (created on first job)
@@ -256,8 +265,17 @@ def _complete_parent_execution() -> None:
             f"Completed parent execution: {_multirun_state.parent_execution_rid} "
             f"({_multirun_state.job_sequence} child jobs)"
         )
-    except Exception as e:
-        logging.warning(f"Failed to complete parent execution: {e}")
+    except Exception:
+        # Log with full stack so a swallowed atexit failure is
+        # at least debuggable from logs. Pre-fix this used
+        # ``logging.warning(f"... {e}")`` which lost the
+        # traceback — an operator seeing the warning had no
+        # way to know what failed inside the upload (catalog
+        # error, network, state machine refusal, etc.).
+        # ``logging.exception`` is bound to the WARNING level
+        # of the root logger by default for this call (see
+        # the ``exc_info=True`` semantics in stdlib logging).
+        logging.exception("Failed to complete parent execution.")
     finally:
         # Clear the state
         reset_multirun_state()

--- a/src/deriva_ml/execution/workflow.py
+++ b/src/deriva_ml/execution/workflow.py
@@ -469,6 +469,15 @@ class Workflow(BaseModel):
             >>> print(f"URL: {url}")
             >>> print(f"Checksum: {checksum}")
         """
+        # The "must be inside a git checkout" guard is a precondition
+        # for honest provenance. But ``allow_dirty=True`` is the
+        # documented escape hatch for ad-hoc / dry-run / notebook
+        # workflows that don't need a clean checkout — refusing to
+        # run those because the cwd isn't inside git defeats the
+        # intent of the flag. When ``allow_dirty=True``, downgrade
+        # the no-git precondition to a warning and return empty
+        # provenance (URL/checksum both empty strings); when False
+        # (the default), keep the hard refuse.
         try:
             subprocess.run(
                 ["git", "rev-parse", "--is-inside-work-tree"],
@@ -477,6 +486,13 @@ class Workflow(BaseModel):
                 check=True,
             )
         except subprocess.CalledProcessError:
+            if allow_dirty:
+                logger.warning(
+                    "Not executing in a Git repository; allow_dirty=True, "
+                    "returning empty URL/checksum. Provenance will not be "
+                    "recoverable for this workflow."
+                )
+                return "", ""
             raise DerivaMLException("Not executing in a Git repository.")
 
         github_url, is_dirty = Workflow._github_url(executable_path)
@@ -609,12 +625,20 @@ class Workflow(BaseModel):
         # Get repo URL from local GitHub repo.
         if executable_path == "REPL":
             return "REPL", True
+        # ``check=True`` is load-bearing: without it ``subprocess.run``
+        # never raises, ``result.stdout`` for a missing ``origin``
+        # remote is an empty string, and ``github_url`` becomes
+        # ``""`` — silently recorded as provenance pointing at
+        # ``/blob/<sha>/<path>`` with no host. The
+        # ``CalledProcessError`` catch was unreachable until this
+        # flag was added.
         try:
             result = subprocess.run(
                 ["git", "remote", "get-url", "origin"],
                 capture_output=True,
                 text=True,
                 cwd=executable_path.parent,
+                check=True,
             )
             github_url = result.stdout.strip().removesuffix(".git")
         except subprocess.CalledProcessError:
@@ -653,8 +677,13 @@ class Workflow(BaseModel):
         except subprocess.CalledProcessError:
             is_dirty = False  # If the Git command fails, assume no changes
 
-        """Get SHA-1 hash of latest commit of the file in the repository"""
-
+        # Get SHA-1 hash of latest commit of the file in the
+        # repository. ``check=False`` here is deliberate: a file
+        # that has never been committed (a new script in a worktree
+        # the user is iterating on) legitimately has no log; the
+        # empty ``sha`` string yields a URL pointing at ``/blob//``,
+        # which the dirty-flow already treats as a non-clean
+        # provenance signal upstream.
         result = subprocess.run(
             ["git", "log", "-n", "1", "--pretty=format:%H", executable_path],
             cwd=repo_root,

--- a/tests/execution/test_environment.py
+++ b/tests/execution/test_environment.py
@@ -1,0 +1,127 @@
+"""Smoke tests for ``deriva_ml.execution.environment`` (audit P1 coverage gap).
+
+The functions in this module are called on every execution and
+their output is serialized as a metadata asset. A platform-
+specific edge case (e.g., ``os.getlogin()`` raising on a
+container with no login session) would crash every execution.
+Pre-fix, none of these helpers were tested at all.
+
+These tests pin the basic shape invariants: each helper returns
+a dict / int with the documented keys, and the aggregate
+``get_execution_environment`` is JSON-serializable end-to-end.
+
+Pure-Python tests; no live catalog required.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from deriva_ml.execution.environment import (
+    get_execution_environment,
+    get_loaded_modules,
+    get_os_info,
+    get_platform_info,
+    get_site_info,
+    get_sys_info,
+    get_umask,
+)
+
+
+class TestGetLoadedModules:
+    def test_returns_dict_of_str_to_str(self):
+        modules = get_loaded_modules()
+        assert isinstance(modules, dict)
+        for name, version in modules.items():
+            assert isinstance(name, str)
+            assert isinstance(version, str)
+
+    def test_includes_deriva_ml_itself(self):
+        """The function lists installed distributions; deriva-ml is one."""
+        modules = get_loaded_modules()
+        # Name match is exact-case as importlib.metadata reports it.
+        # ``deriva-ml`` is the distribution name in pyproject.toml.
+        assert "deriva-ml" in modules
+
+
+class TestGetOsInfo:
+    def test_returns_dict_with_basic_keys(self):
+        info = get_os_info()
+        assert isinstance(info, dict)
+        # The keys vary by platform but the dict should be
+        # non-empty on every supported runtime.
+        assert info, f"get_os_info returned empty dict — likely a platform edge case: {info}"
+
+
+class TestGetPlatformInfo:
+    def test_returns_dict_with_documented_keys(self):
+        info = get_platform_info()
+        assert isinstance(info, dict)
+        # Documented in the docstring as always-present:
+        for key in ("system", "release", "version", "machine", "processor"):
+            assert key in info, f"get_platform_info missing key {key!r}: {info}"
+
+
+class TestGetSiteInfo:
+    def test_returns_documented_keys(self):
+        info = get_site_info()
+        assert isinstance(info, dict)
+        for key in ("PREFIXES", "ENABLE_USER_SITE", "USER_SITE", "USER_BASE"):
+            assert key in info, f"get_site_info missing key {key!r}: {info}"
+
+
+class TestGetSysInfo:
+    def test_returns_dict(self):
+        """``get_sys_info`` returns a non-empty dict of interpreter state."""
+        info = get_sys_info()
+        assert isinstance(info, dict)
+        assert info, "get_sys_info returned empty dict"
+
+
+class TestGetUmask:
+    def test_returns_non_negative_int(self):
+        """``get_umask`` returns the current umask without leaving the
+        process umask permanently changed.
+
+        Implementation uses ``os.umask(0); os.umask(saved)`` — if a
+        regression dropped the restore, every execution would
+        permanently clobber the process umask. We can't observe
+        side-effects perfectly here (the test runs after the
+        function), but we can check the return contract.
+        """
+        before = get_umask()
+        after = get_umask()
+        assert isinstance(before, int)
+        assert before >= 0
+        # Two consecutive calls should return the same value
+        # (function doesn't leak the umask).
+        assert before == after
+
+
+class TestGetExecutionEnvironment:
+    def test_returns_top_level_keys(self):
+        """``get_execution_environment`` aggregates the six sources."""
+        env = get_execution_environment()
+        assert isinstance(env, dict)
+        for key in ("imports", "os", "sys", "sys_path", "site", "platform"):
+            assert key in env, (
+                f"get_execution_environment missing aggregate key {key!r}: "
+                f"keys present = {sorted(env.keys())}"
+            )
+
+    def test_is_json_serializable(self):
+        """The aggregate must serialize to JSON — it's saved as a metadata asset.
+
+        ``json.dumps(env, default=str)`` is the actual serialization
+        path used downstream; pin that it doesn't raise. Using
+        ``default=str`` is the function-under-test's documented
+        coping mechanism for non-JSON-serializable values (e.g.,
+        Path objects); we mirror it here.
+        """
+        env = get_execution_environment()
+        try:
+            json.dumps(env, default=str)
+        except TypeError as e:
+            pytest.fail(f"get_execution_environment is not JSON-serializable: {e}")

--- a/tests/execution/test_multirun_config.py
+++ b/tests/execution/test_multirun_config.py
@@ -1,0 +1,142 @@
+"""Tests for ``deriva_ml.execution.multirun_config`` (audit P1 coverage gap).
+
+Pre-fix, none of the public functions in this module were tested.
+A typo or re-architecting would land silently. This file pins the
+register / lookup / list / get-all surface plus the per-name
+isolation contract.
+
+Pure-Python tests; no live catalog required.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from deriva_ml.execution.multirun_config import (
+    MultirunSpec,
+    get_all_multirun_configs,
+    get_multirun_config,
+    list_multirun_configs,
+    multirun_config,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry():
+    """Clear the module-level registry between tests.
+
+    ``multirun_config`` registers into a process-global dict;
+    without resetting between tests, a registration from an
+    earlier test leaks into later tests (silent name collisions,
+    flaky asserts). The autouse fixture clears both the
+    pre-test state (so tests start from empty) and the
+    post-test state (so leftover registrations don't bleed into
+    the wider test run).
+    """
+    # NOTE: ``from deriva_ml.execution import multirun_config``
+    # at module top imports the FUNCTION (the package __init__
+    # re-exports it under the same name as the module). The
+    # function shadows the submodule on the package namespace,
+    # so we have to reach into ``sys.modules`` to get the
+    # actual module object that carries the private registry.
+    import sys
+
+    mod = sys.modules["deriva_ml.execution.multirun_config"]
+
+    saved = dict(mod._multirun_registry)
+    mod._multirun_registry.clear()
+    yield
+    mod._multirun_registry.clear()
+    mod._multirun_registry.update(saved)
+
+
+class TestMultirunConfigRegister:
+    """``multirun_config()`` registers a spec and returns it."""
+
+    def test_register_returns_a_multirun_spec(self):
+        spec = multirun_config(
+            "lr_sweep",
+            overrides=["model.lr=0.01,0.1"],
+            description="LR sweep",
+        )
+        assert isinstance(spec, MultirunSpec)
+        assert spec.name == "lr_sweep"
+        assert spec.overrides == ["model.lr=0.01,0.1"]
+        assert spec.description == "LR sweep"
+
+    def test_register_lands_in_lookup(self):
+        """A registered spec is retrievable by name."""
+        multirun_config("epoch_sweep", overrides=["model.epochs=5,10"])
+        assert get_multirun_config("epoch_sweep") is not None
+        assert get_multirun_config("epoch_sweep").overrides == ["model.epochs=5,10"]
+
+    def test_register_overwrites_existing_name(self):
+        """Re-registering the same name replaces the previous spec.
+
+        Pin the semantic so a future change that silently warns
+        instead of overwriting (or vice versa) doesn't ship
+        unnoticed.
+        """
+        multirun_config("dup", overrides=["a=1"])
+        multirun_config("dup", overrides=["a=2"])
+        result = get_multirun_config("dup")
+        assert result is not None
+        assert result.overrides == ["a=2"]
+
+    def test_register_with_empty_description(self):
+        """``description`` defaults to empty string."""
+        spec = multirun_config("no_desc", overrides=["x=1"])
+        assert spec.description == ""
+
+
+class TestMultirunConfigLookup:
+    """``get_multirun_config()`` returns the spec or None."""
+
+    def test_unknown_name_returns_none(self):
+        """Lookup of an unregistered name returns ``None``, doesn't raise."""
+        assert get_multirun_config("never_registered") is None
+
+    def test_known_name_returns_spec(self):
+        multirun_config("known", overrides=["x=1"])
+        spec = get_multirun_config("known")
+        assert isinstance(spec, MultirunSpec)
+        assert spec.name == "known"
+
+
+class TestMultirunConfigList:
+    """``list_multirun_configs()`` lists registered names."""
+
+    def test_empty_registry_returns_empty_list(self):
+        """With an empty registry, the listing is ``[]``."""
+        assert list_multirun_configs() == []
+
+    def test_lists_all_registered_names(self):
+        multirun_config("a", overrides=["x=1"])
+        multirun_config("b", overrides=["y=2"])
+        multirun_config("c", overrides=["z=3"])
+        assert set(list_multirun_configs()) == {"a", "b", "c"}
+
+
+class TestMultirunConfigGetAll:
+    """``get_all_multirun_configs()`` returns a defensive copy."""
+
+    def test_returns_dict_of_specs(self):
+        multirun_config("a", overrides=["x=1"])
+        multirun_config("b", overrides=["y=2"])
+        all_configs = get_all_multirun_configs()
+        assert set(all_configs.keys()) == {"a", "b"}
+        for spec in all_configs.values():
+            assert isinstance(spec, MultirunSpec)
+
+    def test_returned_dict_is_a_copy(self):
+        """Mutating the returned dict doesn't affect the registry.
+
+        The function calls ``dict(self._multirun_registry)`` to
+        return a defensive copy; callers shouldn't be able to
+        scribble into the registry through the returned reference.
+        """
+        multirun_config("a", overrides=["x=1"])
+        all_configs = get_all_multirun_configs()
+        all_configs.pop("a")
+        # Registry still has "a".
+        assert get_multirun_config("a") is not None


### PR DESCRIPTION
## Summary

Eighth subsystem in the post-1.37.6 P1 sweep, and the **last subsystem** before all 8 audits are at least partially closed. Closes 9 of the 24 P1s in \`docs/audits/2026-05-22-engineer-audit-execution.md\`. Two themed commits:

| Commit | Theme | Audit IDs |
|---|---|---|
| 1 | Seven small surface fixes | stray docstring, git remote no-check, allow_dirty precedence, asset_file_path falsy bug, from_registry workflow_rid, MultirunState dataclass, _complete_parent_execution logger.exception |
| 2 | Direct coverage for two zero-coverage modules | multirun_config.py, environment.py |

## Notable changes

### Workflow ``allow_dirty`` precedence (correctness)

\`get_url_and_checksum\` had a "Not executing in a Git repository" guard that fired **before** \`allow_dirty\` was consulted. A dry-run / ad-hoc script from outside a checkout could not benefit from \`DERIVA_ML_ALLOW_DIRTY=true\` — defeating the env-flag's documented intent. Combined with \`DERIVA_ML_DRY_RUN=true\` flowing into \`allow_dirty=True\` in the model validator, the whole "allow dirty provenance" surface was broken at the precondition stage.

Fix: when \`allow_dirty=True\`, downgrade the no-git precondition to a warning + return empty URL/checksum. Default behavior (\`allow_dirty=False\`) unchanged.

### \`asset_file_path\` falsy empty list (correctness)

Pre-fix, \`asset_types = asset_types or kwargs.pop("Asset_Type", None) or asset_name\` collapsed an explicit empty list to \`asset_name\`. A user passing \`asset_types=[]\` ("no content tags") got back a \`lookup_term\` failure on the table name. Switched to \`is None\` so explicit empty list is honored.

### \`from_registry\` populates \`workflow_rid\` (correctness)

The classmethod set \`instance.workflow_rid = None\` without loading from SQLite, even though the registry row carries it. Downstream code that relied on \`execution.workflow_rid\` saw None on every resumed execution. Now best-effort populates from \`state_store.get_execution()\`; falls back to None for offline-mode tests.

### \`_complete_parent_execution\` uses logger.exception (observability)

Atexit handler did \`logging.warning(f"... {e}")\` — losing the traceback. An operator seeing the warning had no way to debug what failed inside the upload. Switched to \`logging.exception\` so the stack lands in logs.

### MultirunState → @dataclass (defensive)

Used class-level mutable defaults instead of instance fields. A second instantiation or subclass would silently share state through the class object. Converted to \`@dataclass\`.

### Two zero-coverage modules

- **multirun_config.py** (153 LoC): 10 new tests covering register/lookup/list/get-all + per-name isolation.
- **environment.py** (237 LoC): 9 new smoke tests pinning shape invariants + JSON-serializability of the aggregate \`get_execution_environment\`.

## Deferred to follow-up PRs

This audit has 24 P1s — the largest single subsystem in the codebase. Several findings are real refactors deserving their own PRs:

| ID | Theme | Why deferred |
|---|---|---|
| God class | \`Execution\` is 2,676 LoC, 30+ methods | Multi-day extraction; needs careful module-boundary design |
| \`_initialize_execution\` 118-line method | Mixes 9 distinct steps | Refactor with failure-mode partitioning |
| \`Execution.__init__\` SQLite-vs-catalog ordering | Partial-failure window | Real semantic question (catalog-first vs SQLite-first ordering) |
| \`_update_asset_execution_table\` Output branch | Dead in production but tested | Test-path surgical removal (6+ tests) + function trim |
| \`list_assets\` quadratic schema walk | Performance + bare-except | Cache lifecycle design |
| Duplicate \`list_input_datasets\` / \`list_assets\` | Two parallel implementations | Helper extraction |
| NumPy→Google docstring conversion | \`runner.py\` ~80 lines | Cosmetic, big diff |
| \`_add_asset_rows_to_bag\` lease batching | Three sequential POSTs per commit | Performance optimization |
| \`_add_staged_feature_rows_to_bag\` silent skip | Needs \`mark_feature_records_failed\` API | New state_store API surface |
| \`transition\` double-write | State machine 2× SQLite writes per transition | State machine semantic question |
| \`pending_summary\` no-op stubs | 5+ call sites in prod, asset manifest carries real state | Big behaviour change |
| \`_update_description_in_catalog\` duplicated across classes | Helper extraction | Cross-class refactor |
| \`Execution_Execution\` query 4× | Helper extraction | Cross-file refactor |
| Direct tests for \`metrics_file\`/\`database_catalog\`/\`catalog\` properties | Coverage | Needs basic_execution fixture work |
| Direct test for \`from_registry\` classmethod | Coverage | Pairs with the workflow_rid fix above, but cleaner separately |

## Test plan

- [x] \`uv run pytest tests/execution/\` — 354 passed, 8 skipped.
- [x] \`tests/execution/test_multirun_config.py\` + \`test_environment.py\` — 19 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)