### PR TITLE
refactor(feature): extract reduce_with_selector helper (audit P1 F-8)

### DIFF
--- a/src/deriva_ml/core/mixins/feature.py
+++ b/src/deriva_ml/core/mixins/feature.py
@@ -7,7 +7,6 @@ and listing feature values.
 
 from __future__ import annotations
 
-from collections import defaultdict
 from functools import reduce
 from itertools import chain
 from operator import or_
@@ -522,16 +521,12 @@ class FeatureMixin:
             return
 
         # Group by target RID, apply selector, skip None results.
-        grouped: dict[str, list[FeatureRecord]] = defaultdict(list)
-        for rec in records:
-            target_rid = getattr(rec, target_col, None)
-            if target_rid is not None:
-                grouped[target_rid].append(rec)
+        # Three sites (this one, Dataset.feature_values,
+        # DatasetBag.feature_values) share the same reduction
+        # shape; the helper pins it in one place.
+        from deriva_ml.feature import reduce_with_selector
 
-        for group in grouped.values():
-            chosen = selector(group)
-            if chosen is not None:
-                yield chosen
+        yield from reduce_with_selector(records, target_col, selector)
 
     @validate_call(config=VALIDATION_CONFIG)
     def list_workflow_executions(self, workflow: str) -> list[str]:

--- a/src/deriva_ml/dataset/dataset.py
+++ b/src/deriva_ml/dataset/dataset.py
@@ -603,16 +603,11 @@ class Dataset:
             yield from raw_in_scope
             return
 
-        grouped: dict[str, list[FeatureRecord]] = defaultdict(list)
-        for rec in raw_in_scope:
-            target_rid = getattr(rec, target_col, None)
-            if target_rid is not None:
-                grouped[target_rid].append(rec)
+        # Group by target RID + apply selector — shared helper
+        # so the three feature_values surfaces stay in lockstep.
+        from deriva_ml.feature import reduce_with_selector
 
-        for group in grouped.values():
-            chosen = selector(group)
-            if chosen is not None:
-                yield chosen
+        yield from reduce_with_selector(raw_in_scope, target_col, selector)
 
     def lookup_feature(self, table: str | Table, feature_name: str) -> Feature:
         """Look up a Feature definition — delegates to the owning DerivaML.

--- a/src/deriva_ml/dataset/dataset_bag.py
+++ b/src/deriva_ml/dataset/dataset_bag.py
@@ -593,8 +593,6 @@ class DatasetBag:
             ...     "Image", "Glaucoma", selector=FeatureRecord.select_newest,
             ... ))
         """
-        from collections import defaultdict
-
         from deriva_ml.dataset.bag_feature_cache import BagFeatureCache
 
         if not hasattr(self, "_feature_cache"):
@@ -643,18 +641,13 @@ class DatasetBag:
             yield from records
             return
 
-        # Group by target RID, then apply selector to every group (always call
-        # selector — never short-circuit for single-element groups).
-        grouped: dict[str, list[FeatureRecord]] = defaultdict(list)
-        for rec in records:
-            target_rid = getattr(rec, target_col, None)
-            if target_rid is not None:
-                grouped[target_rid].append(rec)
+        # Group by target RID, then apply selector to every group
+        # — always call selector, never short-circuit for
+        # single-element groups. Shared helper so the three
+        # feature_values surfaces stay in lockstep.
+        from deriva_ml.feature import reduce_with_selector
 
-        for group in grouped.values():
-            chosen = selector(group)
-            if chosen is not None:
-                yield chosen
+        yield from reduce_with_selector(records, target_col, selector)
 
     def lookup_feature(self, table: str | Table, feature_name: str) -> Feature:
         """Look up a feature definition from bag metadata — works fully offline.

--- a/src/deriva_ml/feature.py
+++ b/src/deriva_ml/feature.py
@@ -32,10 +32,10 @@ Typical usage:
     >>> record = DiagnosisRecord(Diagnosis="benign", Confidence=0.97)  # doctest: +SKIP
 """
 
-from collections import Counter
+from collections import Counter, defaultdict
 from pathlib import Path
 from types import UnionType
-from typing import TYPE_CHECKING, Callable, ClassVar, Optional, Type
+from typing import TYPE_CHECKING, Callable, ClassVar, Iterable, Iterator, Optional, Type
 
 from deriva.core.ermrest_model import Column, FindAssociationResult
 from pydantic import BaseModel, create_model
@@ -44,6 +44,63 @@ from deriva_ml.core.exceptions import DerivaMLException
 
 if TYPE_CHECKING:
     from deriva_ml.model.catalog import DerivaModel
+
+
+def reduce_with_selector(
+    records: Iterable["FeatureRecord"],
+    target_col: str,
+    selector: Callable[[list["FeatureRecord"]], "FeatureRecord | None"],
+) -> Iterator["FeatureRecord"]:
+    """Group records by target RID, apply ``selector`` per group, drop ``None`` results.
+
+    Centralises the three-step pattern that previously lived inline
+    in three places — ``feature_values`` on
+    :class:`~deriva_ml.core.mixins.feature.FeatureMixin`,
+    :class:`~deriva_ml.dataset.dataset.Dataset`, and
+    :class:`~deriva_ml.dataset.dataset_bag.DatasetBag`:
+
+    1. Group raw records by their target-RID column (the FK to the
+       target table, e.g. ``Image`` for an Image feature).
+    2. Apply the selector to each group; the selector picks one
+       record from the group (or returns ``None`` to drop).
+    3. Yield surviving selections.
+
+    Records whose ``target_col`` is missing or ``None`` are
+    silently dropped before grouping — they have no target to
+    group under.
+
+    Args:
+        records: Raw feature records to group + reduce. Iterated
+            once.
+        target_col: Name of the FK column on each record that
+            identifies its target row (e.g. ``"Image"``).
+        selector: Callable that takes a non-empty list of records
+            sharing one target RID and returns the chosen record
+            (or ``None`` to skip). Examples:
+            :meth:`FeatureRecord.select_newest`,
+            :meth:`FeatureRecord.select_by_workflow` (returned by
+            the closure factory of the same name).
+
+    Yields:
+        One :class:`FeatureRecord` per target RID for which the
+        selector returned a non-``None`` choice. Order is
+        unspecified (dict iteration order, i.e. insertion order
+        of first-seen target RIDs in ``records``).
+
+    Example:
+        >>> from deriva_ml.feature import FeatureRecord, reduce_with_selector
+        >>> callable(reduce_with_selector)
+        True
+    """
+    grouped: dict[str, list[FeatureRecord]] = defaultdict(list)
+    for rec in records:
+        target_rid = getattr(rec, target_col, None)
+        if target_rid is not None:
+            grouped[target_rid].append(rec)
+    for group in grouped.values():
+        chosen = selector(group)
+        if chosen is not None:
+            yield chosen
 
 
 class FeatureRecord(BaseModel):

--- a/tests/feature/test_reduce_with_selector.py
+++ b/tests/feature/test_reduce_with_selector.py
@@ -1,0 +1,128 @@
+"""Tests for ``deriva_ml.feature.reduce_with_selector`` (audit P1 F-8).
+
+Pre-fix this code lived inline in three call sites:
+
+- ``mixins/feature.py:feature_values``
+- ``dataset/dataset.py:Dataset.feature_values``
+- ``dataset/dataset_bag.py:DatasetBag.feature_values``
+
+Post-extraction all three delegate to this one helper. Pin its
+contract directly so a regression at the helper level is caught
+without needing to spin up the full feature_values machinery.
+
+Pure-Python tests; no live catalog required.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from deriva_ml.feature import reduce_with_selector
+
+
+class TestReduceWithSelector:
+    """Contract for the group-by-RID + apply-selector reduction."""
+
+    def test_groups_by_target_col_and_yields_one_per_group(self):
+        """One record per distinct target RID, selector picks survivor."""
+        records = [
+            SimpleNamespace(Image="img-1", val=1, RCT="t1"),
+            SimpleNamespace(Image="img-1", val=2, RCT="t2"),
+            SimpleNamespace(Image="img-2", val=10, RCT="t1"),
+        ]
+        # Selector picks the highest `val` in each group.
+        result = list(
+            reduce_with_selector(
+                records, "Image", selector=lambda group: max(group, key=lambda r: r.val)
+            )
+        )
+
+        # Two groups → two survivors. ``Image == "img-1"`` keeps val=2
+        # (max), ``"img-2"`` keeps val=10.
+        vals_by_img = {r.Image: r.val for r in result}
+        assert vals_by_img == {"img-1": 2, "img-2": 10}
+
+    def test_drops_records_with_missing_target(self):
+        """Records whose target_col is ``None`` or missing are dropped before grouping."""
+        records = [
+            SimpleNamespace(Image="img-1", val=1),
+            SimpleNamespace(Image=None, val=2),  # explicit None
+            SimpleNamespace(val=3),  # attribute missing entirely
+        ]
+        result = list(
+            reduce_with_selector(records, "Image", selector=lambda group: group[0])
+        )
+        assert len(result) == 1
+        assert result[0].Image == "img-1"
+
+    def test_selector_returning_none_drops_group(self):
+        """A group whose selector returns ``None`` is skipped, not yielded."""
+        records = [
+            SimpleNamespace(Image="img-1", val=5),
+            SimpleNamespace(Image="img-2", val=99),
+        ]
+        # Selector returns None for any group whose first record has val > 10.
+        result = list(
+            reduce_with_selector(
+                records,
+                "Image",
+                selector=lambda group: group[0] if group[0].val <= 10 else None,
+            )
+        )
+        assert len(result) == 1
+        assert result[0].Image == "img-1"
+
+    def test_empty_input_yields_nothing(self):
+        """Empty input → empty output (no calls to selector)."""
+        calls = []
+
+        def tracking_selector(group):
+            calls.append(group)
+            return group[0]
+
+        result = list(reduce_with_selector([], "Image", selector=tracking_selector))
+        assert result == []
+        assert calls == []
+
+    def test_singleton_group_still_calls_selector(self):
+        """A group of one still goes through ``selector`` — never short-circuit.
+
+        This is the behaviour the inline ``dataset_bag.py`` comment
+        called out explicitly ("always call selector — never
+        short-circuit for single-element groups"). The helper must
+        preserve it; if a future "optimisation" skips selector for
+        singletons, selectors that side-effect (e.g. logging,
+        statistics, validation) would silently break.
+        """
+        rec = SimpleNamespace(Image="img-1", val=1)
+        called = []
+
+        def tracking_selector(group):
+            called.append(group)
+            return group[0]
+
+        result = list(
+            reduce_with_selector([rec], "Image", selector=tracking_selector)
+        )
+        assert result == [rec]
+        assert len(called) == 1
+        assert called[0] == [rec]
+
+    def test_iteration_order_is_first_seen(self):
+        """Output order is dict insertion order (first-seen target RID).
+
+        Pinning iteration order is conservative — three call sites
+        share the helper, and at least one downstream test might
+        rely on deterministic ordering even if it shouldn't.
+        Pin the documented behaviour.
+        """
+        records = [
+            SimpleNamespace(Image="img-B", val=1),
+            SimpleNamespace(Image="img-A", val=2),
+            SimpleNamespace(Image="img-B", val=3),
+        ]
+        result = list(
+            reduce_with_selector(records, "Image", selector=lambda group: group[0])
+        )
+        # img-B first seen at index 0, img-A first seen at index 1.
+        assert [r.Image for r in result] == ["img-B", "img-A"]


### PR DESCRIPTION
## Summary

Closes audit P1 F-8 from
``docs/audits/2026-05-22-engineer-audit-feature.md``. Three
``feature_values`` implementations carried the same group-by-RID
+ apply-selector reduction inline:

- ``core/mixins/feature.py:FeatureMixin.feature_values``
- ``dataset/dataset.py:Dataset.feature_values``
- ``dataset/dataset_bag.py:DatasetBag.feature_values``

All three now delegate to one helper:
``deriva_ml.feature.reduce_with_selector(records, target_col, selector)``.

Drops the now-unused ``defaultdict`` imports at the call sites
(top-level in ``mixins/feature.py``; lazy in
``DatasetBag.feature_values``). The other two
``defaultdict`` users in ``dataset.py`` and ``dataset_bag.py``
keep their imports.

## Test plan

- [x] New ``tests/feature/test_reduce_with_selector.py`` (6/6
      pass) — pure-Python coverage for the helper: grouping,
      missing-target drop, ``None``-survivor drop, empty input,
      singleton-group invariant (always-call-selector), iteration
      order (first-seen target).
- [x] ``tests/feature/`` + ``tests/local_db/`` — 338 pass
- [x] ``tests/dataset/`` feature_values tests — 3/3 pass
- [x] ``ruff check`` clean on touched files
- [x] Doctest example in helper docstring runs (single
      ``callable()`` assertion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)