### PR TITLE
refactor(dataset): extract restructure_assets god-function into 5 helpers (audit P1 Ds-restr)

### DIFF
--- a/src/deriva_ml/dataset/restructure.py
+++ b/src/deriva_ml/dataset/restructure.py
@@ -99,10 +99,17 @@ def _default_dir_name_from_target(
             f"target_transform to derive a single directory name. "
             f"Provide target_transform=lambda rec: ... that returns a str."
         )
-    # Single FeatureRecord — find the first term/value column that has a value
+    # Single FeatureRecord — find the first term/value column that has a value.
+    # Skip the catalog's system columns (canonical
+    # ``DerivaSystemColumns``) plus the feature-table-specific
+    # ``Feature_Name`` and ``Execution`` columns. Pulling the
+    # system columns from the canonical constant means new ones
+    # (e.g. a future ``RVT``) propagate without a code change
+    # here — audit Ds-restr P2.
+    from deriva_ml.core.constants import DerivaSystemColumns
+
     record_data = target.model_dump()
-    # Skip well-known metadata columns to find the label column
-    _skip_cols = {"RID", "RCT", "RMT", "RCB", "RMB", "Feature_Name", "Execution"}
+    _skip_cols = {*DerivaSystemColumns, "Feature_Name", "Execution"}
     for col, val in record_data.items():
         if col in _skip_cols:
             continue
@@ -216,9 +223,12 @@ def _get_reachable_assets(bag, asset_table: str) -> list[dict[str, Any]]:
     sql_query = bag._dataset_table_view(asset_table)
 
     with Session(bag.engine) as session:
+        # ``.mappings().all()`` returns row mappings as
+        # public-API ``RowMapping`` objects — same shape as
+        # ``dict(row._mapping)`` but without reaching into a
+        # SQLAlchemy private attribute. Audit Ds-restr P3.
         result = session.execute(sql_query)
-        # Convert rows to dictionaries
-        rows = [dict(row._mapping) for row in result]
+        rows = [dict(m) for m in result.mappings().all()]
 
     return rows
 
@@ -245,6 +255,327 @@ def _detect_asset_table(bag) -> str | None:
         except (KeyError, AttributeError):
             continue
     return None
+
+
+def _validate_targets(targets: "list[str] | dict[str, FeatureSelector] | None") -> None:
+    """Reject the removed dotted ``"Feature.column"`` syntax with a migration hint.
+
+    Pre-Ds-restr this guard was inline in ``restructure_assets``;
+    pulling it out keeps the main function focused on
+    orchestration. The migration message is identical.
+
+    Args:
+        targets: As passed to :func:`restructure_assets`.
+
+    Raises:
+        DerivaMLValidationError: If any target string contains
+            a ``.`` separator.
+    """
+    if targets is None:
+        return
+    from deriva_ml.core.exceptions import DerivaMLValidationError
+
+    target_names = list(targets) if isinstance(targets, dict) else targets
+    for t in target_names:
+        if "." in t:
+            raise DerivaMLValidationError(
+                f"Dotted target syntax {t!r} is no longer supported. "
+                f"Replace with: targets=[{t.split('.')[0]!r}], "
+                f"target_transform=lambda rec: rec.{t.split('.')[1]}"
+            )
+
+
+def _classify_targets(
+    bag: "DatasetBag",
+    asset_table: str,
+    targets: "list[str] | dict[str, FeatureSelector] | None",
+) -> tuple["list[str] | dict[str, Any] | None", list[str]]:
+    """Split ``targets`` into a feature-only spec and a column-name list.
+
+    ``_resolve_targets`` only works with features (via
+    ``bag.feature_values``). Direct column names on the asset
+    table are handled separately. This helper probes each target
+    against ``bag.lookup_feature``; success → feature, failure →
+    column.
+
+    Args:
+        bag: The dataset bag to probe.
+        asset_table: The asset table whose features (and columns)
+            we're resolving against.
+        targets: As passed to :func:`restructure_assets`.
+
+    Returns:
+        Two-tuple ``(feature_targets_spec, column_targets)``:
+
+        - ``feature_targets_spec`` — a list of feature names
+          (when the caller passed a list) or a dict subset of
+          the caller's input (when the caller passed a dict).
+          ``None`` when no targets resolve as features.
+        - ``column_targets`` — names that don't resolve as
+          features; the caller treats these as direct columns
+          on the asset table.
+
+        Returns ``(None, [])`` when ``targets`` itself is ``None``.
+    """
+    if targets is None:
+        return None, []
+
+    target_names_list = list(targets) if isinstance(targets, dict) else list(targets)
+
+    feature_names: list[str] = []
+    column_targets: list[str] = []
+    for t_name in target_names_list:
+        try:
+            bag.lookup_feature(asset_table, t_name)
+            feature_names.append(t_name)
+        except Exception:
+            # Not a recognized feature on asset_table — treat as column.
+            column_targets.append(t_name)
+
+    feature_targets_spec: "list[str] | dict[str, Any] | None" = None
+    if feature_names:
+        if isinstance(targets, dict):
+            feature_targets_spec = {k: v for k, v in targets.items() if k in feature_names}
+        else:
+            feature_targets_spec = feature_names
+    return feature_targets_spec, column_targets
+
+
+def _resolve_source_path(
+    asset: dict[str, Any],
+    asset_table: str,
+    bag: "DatasetBag",
+) -> Path | None:
+    """Locate the on-disk source file for an asset record.
+
+    Tries the asset record's ``Filename`` field first; if that
+    doesn't exist on disk (the value may be a bare basename
+    stored in the SQLite cache pre-materialization), falls back
+    to the canonical BDBag layout
+    ``{bag.path}/data/asset/{RID}/{table}/{filename}``.
+
+    Args:
+        asset: Asset record dict (must have ``Filename``).
+        asset_table: Asset table name (used for the bag-layout
+            fallback path).
+        bag: The bag the asset lives in. Uses the public
+            ``bag.path`` property — pre-Ds-restr this reached
+            through ``bag._catalog._database_model.bag_path``
+            (audit P2).
+
+    Returns:
+        Path to the source file, or ``None`` if neither location
+        exists.
+    """
+    filename = asset.get("Filename")
+    if not filename:
+        return None
+    source_path = Path(filename)
+    if source_path.exists():
+        return source_path
+
+    # Fall back to the canonical BDBag asset layout.
+    # ``bag.path`` is the public API; pre-extraction this site
+    # reached through two private attributes
+    # (``bag._catalog._database_model.bag_path``) wrapped in a
+    # try/except AttributeError. The public property exists
+    # whenever the bag was constructed in the usual way; tests
+    # that build bags with truncated mocks can still hit
+    # ``AttributeError``, so keep the guard.
+    try:
+        bag_root = bag.path
+    except AttributeError:
+        return None
+    candidate = bag_root / "data" / "asset" / asset.get("RID", "") / asset_table / Path(filename).name
+    return candidate if candidate.exists() else None
+
+
+def _resolve_grouping_path(
+    *,
+    asset: dict[str, Any],
+    target_names_list: list[str],
+    column_targets: list[str],
+    feature_targets_spec: "list[str] | dict[str, Any] | None",
+    feature_target_map: dict[str, Any],
+    column_value_map: dict[str, dict[str, str]],
+    target_transform: Callable[..., str] | None,
+    missing: Literal["error", "skip", "unknown"],
+) -> tuple[list[str], bool]:
+    """Build the per-asset grouping path components.
+
+    Each ``targets`` entry contributes one directory level.
+    Resolution order:
+
+    - Column target → ``column_value_map[col][rid]`` (or
+      ``"Unknown"`` / skip / raise per ``missing``).
+    - Feature target → ``feature_target_map[rid]`` (single
+      ``FeatureRecord`` for single-target, ``dict`` for
+      multi-target). Default-derived from
+      ``_default_dir_name_from_target`` unless
+      ``target_transform`` is supplied.
+
+    Pre-Ds-restr this logic was inline in
+    :func:`restructure_assets` (~80 LOC); the extraction is
+    audit's first suggestion.
+
+    Args:
+        asset: The asset record (carries ``RID``).
+        target_names_list: Original ``targets`` keys in order.
+        column_targets: Names that resolve as direct columns
+            (not features). From :func:`_classify_targets`.
+        feature_targets_spec: As returned by
+            :func:`_classify_targets`. Used to detect the
+            "asset is absent from the feature map entirely"
+            condition.
+        feature_target_map: Output of ``_resolve_targets`` —
+            ``{rid: FeatureRecord | dict | None}``.
+        column_value_map: ``{col: {rid: str_value}}`` for
+            column targets.
+        target_transform: As passed to
+            :func:`restructure_assets`.
+        missing: ``"error" | "skip" | "unknown"`` policy.
+
+    Returns:
+        Two-tuple ``(group_path, skip_asset)``. ``group_path`` is
+        the list of directory components (in order); the caller
+        appends to the type-derived prefix. ``skip_asset=True``
+        means the caller should omit this asset entirely
+        (``missing="skip"`` triggered).
+
+    Raises:
+        DerivaMLException: If ``missing="error"`` and a target
+            value is absent.
+        DerivaMLValidationError: If ``target_transform`` returns
+            a non-``str``.
+    """
+    from deriva_ml.core.exceptions import DerivaMLValidationError
+
+    asset_rid = asset.get("RID")
+    feature_raw = feature_target_map.get(asset_rid)
+    group_path: list[str] = []
+
+    # If the RID is absent from the feature_target_map entirely AND
+    # there are feature targets, apply the missing policy at the
+    # group level.
+    if feature_targets_spec and asset_rid not in feature_target_map:
+        if missing == "skip":
+            return [], True
+        if missing == "error":
+            raise DerivaMLException(
+                f"Asset {asset_rid!r} has no value for target feature(s). "
+                f"Pass missing='skip' to drop unlabeled assets, or "
+                f"missing='unknown' to place them in Unknown/."
+            )
+        # missing="unknown": column targets get their values,
+        # feature targets get "Unknown".
+        for t_name in target_names_list:
+            if t_name in column_targets:
+                col_val = column_value_map.get(t_name, {}).get(asset_rid)
+                group_path.append(str(col_val) if col_val is not None else "Unknown")
+            else:
+                group_path.append("Unknown")
+        return group_path, False
+
+    # Normal path: resolve each target in order.
+    for t_name in target_names_list:
+        if t_name in column_targets:
+            col_val = column_value_map.get(t_name, {}).get(asset_rid)
+            if col_val is not None:
+                if target_transform is not None:
+                    dir_name = target_transform(col_val)
+                    if not isinstance(dir_name, str):
+                        raise DerivaMLValidationError(
+                            f"restructure_assets target_transform must return str "
+                            f"(for directory naming); got {type(dir_name).__name__}"
+                        )
+                else:
+                    dir_name = col_val
+            else:
+                if missing == "error":
+                    raise DerivaMLException(
+                        f"Asset {asset_rid!r} has no value for column target {t_name!r}. "
+                        f"Pass missing='skip' to drop unlabeled assets, or "
+                        f"missing='unknown' to place them in Unknown/."
+                    )
+                if missing == "skip":
+                    return [], True
+                dir_name = "Unknown"
+            group_path.append(dir_name)
+        else:
+            # Feature-based target — look up from feature_target_map.
+            # feature_raw is either FeatureRecord (single) or
+            # dict[str, FeatureRecord] (multi-feature).
+            if feature_raw is None:
+                per_feature_val = None
+            elif isinstance(feature_raw, dict):
+                per_feature_val = feature_raw.get(t_name)
+            else:
+                # Single feature target — feature_raw IS the FeatureRecord.
+                per_feature_val = feature_raw
+
+            if per_feature_val is None:
+                dir_name = "Unknown"
+            elif target_transform is not None:
+                dir_name = target_transform(per_feature_val)
+                if not isinstance(dir_name, str):
+                    raise DerivaMLValidationError(
+                        f"restructure_assets target_transform must return str "
+                        f"(for directory naming); got {type(dir_name).__name__}"
+                    )
+            else:
+                dir_name = _default_dir_name_from_target(per_feature_val, [t_name])
+            group_path.append(dir_name)
+
+    return group_path, False
+
+
+def _place_asset(
+    source_path: Path,
+    target_path: Path,
+    *,
+    file_transformer: Callable[[Path, Path], Path] | None,
+    use_symlinks: bool,
+) -> Path:
+    """Write the asset to ``target_path``, returning the actual written path.
+
+    Three modes, in priority order:
+
+    1. ``file_transformer`` provided → call it with
+       ``(source, target)`` and return its result. The
+       transformer owns the write (may change extension / format).
+       ``use_symlinks`` is ignored.
+    2. ``use_symlinks=True`` → ``target_path.symlink_to`` with a
+       ``shutil.copy2`` fallback when the OS refuses symlinks.
+    3. Otherwise → ``shutil.copy2``.
+
+    The caller is responsible for clearing any existing file at
+    ``target_path`` before invoking this helper.
+
+    Args:
+        source_path: On-disk source file (resolved by
+            :func:`_resolve_source_path`).
+        target_path: Suggested destination
+            (``output_dir/.../filename``).
+        file_transformer: Optional callable; see mode 1.
+        use_symlinks: When ``True``, prefer symlinks (mode 2);
+            ignored when ``file_transformer`` is given.
+
+    Returns:
+        Actual path written. For modes 2 and 3 this is
+        ``target_path``; for mode 1 it's whatever the
+        transformer returned.
+    """
+    if file_transformer is not None:
+        return file_transformer(source_path, target_path)
+    if use_symlinks:
+        try:
+            target_path.symlink_to(source_path.resolve())
+        except OSError as e:
+            logger.warning(f"Symlink failed, falling back to copy: {e}")
+            shutil.copy2(source_path, target_path)
+        return target_path
+    shutil.copy2(source_path, target_path)
+    return target_path
 
 
 def restructure_assets(
@@ -475,28 +806,28 @@ def restructure_assets(
             paths are alternatives, not a pipeline — pick one per the
             User Guide "How to feed a bag to a training framework".
     """
-    from deriva_ml.core.exceptions import DerivaMLValidationError
+    # Post Ds-restr extraction, this function orchestrates four
+    # helpers (above):
+    #
+    # 1. ``_validate_targets`` — reject the removed dotted syntax.
+    # 2. ``_classify_targets`` — split into feature vs column.
+    # 3. ``_resolve_grouping_path`` — per-asset directory resolution.
+    # 4. ``_place_asset`` — write the file (symlink / copy / transform).
+    #
+    # ``_resolve_source_path`` handles the on-disk lookup with the
+    # public ``bag.path`` API (pre-Ds-restr this reached through
+    # ``bag._catalog._database_model.bag_path``).
+
     from deriva_ml.dataset.target_resolution import _resolve_targets
 
     output_dir = Path(output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    # Validate targets: dotted "Feature.column" syntax is removed
-    if targets is not None:
-        target_names = list(targets) if isinstance(targets, dict) else targets
-        for t in target_names:
-            if "." in t:
-                raise DerivaMLValidationError(
-                    f"Dotted target syntax {t!r} is no longer supported. "
-                    f"Replace with: targets=[{t.split('.')[0]!r}], "
-                    f"target_transform=lambda rec: rec.{t.split('.')[1]}"
-                )
+    _validate_targets(targets)
 
-    # Default type-to-directory mapping
     if type_to_dir_map is None:
         type_to_dir_map = {"Training": "training", "Testing": "testing", "Unknown": "unknown"}
 
-    # Auto-detect asset table if not provided
     if asset_table is None:
         asset_table = _detect_asset_table(bag)
         if asset_table is None:
@@ -506,7 +837,7 @@ def restructure_assets(
             )
         logger.info(f"Auto-detected asset table: {asset_table}")
 
-    # Step 1: Build dataset type path map with directory name mapping
+    # Step 1: Build dataset type path map with directory name mapping.
     def map_type_to_dir(types: list[str]) -> str | None:
         """Map dataset types to directory name using type_to_dir_map.
 
@@ -517,7 +848,6 @@ def restructure_assets(
         still be traversed and their own types will determine the path.
         """
         if not types:
-            # No types defined - treat as Testing for prediction scenarios
             return type_to_dir_map.get("Testing", "testing")
         if type_selector:
             selected_type = type_selector(types)
@@ -525,222 +855,93 @@ def restructure_assets(
             selected_type = types[0]
         if selected_type in type_to_dir_map:
             return type_to_dir_map[selected_type]
-        # Type not explicitly mapped — treat as transparent container
         return None
 
     type_path_map = _build_dataset_type_path_map(bag, map_type_to_dir)
 
-    # Step 2: Get asset-to-dataset mapping
+    # Step 2: Asset → dataset mapping.
     asset_dataset_map = _get_asset_dataset_mapping(bag, asset_table)
 
-    # Step 3: Separate feature-based targets from column-based targets.
-    # _resolve_targets only works with features (via bag.feature_values).
-    # Direct column names on the asset table must be handled separately.
+    # Step 3: Classify targets, then resolve features.
+    feature_targets_spec, column_targets = _classify_targets(bag, asset_table, targets)
+    target_names_list = list(targets) if isinstance(targets, dict) else (list(targets) if targets else [])
+
     feature_target_map: dict[str, Any] = {}
-    column_targets: list[str] = []
-    feature_targets_spec: "list[str] | dict[str, Any] | None" = None
+    if feature_targets_spec:
+        # ``enforce_vocabulary`` is enforced inside ``_resolve_targets``
+        # so the validation happens at the same boundary as resolution.
+        feature_target_map = _resolve_targets(
+            bag,
+            asset_table,
+            targets=feature_targets_spec,
+            missing=missing,
+            enforce_vocabulary=enforce_vocabulary,
+        )
 
-    if targets is not None:
-        target_names_list = list(targets) if isinstance(targets, dict) else list(targets)
-
-        # Classify each target as feature or column by probing lookup_feature.
-        feature_names: list[str] = []
-        for t_name in target_names_list:
-            try:
-                bag.lookup_feature(asset_table, t_name)
-                feature_names.append(t_name)
-            except Exception:
-                # Not a recognized feature on asset_table — treat as column
-                column_targets.append(t_name)
-
-        # Build the feature-only targets spec to pass to _resolve_targets
-        if feature_names:
-            if isinstance(targets, dict):
-                feature_targets_spec = {k: v for k, v in targets.items() if k in feature_names}
-            else:
-                feature_targets_spec = feature_names
-
-        # Call _resolve_targets only for feature-based targets.
-        # ``enforce_vocabulary`` is enforced inside _resolve_targets so the
-        # validation happens once at the same boundary as the resolution.
-        if feature_targets_spec:
-            feature_target_map = _resolve_targets(
-                bag,
-                asset_table,
-                targets=feature_targets_spec,
-                missing=missing,
-                enforce_vocabulary=enforce_vocabulary,
-            )
-
-    # Step 4: For column-based targets, load a simple {rid: value_str} map
-    # by scanning all asset records once.
-    column_value_map: dict[str, dict[str, str]] = {col: {} for col in column_targets}
-
-    # Step 6: Get all assets reachable through FK paths
+    # Step 4: Fetch reachable assets through FK paths.
     assets = _get_reachable_assets(bag, asset_table)
 
     manifest: dict[Path, Path] = {}
-
     if not assets:
         logger.warning(f"No assets found in table '{asset_table}'")
         return manifest
 
-    # Populate column_value_map from the asset records
+    # Step 5: Build the per-column lookup map by walking assets once.
+    column_value_map: dict[str, dict[str, str]] = {col: {} for col in column_targets}
     for asset in assets:
         for col in column_targets:
             val = asset.get(col)
             if val is not None:
                 column_value_map[col][asset["RID"]] = str(val)
 
-    # Step 7: Process each asset
+    # Step 6: Process each asset.
     for asset in assets:
         asset_rid = asset.get("RID")
 
-        # Get source file path
-        filename = asset.get("Filename")
-        if not filename:
-            logger.warning(f"Asset {asset_rid} has no Filename")
+        source_path = _resolve_source_path(asset, asset_table, bag)
+        if source_path is None:
+            filename = asset.get("Filename")
+            if not filename:
+                logger.warning(f"Asset {asset_rid} has no Filename")
+            else:
+                logger.warning(f"Asset file not found: {filename}")
             continue
 
-        source_path = Path(filename)
-        if not source_path.exists():
-            # Filename may be a bare basename stored in the SQLite cache
-            # before image materialization.  Fall back to the canonical
-            # BDBag asset layout: data/asset/{RID}/{table}/{filename}.
-            try:
-                bag_root = Path(bag._catalog._database_model.bag_path)
-                source_path = bag_root / "data" / "asset" / asset.get("RID", "") / asset_table / Path(filename).name
-            except AttributeError:
-                pass  # catalog doesn't have _database_model (e.g. in tests)
+        type_path = type_path_map.get(asset_dataset_map.get(asset_rid), ["unknown"])
 
-        if not source_path.exists():
-            logger.warning(f"Asset file not found: {filename}")
-            continue
-
-        # Get dataset type path
-        dataset_rid = asset_dataset_map.get(asset_rid)
-        type_path = type_path_map.get(dataset_rid, ["unknown"])
-
-        # Resolve grouping path components from targets.
-        # Each target name contributes one directory level. Target names are
-        # processed in order (column targets get column lookup; feature targets
-        # get resolution from feature_target_map built by _resolve_targets above).
-        group_path: list[str] = []
-        skip_asset = False
-
-        if targets is not None:
-            target_names_list = list(targets) if isinstance(targets, dict) else list(targets)
-            # For single-feature target, feature_target_map[rid] is FeatureRecord|None.
-            # For multi-feature target, feature_target_map[rid] is dict[str, FeatureRecord].
-            # We unpack accordingly when passing to target_transform or _default_dir_name_from_target.
-            feature_raw = feature_target_map.get(asset_rid)
-
-            # If the RID is absent from the feature_target_map entirely AND there are
-            # feature targets, apply the missing policy at the group level.
-            if feature_targets_spec and asset_rid not in feature_target_map:
-                if missing == "skip":
-                    skip_asset = True
-                elif missing == "error":
-                    raise DerivaMLException(
-                        f"Asset {asset_rid!r} has no value for target feature(s). "
-                        f"Pass missing='skip' to drop unlabeled assets, or "
-                        f"missing='unknown' to place them in Unknown/."
-                    )
-                else:
-                    # missing="unknown": place in Unknown dir
-                    # Build partial path from column targets, then add Unknown for features
-                    for t_name in target_names_list:
-                        if t_name in column_targets:
-                            col_val = column_value_map.get(t_name, {}).get(asset_rid)
-                            group_path.append(str(col_val) if col_val is not None else "Unknown")
-                        else:
-                            group_path.append("Unknown")
-            elif not skip_asset:
-                # Normal path: resolve each target in order
-                for t_name in target_names_list:
-                    if t_name in column_targets:
-                        # Column-based target
-                        col_val = column_value_map.get(t_name, {}).get(asset_rid)
-                        if col_val is not None:
-                            if target_transform is not None:
-                                dir_name = target_transform(col_val)
-                                if not isinstance(dir_name, str):
-                                    raise DerivaMLValidationError(
-                                        f"restructure_assets target_transform must return str "
-                                        f"(for directory naming); got {type(dir_name).__name__}"
-                                    )
-                            else:
-                                dir_name = col_val
-                        else:
-                            # Missing column value
-                            if missing == "error":
-                                raise DerivaMLException(
-                                    f"Asset {asset_rid!r} has no value for column target {t_name!r}. "
-                                    f"Pass missing='skip' to drop unlabeled assets, or "
-                                    f"missing='unknown' to place them in Unknown/."
-                                )
-                            elif missing == "skip":
-                                skip_asset = True
-                                break
-                            else:
-                                dir_name = "Unknown"
-                        group_path.append(dir_name)
-                    else:
-                        # Feature-based target: look up from feature_target_map
-                        # feature_raw is either FeatureRecord (single) or
-                        # dict[str, FeatureRecord] (multi-feature). Extract for this feature.
-                        if feature_raw is None:
-                            per_feature_val = None
-                        elif isinstance(feature_raw, dict):
-                            per_feature_val = feature_raw.get(t_name)
-                        else:
-                            # Single feature target — feature_raw IS the FeatureRecord
-                            per_feature_val = feature_raw
-
-                        if per_feature_val is None:
-                            dir_name = "Unknown"
-                        elif target_transform is not None:
-                            dir_name = target_transform(per_feature_val)
-                            if not isinstance(dir_name, str):
-                                raise DerivaMLValidationError(
-                                    f"restructure_assets target_transform must return str "
-                                    f"(for directory naming); got {type(dir_name).__name__}"
-                                )
-                        else:
-                            dir_name = _default_dir_name_from_target(per_feature_val, [t_name])
-                        group_path.append(dir_name)
-
+        # Resolve per-asset grouping path. ``targets is None`` is
+        # the no-grouping path — the helper short-circuits via
+        # an empty ``target_names_list``.
+        if targets is None:
+            group_path, skip_asset = [], False
+        else:
+            group_path, skip_asset = _resolve_grouping_path(
+                asset=asset,
+                target_names_list=target_names_list,
+                column_targets=column_targets,
+                feature_targets_spec=feature_targets_spec,
+                feature_target_map=feature_target_map,
+                column_value_map=column_value_map,
+                target_transform=target_transform,
+                missing=missing,
+            )
         if skip_asset:
             continue
 
-        # Build target directory
         target_dir = output_dir.joinpath(*type_path, *group_path)
         target_dir.mkdir(parents=True, exist_ok=True)
-
-        # Suggested destination preserves the original filename
         target_path = target_dir / source_path.name
 
-        # Handle existing files at the suggested destination
+        # Clear any existing file at the suggested destination.
         if target_path.exists() or target_path.is_symlink():
             target_path.unlink()
 
-        if file_transformer is not None:
-            # Transformer is responsible for writing the output file.
-            # It receives the suggested dest and returns the actual path written,
-            # which may differ in name or extension (e.g. DICOM -> PNG).
-            actual_path = file_transformer(source_path, target_path)
-        elif use_symlinks:
-            try:
-                target_path.symlink_to(source_path.resolve())
-            except OSError as e:
-                # Fall back to copy on platforms that don't support symlinks
-                logger.warning(f"Symlink failed, falling back to copy: {e}")
-                shutil.copy2(source_path, target_path)
-            actual_path = target_path
-        else:
-            shutil.copy2(source_path, target_path)
-            actual_path = target_path
-
+        actual_path = _place_asset(
+            source_path,
+            target_path,
+            file_transformer=file_transformer,
+            use_symlinks=use_symlinks,
+        )
         manifest[source_path] = actual_path
 
     return manifest

--- a/tests/dataset/test_restructure_helpers.py
+++ b/tests/dataset/test_restructure_helpers.py
@@ -1,0 +1,439 @@
+"""Unit tests for ``restructure_assets`` helpers (audit P1 Ds-restr).
+
+Pre-extraction, ``restructure_assets`` was a 500-line function
+(250+ LOC body) that mixed input validation, target
+classification, per-asset grouping resolution, source-path
+lookup, and file placement. The audit asked for the inner
+resolution and placement steps to be extracted so they could
+be unit-tested without a live catalog or bag.
+
+Post-extraction the helpers are:
+
+- ``_validate_targets`` — reject dotted ``"Feature.column"``.
+- ``_classify_targets`` — feature vs column probe.
+- ``_resolve_source_path`` — locate the on-disk file, using
+  ``bag.path`` (the public API; pre-extraction this site
+  reached through two private attributes).
+- ``_resolve_grouping_path`` — per-asset directory components.
+- ``_place_asset`` — symlink / copy / transformer dispatch.
+- ``_default_dir_name_from_target`` — drive-by P2 fix: use
+  ``DerivaSystemColumns`` instead of a hardcoded set.
+
+Pure-Python tests; no live catalog required.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from deriva_ml.core.exceptions import (
+    DerivaMLException,
+    DerivaMLValidationError,
+)
+from deriva_ml.dataset.restructure import (
+    _classify_targets,
+    _default_dir_name_from_target,
+    _place_asset,
+    _resolve_grouping_path,
+    _resolve_source_path,
+    _validate_targets,
+)
+
+
+# ---------------------------------------------------------------------------
+# _validate_targets — dotted syntax rejection
+# ---------------------------------------------------------------------------
+
+
+class TestValidateTargets:
+    def test_none_is_ok(self):
+        _validate_targets(None)  # no raise
+
+    def test_list_without_dots_is_ok(self):
+        _validate_targets(["Diagnosis", "Severity"])  # no raise
+
+    def test_dict_without_dots_is_ok(self):
+        _validate_targets({"Diagnosis": lambda recs: recs[0]})  # no raise
+
+    def test_list_with_dot_raises_with_migration_hint(self):
+        with pytest.raises(DerivaMLValidationError, match="Replace with"):
+            _validate_targets(["Classification.Label"])
+
+    def test_dict_key_with_dot_raises(self):
+        with pytest.raises(DerivaMLValidationError):
+            _validate_targets({"Classification.Label": lambda r: r[0]})
+
+
+# ---------------------------------------------------------------------------
+# _classify_targets — feature vs column probe
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyTargets:
+    def test_none_returns_empty(self):
+        bag = MagicMock()
+        assert _classify_targets(bag, "Image", None) == (None, [])
+
+    def test_all_features(self):
+        bag = MagicMock()
+        bag.lookup_feature.return_value = MagicMock()  # always succeeds
+        spec, cols = _classify_targets(bag, "Image", ["Diagnosis", "Severity"])
+        assert spec == ["Diagnosis", "Severity"]
+        assert cols == []
+
+    def test_all_columns(self):
+        bag = MagicMock()
+        bag.lookup_feature.side_effect = Exception("not a feature")
+        spec, cols = _classify_targets(bag, "Image", ["Filename", "Description"])
+        assert spec is None
+        assert cols == ["Filename", "Description"]
+
+    def test_mixed_split(self):
+        bag = MagicMock()
+
+        # Diagnosis is a feature; Filename isn't.
+        def fake_lookup(table, name):
+            if name == "Diagnosis":
+                return MagicMock()
+            raise Exception("not a feature")
+
+        bag.lookup_feature.side_effect = fake_lookup
+        spec, cols = _classify_targets(bag, "Image", ["Diagnosis", "Filename"])
+        assert spec == ["Diagnosis"]
+        assert cols == ["Filename"]
+
+    def test_dict_input_preserves_selector_for_features(self):
+        bag = MagicMock()
+
+        def fake_lookup(table, name):
+            if name == "Diagnosis":
+                return MagicMock()
+            raise Exception()
+
+        bag.lookup_feature.side_effect = fake_lookup
+        sel = lambda recs: recs[0]
+        spec, cols = _classify_targets(bag, "Image", {"Diagnosis": sel, "Filename": sel})
+        assert spec == {"Diagnosis": sel}
+        assert cols == ["Filename"]
+
+
+# ---------------------------------------------------------------------------
+# _default_dir_name_from_target — P2: SYSTEM_COLUMNS sourcing
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultDirNameFromTarget:
+    def test_none_target(self):
+        assert _default_dir_name_from_target(None, []) == "Unknown"
+
+    def test_string_target_returned_as_is(self):
+        assert _default_dir_name_from_target("benign", []) == "benign"
+
+    def test_dict_target_raises_with_migration_hint(self):
+        with pytest.raises(DerivaMLException, match="target_transform"):
+            _default_dir_name_from_target({"a": 1}, ["a"])
+
+    def test_skips_canonical_system_columns(self):
+        """``DerivaSystemColumns`` are skipped; the first content column wins.
+
+        Pin the P2 fix: the skip set is sourced from the
+        canonical constant ``DerivaSystemColumns`` plus the
+        feature-table-specific ``Feature_Name`` / ``Execution``
+        columns. A future ``RVT`` added to the canonical constant
+        would propagate automatically.
+        """
+        record = MagicMock()
+        record.model_dump.return_value = {
+            "RID": "REC-1",
+            "RCT": "ignored",
+            "RMT": "ignored",
+            "RCB": "ignored",
+            "RMB": "ignored",
+            "Feature_Name": "Diagnosis",
+            "Execution": "EXE-1",
+            "Diagnosis": "Benign",
+        }
+        assert _default_dir_name_from_target(record, ["Diagnosis"]) == "Benign"
+
+    def test_falls_through_to_unknown_when_only_system_cols(self):
+        record = MagicMock()
+        record.model_dump.return_value = {
+            "RID": "REC-1",
+            "RCT": "x",
+            "RMT": "x",
+            "RCB": "x",
+            "RMB": "x",
+            "Feature_Name": "x",
+            "Execution": "x",
+        }
+        assert _default_dir_name_from_target(record, ["Whatever"]) == "Unknown"
+
+
+# ---------------------------------------------------------------------------
+# _resolve_source_path — public bag.path fallback
+# ---------------------------------------------------------------------------
+
+
+class TestResolveSourcePath:
+    def test_returns_filename_when_it_exists(self, tmp_path):
+        f = tmp_path / "real.jpg"
+        f.write_bytes(b"img")
+        result = _resolve_source_path(
+            {"Filename": str(f), "RID": "ASSET-1"}, "Image", MagicMock()
+        )
+        assert result == f
+
+    def test_falls_back_to_bag_path_layout(self, tmp_path):
+        """When ``Filename`` is a bare basename, looks under ``bag.path``."""
+        bag_root = tmp_path / "bag"
+        canonical_dir = bag_root / "data" / "asset" / "ASSET-1" / "Image"
+        canonical_dir.mkdir(parents=True)
+        canonical_file = canonical_dir / "img.jpg"
+        canonical_file.write_bytes(b"img")
+
+        bag = MagicMock()
+        bag.path = bag_root  # public property
+        # ``Filename`` is a bare name (no path) that doesn't exist as-is.
+        result = _resolve_source_path(
+            {"Filename": "img.jpg", "RID": "ASSET-1"}, "Image", bag
+        )
+        assert result == canonical_file
+
+    def test_no_filename_returns_none(self):
+        assert _resolve_source_path({"RID": "ASSET-1"}, "Image", MagicMock()) is None
+
+    def test_neither_location_exists_returns_none(self, tmp_path):
+        bag = MagicMock()
+        bag.path = tmp_path / "no-such-bag"
+        result = _resolve_source_path(
+            {"Filename": "nope.jpg", "RID": "ASSET-1"}, "Image", bag
+        )
+        assert result is None
+
+    def test_attribute_error_on_path_is_handled(self, tmp_path):
+        """Bags constructed by test mocks may not have ``.path``.
+
+        Pre-extraction this site reached through
+        ``bag._catalog._database_model.bag_path`` with the same
+        try/except. The helper preserves the guard against
+        truncated mocks.
+        """
+        bag = MagicMock()
+        del bag.path  # simulate missing attribute
+        type(bag).path = property(lambda self: (_ for _ in ()).throw(AttributeError()))
+
+        result = _resolve_source_path(
+            {"Filename": "img.jpg", "RID": "ASSET-1"}, "Image", bag
+        )
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# _resolve_grouping_path — per-asset directory components
+# ---------------------------------------------------------------------------
+
+
+class TestResolveGroupingPath:
+    """The core dispatch of feature/column targets + missing policy."""
+
+    def test_column_target_with_value(self):
+        path, skip = _resolve_grouping_path(
+            asset={"RID": "ASSET-1"},
+            target_names_list=["Quality"],
+            column_targets=["Quality"],
+            feature_targets_spec=None,
+            feature_target_map={},
+            column_value_map={"Quality": {"ASSET-1": "Sharp"}},
+            target_transform=None,
+            missing="unknown",
+        )
+        assert path == ["Sharp"]
+        assert skip is False
+
+    def test_column_target_missing_with_unknown(self):
+        path, skip = _resolve_grouping_path(
+            asset={"RID": "ASSET-1"},
+            target_names_list=["Quality"],
+            column_targets=["Quality"],
+            feature_targets_spec=None,
+            feature_target_map={},
+            column_value_map={"Quality": {}},
+            target_transform=None,
+            missing="unknown",
+        )
+        assert path == ["Unknown"]
+        assert skip is False
+
+    def test_column_target_missing_with_skip(self):
+        path, skip = _resolve_grouping_path(
+            asset={"RID": "ASSET-1"},
+            target_names_list=["Quality"],
+            column_targets=["Quality"],
+            feature_targets_spec=None,
+            feature_target_map={},
+            column_value_map={"Quality": {}},
+            target_transform=None,
+            missing="skip",
+        )
+        assert skip is True
+
+    def test_column_target_missing_with_error_raises(self):
+        with pytest.raises(DerivaMLException, match="Quality"):
+            _resolve_grouping_path(
+                asset={"RID": "ASSET-1"},
+                target_names_list=["Quality"],
+                column_targets=["Quality"],
+                feature_targets_spec=None,
+                feature_target_map={},
+                column_value_map={"Quality": {}},
+                target_transform=None,
+                missing="error",
+            )
+
+    def test_feature_target_with_record(self):
+        record = MagicMock()
+        record.model_dump.return_value = {
+            "RID": "FEAT-1",
+            "RCT": "x",
+            "RMT": "x",
+            "RCB": "x",
+            "RMB": "x",
+            "Feature_Name": "Diagnosis",
+            "Execution": "x",
+            "Diagnosis": "Benign",
+        }
+        path, skip = _resolve_grouping_path(
+            asset={"RID": "ASSET-1"},
+            target_names_list=["Diagnosis"],
+            column_targets=[],
+            feature_targets_spec=["Diagnosis"],
+            feature_target_map={"ASSET-1": record},
+            column_value_map={},
+            target_transform=None,
+            missing="unknown",
+        )
+        assert path == ["Benign"]
+        assert skip is False
+
+    def test_feature_target_missing_skip(self):
+        path, skip = _resolve_grouping_path(
+            asset={"RID": "ASSET-1"},
+            target_names_list=["Diagnosis"],
+            column_targets=[],
+            feature_targets_spec=["Diagnosis"],
+            feature_target_map={},  # ASSET-1 not present
+            column_value_map={},
+            target_transform=None,
+            missing="skip",
+        )
+        assert skip is True
+
+    def test_feature_target_missing_unknown(self):
+        path, skip = _resolve_grouping_path(
+            asset={"RID": "ASSET-1"},
+            target_names_list=["Diagnosis"],
+            column_targets=[],
+            feature_targets_spec=["Diagnosis"],
+            feature_target_map={},  # ASSET-1 absent → Unknown branch
+            column_value_map={},
+            target_transform=None,
+            missing="unknown",
+        )
+        assert path == ["Unknown"]
+        assert skip is False
+
+    def test_feature_target_missing_error_raises(self):
+        with pytest.raises(DerivaMLException, match="ASSET-1"):
+            _resolve_grouping_path(
+                asset={"RID": "ASSET-1"},
+                target_names_list=["Diagnosis"],
+                column_targets=[],
+                feature_targets_spec=["Diagnosis"],
+                feature_target_map={},
+                column_value_map={},
+                target_transform=None,
+                missing="error",
+            )
+
+    def test_target_transform_must_return_str(self):
+        """Non-str return from target_transform raises ``DerivaMLValidationError``."""
+        with pytest.raises(DerivaMLValidationError, match="must return str"):
+            _resolve_grouping_path(
+                asset={"RID": "ASSET-1"},
+                target_names_list=["Quality"],
+                column_targets=["Quality"],
+                feature_targets_spec=None,
+                feature_target_map={},
+                column_value_map={"Quality": {"ASSET-1": "raw"}},
+                target_transform=lambda val: 42,  # returns int, not str
+                missing="unknown",
+            )
+
+
+# ---------------------------------------------------------------------------
+# _place_asset — file placement dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestPlaceAsset:
+    def test_symlink_mode(self, tmp_path):
+        src = tmp_path / "src.jpg"
+        src.write_bytes(b"img")
+        dst = tmp_path / "dst.jpg"
+        result = _place_asset(src, dst, file_transformer=None, use_symlinks=True)
+        assert result == dst
+        assert dst.is_symlink()
+        assert dst.read_bytes() == b"img"
+
+    def test_copy_mode(self, tmp_path):
+        src = tmp_path / "src.jpg"
+        src.write_bytes(b"img")
+        dst = tmp_path / "dst.jpg"
+        result = _place_asset(src, dst, file_transformer=None, use_symlinks=False)
+        assert result == dst
+        assert not dst.is_symlink()
+        assert dst.read_bytes() == b"img"
+
+    def test_transformer_overrides_symlink(self, tmp_path):
+        """``file_transformer`` takes precedence over ``use_symlinks``."""
+        src = tmp_path / "src.jpg"
+        src.write_bytes(b"img")
+        dst = tmp_path / "dst.jpg"
+        actual = tmp_path / "transformed.png"  # the transformer chose a new path
+
+        def my_transformer(src_p: Path, dst_p: Path) -> Path:
+            actual.write_bytes(b"converted")
+            return actual
+
+        result = _place_asset(
+            src, dst, file_transformer=my_transformer, use_symlinks=True
+        )
+        assert result == actual
+        assert actual.read_bytes() == b"converted"
+        # The suggested destination wasn't touched.
+        assert not dst.exists()
+
+    def test_symlink_falls_back_to_copy_on_oserror(self, tmp_path, monkeypatch):
+        """Platforms refusing symlinks fall back to ``shutil.copy2``."""
+        src = tmp_path / "src.jpg"
+        src.write_bytes(b"img")
+        dst = tmp_path / "dst.jpg"
+
+        original_symlink_to = Path.symlink_to
+
+        def boom(self, target):
+            raise OSError("symlinks not supported")
+
+        monkeypatch.setattr(Path, "symlink_to", boom)
+        # ``shutil.copy2`` should still produce the file.
+        try:
+            result = _place_asset(src, dst, file_transformer=None, use_symlinks=True)
+            assert result == dst
+            assert dst.read_bytes() == b"img"
+            assert not dst.is_symlink()
+        finally:
+            monkeypatch.setattr(Path, "symlink_to", original_symlink_to)


### PR DESCRIPTION
## Summary

Closes audit P1 Ds-restr from
``docs/audits/2026-05-22-engineer-audit-dataset.md``.

Pre-extraction, ``restructure_assets`` was a 500-line function
(250+ LOC body post-docstring) mixing target validation,
classification, per-asset directory resolution, source-path
lookup, and file placement. The audit asked for the inner
resolution and placement steps to be extracted so they could
be unit-tested.

Extracted helpers in ``deriva_ml/dataset/restructure.py``:

- ``_validate_targets`` — dotted-syntax rejection
- ``_classify_targets`` — feature vs column probe
- ``_resolve_source_path`` — on-disk file lookup
- ``_resolve_grouping_path`` — per-asset directory dispatch
- ``_place_asset`` — symlink / copy / transformer

``restructure_assets`` is now an ~80-LOC orchestrator.
Behaviour and return shape unchanged.

Drive-by P2 fixes (audit Ds-restr cluster):

- ``_default_dir_name_from_target`` now sources its skip set
  from the canonical ``DerivaSystemColumns`` constant.
- ``_resolve_source_path`` uses public ``bag.path`` instead
  of reaching through two private attributes.
- ``_get_reachable_assets`` uses ``result.mappings().all()``
  (public SQLAlchemy API) instead of ``dict(row._mapping)``.

## Test plan

- [x] New ``tests/dataset/test_restructure_helpers.py``
      (33 pure-Python tests, ~0.06s). Pins contracts for all
      five helpers and the ``DerivaSystemColumns`` sourcing.
- [x] ``tests/dataset/test_restructure.py`` (existing
      integration coverage) — **33/33 pass** against a live
      catalog (~18 min).
- [x] ``ruff check`` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)