### PR TITLE
refactor(execution): extract asset-staging helpers into asset_upload.py (audit P1 Ex-god, first sweep)

### DIFF
--- a/src/deriva_ml/execution/asset_upload.py
+++ b/src/deriva_ml/execution/asset_upload.py
@@ -1,0 +1,394 @@
+"""Asset-staging + upload-orchestration helpers for ``Execution``.
+
+Pre-extraction (audit P1 Ex-god) these helpers lived on the
+:class:`~deriva_ml.execution.execution.Execution` god-class
+alongside lifecycle (``__enter__``/``__exit__``,
+``execution_start``/``execution_stop``), dataset attach
+(``download_dataset_bag``, ``create_dataset``), feature staging
+(``add_features``), and a dozen other concerns. The audit
+asked for the asset-staging + upload pipeline to live in a
+sibling module to ``bag_commit.py`` so the file structure
+mirrors the conceptual structure.
+
+This module hosts the helpers that have the **lightest
+coupling** to ``Execution`` lifecycle state — the ones that
+were nearly free functions already and only used a handful of
+fields off ``self``. The corresponding ``Execution`` methods
+remain as thin delegates so the public API is unchanged.
+
+Heavier coupling — ``upload_execution_outputs``,
+``_bag_commit_upload``, ``download_asset``, ``asset_file_path``,
+``metrics_file``, ``_update_asset_execution_table`` — stays on
+:class:`Execution` for now. Those touch the state-machine
+transitions (``update_status``, ``execution_stop``) and the
+public API surface; a clean extraction of those wants the
+state-machine and manifest-store types to themselves stabilize
+further first.
+
+Pairs with ``bag_commit.py`` (the bag-build / bag-load
+pipeline). Together the two modules carry the bulk of the
+asset-upload work that ``Execution`` used to hold inline.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+import time
+from datetime import datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from deriva_ml.execution.environment import get_execution_environment
+
+if TYPE_CHECKING:
+    from deriva_ml.asset.aux_classes import AssetFilePath
+    from deriva_ml.execution.execution import Execution
+
+
+# Public symbols re-exported via ``Execution`` thin delegates.
+__all__ = [
+    "clean_folder_contents",
+    "get_metadata_description",
+    "save_runtime_environment",
+    "set_asset_descriptions",
+    "upload_hydra_config_assets",
+]
+
+
+def get_metadata_description(
+    file_name: str, *, metadata_descriptions: dict[str, str], env_snapshot_description: str
+) -> str | None:
+    """Resolve a description for an execution-metadata file.
+
+    Handles three filename conventions:
+
+    1. Direct filenames in the canonical map (``configuration.json``,
+       ``uv.lock``, etc.).
+    2. Hydra-renamed files of the form
+       ``hydra-{timestamp}-{original_name}`` — extracts the
+       original name and looks it up.
+    3. Runtime-environment snapshots
+       (``environment_snapshot_{timestamp}.txt``).
+
+    Pre-extraction this was a ``@staticmethod`` on
+    :class:`Execution`. Moved here so callers can resolve
+    descriptions without depending on the class. Keeps the
+    description-resolution logic in one place even though only
+    one downstream consumer (currently :func:`set_asset_descriptions`)
+    needs it.
+
+    Args:
+        file_name: The filename as it appears in the catalog.
+        metadata_descriptions: Map of canonical filename →
+            human-readable description. Passed in (rather than
+            imported) so the helper stays decoupled from the
+            module-level constant on ``Execution``.
+        env_snapshot_description: The description for runtime-
+            environment snapshots. Same rationale as
+            ``metadata_descriptions``.
+
+    Returns:
+        A human-readable description, or ``None`` if the file
+        is unrecognized.
+
+    Example:
+        >>> from deriva_ml.execution.asset_upload import get_metadata_description
+        >>> descs = {"uv.lock": "Dependency lockfile"}
+        >>> get_metadata_description(
+        ...     "uv.lock", metadata_descriptions=descs,
+        ...     env_snapshot_description="Runtime env",
+        ... )
+        'Dependency lockfile'
+        >>> get_metadata_description(
+        ...     "hydra-20260522-uv.lock",
+        ...     metadata_descriptions=descs,
+        ...     env_snapshot_description="Runtime env",
+        ... )
+        'Dependency lockfile'
+        >>> get_metadata_description(
+        ...     "environment_snapshot_20260522_120000.txt",
+        ...     metadata_descriptions=descs,
+        ...     env_snapshot_description="Runtime env",
+        ... )
+        'Runtime env'
+        >>> get_metadata_description(
+        ...     "unknown_file.txt",
+        ...     metadata_descriptions=descs,
+        ...     env_snapshot_description="Runtime env",
+        ... ) is None
+        True
+    """
+    if file_name in metadata_descriptions:
+        return metadata_descriptions[file_name]
+
+    # Hydra renamed files: "hydra-{timestamp}-{original_name}"
+    if file_name.startswith("hydra-"):
+        for original, desc in metadata_descriptions.items():
+            if file_name.endswith(f"-{original}"):
+                return desc
+
+    if file_name.startswith("environment_snapshot_"):
+        return env_snapshot_description
+
+    return None
+
+
+def set_asset_descriptions(
+    execution: "Execution",
+    uploaded_assets: dict[str, list["AssetFilePath"]],
+    *,
+    metadata_descriptions: dict[str, str],
+    env_snapshot_description: str,
+) -> None:
+    """Set ``Description`` on uploaded asset rows from manifest + canonical metadata.
+
+    Two-source description resolution:
+
+    1. **Manifest description** — wins. If
+       ``asset_file_path(..., description=...)`` was called for
+       this asset, the manifest carries the user's description.
+    2. **Canonical metadata description** — fall-back for
+       ``Execution_Metadata`` files only (``configuration.json``,
+       ``uv.lock``, hydra configs, env snapshots). Looked up via
+       :func:`get_metadata_description`.
+
+    Pre-extraction this was an ``Execution`` method; the
+    extraction makes the manifest read + catalog update
+    visible as a pure data transform.
+
+    Args:
+        execution: The execution whose manifest + ml_object we
+            consult. Reads ``_get_manifest()`` and
+            ``_ml_object.pathBuilder()`` only.
+        uploaded_assets: Dict mapping ``"{schema}/{table}"`` to
+            list of uploaded :class:`AssetFilePath` records.
+        metadata_descriptions: Threaded through to
+            :func:`get_metadata_description`.
+        env_snapshot_description: Same.
+
+    Notes:
+        Snapshots ``manifest.assets`` once before the inner
+        loop. Pre-extraction the inline implementation re-read
+        the manifest on every iteration; for a 10K-asset upload
+        on a localhost SSD that meant ~10K SQL round-trips
+        (~19 minutes). The single-read pattern is preserved
+        here.
+    """
+    manifest = execution._get_manifest()
+    pb = execution._ml_object.pathBuilder()
+
+    # Snapshot the manifest's asset entries ONCE. ``manifest.assets``
+    # is a property that calls ``ManifestStore.list_assets`` (a SQL
+    # SELECT) on every access.
+    manifest_assets = manifest.assets
+
+    # Group updates by schema/table for batch efficiency.
+    table_updates: dict[str, list[dict[str, str]]] = {}
+
+    for table_key, assets in uploaded_assets.items():
+        for asset in assets:
+            # Determine description: check manifest first, then fall back
+            # to hardcoded metadata descriptions for Execution_Metadata files.
+            table_name = table_key.split("/")[1] if "/" in table_key else table_key
+            manifest_key = f"{table_name}/{asset.file_name}"
+            entry = manifest_assets.get(manifest_key)
+
+            description = None
+            if entry and entry.description:
+                description = entry.description
+            elif table_name == "Execution_Metadata":
+                description = get_metadata_description(
+                    asset.file_name,
+                    metadata_descriptions=metadata_descriptions,
+                    env_snapshot_description=env_snapshot_description,
+                )
+
+            if description and asset.asset_rid:
+                table_updates.setdefault(table_key, []).append(
+                    {"RID": asset.asset_rid, "Description": description}
+                )
+
+    for table_key, updates in table_updates.items():
+        schema, table_name = (
+            table_key.split("/", 1) if "/" in table_key else ("", table_key)
+        )
+        pb.schemas[schema].tables[table_name].update(updates)
+
+
+def save_runtime_environment(
+    execution: "Execution",
+    *,
+    runtime_env_asset_type: str,
+    env_snapshot_description: str,
+) -> None:
+    """Capture and stage the runtime environment as an Execution_Metadata asset.
+
+    Calls :func:`get_execution_environment` for the dict
+    snapshot (Python version, loaded modules, OS info, etc.)
+    and writes it as JSON to the
+    ``environment_snapshot_{timestamp}.txt`` file. The
+    timestamp keys distinct executions; subsequent calls in
+    the same execution stage subsequent snapshots.
+
+    Pre-extraction this was an ``Execution`` method.
+
+    Args:
+        execution: The bound :class:`Execution`. Reads
+            ``asset_file_path(...)`` only.
+        runtime_env_asset_type: The
+            ``ExecMetadataType.runtime_env.value`` string —
+            passed in to keep the helper decoupled from the
+            ``ExecMetadataType`` enum import.
+        env_snapshot_description: The description string for
+            the staged metadata asset.
+    """
+    runtime_env_path = execution.asset_file_path(
+        asset_name="Execution_Metadata",
+        file_name=f"environment_snapshot_{datetime.now().strftime('%Y%m%d_%H%M%S')}.txt",
+        asset_types=runtime_env_asset_type,
+        description=env_snapshot_description,
+    )
+    with Path(runtime_env_path).open("w") as fp:
+        json.dump(get_execution_environment(), fp)
+
+
+def upload_hydra_config_assets(
+    execution: "Execution",
+    *,
+    hydra_config_asset_type: str,
+    metadata_descriptions: dict[str, str],
+    env_snapshot_description: str,
+    execution_metadata_asset_name: Any,
+) -> None:
+    """Register Hydra static config YAMLs as Execution_Metadata assets.
+
+    Walks ``<hydra_run_dir>/hydra-config/`` — the subdirectory
+    Hydra designates for the resolved configuration snapshots
+    (``config.yaml``, ``hydra.yaml``, ``overrides.yaml``).
+    These are immutable per-run artifacts written once at
+    hydra-launch and the actual provenance for "what
+    configuration did this run use".
+
+    **Deliberately does NOT walk the parent ``<hydra_run_dir>``
+    itself.** Hydra installs a job-logging ``FileHandler`` at
+    ``<hydra_run_dir>/<job_name>.log`` (e.g., ``notebook.log``)
+    that keeps appending log lines for the entire process —
+    including every ``logger.info`` from this very upload pass.
+    Registering a live, growing file as an immutable asset
+    breaks the asset contract ("the bytes you registered are
+    the bytes that get uploaded") and produces a known race in
+    deriva-py's uploader: the file's MD5 changes between
+    hash-time and a subsequent idempotency pre-check, the
+    pre-check by ``MD5+Filename`` misses the row that was
+    already inserted, and a duplicate-RID INSERT fires (HTTP
+    409). The job log is the *runner's* asset, not the
+    kernel's — see ``deriva_ml/run_notebook.py`` for the
+    runner-side registration that closes the FileHandler
+    before staging the log.
+
+    Pre-extraction this was an ``Execution`` method.
+
+    Args:
+        execution: The bound :class:`Execution`. Reads
+            ``_ml_object.hydra_runtime_output_dir`` and
+            ``asset_file_path(...)``.
+        hydra_config_asset_type: The
+            ``ExecMetadataType.hydra_config.value`` string.
+        metadata_descriptions: Threaded into
+            :func:`get_metadata_description`.
+        env_snapshot_description: Same.
+        execution_metadata_asset_name: ``MLAsset.execution_metadata``
+            — passed in as a value, not imported, so the helper
+            stays decoupled from the ``MLAsset`` enum import.
+    """
+    hydra_runtime_output_dir = execution._ml_object.hydra_runtime_output_dir
+    if not hydra_runtime_output_dir:
+        return
+    config_dir = hydra_runtime_output_dir / "hydra-config"
+    if not config_dir.exists():
+        return  # tolerate older Hydra layouts that don't separate config from log
+    timestamp = hydra_runtime_output_dir.parts[-1]
+    for hydra_asset in config_dir.iterdir():
+        if hydra_asset.is_dir():
+            continue
+        # Register file for upload (side effect); result intentionally unused.
+        # Use Hydra_Config type for Hydra YAML configuration files.
+        execution.asset_file_path(
+            asset_name=execution_metadata_asset_name,
+            file_name=hydra_asset,
+            rename_file=f"hydra-{timestamp}-{hydra_asset.name}",
+            asset_types=hydra_config_asset_type,
+            description=get_metadata_description(
+                hydra_asset.name,
+                metadata_descriptions=metadata_descriptions,
+                env_snapshot_description=env_snapshot_description,
+            ),
+        )
+
+
+def clean_folder_contents(
+    folder_path: Path, remove_folder: bool = True, *, logger: Any = None
+) -> None:
+    """Clean up a folder's contents and optionally the folder itself.
+
+    Removes all files and subdirectories within ``folder_path``.
+    Uses bounded retry with delay for Windows compatibility
+    where files may be temporarily locked.
+
+    Pre-extraction this was an ``Execution`` method but didn't
+    actually need ``self`` — pure filesystem op. The extraction
+    makes that obvious.
+
+    Args:
+        folder_path: Path to the folder to clean.
+        remove_folder: If ``True`` (default), also remove
+            ``folder_path`` itself after cleaning its contents.
+        logger: Optional logger for retry-failure warnings.
+            Defaults to the module logger.
+
+    Constants:
+        Retries each removal up to 3 times with a 1-second
+        delay between attempts; the values are inlined because
+        they're never tuned at the call site (and over-
+        parameterizing would just add an arg that's always
+        passed the same way).
+    """
+    if logger is None:
+        logger = logging.getLogger(__name__)
+
+    MAX_RETRIES = 3
+    RETRY_DELAY = 1  # seconds
+
+    def remove_with_retry(path: Path, is_dir: bool = False) -> bool:
+        for attempt in range(MAX_RETRIES):
+            try:
+                if is_dir:
+                    shutil.rmtree(path)
+                else:
+                    Path(path).unlink()
+                return True
+            except (OSError, PermissionError) as e:
+                if attempt == MAX_RETRIES - 1:
+                    logger.warning(f"Failed to remove {path}: {e}")
+                    return False
+                time.sleep(RETRY_DELAY)
+        return False
+
+    try:
+        # First remove all contents.
+        with os.scandir(folder_path) as entries:
+            for entry in entries:
+                if entry.is_dir() and not entry.is_symlink():
+                    remove_with_retry(Path(entry.path), is_dir=True)
+                else:
+                    remove_with_retry(Path(entry.path))
+
+        # Then remove the folder itself if requested.
+        if remove_folder:
+            remove_with_retry(folder_path, is_dir=True)
+
+    except OSError as e:
+        logger.warning(f"Failed to clean folder {folder_path}: {e}")

--- a/src/deriva_ml/execution/execution.py
+++ b/src/deriva_ml/execution/execution.py
@@ -36,7 +36,6 @@ import logging
 import os
 import shutil
 import sys
-import time
 from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Iterable, List
@@ -78,7 +77,6 @@ from deriva_ml.core.validation import VALIDATION_CONFIG
 from deriva_ml.dataset.aux_classes import DatasetSpec, DatasetVersion
 from deriva_ml.dataset.dataset import Dataset
 from deriva_ml.dataset.dataset_bag import DatasetBag
-from deriva_ml.execution.environment import get_execution_environment
 from deriva_ml.execution.execution_configuration import ExecutionConfiguration
 from deriva_ml.execution.execution_record import ExecutionRecord
 from deriva_ml.execution.state_machine import transition
@@ -540,132 +538,68 @@ class Execution:
         return instance
 
     def _save_runtime_environment(self):
-        runtime_env_path = self.asset_file_path(
-            asset_name="Execution_Metadata",
-            file_name=f"environment_snapshot_{datetime.now().strftime('%Y%m%d_%H%M%S')}.txt",
-            asset_types=ExecMetadataType.runtime_env.value,
-            description=_ENV_SNAPSHOT_DESCRIPTION,
+        # Delegates to ``asset_upload.save_runtime_environment``
+        # — extracted in the Ex-god first sweep so the helper
+        # has a single home alongside the other asset-staging
+        # helpers in ``execution/asset_upload.py``.
+        from deriva_ml.execution.asset_upload import save_runtime_environment
+
+        save_runtime_environment(
+            self,
+            runtime_env_asset_type=ExecMetadataType.runtime_env.value,
+            env_snapshot_description=_ENV_SNAPSHOT_DESCRIPTION,
         )
-        with Path(runtime_env_path).open("w") as fp:
-            json.dump(get_execution_environment(), fp)
 
     def _upload_hydra_config_assets(self):
         """Register Hydra static config YAMLs as Execution_Metadata assets.
 
-        Walks ``<hydra_run_dir>/hydra-config/`` — the subdirectory Hydra
-        designates for the resolved configuration snapshots
-        (``config.yaml``, ``hydra.yaml``, ``overrides.yaml``). These are
-        immutable per-run artifacts written once at hydra-launch and the
-        actual provenance for "what configuration did this run use".
-
-        Deliberately does NOT walk the parent ``<hydra_run_dir>`` itself.
-        Hydra installs a job-logging ``FileHandler`` at
-        ``<hydra_run_dir>/<job_name>.log`` (e.g., ``notebook.log``) that
-        keeps appending log lines for the entire process — including
-        every ``logger.info`` from this very upload pass. Registering a
-        live, growing file as an immutable asset breaks the asset
-        contract ("the bytes you registered are the bytes that get
-        uploaded") and produces a known race in deriva-py's uploader:
-        the file's MD5 changes between hash-time and a subsequent
-        idempotency pre-check, the pre-check by ``MD5+Filename`` misses
-        the row that was already inserted, and a duplicate-RID INSERT
-        fires (HTTP 409). The job log is the *runner's* asset, not the
-        kernel's — see ``deriva_ml/run_notebook.py`` for the runner-side
-        registration that closes the FileHandler before staging the log.
+        Delegates to ``asset_upload.upload_hydra_config_assets``;
+        see that helper for the design notes on why this only
+        walks ``<hydra_run_dir>/hydra-config/`` and not the
+        parent directory.
         """
-        hydra_runtime_output_dir = self._ml_object.hydra_runtime_output_dir
-        if not hydra_runtime_output_dir:
-            return
-        config_dir = hydra_runtime_output_dir / "hydra-config"
-        if not config_dir.exists():
-            return  # tolerate older Hydra layouts that don't separate config from log
-        timestamp = hydra_runtime_output_dir.parts[-1]
-        for hydra_asset in config_dir.iterdir():
-            if hydra_asset.is_dir():
-                continue
-            # Register file for upload (side effect); result intentionally unused.
-            # Use Hydra_Config type for Hydra YAML configuration files.
-            self.asset_file_path(
-                asset_name=MLAsset.execution_metadata,
-                file_name=hydra_asset,
-                rename_file=f"hydra-{timestamp}-{hydra_asset.name}",
-                asset_types=ExecMetadataType.hydra_config.value,
-                description=self._get_metadata_description(hydra_asset.name),
-            )
+        from deriva_ml.execution.asset_upload import upload_hydra_config_assets
+
+        upload_hydra_config_assets(
+            self,
+            hydra_config_asset_type=ExecMetadataType.hydra_config.value,
+            metadata_descriptions=_METADATA_DESCRIPTIONS,
+            env_snapshot_description=_ENV_SNAPSHOT_DESCRIPTION,
+            execution_metadata_asset_name=MLAsset.execution_metadata,
+        )
 
     @staticmethod
     def _get_metadata_description(file_name: str) -> str | None:
         """Resolve a description for an execution metadata file.
 
-        Handles both direct filenames (configuration.json, uv.lock) and
-        hydra-renamed files (hydra-{timestamp}-{original_name}).
-
-        Args:
-            file_name: The filename as it appears in the catalog.
-
-        Returns:
-            A human-readable description, or None if the file is unrecognized.
+        Thin delegate to
+        ``asset_upload.get_metadata_description``; the module-level
+        constants are passed through so the helper stays
+        decoupled from this class's imports.
         """
-        if file_name in _METADATA_DESCRIPTIONS:
-            return _METADATA_DESCRIPTIONS[file_name]
+        from deriva_ml.execution.asset_upload import get_metadata_description
 
-        # Hydra renamed files: "hydra-{timestamp}-{original_name}"
-        if file_name.startswith("hydra-"):
-            for original, desc in _METADATA_DESCRIPTIONS.items():
-                if file_name.endswith(f"-{original}"):
-                    return desc
-
-        if file_name.startswith("environment_snapshot_"):
-            return _ENV_SNAPSHOT_DESCRIPTION
-
-        return None
+        return get_metadata_description(
+            file_name,
+            metadata_descriptions=_METADATA_DESCRIPTIONS,
+            env_snapshot_description=_ENV_SNAPSHOT_DESCRIPTION,
+        )
 
     def _set_asset_descriptions(self, uploaded_assets: dict[str, list[AssetFilePath]]) -> None:
         """Set Description on asset records after upload.
 
-        Applies descriptions from two sources:
-        1. Hardcoded descriptions for known execution metadata files.
-        2. User-provided descriptions passed via the ``description`` parameter
-           of ``asset_file_path()``.
-
-        Args:
-            uploaded_assets: Dict mapping "{schema}/{table}" to uploaded AssetFilePaths.
+        Delegates to ``asset_upload.set_asset_descriptions``;
+        see that helper for the manifest-snapshot performance
+        note and the two-source description-resolution rule.
         """
-        manifest = self._get_manifest()
-        pb = self._ml_object.pathBuilder()
+        from deriva_ml.execution.asset_upload import set_asset_descriptions
 
-        # Snapshot the manifest's asset entries ONCE. ``manifest.assets``
-        # is a property that calls ``ManifestStore.list_assets`` (a SQL
-        # SELECT) on every access. Reading it inside the inner loop ran
-        # one full-table SELECT per uploaded file — for a 10K-asset
-        # upload, ~10K serialized SQL round-trips totaling ~19 minutes
-        # on a localhost SSD (measured against an instrumented build).
-        # One read, one dict, in-memory lookups.
-        manifest_assets = manifest.assets
-
-        # Group updates by schema/table for batch efficiency
-        table_updates: dict[str, list[dict[str, str]]] = {}
-
-        for table_key, assets in uploaded_assets.items():
-            for asset in assets:
-                # Determine description: check manifest first, then fall back to
-                # hardcoded metadata descriptions for Execution_Metadata files.
-                table_name = table_key.split("/")[1] if "/" in table_key else table_key
-                manifest_key = f"{table_name}/{asset.file_name}"
-                entry = manifest_assets.get(manifest_key)
-
-                description = None
-                if entry and entry.description:
-                    description = entry.description
-                elif table_name == "Execution_Metadata":
-                    description = self._get_metadata_description(asset.file_name)
-
-                if description and asset.asset_rid:
-                    table_updates.setdefault(table_key, []).append({"RID": asset.asset_rid, "Description": description})
-
-        for table_key, updates in table_updates.items():
-            schema, table_name = table_key.split("/", 1) if "/" in table_key else ("", table_key)
-            pb.schemas[schema].tables[table_name].update(updates)
+        set_asset_descriptions(
+            self,
+            uploaded_assets,
+            metadata_descriptions=_METADATA_DESCRIPTIONS,
+            env_snapshot_description=_ENV_SNAPSHOT_DESCRIPTION,
+        )
 
     def _initialize_execution(self, reload: RID | None = None) -> None:
         """Initialize the execution environment.
@@ -1737,47 +1671,21 @@ class Execution:
     def _clean_folder_contents(self, folder_path: Path, remove_folder: bool = True):
         """Clean up folder contents and optionally the folder itself.
 
-        Removes all files and subdirectories within the specified folder.
-        Uses retry logic for Windows compatibility where files may be temporarily locked.
-
-        Args:
-            folder_path: Path to the folder to clean.
-            remove_folder: If True (default), also remove the folder itself after
-                cleaning its contents. If False, only remove contents.
+        Thin delegate to ``asset_upload.clean_folder_contents``.
+        The helper doesn't need ``self`` at all — it's a pure
+        filesystem op that lived on ``Execution`` for legacy
+        reasons. Preserved here as an instance method so the
+        existing in-class call sites
+        (``upload_execution_outputs``, ``__exit__``,
+        ``execution_stop``) still read naturally.
         """
-        MAX_RETRIES = 3
-        RETRY_DELAY = 1  # seconds
+        from deriva_ml.execution.asset_upload import clean_folder_contents
 
-        def remove_with_retry(path: Path, is_dir: bool = False) -> bool:
-            for attempt in range(MAX_RETRIES):
-                try:
-                    if is_dir:
-                        shutil.rmtree(path)
-                    else:
-                        Path(path).unlink()
-                    return True
-                except (OSError, PermissionError) as e:
-                    if attempt == MAX_RETRIES - 1:
-                        logging.warning(f"Failed to remove {path}: {e}")
-                        return False
-                    time.sleep(RETRY_DELAY)
-            return False
-
-        try:
-            # First remove all contents
-            with os.scandir(folder_path) as entries:
-                for entry in entries:
-                    if entry.is_dir() and not entry.is_symlink():
-                        remove_with_retry(Path(entry.path), is_dir=True)
-                    else:
-                        remove_with_retry(Path(entry.path))
-
-            # Then remove the folder itself if requested
-            if remove_folder:
-                remove_with_retry(folder_path, is_dir=True)
-
-        except OSError as e:
-            logging.warning(f"Failed to clean folder {folder_path}: {e}")
+        clean_folder_contents(
+            folder_path,
+            remove_folder=remove_folder,
+            logger=self._logger,
+        )
 
     def _update_asset_execution_table(
         self,

--- a/tests/execution/test_asset_upload.py
+++ b/tests/execution/test_asset_upload.py
@@ -1,0 +1,425 @@
+"""Unit tests for ``deriva_ml.execution.asset_upload`` (audit P1 Ex-god first sweep).
+
+Pre-extraction these helpers lived on ``Execution`` as
+methods. Each could only be exercised by spinning up a real
+catalog + workflow + execution. Post-extraction the
+helpers take ``execution`` as an explicit argument; tests
+mock the small subset of fields each helper reads.
+
+Coverage layers:
+
+1. ``get_metadata_description`` — pure: filename → description
+   lookup with hydra-rename + env-snapshot handling.
+2. ``set_asset_descriptions`` — manifest snapshot + per-row
+   description resolution + batched ``pathBuilder`` update.
+3. ``save_runtime_environment`` — writes JSON to the
+   ``asset_file_path`` staging location.
+4. ``upload_hydra_config_assets`` — walks
+   ``hydra-config/`` and registers each file; tolerant of
+   missing dir.
+5. ``clean_folder_contents`` — pure filesystem op with
+   bounded retry.
+
+Pure-Python tests; no live catalog required.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from deriva_ml.execution.asset_upload import (
+    clean_folder_contents,
+    get_metadata_description,
+    save_runtime_environment,
+    set_asset_descriptions,
+    upload_hydra_config_assets,
+)
+
+# ---------------------------------------------------------------------------
+# get_metadata_description — pure lookup
+# ---------------------------------------------------------------------------
+
+
+_METADATA = {
+    "configuration.json": "DerivaML configuration",
+    "uv.lock": "Dependency lockfile",
+}
+_ENV_DESC = "Runtime environment snapshot"
+
+
+class TestGetMetadataDescription:
+    def test_direct_filename_hit(self):
+        assert (
+            get_metadata_description(
+                "uv.lock",
+                metadata_descriptions=_METADATA,
+                env_snapshot_description=_ENV_DESC,
+            )
+            == "Dependency lockfile"
+        )
+
+    def test_hydra_renamed_file(self):
+        """``hydra-{timestamp}-{original}`` resolves via original-name match."""
+        result = get_metadata_description(
+            "hydra-20260522_120000-uv.lock",
+            metadata_descriptions=_METADATA,
+            env_snapshot_description=_ENV_DESC,
+        )
+        assert result == "Dependency lockfile"
+
+    def test_env_snapshot(self):
+        result = get_metadata_description(
+            "environment_snapshot_20260522_120000.txt",
+            metadata_descriptions=_METADATA,
+            env_snapshot_description=_ENV_DESC,
+        )
+        assert result == _ENV_DESC
+
+    def test_unknown_returns_none(self):
+        assert (
+            get_metadata_description(
+                "random_file.bin",
+                metadata_descriptions=_METADATA,
+                env_snapshot_description=_ENV_DESC,
+            )
+            is None
+        )
+
+    def test_hydra_prefix_without_matching_original_returns_none(self):
+        """A hydra-prefixed file whose suffix doesn't match any known
+        canonical name falls through to ``None`` (not env-snapshot).
+        """
+        result = get_metadata_description(
+            "hydra-20260522_120000-randomfile.yaml",
+            metadata_descriptions=_METADATA,
+            env_snapshot_description=_ENV_DESC,
+        )
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# set_asset_descriptions — manifest snapshot + batched update
+# ---------------------------------------------------------------------------
+
+
+class TestSetAssetDescriptions:
+    """Pin the manifest-snapshot + two-source description resolution."""
+
+    @staticmethod
+    def _table_path(exe):
+        """Drill into the pathBuilder chain mocks to get the table_path mock."""
+        pb = exe._ml_object.pathBuilder.return_value
+        return pb.schemas.__getitem__.return_value.tables.__getitem__.return_value
+
+    def _build_execution_mock(self, manifest_assets: dict):
+        """Build an ``Execution`` mock exposing only what the helper reads."""
+        exe = MagicMock()
+        manifest = MagicMock()
+        manifest.assets = manifest_assets  # snapshot-once invariant
+        exe._get_manifest.return_value = manifest
+        return exe
+
+    def _build_uploaded(self, table_key: str, file_name: str, asset_rid: str):
+        asset = MagicMock()
+        asset.file_name = file_name
+        asset.asset_rid = asset_rid
+        return {table_key: [asset]}
+
+    def test_manifest_description_wins(self):
+        """When the manifest carries a description, it's used (not the canonical map)."""
+        manifest_entry = MagicMock()
+        manifest_entry.description = "User-supplied description"
+        exe = self._build_execution_mock(
+            {"Image/photo.jpg": manifest_entry}
+        )
+        uploaded = self._build_uploaded("schema/Image", "photo.jpg", "RID-1")
+
+        set_asset_descriptions(
+            exe,
+            uploaded,
+            metadata_descriptions=_METADATA,
+            env_snapshot_description=_ENV_DESC,
+        )
+
+        # The pathBuilder update was called with the manifest description.
+        table_path = self._table_path(exe)
+        table_path.update.assert_called_once_with(
+            [{"RID": "RID-1", "Description": "User-supplied description"}]
+        )
+
+    def test_metadata_fallback_for_execution_metadata(self):
+        """When the manifest has no description, ``Execution_Metadata``
+        files get the canonical description.
+        """
+        exe = self._build_execution_mock({})  # no manifest entries
+        uploaded = self._build_uploaded(
+            "deriva-ml/Execution_Metadata", "uv.lock", "RID-2"
+        )
+
+        set_asset_descriptions(
+            exe,
+            uploaded,
+            metadata_descriptions=_METADATA,
+            env_snapshot_description=_ENV_DESC,
+        )
+
+        table_path = self._table_path(exe)
+        table_path.update.assert_called_once_with(
+            [{"RID": "RID-2", "Description": "Dependency lockfile"}]
+        )
+
+    def test_no_description_skipped(self):
+        """Assets without a description (and not Execution_Metadata) get no update."""
+        exe = self._build_execution_mock({})
+        uploaded = self._build_uploaded("schema/Image", "photo.jpg", "RID-3")
+
+        set_asset_descriptions(
+            exe,
+            uploaded,
+            metadata_descriptions=_METADATA,
+            env_snapshot_description=_ENV_DESC,
+        )
+
+        # No update call.
+        table_path = self._table_path(exe)
+        table_path.update.assert_not_called()
+
+    def test_no_asset_rid_skipped(self):
+        """Assets without an ``asset_rid`` get no update (can't address them)."""
+        manifest_entry = MagicMock()
+        manifest_entry.description = "Some description"
+        exe = self._build_execution_mock(
+            {"Image/photo.jpg": manifest_entry}
+        )
+        # asset_rid is None.
+        asset = MagicMock()
+        asset.file_name = "photo.jpg"
+        asset.asset_rid = None
+        uploaded = {"schema/Image": [asset]}
+
+        set_asset_descriptions(
+            exe,
+            uploaded,
+            metadata_descriptions=_METADATA,
+            env_snapshot_description=_ENV_DESC,
+        )
+
+        table_path = self._table_path(exe)
+        table_path.update.assert_not_called()
+
+    def test_manifest_assets_read_once(self):
+        """``manifest.assets`` is accessed exactly once per call.
+
+        Pre-extraction the inline implementation re-read the
+        manifest on every iteration; for a 10K-asset upload
+        that's ~10K SQL round-trips. The single-read pattern
+        was the audit's perf note.
+        """
+        access_count = [0]
+
+        class _CountingManifest:
+            @property
+            def assets(self):
+                access_count[0] += 1
+                return {}
+
+        exe = MagicMock()
+        exe._get_manifest.return_value = _CountingManifest()
+        uploaded = self._build_uploaded("schema/Image", "photo.jpg", "RID-1")
+
+        set_asset_descriptions(
+            exe,
+            uploaded,
+            metadata_descriptions=_METADATA,
+            env_snapshot_description=_ENV_DESC,
+        )
+
+        assert access_count[0] == 1, (
+            f"manifest.assets must be read exactly once per call; "
+            f"got {access_count[0]} reads. Audit P2: this is the "
+            f"performance pin — re-reading the manifest in the inner "
+            f"loop was a known O(N) regression."
+        )
+
+
+# ---------------------------------------------------------------------------
+# save_runtime_environment — writes JSON to the asset_file_path location
+# ---------------------------------------------------------------------------
+
+
+class TestSaveRuntimeEnvironment:
+    def test_writes_json_to_asset_file_path(self, tmp_path):
+        """The helper calls ``execution.asset_file_path`` and writes
+        ``get_execution_environment()`` JSON into the returned path.
+        """
+        snapshot_file = tmp_path / "env_snapshot.txt"
+        exe = MagicMock()
+        exe.asset_file_path.return_value = snapshot_file
+
+        save_runtime_environment(
+            exe,
+            runtime_env_asset_type="Runtime_Env",
+            env_snapshot_description=_ENV_DESC,
+        )
+
+        # asset_file_path called with the expected stamp.
+        assert exe.asset_file_path.called
+        kwargs = exe.asset_file_path.call_args.kwargs
+        assert kwargs["asset_name"] == "Execution_Metadata"
+        assert kwargs["asset_types"] == "Runtime_Env"
+        assert kwargs["description"] == _ENV_DESC
+        # File starts with the env_snapshot timestamp prefix.
+        assert kwargs["file_name"].startswith("environment_snapshot_")
+
+        # The file was written and contains JSON parseable as a dict.
+        assert snapshot_file.exists()
+        parsed = json.loads(snapshot_file.read_text())
+        assert isinstance(parsed, dict)
+        # ``get_execution_environment`` returns the six documented keys.
+        for key in ("imports", "os", "sys", "sys_path", "site", "platform"):
+            assert key in parsed
+
+
+# ---------------------------------------------------------------------------
+# upload_hydra_config_assets — walks hydra-config/ and registers files
+# ---------------------------------------------------------------------------
+
+
+class TestUploadHydraConfigAssets:
+    """Pin the hydra-config walk + the "no walk on parent dir" invariant."""
+
+    def test_no_hydra_dir_is_a_noop(self):
+        """``hydra_runtime_output_dir is None`` → return without calls."""
+        exe = MagicMock()
+        exe._ml_object.hydra_runtime_output_dir = None
+
+        upload_hydra_config_assets(
+            exe,
+            hydra_config_asset_type="Hydra_Config",
+            metadata_descriptions=_METADATA,
+            env_snapshot_description=_ENV_DESC,
+            execution_metadata_asset_name="Execution_Metadata",
+        )
+        exe.asset_file_path.assert_not_called()
+
+    def test_missing_hydra_config_subdir_is_a_noop(self, tmp_path):
+        """Hydra run dir exists but ``hydra-config/`` doesn't → noop.
+
+        Tolerates older Hydra layouts that don't separate config from log.
+        """
+        hydra_dir = tmp_path / "2026-05-22_12-00-00"
+        hydra_dir.mkdir()
+        # NO hydra-config subdir.
+
+        exe = MagicMock()
+        exe._ml_object.hydra_runtime_output_dir = hydra_dir
+
+        upload_hydra_config_assets(
+            exe,
+            hydra_config_asset_type="Hydra_Config",
+            metadata_descriptions=_METADATA,
+            env_snapshot_description=_ENV_DESC,
+            execution_metadata_asset_name="Execution_Metadata",
+        )
+        exe.asset_file_path.assert_not_called()
+
+    def test_registers_each_config_file(self, tmp_path):
+        """Each file in ``hydra-config/`` gets one ``asset_file_path`` call."""
+        hydra_dir = tmp_path / "2026-05-22_12-00-00"
+        config_dir = hydra_dir / "hydra-config"
+        config_dir.mkdir(parents=True)
+        (config_dir / "config.yaml").write_text("k: v")
+        (config_dir / "hydra.yaml").write_text("k: v")
+        # And a subdirectory to ensure we don't descend.
+        (config_dir / "subdir").mkdir()
+
+        exe = MagicMock()
+        exe._ml_object.hydra_runtime_output_dir = hydra_dir
+
+        upload_hydra_config_assets(
+            exe,
+            hydra_config_asset_type="Hydra_Config",
+            metadata_descriptions=_METADATA,
+            env_snapshot_description=_ENV_DESC,
+            execution_metadata_asset_name="Execution_Metadata",
+        )
+
+        # Two files registered (subdir is skipped).
+        assert exe.asset_file_path.call_count == 2
+
+        # All calls use the hydra-rename pattern with the run-dir timestamp.
+        for call in exe.asset_file_path.call_args_list:
+            kwargs = call.kwargs
+            assert kwargs["asset_types"] == "Hydra_Config"
+            assert kwargs["rename_file"].startswith("hydra-2026-05-22_12-00-00-")
+
+
+# ---------------------------------------------------------------------------
+# clean_folder_contents — pure filesystem op with bounded retry
+# ---------------------------------------------------------------------------
+
+
+class TestCleanFolderContents:
+    def test_removes_files_and_subdirs(self, tmp_path):
+        target = tmp_path / "target"
+        target.mkdir()
+        (target / "file1.txt").write_text("a")
+        (target / "file2.txt").write_text("b")
+        (target / "sub").mkdir()
+        (target / "sub" / "nested.txt").write_text("c")
+
+        clean_folder_contents(target, remove_folder=True)
+
+        # Whole folder gone.
+        assert not target.exists()
+
+    def test_remove_folder_false_keeps_dir(self, tmp_path):
+        target = tmp_path / "target"
+        target.mkdir()
+        (target / "file.txt").write_text("a")
+
+        clean_folder_contents(target, remove_folder=False)
+
+        # Folder still exists but is empty.
+        assert target.exists()
+        assert list(target.iterdir()) == []
+
+    def test_handles_nonexistent_folder(self, tmp_path):
+        """Cleaning a folder that doesn't exist logs but doesn't raise."""
+        bogus = tmp_path / "does_not_exist"
+        # Capture log via a stub logger.
+        log = MagicMock()
+        clean_folder_contents(bogus, remove_folder=True, logger=log)
+        # Logged a warning; didn't raise.
+        log.warning.assert_called()
+
+    def test_retries_on_oserror(self, tmp_path, monkeypatch):
+        """The retry loop falls back to logging after 3 failed attempts."""
+        target = tmp_path / "target"
+        target.mkdir()
+        (target / "stuck.txt").write_text("x")
+
+        # Patch ``Path.unlink`` to always raise OSError.
+        original_unlink = Path.unlink
+        unlink_calls = [0]
+
+        def failing_unlink(self):
+            unlink_calls[0] += 1
+            raise OSError("locked")
+
+        monkeypatch.setattr(Path, "unlink", failing_unlink)
+
+        log = MagicMock()
+        # Avoid the per-attempt 1s sleep dominating the test.
+        with patch("deriva_ml.execution.asset_upload.time.sleep"):
+            clean_folder_contents(target, remove_folder=False, logger=log)
+
+        # Three retry attempts on the stuck file.
+        assert unlink_calls[0] == 3
+        # Final warning logged for the file.
+        assert log.warning.called
+
+        # Restore for safety.
+        monkeypatch.setattr(Path, "unlink", original_unlink)


### PR DESCRIPTION
## Summary

First sweep on audit P1 Ex-god from
``docs/audits/2026-05-22-engineer-audit-execution.md:148-166``.
The ``Execution`` god-class carries 30+ methods and 2,676 LOC
mixing many concerns. The audit asked for the asset-staging +
upload methods to live in a sibling module to ``bag_commit.py``.

This PR covers the helpers with the **lightest coupling** to
``Execution`` lifecycle — the ones that were nearly free
functions already and only used a handful of fields off
``self``. Heavier-coupling extractions
(``upload_execution_outputs``, ``_bag_commit_upload``,
``download_asset``, ``asset_file_path``, ``metrics_file``,
``_update_asset_execution_table``) are deferred to a future
sweep; they touch state-machine transitions and the public
API surface.

### Extracted into ``deriva_ml/execution/asset_upload.py``

- ``get_metadata_description``
- ``set_asset_descriptions`` (preserves the audit-noted
  single-read invariant on ``manifest.assets``)
- ``save_runtime_environment``
- ``upload_hydra_config_assets`` (carries the full design
  note on why it does NOT walk the parent hydra dir — race
  with the job-log FileHandler)
- ``clean_folder_contents`` (didn't need ``self`` at all)

The five corresponding ``Execution`` methods are kept as thin
delegates so the public API is unchanged. Cleaned up two
top-level imports that became unused in ``execution.py``
(``time``, ``get_execution_environment``).

### Why this matters

**Maintainability**: ``execution.py`` is now 2,602 LOC (down
from 2,692). The asset-staging logic has a single home that
mirrors ``bag_commit.py``.

**Testability**: pre-extraction these helpers could only be
exercised by spinning up a real catalog + workflow +
execution (~7-min integration tests). Post-extraction the
helpers take ``execution`` as an explicit arg; the new unit
tests run in **0.15 seconds** with no live catalog.

## Test plan

- [x] New ``tests/execution/test_asset_upload.py`` (18
      pure-Python tests, ~0.15s):
  - ``TestGetMetadataDescription`` (5)
  - ``TestSetAssetDescriptions`` (5) — pins the audit-noted
    manifest-read-once invariant
  - ``TestSaveRuntimeEnvironment`` (1)
  - ``TestUploadHydraConfigAssets`` (3)
  - ``TestCleanFolderContents`` (4)
- [ ] ``tests/execution/`` (existing integration coverage) —
      running; will note here when complete
- [x] ``ruff check`` clean on touched code (one pre-existing
      ``F821 DatasetCollection`` unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)