### PR TITLE
refactor(dataset): extract estimate_bag_size god-function into 3 helpers (audit P1 Ds-est)

### DIFF
--- a/src/deriva_ml/dataset/_estimate.py
+++ b/src/deriva_ml/dataset/_estimate.py
@@ -1,0 +1,400 @@
+"""Extracted helpers for :meth:`Dataset.estimate_bag_size` (audit P1 Ds-est).
+
+Pre-extraction, ``estimate_bag_size`` was a 220-line method that
+did everything from snapshot resolution through async query
+orchestration through final dict assembly. The audit flagged it
+as a god-function because the fine-grained steps — URI
+extraction, query-item building, result aggregation, CSV
+estimation, asset detection, final assembly — could not be
+unit-tested without standing up a live catalog.
+
+This module breaks the work into three free functions:
+
+- :func:`build_estimate_queries` — pure: walks the
+  ``aggregate_queries`` output and constructs the list of
+  ``QueryItem`` records that the async layer will execute. No
+  catalog calls; testable with synthetic ``table_queries`` input.
+- :func:`run_estimate_queries` — orchestration: fires every
+  query against the async catalog and groups results by table +
+  query type. Testable with a mock catalog that returns canned
+  JSON.
+- :func:`assemble_estimate` — pure: takes the orchestrator's
+  three result maps and produces the final estimate dict.
+  Testable with synthetic dicts.
+
+The ``Dataset.estimate_bag_size`` method is now a thin shim
+that composes these three steps. The async-from-sync bridge
+still lives in the calling method (``run_async``) because it
+imports a deriva-ml internal helper that's awkward to reach
+from a leaf module.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Literal
+
+if TYPE_CHECKING:
+    from deriva.core import AsyncErmrestCatalog, AsyncErmrestSnapshot
+
+
+QueryType = Literal["csv", "fetch", "sample"]
+"""Three classes of query needed for an estimate.
+
+- ``csv``: fetch the full RID list for a table along an FK path
+  (union of paths gives the exact row count).
+- ``fetch``: fetch ``(RID, Length)`` pairs for an asset table
+  (sum of de-duplicated lengths gives the exact asset bytes).
+- ``sample``: fetch up to 100 rows for CSV serialisation size
+  estimation (one sample per table; first path wins).
+"""
+
+
+@dataclass(frozen=True)
+class QueryItem:
+    """One unit of work for the async estimate orchestrator.
+
+    Attributes:
+        table_name: Target table the query is about.
+        path: Catalog-relative URI, starting at one of
+            ``/aggregate/``, ``/entity/``, or ``/attribute/``.
+            Already stripped of the
+            ``https://host/ermrest/catalog/N`` prefix.
+        query_type: Which post-processing branch applies to the
+            response — see :data:`QueryType`.
+    """
+
+    table_name: str
+    path: str
+    query_type: QueryType
+
+
+def _extract_path(uri: str) -> str:
+    """Strip the catalog-server prefix from a full datapath URI.
+
+    Datapath builders return absolute URIs like
+    ``https://host/ermrest/catalog/N/entity/Schema:Table``;
+    the async catalog wrapper wants the path starting from
+    the operation marker (``/entity/``, ``/aggregate/``,
+    ``/attribute/``).
+
+    Args:
+        uri: A full datapath URI.
+
+    Returns:
+        Catalog-relative path, e.g. ``/entity/Schema:Table``.
+
+    Raises:
+        ValueError: If the URI doesn't contain a recognised
+            operation marker.
+
+    Example:
+        >>> _extract_path("https://srv/ermrest/catalog/3/entity/X:Y")
+        '/entity/X:Y'
+        >>> _extract_path("https://srv/ermrest/catalog/3/aggregate/X:Y/cnt(RID)")
+        '/aggregate/X:Y/cnt(RID)'
+    """
+    for marker in ("/aggregate/", "/entity/", "/attribute/"):
+        idx = uri.find(marker)
+        if idx >= 0:
+            return uri[idx:]
+    raise ValueError(f"Cannot extract catalog path from URI: {uri}")
+
+
+def build_estimate_queries(
+    table_queries: dict[str, list[tuple[Any, Any, bool]]],
+) -> list[QueryItem]:
+    """Build the full list of queries for an estimate run.
+
+    For each ``(table_name, [(datapath, target_table, is_asset), ...])``
+    entry in ``table_queries``, emits:
+
+    - One ``csv`` query per FK path (RID list for union counting).
+    - One ``fetch`` query per FK path **when ``is_asset`` is True**
+      (``(RID, Length)`` pairs for asset size summation).
+    - One ``sample`` query **per table** (only the first path's
+      sample is taken; subsequent paths share the same row shape
+      so re-sampling is wasted work).
+
+    Args:
+        table_queries: ``DatasetBagBuilder.aggregate_queries(dataset)``
+            output — a mapping from table name to a list of
+            ``(datapath, target_table, is_asset)`` triples, one
+            per FK path that reaches the table.
+
+    Returns:
+        Ordered list of :class:`QueryItem` ready to feed to
+        :func:`run_estimate_queries`. Order is
+        ``(per table, per FK path, csv → fetch → first-time sample)``.
+
+    Example:
+        >>> # Pure-Python contract — see test_estimate_helpers.py for
+        >>> # a fixture-driven example. Helpers don't fabricate datapaths
+        >>> # in a doctest.
+        >>> from deriva_ml.dataset._estimate import build_estimate_queries
+        >>> build_estimate_queries({})
+        []
+    """
+    items: list[QueryItem] = []
+    sampled_tables: set[str] = set()
+
+    for table_name, path_entries in table_queries.items():
+        for dp, target_table, is_asset in path_entries:
+            # Fetch the RID list for row-count union.
+            rid_rs = dp.attributes(target_table.RID)
+            items.append(
+                QueryItem(
+                    table_name=table_name,
+                    path=_extract_path(rid_rs.uri),
+                    query_type="csv",
+                )
+            )
+
+            if is_asset:
+                entity_path = _extract_path(dp.uri).removeprefix("/entity/")
+                items.append(
+                    QueryItem(
+                        table_name=table_name,
+                        path=f"/attribute/{entity_path}/RID,Length",
+                        query_type="fetch",
+                    )
+                )
+
+            # Sample a few rows to estimate CSV serialisation size.
+            # Only one sample per table — first path wins. Subsequent
+            # paths through the same table share the same row shape,
+            # so a second sample would be wasted work.
+            if table_name not in sampled_tables:
+                sampled_tables.add(table_name)
+                items.append(
+                    QueryItem(
+                        table_name=table_name,
+                        path=f"{_extract_path(dp.uri)}?limit=100",
+                        query_type="sample",
+                    )
+                )
+
+    return items
+
+
+async def run_estimate_queries(
+    catalog: "AsyncErmrestCatalog | AsyncErmrestSnapshot",
+    items: list[QueryItem],
+    *,
+    logger: Any = None,
+) -> tuple[
+    dict[str, set[str]],
+    dict[str, dict[str, int]],
+    dict[str, list[dict]],
+]:
+    """Fire every query concurrently; group results by table + type.
+
+    Single failure per query is **swallowed with a debug log**
+    rather than aborting the whole estimate — partial estimates
+    are still useful and matches the pre-extraction contract.
+    Caller-side failures (e.g. credential resolution, snapshot
+    resolution) still propagate.
+
+    Args:
+        catalog: A snapshot-scoped async catalog connection. The
+            function calls ``catalog.get_async`` for each item
+            and then closes the connection on its way out.
+        items: Output of :func:`build_estimate_queries`.
+        logger: Optional logger for per-query failure debug
+            lines. Defaults to the dataset module logger.
+
+    Returns:
+        Three dicts in a tuple:
+
+        - ``rids_by_table`` — table name → set of RIDs from
+          ``csv`` queries (union across FK paths).
+        - ``asset_lengths_by_table`` — table name → ``{RID:
+          Length}`` from ``fetch`` queries (first occurrence
+          wins; the same asset across paths must have the same
+          length so collisions are benign).
+        - ``sample_rows_by_table`` — table name → list of sample
+          rows from the ``sample`` query (only one sample per
+          table; subsequent ``sample`` results for the same
+          table are ignored).
+
+    Example:
+        >>> # See test_estimate_helpers.py for a mock-catalog
+        >>> # exercise that doesn't need a live server.
+        >>> ...  # doctest: +SKIP
+    """
+    import asyncio
+
+    if logger is None:
+        from deriva_ml.core.logging_config import get_logger
+
+        logger = get_logger(__name__)
+
+    async def _run_one(item: QueryItem) -> tuple[str, QueryType, Any]:
+        try:
+            response = await catalog.get_async(item.path)
+            return item.table_name, item.query_type, response.json()
+        except Exception as exc:
+            logger.debug(
+                "estimate_bag_size query failed for %s (%s): %s",
+                item.table_name,
+                item.path,
+                exc,
+            )
+            return item.table_name, item.query_type, []
+
+    try:
+        results = await asyncio.gather(*[_run_one(it) for it in items])
+    finally:
+        await catalog.close()
+
+    rids_by_table: dict[str, set[str]] = defaultdict(set)
+    asset_lengths_by_table: dict[str, dict[str, int]] = defaultdict(dict)
+    sample_rows_by_table: dict[str, list[dict]] = {}
+
+    for table_name, query_type, rows in results:
+        if query_type == "csv":
+            rids_by_table[table_name].update(r["RID"] for r in rows if "RID" in r)
+        elif query_type == "fetch":
+            for r in rows:
+                rid = r.get("RID")
+                if rid and rid not in asset_lengths_by_table[table_name]:
+                    asset_lengths_by_table[table_name][rid] = r.get("Length") or 0
+        elif query_type == "sample":
+            # Only the first sample per table — set during query
+            # building. Subsequent ``sample`` responses for the
+            # same table are dropped.
+            if table_name not in sample_rows_by_table and rows:
+                sample_rows_by_table[table_name] = rows
+
+    return rids_by_table, asset_lengths_by_table, sample_rows_by_table
+
+
+def assemble_estimate(
+    *,
+    table_queries: dict[str, list[tuple[Any, Any, bool]]],
+    rids_by_table: dict[str, set[str]],
+    asset_lengths_by_table: dict[str, dict[str, int]],
+    sample_rows_by_table: dict[str, list[dict]],
+    estimate_csv_bytes: Any,
+    human_readable_size: Any,
+) -> dict[str, Any]:
+    """Assemble the final estimate dict from orchestrator outputs.
+
+    Pure data transform — same shape as the legacy method's
+    closing block but isolated for testability against synthetic
+    inputs.
+
+    Args:
+        table_queries: Same input that
+            :func:`build_estimate_queries` received; needed here
+            to determine which tables are assets (the
+            ``is_asset`` flag on any FK path).
+        rids_by_table: First output of
+            :func:`run_estimate_queries`.
+        asset_lengths_by_table: Second output.
+        sample_rows_by_table: Third output.
+        estimate_csv_bytes: Callable
+            ``(sample_rows, row_count) -> int`` —
+            :meth:`Dataset._estimate_csv_bytes`. Passed as a
+            callable so this helper stays free of the
+            :class:`Dataset` import. Same trick for
+            ``human_readable_size``.
+        human_readable_size: Callable ``(bytes) -> str`` —
+            :meth:`Dataset._human_readable_size`.
+
+    Returns:
+        The full estimate dict — same shape and keys as the
+        pre-extraction :meth:`Dataset.estimate_bag_size` return
+        value.
+
+    Example:
+        >>> from deriva_ml.dataset._estimate import assemble_estimate
+        >>> result = assemble_estimate(
+        ...     table_queries={},
+        ...     rids_by_table={},
+        ...     asset_lengths_by_table={},
+        ...     sample_rows_by_table={},
+        ...     estimate_csv_bytes=lambda rows, n: 0,
+        ...     human_readable_size=lambda n: f"{n}B",
+        ... )
+        >>> result["total_rows"]
+        0
+        >>> result["total_estimated_size"]
+        '0B'
+    """
+    # CSV bytes from samples.
+    csv_bytes_by_table: dict[str, int] = {}
+    for table_name, sample_rows in sample_rows_by_table.items():
+        row_count = len(rids_by_table.get(table_name, set()))
+        csv_bytes_by_table[table_name] = estimate_csv_bytes(sample_rows, row_count)
+
+    # Which tables are assets (any FK path declared it so).
+    asset_tables = {
+        table_name
+        for table_name, entries in table_queries.items()
+        if any(is_asset for _, _, is_asset in entries)
+    }
+
+    table_estimates: dict[str, dict[str, Any]] = {}
+    total_rows = 0
+    total_asset_bytes = 0
+    total_csv_bytes = 0
+
+    for table_name, rids in rids_by_table.items():
+        row_count = len(rids)
+        is_asset = table_name in asset_tables
+        # ``asset_lengths_by_table`` is typed as a plain dict so
+        # the helper accepts both ``dict`` and ``defaultdict``
+        # inputs — use ``.get`` to avoid a KeyError when a non-
+        # asset table has no entry. Original code used a
+        # defaultdict so this branch was implicit; the helper
+        # is testable with a plain dict.
+        asset_bytes = sum(asset_lengths_by_table.get(table_name, {}).values())
+        csv_bytes = csv_bytes_by_table.get(table_name, 0)
+        table_estimates[table_name] = {
+            "row_count": row_count,
+            "is_asset": is_asset,
+            "asset_bytes": asset_bytes,
+            "csv_bytes": csv_bytes,
+        }
+        total_rows += row_count
+        total_asset_bytes += asset_bytes
+        total_csv_bytes += csv_bytes
+
+    # Tables that only appear in ``fetch`` results (unlikely
+    # but defensive — an asset path with no ``csv`` query would
+    # land here).
+    for table_name, lengths in asset_lengths_by_table.items():
+        if table_name not in table_estimates:
+            csv_bytes = csv_bytes_by_table.get(table_name, 0)
+            table_estimates[table_name] = {
+                "row_count": len(lengths),
+                "is_asset": True,
+                "asset_bytes": sum(lengths.values()),
+                "csv_bytes": csv_bytes,
+            }
+            total_rows += len(lengths)
+            total_asset_bytes += sum(lengths.values())
+            total_csv_bytes += csv_bytes
+
+    total_size = total_asset_bytes + total_csv_bytes
+    return {
+        "tables": table_estimates,
+        "total_rows": total_rows,
+        "total_asset_bytes": total_asset_bytes,
+        "total_asset_size": human_readable_size(total_asset_bytes),
+        "total_csv_bytes": total_csv_bytes,
+        "total_csv_size": human_readable_size(total_csv_bytes),
+        "total_estimated_bytes": total_size,
+        "total_estimated_size": human_readable_size(total_size),
+    }
+
+
+__all__ = [
+    "QueryItem",
+    "QueryType",
+    "assemble_estimate",
+    "build_estimate_queries",
+    "run_estimate_queries",
+]

--- a/src/deriva_ml/dataset/dataset.py
+++ b/src/deriva_ml/dataset/dataset.py
@@ -2492,6 +2492,17 @@ class Dataset:
                 - total_estimated_bytes: asset + CSV bytes combined
                 - total_estimated_size: human-readable combined size
         """
+        # Post Ds-est extraction this method composes three free
+        # functions in ``dataset/_estimate.py``: query construction,
+        # async orchestration, and final assembly. The async-from-
+        # sync bridge (``run_async``) still lives here because it's
+        # the one piece tied to deriva-ml internals.
+        from deriva_ml.dataset._estimate import (
+            assemble_estimate,
+            build_estimate_queries,
+            run_estimate_queries,
+        )
+
         if isinstance(version, str):
             version = DatasetVersion.parse(version)
 
@@ -2521,145 +2532,26 @@ class Dataset:
         else:
             catalog = AsyncErmrestCatalog(protocol, hostname, snapshot_catalog_id, credentials)
 
-        def _extract_path(uri: str) -> str:
-            """Extract the catalog-relative path from a full datapath URI.
+        # 1. Build the query plan (pure).
+        items = build_estimate_queries(table_queries)
 
-            Strips the ``https://host/ermrest/catalog/N`` prefix, returning the
-            path starting from ``/aggregate/``, ``/entity/``, ``/attribute/``, etc.
-            """
-            for marker in ("/aggregate/", "/entity/", "/attribute/"):
-                idx = uri.find(marker)
-                if idx >= 0:
-                    return uri[idx:]
-            raise ValueError(f"Cannot extract catalog path from URI: {uri}")
+        # 2. Execute the queries concurrently against the snapshot.
+        # ``run_async`` is the notebook-loop-fallback bridge used
+        # elsewhere in the codebase (e.g. bag-commit's
+        # ``BagCatalogLoader.arun``).
+        rids_by_table, asset_lengths_by_table, sample_rows_by_table = run_async(
+            run_estimate_queries(catalog, items, logger=self._logger)
+        )
 
-        # Build query paths using the datapath API.  For each
-        # (table_name, path_entries) we fetch RID lists (and RID+Length for
-        # assets) so we can compute the exact union across all FK paths.
-        # (table_name, query_path, query_type)
-        query_items: list[tuple[str, str, str]] = []
-        # Track which tables already have a sample query to avoid duplicates
-        # when multiple FK paths reach the same table.
-        sampled_tables: set[str] = set()
-
-        for table_name, path_entries in table_queries.items():
-            for dp, target_table, is_asset in path_entries:
-                # Fetch RID list for row-count union
-                rid_rs = dp.attributes(target_table.RID)
-                query_items.append((table_name, _extract_path(rid_rs.uri), "csv"))
-
-                if is_asset:
-                    entity_path = _extract_path(dp.uri).removeprefix("/entity/")
-                    fetch_path = f"/attribute/{entity_path}/RID,Length"
-                    query_items.append((table_name, fetch_path, "fetch"))
-
-                # Sample a few rows to estimate CSV serialization size.
-                # Only one sample per table (first path wins).
-                if table_name not in sampled_tables:
-                    sampled_tables.add(table_name)
-                    entity_path = _extract_path(dp.uri)
-                    sample_path = f"{entity_path}?limit=100"
-                    query_items.append((table_name, sample_path, "sample"))
-
-        # Execute all queries concurrently using asyncio.gather
-        import asyncio
-
-        async def _run_query(table_name: str, query_path: str, query_type: str) -> tuple[str, str, Any]:
-            try:
-                response = await catalog.get_async(query_path)
-                return table_name, query_type, response.json()
-            except Exception as exc:
-                self._logger.debug("estimate_bag_size query failed for %s (%s): %s", table_name, query_path, exc)
-                return table_name, query_type, []
-
-        async def _run_all_queries():
-            tasks = [_run_query(name, path, qtype) for name, path, qtype in query_items]
-            results = await asyncio.gather(*tasks)
-            await catalog.close()
-            return results
-
-        # Run the async queries from the sync context. See
-        # :func:`deriva_ml.core.async_helpers.run_async` — same
-        # notebook-loop-fallback dance that the bag-commit path
-        # uses for ``BagCatalogLoader.arun``.
-        all_results = run_async(_run_all_queries())
-
-        # Compute exact union of RIDs across all paths for each table.
-        rids_by_table: dict[str, set[str]] = defaultdict(set)
-        # For assets, collect {RID: Length} across paths (first wins; same asset = same Length).
-        asset_lengths_by_table: dict[str, dict[str, int]] = defaultdict(dict)
-        # Collect sample rows for CSV size estimation.
-        sample_rows_by_table: dict[str, list[dict]] = {}
-
-        for table_name, query_type, rows in all_results:
-            if query_type == "csv":
-                rids_by_table[table_name].update(r["RID"] for r in rows if "RID" in r)
-            elif query_type == "fetch":
-                for r in rows:
-                    rid = r.get("RID")
-                    if rid and rid not in asset_lengths_by_table[table_name]:
-                        asset_lengths_by_table[table_name][rid] = r.get("Length") or 0
-            elif query_type == "sample":
-                # Keep only the first sample per table (set during query building)
-                if table_name not in sample_rows_by_table and rows:
-                    sample_rows_by_table[table_name] = rows
-
-        # Estimate CSV size per table from sample rows.
-        csv_bytes_by_table: dict[str, int] = {}
-        for table_name, sample_rows in sample_rows_by_table.items():
-            row_count = len(rids_by_table.get(table_name, set()))
-            csv_bytes_by_table[table_name] = self._estimate_csv_bytes(sample_rows, row_count)
-
-        # Determine which tables are assets from the original table_queries
-        asset_tables = {
-            table_name for table_name, entries in table_queries.items() if any(is_asset for _, _, is_asset in entries)
-        }
-
-        table_estimates: dict[str, dict[str, Any]] = {}
-        total_rows = 0
-        total_asset_bytes = 0
-        total_csv_bytes = 0
-
-        for table_name, rids in rids_by_table.items():
-            row_count = len(rids)
-            is_asset = table_name in asset_tables
-            asset_bytes = sum(asset_lengths_by_table[table_name].values())
-            csv_bytes = csv_bytes_by_table.get(table_name, 0)
-            table_estimates[table_name] = {
-                "row_count": row_count,
-                "is_asset": is_asset,
-                "asset_bytes": asset_bytes,
-                "csv_bytes": csv_bytes,
-            }
-            total_rows += row_count
-            total_asset_bytes += asset_bytes
-            total_csv_bytes += csv_bytes
-
-        # Handle tables that only appear in fetch results (unlikely but safe)
-        for table_name, lengths in asset_lengths_by_table.items():
-            if table_name not in table_estimates:
-                csv_bytes = csv_bytes_by_table.get(table_name, 0)
-                table_estimates[table_name] = {
-                    "row_count": len(lengths),
-                    "is_asset": True,
-                    "asset_bytes": sum(lengths.values()),
-                    "csv_bytes": csv_bytes,
-                }
-                total_rows += len(lengths)
-                total_asset_bytes += sum(lengths.values())
-                total_csv_bytes += csv_bytes
-
-        total_size = total_asset_bytes + total_csv_bytes
-        return {
-            "tables": table_estimates,
-            "total_rows": total_rows,
-            "total_asset_bytes": total_asset_bytes,
-            "total_asset_size": self._human_readable_size(total_asset_bytes),
-            "total_csv_bytes": total_csv_bytes,
-            "total_csv_size": self._human_readable_size(total_csv_bytes),
-            "total_estimated_bytes": total_size,
-            "total_estimated_size": self._human_readable_size(total_size),
-        }
+        # 3. Assemble the final dict (pure).
+        return assemble_estimate(
+            table_queries=table_queries,
+            rids_by_table=rids_by_table,
+            asset_lengths_by_table=asset_lengths_by_table,
+            sample_rows_by_table=sample_rows_by_table,
+            estimate_csv_bytes=self._estimate_csv_bytes,
+            human_readable_size=self._human_readable_size,
+        )
 
     @validate_call(config=VALIDATION_CONFIG)
     def bag_info(

--- a/tests/dataset/test_estimate_helpers.py
+++ b/tests/dataset/test_estimate_helpers.py
@@ -1,0 +1,374 @@
+"""Unit tests for ``deriva_ml.dataset._estimate`` (audit P1 Ds-est).
+
+Pre-extraction, ``Dataset.estimate_bag_size`` was a 220-line
+god-function whose fine-grained steps could not be unit-tested
+without a live catalog. The audit asked for three helpers that
+each have a clear contract; this file pins those contracts with
+pure-Python tests.
+
+Coverage layers:
+
+1. ``_extract_path`` — URI string-stripping. Pure.
+2. ``build_estimate_queries`` — given a synthetic ``table_queries``
+   shape, returns the expected list of ``QueryItem`` records.
+   Uses ``MagicMock`` to stand in for datapaths and tables.
+3. ``run_estimate_queries`` — async orchestration with a mock
+   catalog that returns canned JSON. Verifies grouping by table
+   + query type, the per-query failure-swallowing contract, and
+   that ``catalog.close`` is called even on partial failure.
+4. ``assemble_estimate`` — given the three orchestrator outputs,
+   produces the final estimate dict. Pinned via synthetic inputs.
+
+No live catalog required.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+
+from deriva_ml.dataset._estimate import (
+    QueryItem,
+    _extract_path,
+    assemble_estimate,
+    build_estimate_queries,
+    run_estimate_queries,
+)
+
+
+class TestExtractPath:
+    """``_extract_path`` strips the catalog-server prefix."""
+
+    def test_entity_uri(self):
+        assert (
+            _extract_path("https://srv/ermrest/catalog/3/entity/X:Y")
+            == "/entity/X:Y"
+        )
+
+    def test_aggregate_uri(self):
+        assert (
+            _extract_path("https://srv/ermrest/catalog/3/aggregate/X:Y/cnt(RID)")
+            == "/aggregate/X:Y/cnt(RID)"
+        )
+
+    def test_attribute_uri(self):
+        assert (
+            _extract_path("https://srv/ermrest/catalog/3/attribute/X:Y/RID,Length")
+            == "/attribute/X:Y/RID,Length"
+        )
+
+    def test_unrecognised_uri_raises(self):
+        with pytest.raises(ValueError, match="Cannot extract"):
+            _extract_path("https://srv/ermrest/catalog/3/some-other-shape")
+
+
+def _fake_datapath(entity_uri: str, attr_uri: str) -> MagicMock:
+    """Build a datapath stub whose ``.uri`` returns ``entity_uri`` and whose
+    ``.attributes(...)`` returns an object with ``.uri == attr_uri``."""
+    dp = MagicMock()
+    dp.uri = entity_uri
+    dp.attributes.return_value.uri = attr_uri
+    return dp
+
+
+class TestBuildEstimateQueries:
+    """``build_estimate_queries`` emits one item per query type."""
+
+    def test_empty_input(self):
+        assert build_estimate_queries({}) == []
+
+    def test_non_asset_single_path_emits_csv_and_sample(self):
+        """Non-asset table, one path → ``csv`` + ``sample``, no ``fetch``."""
+        dp = _fake_datapath(
+            entity_uri="https://srv/ermrest/catalog/3/entity/X:Y",
+            attr_uri="https://srv/ermrest/catalog/3/attribute/X:Y/RID",
+        )
+        target = MagicMock()
+        target.RID = "RID-col-stub"
+        items = build_estimate_queries({"Y": [(dp, target, False)]})
+        assert [it.query_type for it in items] == ["csv", "sample"]
+        assert items[0].path == "/attribute/X:Y/RID"
+        assert items[1].path == "/entity/X:Y?limit=100"
+
+    def test_asset_single_path_emits_csv_fetch_sample(self):
+        """Asset table → ``csv`` + ``fetch`` + ``sample``."""
+        dp = _fake_datapath(
+            entity_uri="https://srv/ermrest/catalog/3/entity/X:Y",
+            attr_uri="https://srv/ermrest/catalog/3/attribute/X:Y/RID",
+        )
+        target = MagicMock()
+        target.RID = "RID-col-stub"
+        items = build_estimate_queries({"Y": [(dp, target, True)]})
+        assert [it.query_type for it in items] == ["csv", "fetch", "sample"]
+        assert items[1].path == "/attribute/X:Y/RID,Length"
+
+    def test_two_paths_to_same_table_only_one_sample(self):
+        """Multiple FK paths to one table → one sample query (first wins).
+
+        Subsequent paths through the same table share row shape;
+        re-sampling would be wasted work.
+        """
+        dp1 = _fake_datapath(
+            entity_uri="https://srv/ermrest/catalog/3/entity/A:Y",
+            attr_uri="https://srv/ermrest/catalog/3/attribute/A:Y/RID",
+        )
+        dp2 = _fake_datapath(
+            entity_uri="https://srv/ermrest/catalog/3/entity/B:Y",
+            attr_uri="https://srv/ermrest/catalog/3/attribute/B:Y/RID",
+        )
+        target = MagicMock()
+        items = build_estimate_queries({"Y": [(dp1, target, False), (dp2, target, False)]})
+        sample_items = [it for it in items if it.query_type == "sample"]
+        assert len(sample_items) == 1
+        # The first path's URI wins.
+        assert sample_items[0].path == "/entity/A:Y?limit=100"
+        # Both paths still get their own ``csv`` query.
+        csv_items = [it for it in items if it.query_type == "csv"]
+        assert len(csv_items) == 2
+
+
+# ---------------------------------------------------------------------------
+# run_estimate_queries — async orchestration with mock catalog
+# ---------------------------------------------------------------------------
+
+
+class _FakeAsyncResponse:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+class _FakeAsyncCatalog:
+    """Mock async catalog that returns canned responses per path.
+
+    Attributes:
+        responses: dict mapping path → payload (or callable raising
+            for that path).
+        get_calls: list of paths the orchestrator requested.
+        closed: True after ``close()`` is awaited.
+    """
+
+    def __init__(self, responses):
+        self.responses = responses
+        self.get_calls: list[str] = []
+        self.closed = False
+
+    async def get_async(self, path):
+        self.get_calls.append(path)
+        resp = self.responses.get(path)
+        if callable(resp):
+            resp()  # may raise
+        return _FakeAsyncResponse(resp)
+
+    async def close(self):
+        self.closed = True
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro) if not _have_running_loop() else asyncio.run(coro)
+
+
+def _have_running_loop() -> bool:
+    try:
+        asyncio.get_running_loop()
+        return True
+    except RuntimeError:
+        return False
+
+
+class TestRunEstimateQueries:
+    """``run_estimate_queries`` orchestrates queries and groups results."""
+
+    def test_csv_results_union_rids(self):
+        cat = _FakeAsyncCatalog(
+            {
+                "/p1": [{"RID": "A"}, {"RID": "B"}],
+                "/p2": [{"RID": "B"}, {"RID": "C"}],
+            }
+        )
+        items = [
+            QueryItem("T", "/p1", "csv"),
+            QueryItem("T", "/p2", "csv"),
+        ]
+        rids, lengths, samples = asyncio.run(run_estimate_queries(cat, items))
+        # Union, not concat.
+        assert rids == {"T": {"A", "B", "C"}}
+        assert lengths == {}
+        assert samples == {}
+        assert cat.closed is True
+
+    def test_fetch_results_collect_rid_length(self):
+        cat = _FakeAsyncCatalog(
+            {
+                "/p1": [
+                    {"RID": "A", "Length": 100},
+                    {"RID": "B", "Length": 200},
+                ]
+            }
+        )
+        items = [QueryItem("T", "/p1", "fetch")]
+        rids, lengths, samples = asyncio.run(run_estimate_queries(cat, items))
+        assert lengths == {"T": {"A": 100, "B": 200}}
+
+    def test_fetch_first_occurrence_wins(self):
+        """Same RID appearing twice keeps the first Length value."""
+        cat = _FakeAsyncCatalog(
+            {
+                "/p1": [{"RID": "A", "Length": 100}],
+                "/p2": [{"RID": "A", "Length": 999}],
+            }
+        )
+        items = [
+            QueryItem("T", "/p1", "fetch"),
+            QueryItem("T", "/p2", "fetch"),
+        ]
+        rids, lengths, samples = asyncio.run(run_estimate_queries(cat, items))
+        assert lengths == {"T": {"A": 100}}
+
+    def test_sample_only_keeps_first_per_table(self):
+        cat = _FakeAsyncCatalog(
+            {
+                "/p1": [{"row": 1}],
+                "/p2": [{"row": 2}, {"row": 3}],
+            }
+        )
+        items = [
+            QueryItem("T", "/p1", "sample"),
+            QueryItem("T", "/p2", "sample"),
+        ]
+        rids, lengths, samples = asyncio.run(run_estimate_queries(cat, items))
+        assert samples == {"T": [{"row": 1}]}
+
+    def test_per_query_failure_is_swallowed_with_debug_log(self):
+        """A failing query produces an empty-list result; other queries succeed."""
+
+        def _boom():
+            raise RuntimeError("query failed")
+
+        cat = _FakeAsyncCatalog({"/good": [{"RID": "A"}], "/bad": _boom})
+        items = [
+            QueryItem("T", "/good", "csv"),
+            QueryItem("T", "/bad", "csv"),
+        ]
+        rids, lengths, samples = asyncio.run(run_estimate_queries(cat, items))
+        # The good query landed; the bad one returned an empty list,
+        # contributing zero RIDs to the union.
+        assert rids == {"T": {"A"}}
+
+    def test_close_runs_even_on_partial_failure(self):
+        """``catalog.close()`` is awaited even when individual queries failed."""
+
+        def _boom():
+            raise RuntimeError("boom")
+
+        cat = _FakeAsyncCatalog({"/p1": _boom})
+        items = [QueryItem("T", "/p1", "csv")]
+        asyncio.run(run_estimate_queries(cat, items))
+        assert cat.closed is True
+
+
+# ---------------------------------------------------------------------------
+# assemble_estimate — pure data assembly
+# ---------------------------------------------------------------------------
+
+
+def _stub_estimate_csv_bytes(rows, n):
+    # Trivial: 50 bytes per row, scaled by row count.
+    return 50 * n
+
+
+def _stub_human_readable(n):
+    return f"{n}B"
+
+
+class TestAssembleEstimate:
+    """``assemble_estimate`` produces the final estimate dict."""
+
+    def test_empty_inputs(self):
+        result = assemble_estimate(
+            table_queries={},
+            rids_by_table={},
+            asset_lengths_by_table={},
+            sample_rows_by_table={},
+            estimate_csv_bytes=_stub_estimate_csv_bytes,
+            human_readable_size=_stub_human_readable,
+        )
+        assert result["total_rows"] == 0
+        assert result["total_asset_bytes"] == 0
+        assert result["total_csv_bytes"] == 0
+        assert result["total_estimated_bytes"] == 0
+        assert result["tables"] == {}
+
+    def test_non_asset_table(self):
+        table_queries = {"T": [(MagicMock(), MagicMock(), False)]}
+        rids = {"T": {"A", "B", "C"}}
+        samples = {"T": [{"row": 1}]}
+        result = assemble_estimate(
+            table_queries=table_queries,
+            rids_by_table=rids,
+            asset_lengths_by_table={},
+            sample_rows_by_table=samples,
+            estimate_csv_bytes=_stub_estimate_csv_bytes,
+            human_readable_size=_stub_human_readable,
+        )
+        assert result["tables"]["T"]["row_count"] == 3
+        assert result["tables"]["T"]["is_asset"] is False
+        assert result["tables"]["T"]["asset_bytes"] == 0
+        # 50 bytes/row × 3 rows = 150
+        assert result["tables"]["T"]["csv_bytes"] == 150
+        assert result["total_rows"] == 3
+        assert result["total_csv_bytes"] == 150
+
+    def test_asset_table_sums_lengths(self):
+        table_queries = {"A": [(MagicMock(), MagicMock(), True)]}
+        rids = {"A": {"R1", "R2"}}
+        lengths = {"A": {"R1": 1000, "R2": 2000}}
+        result = assemble_estimate(
+            table_queries=table_queries,
+            rids_by_table=rids,
+            asset_lengths_by_table=lengths,
+            sample_rows_by_table={},
+            estimate_csv_bytes=_stub_estimate_csv_bytes,
+            human_readable_size=_stub_human_readable,
+        )
+        assert result["tables"]["A"]["is_asset"] is True
+        assert result["tables"]["A"]["asset_bytes"] == 3000
+        assert result["total_asset_bytes"] == 3000
+
+    def test_asset_only_in_fetch_results_still_counted(self):
+        """An asset table that has fetch results but no csv RIDs still appears.
+
+        Defensive: the pre-extraction code had a safety branch for
+        this, and the helper preserves it.
+        """
+        table_queries = {"A": [(MagicMock(), MagicMock(), True)]}
+        # ``A`` has fetch lengths but the csv branch produced no RIDs.
+        result = assemble_estimate(
+            table_queries=table_queries,
+            rids_by_table={},
+            asset_lengths_by_table={"A": {"R1": 500}},
+            sample_rows_by_table={},
+            estimate_csv_bytes=_stub_estimate_csv_bytes,
+            human_readable_size=_stub_human_readable,
+        )
+        assert "A" in result["tables"]
+        assert result["tables"]["A"]["row_count"] == 1
+        assert result["tables"]["A"]["asset_bytes"] == 500
+
+    def test_human_readable_size_callable_invoked(self):
+        """The ``human_readable_size`` callable formats every total."""
+        result = assemble_estimate(
+            table_queries={},
+            rids_by_table={},
+            asset_lengths_by_table={},
+            sample_rows_by_table={},
+            estimate_csv_bytes=_stub_estimate_csv_bytes,
+            human_readable_size=lambda n: f"~{n}!",
+        )
+        assert result["total_asset_size"] == "~0!"
+        assert result["total_csv_size"] == "~0!"
+        assert result["total_estimated_size"] == "~0!"


### PR DESCRIPTION
## Summary

Closes audit P1 Ds-est from
``docs/audits/2026-05-22-engineer-audit-dataset.md``.

Pre-extraction, ``Dataset.estimate_bag_size`` was a 220-line
method that mixed snapshot resolution, async catalog
construction, URI parsing, query orchestration, aggregation,
and final assembly. The audit flagged it as a god-function
because the fine-grained steps could not be unit-tested
without a live catalog.

Extracted into ``deriva_ml/dataset/_estimate.py``:

- ``build_estimate_queries(table_queries) -> list[QueryItem]`` —
  pure: data-shape construction.
- ``run_estimate_queries(catalog, items)`` (async) —
  orchestration; per-query failure swallow preserved;
  ``close()`` runs in ``finally``.
- ``assemble_estimate(...)`` — pure data assembly. Accepts the
  format helpers (``estimate_csv_bytes``, ``human_readable_size``)
  as callables so it doesn't import :class:`Dataset`.

``Dataset.estimate_bag_size`` is now a 60-LOC shim composing
the three steps. Behaviour and return shape unchanged.

Quiet correctness improvement: ``assemble_estimate`` uses
``.get(table_name, {})`` on ``asset_lengths_by_table``, so the
helper accepts both ``dict`` and ``defaultdict`` inputs. The
production call path still hands it a ``defaultdict`` so
behaviour is unchanged in practice.

## Test plan

- [x] New ``tests/dataset/test_estimate_helpers.py`` (19 pass,
      ~0.04s pure-Python). Covers ``_extract_path``,
      ``build_estimate_queries``, ``run_estimate_queries`` (with
      a mock async catalog), and ``assemble_estimate``.
- [x] ``tests/dataset/test_estimate_bag_size.py`` (existing
      integration coverage) — 13 pass
- [x] ``ruff check`` clean
- [x] Doctest collection on ``_estimate.py`` — 3 examples
      execute, 1 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)