### PR TITLE
fix+test(asset/feature): close audit gaps + uncover Asset.download bug (audit P1 A3, F-2, F-20)

### DIFF
--- a/src/deriva_ml/asset/asset.py
+++ b/src/deriva_ml/asset/asset.py
@@ -325,12 +325,25 @@ class Asset:
             >>> print(f"Downloaded to: {local_path}")  # doctest: +SKIP
         """
 
-        # Use hatrac to download the file
+        # Use hatrac to download the file. ``DerivaML`` doesn't
+        # expose a ``hatrac`` attribute (the legacy assumption in
+        # this method), so construct a ``HatracStore`` on demand —
+        # same pattern as ``Execution.download_asset``. Audit P1 A3
+        # uncovered this latent bug: the pre-fix code did
+        # ``self._ml_instance.hatrac.get_obj(...)`` which always
+        # raised ``AttributeError`` against a real ``DerivaML``.
+        from deriva.core.hatrac_store import HatracStore
+
         dest_dir = Path(dest_dir)
         dest_dir.mkdir(parents=True, exist_ok=True)
 
         dest_path = dest_dir / self.filename
-        self._ml_instance.hatrac.get_obj(self.url, destfilename=str(dest_path))
+        hs = HatracStore(
+            "https",
+            self._ml_instance.host_name,
+            self._ml_instance.credential,
+        )
+        hs.get_obj(self.url, destfilename=str(dest_path))
 
         return dest_path
 

--- a/src/deriva_ml/feature.py
+++ b/src/deriva_ml/feature.py
@@ -402,7 +402,15 @@ class FeatureRecord(BaseModel):
                 term columns or multiple term columns.
         """
 
-        def _selector(records: list["FeatureRecord"]) -> "FeatureRecord":
+        def _selector(records: list["FeatureRecord"]) -> "FeatureRecord | None":
+            # Empty input → return ``None`` per the selector
+            # convention (matches :meth:`select_by_workflow` and
+            # :meth:`select_by_execution`; ``feature_values`` skips
+            # ``None`` survivors when reducing groups). Pre-fix
+            # (audit F-2) this hit ``records[0]`` below and
+            # raised ``IndexError``. Audit F-20 added the test.
+            if not records:
+                return None
             col = column
             if col is None:
                 # Auto-detect from feature metadata on the record class.

--- a/tests/asset/test_asset.py
+++ b/tests/asset/test_asset.py
@@ -326,6 +326,79 @@ class TestAssetMetadata:
 
 
 # =============================================================================
+# TestAssetDownload - bare-bytes download primitive (audit P1 A3)
+# =============================================================================
+
+
+class TestAssetDownload:
+    """Tests for ``Asset.download`` — the bare-bytes download primitive.
+
+    Pre-coverage (audit P1 A3) this method had no test. The
+    method is documented as the no-catalog-side-effects
+    alternative to :meth:`Execution.download_asset`; tests
+    here pin the file-on-disk contract and the lack of
+    catalog-side-effects.
+    """
+
+    def test_download_writes_file_to_dest_dir(self, basic_execution, tmp_path):
+        """``download(dest_dir)`` writes ``dest_dir/filename`` and returns its Path."""
+        ml = basic_execution._ml_object
+
+        with basic_execution.execute() as execution:
+            create_test_asset(execution, "download_test.txt", "Download content")
+        uploaded = basic_execution.upload_execution_outputs()
+        asset_rid = uploaded["deriva-ml/Execution_Asset"][0].asset_rid
+
+        asset = ml.lookup_asset(asset_rid)
+        dest = tmp_path / "out"
+        result = asset.download(dest)
+
+        # Returned path is the file inside dest_dir.
+        assert result == dest / "download_test.txt"
+        # File exists and has the original bytes.
+        assert result.exists()
+        assert result.read_text() == "Download content"
+
+    def test_download_creates_dest_dir_if_missing(self, basic_execution, tmp_path):
+        """``dest_dir`` is created when it doesn't exist (mkdir parents=True)."""
+        ml = basic_execution._ml_object
+
+        with basic_execution.execute() as execution:
+            create_test_asset(execution, "mkdir_test.txt", "mkdir content")
+        uploaded = basic_execution.upload_execution_outputs()
+        asset_rid = uploaded["deriva-ml/Execution_Asset"][0].asset_rid
+
+        asset = ml.lookup_asset(asset_rid)
+        # Two levels of nesting — none of these exist yet.
+        dest = tmp_path / "a" / "b" / "c"
+        assert not dest.exists()
+        result = asset.download(dest)
+
+        assert dest.is_dir()
+        assert result.exists()
+
+    def test_download_accepts_string_dest_dir(self, basic_execution, tmp_path):
+        """``dest_dir`` accepts ``str`` (not just ``Path``).
+
+        The method docstring uses ``Path`` examples but the body
+        wraps the arg with ``Path(dest_dir)``. Pin that contract.
+        """
+        ml = basic_execution._ml_object
+
+        with basic_execution.execute() as execution:
+            create_test_asset(execution, "str_dest.txt", "str dest content")
+        uploaded = basic_execution.upload_execution_outputs()
+        asset_rid = uploaded["deriva-ml/Execution_Asset"][0].asset_rid
+
+        asset = ml.lookup_asset(asset_rid)
+        # Pass a string path, not a Path object.
+        dest = str(tmp_path / "str-out")
+        result = asset.download(dest)
+        assert result.exists()
+        assert result.read_text() == "str dest content"
+
+
+# =============================================================================
 # TestAssetRepr - Asset representation
 # =============================================================================
 

--- a/tests/feature/test_select_majority_vote.py
+++ b/tests/feature/test_select_majority_vote.py
@@ -207,3 +207,30 @@ def test_select_majority_vote_auto_detect_rejects_multi_term_feature() -> None:
     assert "['Diagnosis', 'Severity']" in msg, (
         f"Expected sorted column list in error; got: {msg}"
     )
+
+
+def test_select_majority_vote_returns_none_on_empty_records() -> None:
+    """Empty ``records`` → ``None``, matching the selector convention.
+
+    Pre-fix (audit F-2) the inner ``records[0]`` access raised
+    ``IndexError`` on empty input; ``select_by_workflow`` and
+    ``select_by_execution`` already returned ``None`` in the
+    same situation. The fix aligned ``select_majority_vote``
+    with the convention; ``feature_values`` (and friends)
+    drop ``None`` survivors during group reduction, so a
+    feature with no records for an asset is silently skipped
+    rather than crashing the whole iteration.
+
+    Audit F-20 #3 — explicit empty-records test.
+    """
+    selector = FeatureRecord.select_majority_vote()  # column=None
+    # Pass an empty list with no record-class context — the
+    # auto-detect branch must not run.
+    result = selector([])
+    assert result is None
+
+    # Same behavior with an explicit column — pinning the
+    # short-circuit so a future "split the column-vs-no-column
+    # branches" refactor doesn't lose the empty guard.
+    selector_with_col = FeatureRecord.select_majority_vote(column="Anything")
+    assert selector_with_col([]) is None


### PR DESCRIPTION
## Summary

Three small Category 3 audit P1 items in one PR — all share
the "no test exists" pattern. **Importantly, the A3 test
uncovered a latent ``AttributeError`` in
``Asset.download`` that would fail every production call.**

### A3 — ``Asset.download`` has no test [P1]

Added ``TestAssetDownload`` (3 integration tests against a
live catalog): happy path, ``dest_dir`` auto-creation, and
``str``-acceptance.

**Latent bug uncovered**: ``Asset.download`` called
``self._ml_instance.hatrac.get_obj(...)``, but ``DerivaML``
doesn't expose a ``hatrac`` attribute. Fixed by constructing
a ``HatracStore`` on demand using ``host_name`` and
``credential`` — same pattern as ``Execution.download_asset``.

### F-2 — ``select_majority_vote`` IndexErrors on empty records [P2]

``records[0]`` and ``max(counts.values())`` both raised on
empty input. Other selectors (``select_by_workflow``,
``select_by_execution``) already returned ``None``. Aligned
the convention: empty → ``None``.

### F-20 #3 — empty-records test for ``select_majority_vote`` [P1]

Added ``test_select_majority_vote_returns_none_on_empty_records``
covering both auto-detect (no column) and explicit-column
empty-input cases. Pins the F-2 fix.

### Other audit P1 items checked & already addressed

- **F-7** (docstring example) — already fixed (str argument)
- **F-20 #1/#2** (auto-detect single/multi term tests) — covered
- **F-6** (FK classification by name) — covered
- **A1** (retired ``list_feature_values``) — method already deleted
- **B1** (private export) — already cleaned up

## Test plan

- [x] ``tests/feature/test_select_majority_vote.py`` — 8/8 pass
- [x] ``tests/asset/test_asset.py::TestAssetDownload`` — 3/3 pass
      against a live catalog
- [x] ``ruff check`` clean on touched code (two pre-existing
      ``asset.py`` lint warnings unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)