### PR TITLE
refactor(asset+model): centralise sort invariant + Asset_Type path (audit P1 Y3+A2)

### DIFF
--- a/src/deriva_ml/asset/asset.py
+++ b/src/deriva_ml/asset/asset.py
@@ -125,6 +125,11 @@ class Asset:
         self.description = description
         self._asset_types = asset_types or []
         self._execution_rid = execution_rid
+        # Lazy cache for ``_asset_type_path``. ``self.asset_table``
+        # is immutable for the wrapper's lifetime so a per-instance
+        # cache is safe; resolves the FK + datapath on first use,
+        # avoids redoing it on every type-mutation call.
+        self._asset_type_path_cache: tuple[Any, str] | None = None
 
     def __repr__(self) -> str:
         """Return a string representation of the Asset for debugging."""
@@ -132,6 +137,51 @@ class Asset:
             f"<deriva_ml.Asset at {hex(id(self))}: rid='{self.asset_rid}', "
             f"table='{self.asset_table}', file='{self.filename}', types={self._asset_types}>"
         )
+
+    def _asset_type_path(self) -> tuple[Any, str]:
+        """Return the ``Asset_Type`` association path + asset-FK column name.
+
+        Centralises three identical resolution blocks that previously
+        lived inline in :meth:`_load_asset_types`, :meth:`add_asset_type`,
+        and :meth:`remove_asset_type`. All three did the same dance:
+
+        1. Resolve ``self.asset_table`` to the model :class:`Table`.
+        2. Look up the ``Asset_Type`` association via
+           ``model.find_association(table, "Asset_Type")``.
+        3. Build the pathBuilder path
+           ``pb.schemas[<schema>].tables[<assoc-table>]``.
+
+        Result is cached on the instance because ``self.asset_table``
+        is immutable for the wrapper's lifetime — a per-instance
+        cache turns three round-trips through ``find_association``
+        into one.
+
+        Returns:
+            Tuple of ``(type_path, asset_fk_column_name)`` where
+            ``type_path`` is the pathBuilder datapath for the
+            association table and ``asset_fk_column_name`` is the
+            FK column name on that table that references the asset
+            row (e.g. ``"Image"`` on ``Image_Asset_Type``).
+
+        Raises:
+            NoAssociationException: When the asset table has no
+                ``Asset_Type`` association. Callers handle this
+                per their own taste (``_load_asset_types`` returns
+                an empty list, the mutators bubble it up).
+        """
+        if self._asset_type_path_cache is not None:
+            return self._asset_type_path_cache
+
+        asset_table_obj = self._ml_instance.model.name_to_table(self.asset_table)
+        type_assoc_table, asset_fk, _ = self._ml_instance.model.find_association(
+            asset_table_obj, "Asset_Type"
+        )
+
+        pb = self._ml_instance.pathBuilder()
+        type_path = pb.schemas[type_assoc_table.schema.name].tables[type_assoc_table.name]
+
+        self._asset_type_path_cache = (type_path, asset_fk)
+        return self._asset_type_path_cache
 
     @property
     def asset_types(self) -> list[str]:
@@ -146,17 +196,12 @@ class Asset:
 
     def _load_asset_types(self) -> None:
         """Load asset types from the catalog."""
-        # Find the asset type association table
-        asset_table_obj = self._ml_instance.model.name_to_table(self.asset_table)
         try:
-            type_assoc_table, asset_fk, _ = self._ml_instance.model.find_association(asset_table_obj, "Asset_Type")
+            type_path, asset_fk = self._asset_type_path()
         except NoAssociationException:
             # No type association for this asset table
             self._asset_types = []
             return
-
-        pb = self._ml_instance.pathBuilder()
-        type_path = pb.schemas[type_assoc_table.schema.name].tables[type_assoc_table.name]
 
         types = list(
             type_path.filter(type_path.columns[asset_fk] == self.asset_rid).attributes(type_path.Asset_Type).fetch()
@@ -230,11 +275,7 @@ class Asset:
         Example:
             >>> asset.add_asset_type("Training_Data")  # doctest: +SKIP
         """
-        asset_table_obj = self._ml_instance.model.name_to_table(self.asset_table)
-        type_assoc_table, asset_fk, _ = self._ml_instance.model.find_association(asset_table_obj, "Asset_Type")
-
-        pb = self._ml_instance.pathBuilder()
-        type_path = pb.schemas[type_assoc_table.schema.name].tables[type_assoc_table.name]
+        type_path, asset_fk = self._asset_type_path()
 
         # Insert the association
         type_path.insert([{asset_fk: self.asset_rid, "Asset_Type": type_name}])
@@ -252,11 +293,7 @@ class Asset:
         Example:
             >>> asset.remove_asset_type("Temporary")  # doctest: +SKIP
         """
-        asset_table_obj = self._ml_instance.model.name_to_table(self.asset_table)
-        type_assoc_table, asset_fk, _ = self._ml_instance.model.find_association(asset_table_obj, "Asset_Type")
-
-        pb = self._ml_instance.pathBuilder()
-        type_path = pb.schemas[type_assoc_table.schema.name].tables[type_assoc_table.name]
+        type_path, asset_fk = self._asset_type_path()
 
         # Delete the association
         type_path.filter((type_path.columns[asset_fk] == self.asset_rid) & (type_path.Asset_Type == type_name)).delete()

--- a/src/deriva_ml/core/upload_layout.py
+++ b/src/deriva_ml/core/upload_layout.py
@@ -211,7 +211,12 @@ def asset_table_upload_spec(model: DerivaModel, asset_table: str | Table, chunk_
     Returns:
         A dictionary containing the upload specification for the asset table.
     """
-    metadata_columns = sorted(model.asset_metadata(asset_table))
+    # ``asset_metadata_sorted`` pins the alphabetic-order
+    # invariant in one place — both this upload-spec builder
+    # and the bag-commit row writer must produce columns in the
+    # same order so the regex captures align with the recorded
+    # values.
+    metadata_columns = model.asset_metadata_sorted(asset_table)
     asset_table = model.name_to_table(asset_table)
     schema = model.name_to_table(asset_table).schema.name
 

--- a/src/deriva_ml/execution/bag_commit.py
+++ b/src/deriva_ml/execution/bag_commit.py
@@ -261,7 +261,11 @@ def _add_asset_rows_to_bag(
     ml = execution._ml_object
     asset_table = model.name_to_table(asset_table_name)
 
-    metadata_cols = sorted(model.asset_metadata(asset_table_name))
+    # See ``DerivaModel.asset_metadata_sorted`` — both this call
+    # site and ``asset_table_upload_spec`` must produce metadata
+    # columns in the same alphabetic order, since the upload regex
+    # captures them positionally.
+    metadata_cols = model.asset_metadata_sorted(asset_table_name)
 
     asset_rows: list[dict[str, Any]] = []
     for filename, entry in entries:

--- a/src/deriva_ml/model/catalog.py
+++ b/src/deriva_ml/model/catalog.py
@@ -722,6 +722,42 @@ class DerivaModel:
             key=lambda c: c.name,
         )
 
+    def asset_metadata_sorted(self, table: TableInput) -> list[str]:
+        """Return the asset-metadata column **names** in deterministic order.
+
+        Sorted by name. Pins the alphabetic-order invariant in one
+        place so call sites stay in lockstep:
+
+        - :func:`~deriva_ml.core.upload_layout.asset_table_upload_spec`
+          builds the upload regex from these names; the directory
+          order in the staging tree must match the regex order.
+        - :func:`~deriva_ml.execution.bag_commit._add_asset_rows_to_bag`
+          emits metadata columns into the bag in the same order so
+          the recorded rows align with the upload regex captures.
+
+        Pre-extraction, each call site re-wrote
+        ``sorted(model.asset_metadata(table))`` inline. Centralising
+        the call shape means a future change to the ordering rule
+        (e.g. case-insensitive sort, or sorted by FK target) lands
+        once and everyone follows.
+
+        Args:
+            table: Asset table name or :class:`Table` instance.
+
+        Returns:
+            Sorted list of metadata column names. Empty list if
+            the table carries no extra columns.
+
+        Raises:
+            DerivaMLTableTypeError: If ``table`` isn't an asset table.
+
+        Example:
+            >>> from deriva_ml.model.catalog import DerivaModel  # doctest: +SKIP
+            >>> model.asset_metadata_sorted("Image")  # doctest: +SKIP
+            ['Asset_Role', 'Description']
+        """
+        return sorted(self.asset_metadata(table))
+
     def apply(self) -> None:
         """Apply pending annotation/schema changes via the underlying Model.
 

--- a/tests/asset/test_metadata_sort_invariant.py
+++ b/tests/asset/test_metadata_sort_invariant.py
@@ -2,19 +2,25 @@
 
 Closes audit P1 X2: the upload-spec regex order
 (``core/upload_layout.py``) and the bag-build row emit
-(``execution/bag_commit.py``) both rely on
-``sorted(model.asset_metadata(table))`` to produce a deterministic
+(``execution/bag_commit.py``) both rely on a deterministic
 metadata-column order. If one site switched to e.g. a bare
 ``list(...)`` or a different sort key, the regex would mismatch
 the directory layout the bag-build code emitted, and uploads
 would silently fail to match.
 
+Post-Y3 refactor both sites call
+``model.asset_metadata_sorted(table)`` (a centralised helper on
+:class:`DerivaModel`). The structural test pins that call shape;
+the behavioural test pins the underlying sort semantics
+(Python's default case-sensitive alphabetical sort, applied to
+the metadata-column-name set).
+
 Two layers of pin:
 
 1. **Structural** — both call sites use the literal
-   ``sorted(model.asset_metadata(...))`` pattern. A regression
-   that drops the ``sorted()`` wrapper fails this test
-   immediately.
+   ``model.asset_metadata_sorted(...)`` helper. A regression
+   that drops back to a bare ``list(model.asset_metadata(...))``
+   fails this test.
 
 2. **Behavioural** — when invoked with a mocked model that
    returns the same metadata-column set, the two sites produce
@@ -42,29 +48,52 @@ from deriva_ml.execution import bag_commit
 # ---------------------------------------------------------------------------
 
 
-_SORTED_PATTERN = re.compile(r"sorted\(\s*(?:\w+\.)?model\.asset_metadata\(")
+_SORTED_HELPER_PATTERN = re.compile(r"model\.asset_metadata_sorted\(")
 
 
-def test_upload_layout_uses_sorted_model_asset_metadata() -> None:
-    """``upload_layout.asset_table_upload_spec`` wraps its metadata read in ``sorted()``."""
+def test_upload_layout_uses_sorted_helper() -> None:
+    """``upload_layout.asset_table_upload_spec`` reads metadata via the centralised helper."""
     src = inspect.getsource(upload_layout.asset_table_upload_spec)
-    assert _SORTED_PATTERN.search(src), (
+    assert _SORTED_HELPER_PATTERN.search(src), (
         "upload_layout.asset_table_upload_spec must produce metadata "
-        "columns via sorted(model.asset_metadata(...)). A regression "
-        "that drops the sort would break the regex-vs-directory "
-        "layout invariant and silently fail uploads."
+        "columns via model.asset_metadata_sorted(...). A regression "
+        "that drops back to a bare list(model.asset_metadata(...)) "
+        "would break the regex-vs-directory layout invariant and "
+        "silently fail uploads."
     )
 
 
-def test_bag_commit_uses_sorted_model_asset_metadata() -> None:
-    """``bag_commit._add_asset_rows_to_bag`` wraps its metadata read in ``sorted()``."""
+def test_bag_commit_uses_sorted_helper() -> None:
+    """``bag_commit._add_asset_rows_to_bag`` reads metadata via the centralised helper."""
     src = inspect.getsource(bag_commit._add_asset_rows_to_bag)
-    assert _SORTED_PATTERN.search(src), (
+    assert _SORTED_HELPER_PATTERN.search(src), (
         "bag_commit._add_asset_rows_to_bag must produce metadata "
-        "columns via sorted(model.asset_metadata(...)). A regression "
-        "that drops the sort would break the directory-vs-regex "
-        "invariant on the upload path."
+        "columns via model.asset_metadata_sorted(...). A regression "
+        "that drops back to a bare list(model.asset_metadata(...)) "
+        "would break the directory-vs-regex invariant on the upload "
+        "path."
     )
+
+
+def test_sorted_helper_returns_sorted_names() -> None:
+    """The centralised helper actually returns alphabetically-sorted names.
+
+    Belt-and-braces with the structural test: catches a future
+    refactor that keeps the helper name but quietly drops the
+    ``sorted(...)`` wrapper inside.
+    """
+    from deriva_ml.model.catalog import DerivaModel
+
+    fake_model = MagicMock(spec=DerivaModel)
+    fake_model.asset_metadata.return_value = {
+        "Zebra",
+        "Acquisition_Date",
+        "Bravo",
+    }
+    # Call the unbound method against the mock so we exercise the
+    # real implementation, not a mock-out.
+    result = DerivaModel.asset_metadata_sorted(fake_model, "Image")
+    assert result == ["Acquisition_Date", "Bravo", "Zebra"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Two cross-file dedup extractions from the asset audit's deferred backlog.

- **Y3** (``63f9380c``): ``DerivaModel.asset_metadata_sorted(table) -> list[str]``
  centralises the alphabetic-sort invariant. Two call sites
  (``upload_layout.asset_table_upload_spec`` + ``bag_commit._add_asset_rows_to_bag``)
  previously re-wrote ``sorted(model.asset_metadata(table))``
  inline; both must produce metadata columns in the same order
  or the upload regex captures fall out of alignment with the
  directory layout. Updates the X2 invariant tests
  (``test_metadata_sort_invariant.py``) to pin the new helper.
- **A2** (``db43b850``): ``Asset._asset_type_path() -> (type_path, asset_fk)``
  centralises the three-line ``find_association(\"Asset_Type\")``
  resolution dance previously duplicated across
  ``_load_asset_types``, ``add_asset_type``, ``remove_asset_type``.
  Caches on the instance (``self.asset_table`` is immutable for
  the wrapper's lifetime), so three round-trips collapse to one.

## Test plan

- [x] ``tests/asset/`` — 79 pass
- [x] ``tests/model/`` — 104 pass (catalog + database + annotations)
- [x] ``test_metadata_sort_invariant.py`` — updated structural pin
      to grep for the new helper; added a behavioural pin against
      the helper itself

🤖 Generated with [Claude Code](https://claude.com/claude-code)