### PR TITLE
perf(execution): batch all bag-commit leases into one POST (audit P1 Ex-batch)

### DIFF
--- a/src/deriva_ml/execution/bag_commit.py
+++ b/src/deriva_ml/execution/bag_commit.py
@@ -73,8 +73,9 @@ from deriva_ml.core.upload_layout import asset_type_path, flat_asset_dir
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-    from deriva_ml.asset.manifest import AssetManifest
+    from deriva_ml.asset.manifest import AssetEntry, AssetManifest
     from deriva_ml.execution.execution import Execution
+    from deriva_ml.execution.rid_lease import LeaseAggregator
 
     ProgressCallback = Callable[[UploadProgress], None]
 
@@ -194,6 +195,17 @@ def build_execution_bag(
         # callbacks can report a coherent 0-100 progression.
         total_assets = sum(len(es) for es in by_table.values())
         staged_so_far = 0
+
+        # All RID leases for the commit go through one aggregator
+        # so the whole bag costs **one** ``post_lease_batch`` POST,
+        # not one per asset-table + one per feature-group. Audit
+        # P1 Ex-batch — a 3-table 5-feature-group commit drops
+        # from 11 round trips to 1.
+        from deriva_ml.execution.rid_lease import LeaseAggregator
+
+        lease_agg = LeaseAggregator()
+        deferred_emits: list[tuple[str, list[dict[str, Any]]]] = []
+
         for asset_table_name, entries in by_table.items():
             staged_so_far = _add_asset_rows_to_bag(
                 bb=bb,
@@ -203,6 +215,8 @@ def build_execution_bag(
                 progress_callback=progress_callback,
                 staged_so_far=staged_so_far,
                 total_assets=total_assets,
+                lease_agg=lease_agg,
+                deferred_emits=deferred_emits,
             )
 
         _add_staged_feature_rows_to_bag(
@@ -210,7 +224,22 @@ def build_execution_bag(
             execution=execution,
             manifest=manifest,
             pending=pending,
+            lease_agg=lease_agg,
+            deferred_emits=deferred_emits,
         )
+
+        # One POST resolves every reserved token to its leased
+        # RID. The deferred emits below substitute the leased
+        # RID into each row's ``RID`` slot (rows carried a
+        # placeholder token there) and call ``bb.add_rows``.
+        lease_agg.flush(catalog=execution._ml_object.catalog)
+        for table_name, token_rows in deferred_emits:
+            for row in token_rows:
+                # Each row's "RID" field was set to a token at
+                # reserve-time. Replace with the leased RID
+                # post-flush.
+                row["RID"] = lease_agg.resolve(row["RID"])
+            bb.add_rows(table_name, token_rows)
 
         return bb.finalize(make_bdbag=True)
 
@@ -224,6 +253,8 @@ def _add_asset_rows_to_bag(
     progress_callback: "ProgressCallback | None" = None,
     staged_so_far: int = 0,
     total_assets: int = 0,
+    lease_agg: "LeaseAggregator",
+    deferred_emits: list[tuple[str, list[dict[str, Any]]]],
 ) -> int:
     """Add asset rows + ``*_Execution`` + ``*_Asset_Type`` rows for one table.
 
@@ -258,7 +289,6 @@ def _add_asset_rows_to_bag(
         global counter. Always non-negative.
     """
     model = execution._model
-    ml = execution._ml_object
     asset_table = model.name_to_table(asset_table_name)
 
     # See ``DerivaModel.asset_metadata_sorted`` — both this call
@@ -333,17 +363,18 @@ def _add_asset_rows_to_bag(
     # preserves the caller-supplied RID, blocking the server's
     # default). Sending without an RID lands a NULL and fails
     # the table's RID NOT-NULL unique constraint.
-    from deriva_ml.execution.rid_lease import (
-        generate_lease_token,
-        post_lease_batch,
-    )
+    #
+    # Pre-Ex-batch this function made two ``post_lease_batch``
+    # POSTs (one for exec_assoc rows, one for type rows). Now it
+    # reserves tokens against the shared ``lease_agg``; the
+    # driver flushes once at end-of-commit and resolves each
+    # row's placeholder ``RID`` token to its leased RID.
 
     exec_assoc, asset_fk, execution_fk = model.find_association(asset_table_name, "Execution")
-    exec_tokens = [generate_lease_token() for _filename, _e in entries]
-    exec_lease_map = post_lease_batch(catalog=ml.catalog, tokens=exec_tokens)
+    exec_tokens = lease_agg.reserve(len(entries))
     assoc_rows = [
         {
-            "RID": exec_lease_map[exec_tokens[i]],
+            "RID": exec_tokens[i],  # placeholder — driver resolves post-flush
             asset_fk: entry.rid,
             execution_fk: execution.execution_rid,
             "Asset_Role": "Output",
@@ -351,7 +382,7 @@ def _add_asset_rows_to_bag(
         for i, (_filename, entry) in enumerate(entries)
     ]
     if assoc_rows:
-        bb.add_rows(exec_assoc.name, assoc_rows)
+        deferred_emits.append((exec_assoc.name, assoc_rows))
 
     # {Asset}_Asset_Type association rows. Asset types live in a
     # per-execution JSONL file populated by ``asset_file_path``;
@@ -370,20 +401,18 @@ def _add_asset_rows_to_bag(
         for asset_type in type_map.get(_filename, []):
             type_pairs.append((entry, asset_type))
 
-    type_rows: list[dict[str, Any]] = []
     if type_pairs:
-        type_tokens = [generate_lease_token() for _ in type_pairs]
-        type_lease_map = post_lease_batch(catalog=ml.catalog, tokens=type_tokens)
+        type_tokens = lease_agg.reserve(len(type_pairs))
+        type_rows: list[dict[str, Any]] = []
         for i, (entry, asset_type) in enumerate(type_pairs):
             type_rows.append(
                 {
-                    "RID": type_lease_map[type_tokens[i]],
+                    "RID": type_tokens[i],  # placeholder
                     asset_table_name: entry.rid,
                     "Asset_Type": asset_type,
                 }
             )
-    if type_rows:
-        bb.add_rows(type_assoc.name, type_rows)
+        deferred_emits.append((type_assoc.name, type_rows))
 
     return staged_so_far
 
@@ -394,6 +423,8 @@ def _add_staged_feature_rows_to_bag(
     execution: "Execution",
     manifest: "AssetManifest",
     pending: dict[str, Any],
+    lease_agg: "LeaseAggregator",
+    deferred_emits: list[tuple[str, list[dict[str, Any]]]],
 ) -> None:
     """Add staged feature records to the bag, rewriting asset RIDs.
 
@@ -478,27 +509,24 @@ def _add_staged_feature_rows_to_bag(
     # association rows do: the loader inserts under
     # ``nondefaults=RID`` (commit semantics), so missing/empty
     # RID lands as NULL and the table's unique constraint fires.
-    # Lease one RID per row, write it into the payload, then
-    # ``add_rows``.
-    from deriva_ml.execution.rid_lease import (
-        generate_lease_token,
-        post_lease_batch,
-    )
-
+    # Reserve tokens against the shared aggregator and defer
+    # the ``bb.add_rows`` until after the driver's single
+    # ``flush()``. Audit P1 Ex-batch — pre-fix this loop made
+    # one POST per qualified feature-table group; now zero POSTs
+    # (the driver's single flush covers everything).
     for qualified, payloads in groups.items():
         # Strip any pre-existing RID values (the staged JSON may
         # carry empty strings from CSV → SQLite round-trip). We
         # supply the leased RID afresh.
         for p in payloads:
             p.pop("RID", None)
-        tokens = [generate_lease_token() for _ in payloads]
-        lease_map = post_lease_batch(catalog=ml.catalog, tokens=tokens)
+        tokens = lease_agg.reserve(len(payloads))
         for i, p in enumerate(payloads):
-            p["RID"] = lease_map[tokens[i]]
+            p["RID"] = tokens[i]  # placeholder — driver resolves post-flush
         # ``qualified`` is "schema.Table"; BagBuilder accepts the
         # qualified form natively, but the bag's per-schema CSV
         # layout uses the bare table name. ``add_rows`` resolves.
-        bb.add_rows(qualified, payloads)
+        deferred_emits.append((qualified, payloads))
 
 
 def load_execution_bag(

--- a/src/deriva_ml/execution/rid_lease.py
+++ b/src/deriva_ml/execution/rid_lease.py
@@ -83,6 +83,136 @@ def post_lease_batch(
     return result
 
 
+class LeaseAggregator:
+    """Accumulate lease tokens from multiple call sites, flush in one POST.
+
+    Pre-extraction (audit P1 Ex-batch), ``bag_commit`` made three
+    separate ``post_lease_batch`` calls per commit — one for
+    ``*_Execution`` association rows, one for ``*_Asset_Type``
+    association rows, one for feature rows. Each is a serialized
+    round trip to ERMrest. For a 1,000-asset commit with 3 types
+    each + features, that's 3 sequential POSTs that could be one
+    batch.
+
+    This aggregator collapses them. Call sites:
+
+    1. ``reserve(n)`` — get a list of ``n`` fresh tokens and
+       register them with the aggregator. Returns the tokens so
+       the caller can map them onto rows (the production pattern
+       keeps token order aligned with row order).
+    2. After every site has reserved its tokens, call ``flush()``
+       once. This issues a single ``post_lease_batch`` for all
+       accumulated tokens.
+    3. ``resolve(token)`` — look up the leased RID for a token
+       after ``flush()``. Raises ``KeyError`` for an unknown
+       token (call ``reserve`` first) or if ``flush()`` hasn't
+       been called yet.
+
+    The aggregator is single-shot: ``flush()`` is intended to be
+    called once at the end of a commit. Multiple ``reserve`` →
+    one ``flush`` is the supported flow. Calling ``reserve``
+    after ``flush()`` raises :class:`RuntimeError` — would
+    create a token that was never POSTed.
+
+    Note: ``post_lease_batch`` is still the underlying primitive.
+    The aggregator just defers the call so multiple sites pay
+    one round-trip instead of N.
+
+    Example:
+        >>> from deriva_ml.execution.rid_lease import LeaseAggregator
+        >>> agg = LeaseAggregator()
+        >>> tokens_a = agg.reserve(2)
+        >>> tokens_b = agg.reserve(3)
+        >>> len(tokens_a) == 2
+        True
+        >>> len(tokens_b) == 3
+        True
+        >>> # agg.flush(catalog=cat) would POST 5 tokens in one batch
+    """
+
+    def __init__(self) -> None:
+        self._tokens: list[str] = []
+        self._lease_map: dict[str, str] | None = None
+
+    def reserve(self, n: int) -> list[str]:
+        """Reserve ``n`` lease tokens and register them with this aggregator.
+
+        Args:
+            n: How many tokens to reserve. Non-negative.
+
+        Returns:
+            List of ``n`` UUID4 strings. Order matches caller
+            insertion order; the production pattern is to zip
+            this list against row data so the leased RIDs land
+            in the right rows after ``flush()``.
+
+        Raises:
+            RuntimeError: If called after ``flush()`` —
+                creating a token post-flush would leave it
+                un-POSTed, breaking the invariant that
+                ``resolve()`` can always answer for any
+                reserved token.
+            ValueError: If ``n`` is negative.
+        """
+        if self._lease_map is not None:
+            raise RuntimeError(
+                "LeaseAggregator.reserve() called after flush(); "
+                "this aggregator is single-shot. Build a fresh aggregator "
+                "for any additional leases."
+            )
+        if n < 0:
+            raise ValueError(f"reserve() requires n >= 0, got {n}")
+        new_tokens = [generate_lease_token() for _ in range(n)]
+        self._tokens.extend(new_tokens)
+        return new_tokens
+
+    def flush(self, *, catalog: "ErmrestCatalog") -> dict[str, str]:
+        """POST every accumulated token in one batch; return token → RID.
+
+        Args:
+            catalog: Live :class:`ErmrestCatalog` to POST against.
+
+        Returns:
+            Dict mapping every reserved token to its leased
+            RID. Empty if ``reserve()`` was never called (a
+            no-op flush; useful in code paths where the
+            aggregator is unconditionally flushed but may
+            have nothing to lease).
+
+        Raises:
+            RuntimeError: If called twice. The aggregator is
+                single-shot.
+        """
+        if self._lease_map is not None:
+            raise RuntimeError(
+                "LeaseAggregator.flush() called twice; this aggregator "
+                "is single-shot."
+            )
+        self._lease_map = post_lease_batch(catalog=catalog, tokens=self._tokens)
+        return self._lease_map
+
+    def resolve(self, token: str) -> str:
+        """Return the leased RID for ``token``.
+
+        Args:
+            token: A token previously returned by ``reserve()``.
+
+        Returns:
+            The RID assigned to this token at flush time.
+
+        Raises:
+            RuntimeError: If ``flush()`` hasn't been called yet.
+            KeyError: If ``token`` was never reserved by this
+                aggregator.
+        """
+        if self._lease_map is None:
+            raise RuntimeError(
+                "LeaseAggregator.resolve() called before flush(); "
+                "no RID has been assigned to any token yet."
+            )
+        return self._lease_map[token]
+
+
 def _validate_pending_asset_leases(
     catalog: "ErmrestCatalog",
     entries: "Iterable[tuple[str, str]]",

--- a/tests/execution/test_bag_commit_unit.py
+++ b/tests/execution/test_bag_commit_unit.py
@@ -395,18 +395,26 @@ def test_report_to_asset_map_filters_metadata_to_declared_cols(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-def test_add_asset_rows_leases_one_batch_per_association(tmp_path, monkeypatch):
-    """Two pending assets (no asset-types) → one ``post_lease_batch``
-    call for the Execution association, two tokens; ``add_rows`` is
-    called for the asset table and the Execution association table.
+def test_add_asset_rows_reserves_one_batch_when_no_types(tmp_path, monkeypatch):
+    """Two pending assets, no asset-types → one ``lease_agg.reserve`` call
+    (Execution association), no inline POST.
 
-    Pins audit §C.1's lease-batching invariant. Without this guard,
-    a regression that switches to a per-entry POST would multiply
-    catalog round-trips.
+    Post Ex-batch, ``_add_asset_rows_to_bag`` doesn't POST to
+    ERMrest_RID_Lease at all — it reserves tokens against the
+    shared aggregator that the driver flushes once at end of
+    commit. This pins:
+
+    1. Zero direct POSTs from this function.
+    2. The Execution-association rows land in ``deferred_emits``
+       carrying placeholder tokens (the driver resolves them
+       after flush).
+    3. The on-disk asset rows still go straight to ``bb.add_rows``
+       (no RID rewrite needed — their RIDs come from the
+       manifest, not from the lease).
     """
     from deriva_ml.execution import bag_commit
+    from deriva_ml.execution.rid_lease import LeaseAggregator
 
-    # ----- model: Image + Image_Execution association -----
     image = _FakeTable(name="Image", schema=_FakeSchema(name="deriva-ml"))
     image_execution = _FakeTable(name="Image_Execution", schema=_FakeSchema(name="deriva-ml"))
     model = _FakeModel(
@@ -414,8 +422,6 @@ def test_add_asset_rows_leases_one_batch_per_association(tmp_path, monkeypatch):
         metadata_cols={"Image": set()},
         associations={
             ("Image", "Execution"): (image_execution, "Image", "Execution"),
-            # Asset_Type is consulted but with an empty type-map the
-            # association lookup still has to succeed; provide it.
             ("Image", "Asset_Type"): (
                 _FakeTable(name="Image_Asset_Type", schema=_FakeSchema(name="deriva-ml")),
                 "Image",
@@ -430,9 +436,6 @@ def test_add_asset_rows_leases_one_batch_per_association(tmp_path, monkeypatch):
         _ml_object=_FakeMLObject(),
     )
 
-    # ----- two pending asset files on disk -----
-    # The flat-asset-dir layout is
-    # ``{working_dir}/{exe_rid}/asset/Image/``.
     flat_dir = tmp_path / "EXE-A" / "asset" / "Image"
     flat_dir.mkdir(parents=True)
     (flat_dir / "a.jpg").write_bytes(b"alpha")
@@ -443,75 +446,83 @@ def test_add_asset_rows_leases_one_batch_per_association(tmp_path, monkeypatch):
         ("b.jpg", AssetEntry(asset_table="Image", schema="deriva-ml", rid="ASSET-B", status="pending")),
     ]
 
-    # ----- stub the asset-type-map reader to return no types -----
     monkeypatch.setattr(bag_commit, "_read_asset_type_map", lambda execution, asset_table: {})
-
-    # ----- stub the flat_asset_dir helper to point at our tmp tree -----
     monkeypatch.setattr(
         bag_commit,
         "flat_asset_dir",
         lambda working_dir, execution_rid, table_name: working_dir / execution_rid / "asset" / table_name,
     )
 
-    # ----- stub post_lease_batch: deterministic token → RID mapping -----
-    lease_calls: list[list[str]] = []
-
-    def _fake_post_lease_batch(*, catalog, tokens):
-        lease_calls.append(list(tokens))
-        return {token: f"LEASED-{i}" for i, token in enumerate(tokens)}
+    # Make ``post_lease_batch`` raise so we catch any accidental
+    # in-function POST. Only the driver's single flush should
+    # POST — and this test never calls flush.
+    def _post_must_not_be_called(*, catalog, tokens):
+        raise AssertionError(
+            "post_lease_batch must not be called inside _add_asset_rows_to_bag; "
+            "the driver's lease_agg.flush() owns the single round trip."
+        )
 
     monkeypatch.setattr(
         "deriva_ml.execution.rid_lease.post_lease_batch",
-        _fake_post_lease_batch,
+        _post_must_not_be_called,
     )
 
-    # ----- run -----
     bb = _MockBagBuilder()
+    lease_agg = LeaseAggregator()
+    deferred_emits: list = []
+
     final_staged = bag_commit._add_asset_rows_to_bag(
         bb=bb,
-        execution=execution,  # type: ignore[arg-type]  # duck-typed
+        execution=execution,  # type: ignore[arg-type]
         asset_table_name="Image",
         entries=entries,
         progress_callback=None,
         staged_so_far=0,
         total_assets=2,
+        lease_agg=lease_agg,
+        deferred_emits=deferred_emits,
     )
 
-    # ----- assertions -----
     assert final_staged == 2
 
-    # Exactly one batched lease call for the Execution association
-    # (no Asset_Type pairs → no second batch).
-    assert len(lease_calls) == 1
-    assert len(lease_calls[0]) == 2  # one token per entry
+    # Two tokens reserved on the aggregator (one per entry's
+    # Execution-association row). No Asset_Type pairs ⇒ no
+    # second reservation.
+    assert len(lease_agg._tokens) == 2  # noqa: SLF001 — pinning internal state by design
 
-    # ``add_rows`` was called for the Image table (asset rows) and
-    # the Image_Execution association table.
-    add_rows_tables = [t for t, _rows in bb.add_rows_calls]
+    # Asset rows still emitted directly to ``bb.add_rows`` (they
+    # use the manifest's RID, not a leased one).
+    add_rows_tables = [t for t, _ in bb.add_rows_calls]
     assert "Image" in add_rows_tables
-    assert "Image_Execution" in add_rows_tables
-    # Two asset rows, two execution-association rows.
     image_rows = next(rows for t, rows in bb.add_rows_calls if t == "Image")
-    exec_rows = next(rows for t, rows in bb.add_rows_calls if t == "Image_Execution")
     assert len(image_rows) == 2
-    assert len(exec_rows) == 2
 
-    # Every association row carries the leased RID (not None).
-    assert all(row["RID"].startswith("LEASED-") for row in exec_rows)
-    # Every association row carries ``Asset_Role="Output"``.
+    # The Image_Execution association rows were DEFERRED — they
+    # carry placeholder tokens in the RID slot. The driver's
+    # post-flush walk resolves them.
+    deferred_tables = [t for t, _ in deferred_emits]
+    assert "Image_Execution" in deferred_tables
+    exec_rows = next(rows for t, rows in deferred_emits if t == "Image_Execution")
+    assert len(exec_rows) == 2
+    # RID slot holds the reserved tokens (UUID4-ish strings), not
+    # a leased catalog RID.
+    assert set(row["RID"] for row in exec_rows) == set(lease_agg._tokens)
+    # ``Asset_Role`` is still pinned to "Output".
     assert all(row["Asset_Role"] == "Output" for row in exec_rows)
 
-    # ``bb.add_asset`` was called once per entry.
+    # Asset hardlinks still happen directly.
     assert len(bb.add_asset_calls) == 2
-    asset_rids = sorted(rid for _table, rid, _src in bb.add_asset_calls)
-    assert asset_rids == ["ASSET-A", "ASSET-B"]
 
 
-def test_add_asset_rows_with_types_leases_two_batches(tmp_path, monkeypatch):
-    """Pending assets with asset-types → two ``post_lease_batch`` calls:
-    one for the Execution association, one for the Asset_Type pairs.
+def test_add_asset_rows_with_types_reserves_both_associations(tmp_path, monkeypatch):
+    """Pending assets WITH asset-types → two ``lease_agg.reserve`` calls
+    on the aggregator (Execution + Asset_Type), no inline POSTs.
+
+    The two reservations accumulate on the same aggregator —
+    pre-fix this was two separate ``post_lease_batch`` POSTs.
     """
     from deriva_ml.execution import bag_commit
+    from deriva_ml.execution.rid_lease import LeaseAggregator
 
     image = _FakeTable(name="Image", schema=_FakeSchema(name="deriva-ml"))
     image_execution = _FakeTable(name="Image_Execution", schema=_FakeSchema(name="deriva-ml"))
@@ -539,7 +550,6 @@ def test_add_asset_rows_with_types_leases_two_batches(tmp_path, monkeypatch):
         ("a.jpg", AssetEntry(asset_table="Image", schema="deriva-ml", rid="ASSET-A", status="pending")),
     ]
 
-    # One entry with two asset types → two (entry, type) pairs.
     monkeypatch.setattr(
         bag_commit,
         "_read_asset_type_map",
@@ -551,18 +561,17 @@ def test_add_asset_rows_with_types_leases_two_batches(tmp_path, monkeypatch):
         lambda working_dir, execution_rid, table_name: working_dir / execution_rid / "asset" / table_name,
     )
 
-    lease_calls: list[list[str]] = []
-
-    def _fake_post_lease_batch(*, catalog, tokens):
-        lease_calls.append(list(tokens))
-        return {token: f"LEASED-{i}" for i, token in enumerate(tokens)}
+    def _post_must_not_be_called(*, catalog, tokens):
+        raise AssertionError("post_lease_batch must not be called inside _add_asset_rows_to_bag")
 
     monkeypatch.setattr(
         "deriva_ml.execution.rid_lease.post_lease_batch",
-        _fake_post_lease_batch,
+        _post_must_not_be_called,
     )
 
     bb = _MockBagBuilder()
+    lease_agg = LeaseAggregator()
+    deferred_emits: list = []
     bag_commit._add_asset_rows_to_bag(
         bb=bb,
         execution=execution,  # type: ignore[arg-type]
@@ -571,18 +580,21 @@ def test_add_asset_rows_with_types_leases_two_batches(tmp_path, monkeypatch):
         progress_callback=None,
         staged_so_far=0,
         total_assets=1,
+        lease_agg=lease_agg,
+        deferred_emits=deferred_emits,
     )
 
-    # Two batched calls: one for Execution association, one for the
-    # two Asset_Type pairs. Each one's token count matches the row
-    # count it leased for.
-    assert len(lease_calls) == 2
-    assert len(lease_calls[0]) == 1  # Execution association: one row
-    assert len(lease_calls[1]) == 2  # Asset_Type: two pairs
+    # 1 token for the exec association + 2 tokens for the two
+    # (asset, type) pairs = 3 tokens total. All accumulated on
+    # one aggregator — the driver will flush them in ONE POST,
+    # which is the whole point of Ex-batch.
+    assert len(lease_agg._tokens) == 3  # noqa: SLF001
 
-    add_rows_tables = [t for t, _rows in bb.add_rows_calls]
-    assert "Image_Asset_Type" in add_rows_tables
-    type_rows = next(rows for t, rows in bb.add_rows_calls if t == "Image_Asset_Type")
+    # Both deferred emits land — Image_Execution and Image_Asset_Type.
+    deferred_tables = [t for t, _ in deferred_emits]
+    assert "Image_Execution" in deferred_tables
+    assert "Image_Asset_Type" in deferred_tables
+    type_rows = next(rows for t, rows in deferred_emits if t == "Image_Asset_Type")
     assert len(type_rows) == 2
     assert sorted(r["Asset_Type"] for r in type_rows) == ["TypeX", "TypeY"]
 
@@ -596,6 +608,7 @@ def test_add_asset_rows_skips_missing_files(tmp_path, monkeypatch):
     commit. The other assets still upload.
     """
     from deriva_ml.execution import bag_commit
+    from deriva_ml.execution.rid_lease import LeaseAggregator
 
     image = _FakeTable(name="Image", schema=_FakeSchema(name="deriva-ml"))
     image_execution = _FakeTable(name="Image_Execution", schema=_FakeSchema(name="deriva-ml"))
@@ -617,7 +630,6 @@ def test_add_asset_rows_skips_missing_files(tmp_path, monkeypatch):
 
     flat_dir = tmp_path / "EXE-A" / "asset" / "Image"
     flat_dir.mkdir(parents=True)
-    # only one of two entries has a file on disk
     (flat_dir / "present.jpg").write_bytes(b"alpha")
 
     entries = [
@@ -631,12 +643,10 @@ def test_add_asset_rows_skips_missing_files(tmp_path, monkeypatch):
         "flat_asset_dir",
         lambda working_dir, execution_rid, table_name: working_dir / execution_rid / "asset" / table_name,
     )
-    monkeypatch.setattr(
-        "deriva_ml.execution.rid_lease.post_lease_batch",
-        lambda *, catalog, tokens: {token: f"LEASED-{i}" for i, token in enumerate(tokens)},
-    )
 
     bb = _MockBagBuilder()
+    lease_agg = LeaseAggregator()
+    deferred_emits: list = []
     final_staged = bag_commit._add_asset_rows_to_bag(
         bb=bb,
         execution=execution,  # type: ignore[arg-type]
@@ -645,6 +655,8 @@ def test_add_asset_rows_skips_missing_files(tmp_path, monkeypatch):
         progress_callback=None,
         staged_so_far=0,
         total_assets=2,
+        lease_agg=lease_agg,
+        deferred_emits=deferred_emits,
     )
 
     # Only the present file gets staged.

--- a/tests/execution/test_lease_aggregator.py
+++ b/tests/execution/test_lease_aggregator.py
@@ -1,0 +1,145 @@
+"""Tests for ``deriva_ml.execution.rid_lease.LeaseAggregator`` (audit P1 Ex-batch).
+
+Pre-extraction, ``bag_commit`` made three separate
+``post_lease_batch`` calls per commit — one for the Execution
+association, one for Asset_Type pairs, one for each feature
+group. The aggregator collapses all reservations into a single
+POST at commit time.
+
+Pure-Python tests; no live catalog required.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from deriva_ml.execution.rid_lease import LeaseAggregator
+
+
+class TestReserveAndResolve:
+    """Tokens reserved on the aggregator survive flush + resolve."""
+
+    def test_reserve_returns_unique_tokens(self):
+        agg = LeaseAggregator()
+        tokens = agg.reserve(5)
+        assert len(tokens) == 5
+        assert len(set(tokens)) == 5  # uniqueness
+
+    def test_multiple_reserves_accumulate(self):
+        """Tokens from multiple ``reserve`` calls land on the same aggregator."""
+        agg = LeaseAggregator()
+        a = agg.reserve(2)
+        b = agg.reserve(3)
+        # Internal token list is the concatenation in call order.
+        assert agg._tokens == a + b  # noqa: SLF001
+
+    def test_reserve_zero_is_a_noop(self):
+        """``reserve(0)`` returns an empty list and adds no tokens."""
+        agg = LeaseAggregator()
+        result = agg.reserve(0)
+        assert result == []
+        assert agg._tokens == []  # noqa: SLF001
+
+    def test_reserve_negative_raises(self):
+        agg = LeaseAggregator()
+        with pytest.raises(ValueError, match="n >= 0"):
+            agg.reserve(-1)
+
+    def test_resolve_before_flush_raises(self):
+        """``resolve(t)`` without a prior ``flush()`` is a programming error."""
+        agg = LeaseAggregator()
+        token = agg.reserve(1)[0]
+        with pytest.raises(RuntimeError, match="before flush"):
+            agg.resolve(token)
+
+
+class TestFlush:
+    """``flush()`` issues exactly one ``post_lease_batch`` POST."""
+
+    def test_flush_posts_all_reserved_tokens_in_one_call(self, monkeypatch):
+        """One flush → one ``post_lease_batch`` call with the union of tokens."""
+        calls: list[list[str]] = []
+
+        def _fake_post(*, catalog, tokens):
+            calls.append(list(tokens))
+            return {t: f"LEASED-{i}" for i, t in enumerate(tokens)}
+
+        monkeypatch.setattr(
+            "deriva_ml.execution.rid_lease.post_lease_batch", _fake_post
+        )
+
+        agg = LeaseAggregator()
+        agg.reserve(2)
+        agg.reserve(3)
+        agg.reserve(1)
+
+        result = agg.flush(catalog=object())
+
+        # Exactly one POST.
+        assert len(calls) == 1
+        # All 6 reserved tokens went together.
+        assert len(calls[0]) == 6
+        assert len(result) == 6
+
+    def test_flush_then_resolve_returns_leased_rids(self, monkeypatch):
+        """After flush, every reserved token resolves to its leased RID."""
+        monkeypatch.setattr(
+            "deriva_ml.execution.rid_lease.post_lease_batch",
+            lambda *, catalog, tokens: {t: f"RID-{i}" for i, t in enumerate(tokens)},
+        )
+        agg = LeaseAggregator()
+        tokens = agg.reserve(3)
+        agg.flush(catalog=object())
+        rids = [agg.resolve(t) for t in tokens]
+        assert rids == ["RID-0", "RID-1", "RID-2"]
+
+    def test_flush_empty_aggregator_is_a_noop(self, monkeypatch):
+        """Flushing without any reserve calls returns an empty map.
+
+        Used in commit paths where the aggregator is unconditionally
+        flushed but the commit might have nothing to lease (e.g.
+        zero pending entries).
+        """
+        called = []
+        monkeypatch.setattr(
+            "deriva_ml.execution.rid_lease.post_lease_batch",
+            lambda *, catalog, tokens: called.append(tokens) or {},
+        )
+        agg = LeaseAggregator()
+        result = agg.flush(catalog=object())
+        assert result == {}
+        # ``post_lease_batch`` itself short-circuits on empty tokens,
+        # but the aggregator should call through with the empty list.
+        assert called == [[]]
+
+    def test_double_flush_raises(self, monkeypatch):
+        monkeypatch.setattr(
+            "deriva_ml.execution.rid_lease.post_lease_batch",
+            lambda *, catalog, tokens: {},
+        )
+        agg = LeaseAggregator()
+        agg.flush(catalog=object())
+        with pytest.raises(RuntimeError, match="twice"):
+            agg.flush(catalog=object())
+
+    def test_reserve_after_flush_raises(self, monkeypatch):
+        """Reserving after flush would leave the new token un-POSTed."""
+        monkeypatch.setattr(
+            "deriva_ml.execution.rid_lease.post_lease_batch",
+            lambda *, catalog, tokens: {},
+        )
+        agg = LeaseAggregator()
+        agg.flush(catalog=object())
+        with pytest.raises(RuntimeError, match="after flush"):
+            agg.reserve(1)
+
+    def test_resolve_unknown_token_raises_keyerror(self, monkeypatch):
+        monkeypatch.setattr(
+            "deriva_ml.execution.rid_lease.post_lease_batch",
+            lambda *, catalog, tokens: {t: f"RID-{i}" for i, t in enumerate(tokens)},
+        )
+        agg = LeaseAggregator()
+        agg.reserve(1)
+        agg.flush(catalog=object())
+        with pytest.raises(KeyError):
+            agg.resolve("not-a-real-token")


### PR DESCRIPTION
## Summary

Closes audit P1 Ex-batch from
``docs/audits/2026-05-22-engineer-audit-execution.md``.

Pre-fix, ``bag_commit`` made up to **11 sequential
``post_lease_batch`` POSTs** per commit (3-table 5-feature
case): one per asset table for ``*_Execution`` rows, one per
asset table for ``*_Asset_Type`` rows, one per feature-table
group. Each is a round trip the rest of the commit can't
proceed without.

Introduces ``LeaseAggregator`` in
``deriva_ml.execution.rid_lease``:

- ``reserve(n)`` — get ``n`` fresh tokens, accumulate them.
- ``flush(catalog=...)`` — POST every reserved token in one
  batched call.
- ``resolve(token)`` — look up the leased RID after flush.

Wires it into ``build_execution_bag``: a single aggregator
spans the whole commit, every ``_add_*`` function reserves
tokens and defers ``bb.add_rows`` via a ``deferred_emits``
list, then the driver flushes once and walks the deferred
emits with the resolved RIDs.

**Net**: one ``post_lease_batch`` POST per commit, regardless
of asset/type/feature-group count.

## Test plan

- [x] New ``tests/execution/test_lease_aggregator.py`` (11/11
      pass) — pure-Python contract for ``LeaseAggregator``:
      reserve uniqueness/accumulation, error paths
      (reserve-after-flush, double-flush, resolve-before-flush,
      unknown token), and the empty-aggregator no-op.
- [x] ``tests/execution/test_bag_commit_unit.py`` — 3 existing
      Ex-batch tests rewritten to pin the **new** contract:
      ``_add_asset_rows_to_bag`` issues **zero** POSTs and lands
      its rows in ``deferred_emits``. Old tests pinned the
      bug (one POST per association).
- [x] ``tests/execution/`` — 373 pass, 8 skip (was 362/8;
      +11 new aggregator tests, including the rewritten 3)
- [x] ``ruff check`` clean (fixed 2 pre-existing ``F821``s as a drive-by)

🤖 Generated with [Claude Code](https://claude.com/claude-code)