### PR TITLE
refactor(execution): extract bag_commit_upload + update_asset_execution_table (audit P1 Ex-god, second sweep)

### DIFF
--- a/src/deriva_ml/execution/asset_upload.py
+++ b/src/deriva_ml/execution/asset_upload.py
@@ -10,20 +10,26 @@ asked for the asset-staging + upload pipeline to live in a
 sibling module to ``bag_commit.py`` so the file structure
 mirrors the conceptual structure.
 
-This module hosts the helpers that have the **lightest
-coupling** to ``Execution`` lifecycle state — the ones that
-were nearly free functions already and only used a handful of
-fields off ``self``. The corresponding ``Execution`` methods
-remain as thin delegates so the public API is unchanged.
+**First sweep** (PR #216): the helpers with the lightest
+coupling to ``Execution`` lifecycle state — the ones that
+were nearly free functions already
+(``get_metadata_description``, ``set_asset_descriptions``,
+``save_runtime_environment``, ``upload_hydra_config_assets``,
+``clean_folder_contents``).
 
-Heavier coupling — ``upload_execution_outputs``,
-``_bag_commit_upload``, ``download_asset``, ``asset_file_path``,
-``metrics_file``, ``_update_asset_execution_table`` — stays on
-:class:`Execution` for now. Those touch the state-machine
-transitions (``update_status``, ``execution_stop``) and the
-public API surface; a clean extraction of those wants the
-state-machine and manifest-store types to themselves stabilize
-further first.
+**Second sweep** (this PR): the catalog-writing orchestrators —
+``bag_commit_upload`` (transient bag build + load) and
+``update_asset_execution_table`` (per-execution + per-type
+association rows). These have heavier ``self`` coupling
+(read ``execution_rid``, ``_model``, ``_ml_object``,
+``_working_dir``, ``_manifest_store``) but no state-machine
+touching — that stays on :class:`Execution`.
+
+Still on :class:`Execution` (public API + state-machine
+entanglement): ``upload_execution_outputs``,
+``download_asset``, ``asset_file_path``, ``metrics_file``.
+Future sweeps may continue the extraction once the
+state-machine and manifest-store types stabilize further.
 
 Pairs with ``bag_commit.py`` (the bag-build / bag-load
 pipeline). Together the two modules carry the bulk of the
@@ -39,21 +45,27 @@ import shutil
 import time
 from datetime import datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Callable
 
+from deriva.core import format_exception
+
+from deriva_ml.core.exceptions import DerivaMLException
 from deriva_ml.execution.environment import get_execution_environment
 
 if TYPE_CHECKING:
     from deriva_ml.asset.aux_classes import AssetFilePath
+    from deriva_ml.core.ermrest import UploadProgress
     from deriva_ml.execution.execution import Execution
 
 
 # Public symbols re-exported via ``Execution`` thin delegates.
 __all__ = [
+    "bag_commit_upload",
     "clean_folder_contents",
     "get_metadata_description",
     "save_runtime_environment",
     "set_asset_descriptions",
+    "update_asset_execution_table",
     "upload_hydra_config_assets",
 ]
 
@@ -392,3 +404,315 @@ def clean_folder_contents(
 
     except OSError as e:
         logger.warning(f"Failed to clean folder {folder_path}: {e}")
+
+
+# ---------------------------------------------------------------------------
+# Catalog-writing orchestrators (audit P1 Ex-god, second sweep)
+# ---------------------------------------------------------------------------
+
+
+def update_asset_execution_table(
+    execution: "Execution",
+    uploaded_assets: dict[str, list["AssetFilePath"]],
+    *,
+    asset_role: str,
+    asset_role_vocab_term: str,
+    input_file_tag: str,
+    output_file_tag: str,
+    asset_type_path_fn: Callable[..., Path],
+) -> None:
+    """Link assets to an execution and auto-tag them by role.
+
+    Writes two kinds of association rows for each asset:
+
+    1. ``{Asset}_Execution`` — links the asset RID to the
+       execution with the given ``Asset_Role`` (``"Input"`` or
+       ``"Output"``). Consumers query it via
+       ``execution.list_assets(asset_role="Input")``.
+
+    2. ``{Asset}_Asset_Type`` — auto-tags each asset's content
+       classification:
+
+       - For ``"Output"``: every user-supplied type from the
+         ``asset_file_path`` calls **plus** ``Output_File``
+         (added automatically if not already in the list).
+         So a model file uploaded with ``ExecAssetType.model_file``
+         ends up tagged ``["Model_File", "Output_File"]``.
+       - For ``"Input"``: just ``Input_File`` is added. The
+         asset's existing content types (from when it was
+         originally created) are preserved.
+
+    Both inserts use ``on_conflict_skip=True`` so re-running is
+    idempotent — an asset that already has the
+    ``Input_File``/``Output_File`` tag from a prior
+    execution-link is unchanged.
+
+    Pre-extraction this was an ``Execution`` method. The
+    audit (P1) noted that **only the Input branch is exercised
+    in production** — the Output flow now lives in
+    :func:`bag_commit._add_asset_rows_to_bag`. The Output
+    branch is preserved here for now because it's pinned by
+    the asset-role-auto-tag tests; dropping it requires
+    rewriting those tests against the bag-commit path. Tracked
+    as a follow-up.
+
+    Args:
+        execution: The bound :class:`Execution`. Reads
+            ``_dry_run``, ``_ml_object``, ``_model``,
+            ``execution_rid``, and ``_working_dir`` only.
+        uploaded_assets: ``{schema/table_name: [AssetFilePath, ...]}``.
+            Each ``AssetFilePath`` carries the asset RID and
+            (for outputs) the user-supplied content types.
+        asset_role: ``"Input"`` or ``"Output"`` from the
+            ``Asset_Role`` vocabulary.
+        asset_role_vocab_term: The ``MLVocab.asset_role`` enum
+            value (e.g., ``"Asset_Role"``). Threaded through to
+            ``lookup_term`` so the helper stays decoupled from
+            ``MLVocab`` imports.
+        input_file_tag: ``ExecAssetType.input_file.value``.
+        output_file_tag: ``ExecAssetType.output_file.value``.
+        asset_type_path_fn: The ``asset_type_path`` function
+            from ``core.upload_layout`` — passed in to keep
+            the helper free of that import.
+    """
+    if execution._dry_run:
+        # Don't do any updates if we are doing a dry run.
+        return
+
+    execution._ml_object.lookup_term(asset_role_vocab_term, asset_role)
+
+    # Direction-tag for the {Asset}_Asset_Type write below. The
+    # direction is multi-valued alongside content types — a file
+    # uploaded as ExecAssetType.model_file ends up tagged with
+    # both Model_File AND Output_File. The directional tag makes
+    # "give me every asset that's ever served as input" queryable
+    # through Asset_Type alone, regardless of which execution
+    # it was input to.
+    direction_tag = input_file_tag if asset_role == "Input" else output_file_tag
+
+    pb = execution._ml_object.pathBuilder()
+    for asset_table, asset_list in uploaded_assets.items():
+        # Peel off the schema from the asset table.
+        asset_table_name = asset_table.split("/")[1]
+        asset_exe, asset_fk, execution_fk = execution._model.find_association(
+            asset_table_name, "Execution"
+        )
+        asset_exe_path = pb.schemas[asset_exe.schema.name].tables[asset_exe.name]
+
+        asset_exe_path.insert(
+            [
+                {
+                    asset_fk: asset_path.asset_rid,
+                    execution_fk: execution.execution_rid,
+                    "Asset_Role": asset_role,
+                }
+                for asset_path in asset_list
+            ],
+            on_conflict_skip=True,
+        )
+
+        # Resolve the {Asset}_Asset_Type association once per
+        # asset_table loop iteration — we need it for both the
+        # Output (user-supplied + Output_File) and Input
+        # (Input_File only) branches below.
+        asset_asset_type, _, _ = execution._model.find_association(
+            asset_table_name, "Asset_Type"
+        )
+        type_path = pb.schemas[asset_asset_type.schema.name].tables[
+            asset_asset_type.name
+        ]
+
+        if asset_role == "Input":
+            # Input branch: auto-tag each downloaded asset with
+            # Input_File. We don't touch the asset's existing
+            # content types — the asset was created by someone
+            # else (likely a prior execution's output); whatever
+            # types it carries should stay. ``on_conflict_skip``
+            # makes re-downloads idempotent.
+            type_path.insert(
+                [
+                    {asset_table_name: asset_path.asset_rid, "Asset_Type": direction_tag}
+                    for asset_path in asset_list
+                ],
+                on_conflict_skip=True,
+            )
+            continue
+
+        # Output branch: read the user-supplied per-file type
+        # map produced during asset_file_path() calls, then
+        # auto-add Output_File to every asset's type list (if
+        # not already present). The user can still explicitly
+        # pass ExecAssetType.output_file; we just don't require
+        # it anymore.
+        asset_type_map: dict[str, list[str]] = {}
+        with Path(
+            asset_type_path_fn(
+                execution._working_dir,
+                execution.execution_rid,
+                execution._model.name_to_table(asset_table_name),
+            )
+        ).open("r") as asset_type_file:
+            for line in asset_type_file:
+                asset_type_map.update(json.loads(line.strip()))
+
+        # Ensure the directional Output_File tag is in every
+        # asset's type list. Use a list (preserving order) +
+        # membership check rather than a set, so user-specified
+        # tag ordering is preserved for any downstream consumer
+        # that cares.
+        for asset_path in asset_list:
+            types = asset_type_map[asset_path.file_name]
+            if direction_tag not in types:
+                types.append(direction_tag)
+            asset_path.asset_types = types
+
+        type_path.insert(
+            [
+                {asset_table_name: asset.asset_rid, "Asset_Type": t}
+                for asset in asset_list
+                for t in asset_type_map[asset.file_name]
+            ],
+            on_conflict_skip=True,
+        )
+
+
+def bag_commit_upload(
+    execution: "Execution",
+    *,
+    progress_callback: "Callable[[UploadProgress], None] | None" = None,
+) -> dict[str, list["AssetFilePath"]]:
+    """Upload pending execution outputs via the bag pipeline.
+
+    Builds a transient bag from the execution's pending
+    manifest entries and staged feature records, then loads it
+    into the destination catalog. The bag's asset bytes are
+    hardlinked from flat storage (zero disk copies); rows are
+    inserted by :class:`BagCatalogLoader` in FK-safe order;
+    bytes get PUT to Hatrac.
+
+    After a successful load, marks every pending manifest
+    entry as ``uploaded`` (matches the legacy contract that
+    the manifest reflects the destination's state after a
+    commit). The transient bag dir is left in place at
+    ``working_dir/upload/{execution_rid}/`` so post-mortem
+    inspection is possible if needed; users may delete the
+    ``upload/{rid}/`` directory by hand once they no longer
+    need it. The caller's ``clean_folder`` flag controls
+    cleanup of the separate ``execution_root`` only (see
+    :meth:`Execution.upload_execution_outputs`).
+
+    Pre-extraction this was the ``_bag_commit_upload`` method
+    on ``Execution``. The helper now takes ``execution`` as
+    an explicit first arg so tests can mock the small subset
+    of fields it touches (``_working_dir``, ``execution_rid``,
+    ``_logger``, ``_get_manifest()``, ``_manifest_store``).
+
+    Args:
+        execution: The bound :class:`Execution`.
+        progress_callback: Optional callback for bag-build +
+            bag-load progress updates.
+
+    Returns:
+        ``{"{schema}/{table}": [AssetFilePath, ...]}`` for the
+        asset rows that landed at the destination.
+
+    Raises:
+        DerivaMLException: If the bag-load fails. Pending
+            feature records are marked failed with the loader's
+            error so the user can retry from a known state.
+    """
+    from deriva_ml.execution.bag_commit import (
+        build_execution_bag,
+        load_execution_bag,
+        report_to_asset_map,
+    )
+
+    # Issue #178: per-execution upload staging lives under a
+    # dedicated ``upload/`` parent — not at the cache root, where
+    # it used to sit beside ``cache/`` and ``schema-cache.json``
+    # and was easy to mistake for cache state.
+    bag_dir = Path(execution._working_dir) / "upload" / execution.execution_rid
+    if bag_dir.exists():
+        # An earlier (failed) attempt may have left a partial
+        # bag on disk. Wipe it so the build starts clean —
+        # bdbag's update path expects scaffolding it controls.
+        shutil.rmtree(bag_dir)
+
+    execution._logger.info("Building commit bag at %s", bag_dir)
+    # ``build_execution_bag`` leases pending RIDs as its first
+    # step. Capture the post-lease ``pending`` snapshot *after*
+    # the build so ``entry.rid`` reflects the leased value (the
+    # destination catalog now knows about these RIDs).
+    bag_dir = build_execution_bag(
+        execution,
+        bag_dir,
+        progress_callback=progress_callback,
+    )
+    manifest = execution._get_manifest()
+    pending = manifest.pending_assets()
+
+    execution._logger.info("Loading commit bag into destination catalog")
+    try:
+        report = load_execution_bag(
+            execution,
+            bag_dir,
+            progress_callback=progress_callback,
+        )
+    except Exception as e:
+        error = format_exception(e)
+        execution._logger.error("BagCatalogLoader failed: %s", error)
+        # Mark every pending feature record as failed with the
+        # loader's error so the user can retry from a known
+        # state.
+        try:
+            pending_features = execution._manifest_store.list_pending_feature_records(
+                execution.execution_rid
+            )
+            if pending_features:
+                execution._manifest_store.mark_feature_records_failed(
+                    [(r.stage_id, f"bag-load failed: {error}") for r in pending_features]
+                )
+        except Exception as mark_err:  # noqa: BLE001 — never mask the original failure
+            execution._logger.warning(
+                "Could not mark pending features as failed: %s",
+                mark_err,
+            )
+        raise DerivaMLException(
+            f"Failed to upload execution outputs via bag pipeline: {error}"
+        )
+
+    # Mark every leased manifest entry as uploaded — its RID
+    # was set during the bag build step's lease. Batch the
+    # SQLite update; one transaction beats N for a typical
+    # execution.
+    manifest_updates = [(key, entry.rid) for key, entry in pending.items()]
+    manifest.mark_uploaded_batch(manifest_updates)
+
+    # Mark staged feature records as uploaded too. The bag
+    # carried them; if the load succeeded, they're at the
+    # destination.
+    pending_features = execution._manifest_store.list_pending_feature_records(
+        execution.execution_rid
+    )
+    if pending_features:
+        execution._manifest_store.mark_feature_records_uploaded(
+            [r.stage_id for r in pending_features]
+        )
+
+    manifest = execution._get_manifest()  # re-read with post-mark statuses
+    # Restrict the return to assets that went through *this*
+    # commit call — additive uploads (kernel commits, then
+    # runner registers more) need the call-scoped subset, not
+    # the full manifest history.
+    asset_map = report_to_asset_map(
+        execution=execution,
+        report=report,
+        manifest=manifest,
+        keys=list(pending.keys()),
+    )
+    execution._logger.info(
+        "Commit bag loaded: %d rows inserted, %d asset upload(s) attempted",
+        report.total_rows_inserted,
+        sum(s.assets_attempted for s in report.table_stats.values()),
+    )
+    return asset_map

--- a/src/deriva_ml/execution/asset_upload.py
+++ b/src/deriva_ml/execution/asset_upload.py
@@ -448,13 +448,27 @@ def update_asset_execution_table(
     execution-link is unchanged.
 
     Pre-extraction this was an ``Execution`` method. The
-    audit (P1) noted that **only the Input branch is exercised
-    in production** — the Output flow now lives in
-    :func:`bag_commit._add_asset_rows_to_bag`. The Output
-    branch is preserved here for now because it's pinned by
-    the asset-role-auto-tag tests; dropping it requires
-    rewriting those tests against the bag-commit path. Tracked
-    as a follow-up.
+    audit (P1) recommended **dropping the Output branch as
+    "dead in production"** because the only production caller
+    in ``execution.py`` invokes the Input branch. **That
+    recommendation is rejected.** ``Asset_Role`` Input vs
+    Output is real public-API behaviour:
+    ``execution.list_assets(asset_role="Input"|"Output")``
+    queries the per-execution-link direction tag written by
+    this method. A prior pass eliminated this in error; the
+    audit's framing reflected that mistaken state. Do NOT
+    drop the Output branch without first migrating the
+    consumers that depend on the Output role assignment
+    (``test_asset_role_auto_tag.py`` and any catalog query
+    that filters by ``Asset_Role == "Output"``).
+
+    The bag-commit Output flow in
+    :func:`bag_commit._add_asset_rows_to_bag` writes the same
+    rows for assets that go through the bag pipeline; this
+    branch handles assets that don't. The audit's
+    consolidation suggestion ("drop the branch, route
+    everything through bag-commit") is a future cleanup
+    project, not a current-PR change.
 
     Args:
         execution: The bound :class:`Execution`. Reads

--- a/src/deriva_ml/execution/execution.py
+++ b/src/deriva_ml/execution/execution.py
@@ -1553,120 +1553,13 @@ class Execution:
     ) -> dict[str, list[AssetFilePath]]:
         """Upload pending execution outputs via the bag pipeline.
 
-        Builds a transient bag from the execution's pending
-        manifest entries and staged feature records, then loads
-        it into the destination catalog. The bag's asset bytes
-        are hardlinked from flat storage (zero disk copies); rows
-        are inserted by :class:`BagCatalogLoader` in FK-safe
-        order; bytes get PUT to Hatrac.
-
-        After a successful load, marks every pending manifest
-        entry as ``uploaded`` (matches the legacy contract that
-        the manifest reflects the destination's state after a
-        commit). The transient bag dir is left in place at
-        ``working_dir/upload/{execution_rid}/`` so post-mortem
-        inspection is possible if needed; users may delete the
-        ``upload/{rid}/`` directory by hand once they no longer
-        need it. The caller's ``clean_folder`` flag controls
-        cleanup of the separate ``execution_root`` only (see
-        :meth:`upload_execution_outputs`).
-
-        Returns:
-            ``{"{schema}/{table}": [AssetFilePath, ...]}`` for the
-            asset rows that landed at the destination.
+        Thin delegate to ``asset_upload.bag_commit_upload``;
+        see that helper for the bag-build → bag-load → manifest-mark
+        flow.
         """
-        from deriva_ml.execution.bag_commit import (
-            build_execution_bag,
-            load_execution_bag,
-            report_to_asset_map,
-        )
+        from deriva_ml.execution.asset_upload import bag_commit_upload
 
-        # Issue #178: per-execution upload staging lives under a
-        # dedicated ``upload/`` parent — not at the cache root, where
-        # it used to sit beside ``cache/`` and ``schema-cache.json``
-        # and was easy to mistake for cache state. The cache root now
-        # contains only caches; per-execution scratch is here.
-        bag_dir = Path(self._working_dir) / "upload" / self.execution_rid
-        if bag_dir.exists():
-            # An earlier (failed) attempt may have left a partial
-            # bag on disk. Wipe it so the build starts clean —
-            # bdbag's update path expects scaffolding it controls.
-            shutil.rmtree(bag_dir)
-
-        self._logger.info("Building commit bag at %s", bag_dir)
-        # ``build_execution_bag`` leases pending RIDs as its first
-        # step. Capture the post-lease ``pending`` snapshot *after*
-        # the build so ``entry.rid`` reflects the leased value (the
-        # destination catalog now knows about these RIDs).
-        bag_dir = build_execution_bag(
-            self,
-            bag_dir,
-            progress_callback=progress_callback,
-        )
-        manifest = self._get_manifest()
-        pending = manifest.pending_assets()
-
-        self._logger.info("Loading commit bag into destination catalog")
-        try:
-            report = load_execution_bag(
-                self,
-                bag_dir,
-                progress_callback=progress_callback,
-            )
-        except Exception as e:
-            error = format_exception(e)
-            self._logger.error("BagCatalogLoader failed: %s", error)
-            # Mark every pending feature record as failed with the
-            # loader's error so the user can retry from a known
-            # state. Bag commit is atomic at load time, so all
-            # pending records share the same failure mode (the
-            # bag's load transaction either committed or didn't).
-            # Preserving the loader error message in each record's
-            # ``error`` column is the right observability shape.
-            try:
-                pending_features = self._manifest_store.list_pending_feature_records(self.execution_rid)
-                if pending_features:
-                    self._manifest_store.mark_feature_records_failed(
-                        [(r.stage_id, f"bag-load failed: {error}") for r in pending_features]
-                    )
-            except Exception as mark_err:  # noqa: BLE001 — never mask the original failure
-                self._logger.warning(
-                    "Could not mark pending features as failed: %s",
-                    mark_err,
-                )
-            raise DerivaMLException(f"Failed to upload execution outputs via bag pipeline: {error}")
-
-        # Mark every leased manifest entry as uploaded — its RID
-        # was set during the bag build step's lease. Batch the
-        # SQLite update; one transaction beats N for a typical
-        # execution.
-        manifest_updates = [(key, entry.rid) for key, entry in pending.items()]
-        manifest.mark_uploaded_batch(manifest_updates)
-
-        # Mark staged feature records as uploaded too. The bag
-        # carried them; if the load succeeded, they're at the
-        # destination.
-        pending_features = self._manifest_store.list_pending_feature_records(self.execution_rid)
-        if pending_features:
-            self._manifest_store.mark_feature_records_uploaded([r.stage_id for r in pending_features])
-
-        manifest = self._get_manifest()  # re-read with post-mark statuses
-        # Restrict the return to assets that went through *this*
-        # commit call — additive uploads (kernel commits, then
-        # runner registers more) need the call-scoped subset, not
-        # the full manifest history.
-        asset_map = report_to_asset_map(
-            execution=self,
-            report=report,
-            manifest=manifest,
-            keys=list(pending.keys()),
-        )
-        self._logger.info(
-            "Commit bag loaded: %d rows inserted, %d asset upload(s) attempted",
-            report.total_rows_inserted,
-            sum(s.assets_attempted for s in report.table_stats.values()),
-        )
-        return asset_map
+        return bag_commit_upload(self, progress_callback=progress_callback)
 
     def _clean_folder_contents(self, folder_path: Path, remove_folder: bool = True):
         """Clean up folder contents and optionally the folder itself.
@@ -1694,133 +1587,27 @@ class Execution:
     ) -> None:
         """Link assets to this execution and auto-tag them by role.
 
-        Writes two kinds of association rows for each asset:
-
-        1. ``{Asset}_Execution`` — links the asset RID to this
-           execution with the given ``Asset_Role`` (``"Input"`` or
-           ``"Output"``). This is the per-execution-link direction
-           tag; consumers query it via
-           ``execution.list_assets(asset_role="Input")``.
-
-        2. ``{Asset}_Asset_Type`` — auto-tags each asset's content
-           classification:
-
-           - For ``Output``: every user-supplied type from the
-             ``asset_file_path`` calls **plus** ``Output_File``
-             (added automatically if not already in the list).
-             So a model file uploaded with
-             ``ExecAssetType.model_file`` ends up tagged
-             ``["Model_File", "Output_File"]``.
-           - For ``Input``: just ``Input_File`` is added. The
-             asset's existing content types (from when it was
-             originally created) are preserved; we don't overwrite
-             them. So a model file consumed as input ends up
-             tagged ``["Model_File", "Input_File"]``.
-
-           Both inserts use ``on_conflict_skip=True`` so re-running
-           is idempotent — an asset that already has the
-           ``Input_File``/``Output_File`` tag from a prior
-           execution-link is unchanged.
-
-        Args:
-            uploaded_assets: ``{schema/table_name: [AssetFilePath, ...]}``.
-                Each ``AssetFilePath`` carries the asset RID and
-                (for outputs) the user-supplied content types.
-            asset_role: ``"Input"`` or ``"Output"`` from the
-                ``Asset_Role`` vocabulary.
+        Thin delegate to ``asset_upload.update_asset_execution_table``;
+        see that helper for the per-branch (Input/Output) logic.
+        Audit ledger: only the Input branch is exercised in
+        production — the Output flow now lives in
+        :func:`bag_commit._add_asset_rows_to_bag`. The Output
+        branch stays for now because the asset-role-auto-tag
+        tests pin it; dropping it requires rewriting those
+        tests against the bag-commit path. Tracked as a
+        follow-up.
         """
-        # Make sure the asset role is in the controlled vocabulary table.
-        if self._dry_run:
-            # Don't do any updates of we are doing a dry run.
-            return
-        self._ml_object.lookup_term(MLVocab.asset_role, asset_role)
+        from deriva_ml.execution.asset_upload import update_asset_execution_table
 
-        # Direction-tag for the {Asset}_Asset_Type write below. The
-        # direction is multi-valued alongside content types — a file
-        # uploaded as ExecAssetType.model_file ends up tagged with
-        # both Model_File AND Output_File. The directional tag makes
-        # "give me every asset that's ever served as input" queryable
-        # through Asset_Type alone, regardless of which execution
-        # it was input to.
-        direction_tag = ExecAssetType.input_file.value if asset_role == "Input" else ExecAssetType.output_file.value
-
-        pb = self._ml_object.pathBuilder()
-        for asset_table, asset_list in uploaded_assets.items():
-            asset_table_name = asset_table.split("/")[1]  # Peel off the schema from the asset table
-            asset_exe, asset_fk, execution_fk = self._model.find_association(asset_table_name, "Execution")
-            asset_exe_path = pb.schemas[asset_exe.schema.name].tables[asset_exe.name]
-
-            asset_exe_path.insert(
-                [
-                    {
-                        asset_fk: asset_path.asset_rid,
-                        execution_fk: self.execution_rid,
-                        "Asset_Role": asset_role,
-                    }
-                    for asset_path in asset_list
-                ],
-                on_conflict_skip=True,
-            )
-
-            # Resolve the {Asset}_Asset_Type association once per
-            # asset_table loop iteration — we need it for both the
-            # Output (user-supplied + Output_File) and Input
-            # (Input_File only) branches below.
-            asset_asset_type, _, _ = self._model.find_association(asset_table_name, "Asset_Type")
-            type_path = pb.schemas[asset_asset_type.schema.name].tables[asset_asset_type.name]
-
-            if asset_role == "Input":
-                # Input branch: auto-tag each downloaded asset with
-                # Input_File. We don't touch the asset's existing
-                # content types — the asset was created by someone
-                # else (likely a prior execution's output); whatever
-                # types it carries should stay. ``on_conflict_skip``
-                # makes re-downloads idempotent.
-                type_path.insert(
-                    [
-                        {asset_table_name: asset_path.asset_rid, "Asset_Type": direction_tag}
-                        for asset_path in asset_list
-                    ],
-                    on_conflict_skip=True,
-                )
-                continue
-
-            # Output branch: read the user-supplied per-file type
-            # map produced during asset_file_path() calls, then
-            # auto-add Output_File to every asset's type list (if
-            # not already present). The user can still explicitly
-            # pass ExecAssetType.output_file; we just don't require
-            # it anymore.
-            asset_type_map = {}
-            with Path(
-                asset_type_path(
-                    self._working_dir,
-                    self.execution_rid,
-                    self._model.name_to_table(asset_table_name),
-                )
-            ).open("r") as asset_type_file:
-                for line in asset_type_file:
-                    asset_type_map.update(json.loads(line.strip()))
-
-            # Ensure the directional Output_File tag is in every
-            # asset's type list. Use a list (preserving order) +
-            # membership check rather than a set, so user-specified
-            # tag ordering is preserved for any downstream consumer
-            # that cares.
-            for asset_path in asset_list:
-                types = asset_type_map[asset_path.file_name]
-                if direction_tag not in types:
-                    types.append(direction_tag)
-                asset_path.asset_types = types
-
-            type_path.insert(
-                [
-                    {asset_table_name: asset.asset_rid, "Asset_Type": t}
-                    for asset in asset_list
-                    for t in asset_type_map[asset.file_name]
-                ],
-                on_conflict_skip=True,
-            )
+        update_asset_execution_table(
+            self,
+            uploaded_assets,
+            asset_role=asset_role,
+            asset_role_vocab_term=MLVocab.asset_role,
+            input_file_tag=ExecAssetType.input_file.value,
+            output_file_tag=ExecAssetType.output_file.value,
+            asset_type_path_fn=asset_type_path,
+        )
 
     @validate_call(config=VALIDATION_CONFIG)
     def asset_file_path(

--- a/src/deriva_ml/execution/execution.py
+++ b/src/deriva_ml/execution/execution.py
@@ -1588,14 +1588,19 @@ class Execution:
         """Link assets to this execution and auto-tag them by role.
 
         Thin delegate to ``asset_upload.update_asset_execution_table``;
-        see that helper for the per-branch (Input/Output) logic.
-        Audit ledger: only the Input branch is exercised in
-        production — the Output flow now lives in
-        :func:`bag_commit._add_asset_rows_to_bag`. The Output
-        branch stays for now because the asset-role-auto-tag
-        tests pin it; dropping it requires rewriting those
-        tests against the bag-commit path. Tracked as a
-        follow-up.
+        see that helper for the per-branch (Input/Output)
+        logic.
+
+        **Audit ledger note (Output branch is NOT dead):**
+        The 2026-05-22 audit recommended dropping the Output
+        branch as "dead in production." That recommendation
+        is rejected — ``Asset_Role`` Input vs Output is real
+        public-API behaviour (``execution.list_assets(asset_role=...)``).
+        A prior pass eliminated this in error; do not repeat
+        that mistake. The bag-commit Output flow at
+        ``bag_commit._add_asset_rows_to_bag`` writes the same
+        rows for bag-pipeline assets; this branch handles
+        non-bag callers.
         """
         from deriva_ml.execution.asset_upload import update_asset_execution_table
 

--- a/tests/execution/test_asset_upload.py
+++ b/tests/execution/test_asset_upload.py
@@ -1,4 +1,4 @@
-"""Unit tests for ``deriva_ml.execution.asset_upload`` (audit P1 Ex-god first sweep).
+"""Unit tests for ``deriva_ml.execution.asset_upload`` (audit P1 Ex-god first + second sweeps).
 
 Pre-extraction these helpers lived on ``Execution`` as
 methods. Each could only be exercised by spinning up a real
@@ -19,6 +19,9 @@ Coverage layers:
    missing dir.
 5. ``clean_folder_contents`` — pure filesystem op with
    bounded retry.
+6. ``update_asset_execution_table`` (second sweep) — per-role
+   dispatch (Input vs Output), dry-run skip, Asset_Role
+   vocab lookup.
 
 Pure-Python tests; no live catalog required.
 """
@@ -34,6 +37,7 @@ from deriva_ml.execution.asset_upload import (
     get_metadata_description,
     save_runtime_environment,
     set_asset_descriptions,
+    update_asset_execution_table,
     upload_hydra_config_assets,
 )
 
@@ -423,3 +427,193 @@ class TestCleanFolderContents:
 
         # Restore for safety.
         monkeypatch.setattr(Path, "unlink", original_unlink)
+
+
+# ---------------------------------------------------------------------------
+# update_asset_execution_table — second sweep (audit Ex-god)
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateAssetExecutionTable:
+    """Pin the per-role dispatch for asset → execution association rows."""
+
+    def _build_execution_mock(
+        self,
+        *,
+        dry_run: bool = False,
+        with_associations: bool = True,
+    ) -> MagicMock:
+        """Build an ``Execution`` mock with the minimum surface the helper reads."""
+        exe = MagicMock()
+        exe._dry_run = dry_run
+        exe.execution_rid = "EX-1"
+        exe._working_dir = "/tmp/wdir"
+
+        # ``_model.find_association`` returns
+        # ``(assoc_table_obj, asset_fk_col, exec_fk_col)``.
+        assoc_table = MagicMock()
+        assoc_table.schema.name = "deriva-ml"
+        assoc_table.name = "Image_Execution"
+
+        type_assoc_table = MagicMock()
+        type_assoc_table.schema.name = "deriva-ml"
+        type_assoc_table.name = "Image_Asset_Type"
+
+        if with_associations:
+            def fake_find_assoc(table_name, partner):
+                if partner == "Execution":
+                    return (assoc_table, "Image", "Execution")
+                if partner == "Asset_Type":
+                    return (type_assoc_table, None, None)
+                raise KeyError(partner)
+
+            exe._model.find_association.side_effect = fake_find_assoc
+        return exe
+
+    def _drill_to_table(self, exe, schema, table):
+        """Drill into the pathBuilder mock chain to a specific table_path."""
+        return exe._ml_object.pathBuilder.return_value.schemas.__getitem__.return_value.tables.__getitem__.return_value
+
+    def test_dry_run_skips_all_work(self):
+        """``execution._dry_run`` is True → the helper returns immediately.
+
+        No catalog calls, no vocab lookup, no pathBuilder access.
+        """
+        exe = self._build_execution_mock(dry_run=True)
+        asset = MagicMock()
+        asset.asset_rid = "ASSET-1"
+
+        update_asset_execution_table(
+            exe,
+            {"deriva-ml/Image": [asset]},
+            asset_role="Input",
+            asset_role_vocab_term="Asset_Role",
+            input_file_tag="Input_File",
+            output_file_tag="Output_File",
+            asset_type_path_fn=lambda *_: Path("/never/called"),
+        )
+
+        # No vocab lookup, no pathBuilder access in dry-run.
+        exe._ml_object.lookup_term.assert_not_called()
+        exe._ml_object.pathBuilder.assert_not_called()
+
+    def test_input_branch_inserts_execution_and_input_file_tag(self):
+        """Input role → ``{Asset}_Execution`` insert + ``Input_File`` tag insert."""
+        exe = self._build_execution_mock()
+        asset = MagicMock()
+        asset.asset_rid = "ASSET-1"
+
+        update_asset_execution_table(
+            exe,
+            {"deriva-ml/Image": [asset]},
+            asset_role="Input",
+            asset_role_vocab_term="Asset_Role",
+            input_file_tag="Input_File",
+            output_file_tag="Output_File",
+            asset_type_path_fn=lambda *_: Path("/never/called"),
+        )
+
+        # Asset_Role vocab lookup happened.
+        exe._ml_object.lookup_term.assert_called_once_with("Asset_Role", "Input")
+
+        # Two inserts happened: one for Image_Execution, one for Image_Asset_Type.
+        # We can verify the calls via the pathBuilder mock chain.
+        pb = exe._ml_object.pathBuilder.return_value
+        # pb.schemas["deriva-ml"].tables[...].insert was called twice.
+        table_path = pb.schemas.__getitem__.return_value.tables.__getitem__.return_value
+        assert table_path.insert.call_count == 2
+
+        # First call is the {Asset}_Execution insert; second is the
+        # {Asset}_Asset_Type insert with Input_File tag.
+        type_insert_call = table_path.insert.call_args_list[1]
+        rows = type_insert_call.args[0]
+        assert all(row["Asset_Type"] == "Input_File" for row in rows)
+        # on_conflict_skip=True is preserved.
+        assert type_insert_call.kwargs == {"on_conflict_skip": True}
+
+    def test_output_branch_reads_type_map_and_adds_output_file_tag(self, tmp_path):
+        """Output role → reads per-file type map, auto-adds ``Output_File`` tag."""
+        # Stage a JSONL file with the per-file type map.
+        type_file = tmp_path / "asset_type.jsonl"
+        type_file.write_text(json.dumps({"photo.jpg": ["Model_File"]}) + "\n")
+
+        exe = self._build_execution_mock()
+        asset = MagicMock()
+        asset.asset_rid = "ASSET-1"
+        asset.file_name = "photo.jpg"
+
+        def fake_asset_type_path_fn(working_dir, exec_rid, table):
+            return type_file
+
+        update_asset_execution_table(
+            exe,
+            {"deriva-ml/Image": [asset]},
+            asset_role="Output",
+            asset_role_vocab_term="Asset_Role",
+            input_file_tag="Input_File",
+            output_file_tag="Output_File",
+            asset_type_path_fn=fake_asset_type_path_fn,
+        )
+
+        # Asset_Role vocab lookup happened.
+        exe._ml_object.lookup_term.assert_called_once_with("Asset_Role", "Output")
+
+        # The asset's ``asset_types`` was mutated to include Output_File.
+        assert "Output_File" in asset.asset_types
+        assert "Model_File" in asset.asset_types
+
+        # The type insert was called with rows for BOTH tags.
+        pb = exe._ml_object.pathBuilder.return_value
+        table_path = pb.schemas.__getitem__.return_value.tables.__getitem__.return_value
+        type_insert_call = table_path.insert.call_args_list[1]
+        rows = type_insert_call.args[0]
+        tag_values = {row["Asset_Type"] for row in rows}
+        assert tag_values == {"Model_File", "Output_File"}
+
+    def test_output_branch_does_not_duplicate_existing_output_file_tag(self, tmp_path):
+        """When the type map already has ``Output_File``, it's not added twice."""
+        type_file = tmp_path / "asset_type.jsonl"
+        type_file.write_text(
+            json.dumps({"photo.jpg": ["Model_File", "Output_File"]}) + "\n"
+        )
+
+        exe = self._build_execution_mock()
+        asset = MagicMock()
+        asset.asset_rid = "ASSET-1"
+        asset.file_name = "photo.jpg"
+
+        update_asset_execution_table(
+            exe,
+            {"deriva-ml/Image": [asset]},
+            asset_role="Output",
+            asset_role_vocab_term="Asset_Role",
+            input_file_tag="Input_File",
+            output_file_tag="Output_File",
+            asset_type_path_fn=lambda *_: type_file,
+        )
+
+        # ``asset_types`` should still have exactly the two tags.
+        assert sorted(asset.asset_types) == ["Model_File", "Output_File"]
+
+    def test_uses_passed_in_vocab_term(self):
+        """The ``asset_role_vocab_term`` arg is threaded through to ``lookup_term``.
+
+        Pins the audit-friendly decoupling: the helper doesn't
+        import ``MLVocab``, so a future refactor of the enum
+        doesn't ripple through this module.
+        """
+        exe = self._build_execution_mock()
+        asset = MagicMock()
+        asset.asset_rid = "ASSET-1"
+
+        update_asset_execution_table(
+            exe,
+            {"deriva-ml/Image": [asset]},
+            asset_role="Input",
+            asset_role_vocab_term="My_Custom_Vocab",
+            input_file_tag="Input_File",
+            output_file_tag="Output_File",
+            asset_type_path_fn=lambda *_: Path("/never/called"),
+        )
+
+        exe._ml_object.lookup_term.assert_called_once_with("My_Custom_Vocab", "Input")


### PR DESCRIPTION
## Summary

Second sweep on audit P1 Ex-god. The heavier-coupled
asset-upload orchestrators move out of ``Execution`` into
``asset_upload.py``.

### Extracted

- ``bag_commit_upload`` — builds the transient bag, loads it,
  marks pending manifest entries + feature records as
  uploaded.
- ``update_asset_execution_table`` — writes ``{Asset}_Execution``
  + ``{Asset}_Asset_Type`` association rows. All enum-shaped
  args are passed in so the helper stays decoupled from
  ``MLVocab`` / ``ExecAssetType``.

The two corresponding ``Execution`` methods are now thin
delegates (~12 lines each).

### ⚠ Asset_Role Input/Output assignment PRESERVED (audit recommendation rejected)

The 2026-05-22 audit recommended dropping the Output branch
of ``_update_asset_execution_table`` as "dead in production."
**That recommendation is rejected** and the docstrings have
been hardened to make this explicit:

- ``Asset_Role="Input"`` and ``Asset_Role="Output"`` are real
  public-API behaviour. ``execution.list_assets(asset_role=...)``
  queries the per-execution-link direction tag written by
  this method.
- A prior pass eliminated this in error; the audit's "dead
  branch" framing reflected that mistaken state. The Output
  branch (and the Asset_Role writes) MUST stay.
- The audit's observation that the production caller in
  ``execution.py`` only invokes the Input branch is correct
  but misleading: the Output flow now also happens in
  ``bag_commit._add_asset_rows_to_bag`` (different code path,
  same semantic).
- What's actually deferred (next-minor work, not a deletion):
  **consolidating** the two role-assignment sites into one
  source of truth, with the 699-LOC
  ``test_asset_role_auto_tag.py`` test suite migrating to
  exercise the consolidated path.

The strengthened docstrings (commit ``27954a4a``) live in both
``asset_upload.update_asset_execution_table`` and
``Execution._update_asset_execution_table`` so future readers
can't miss the warning.

### Sizes

- ``execution.py``: 2,602 → 2,387 LOC (-215 net this sweep;
  -305 cumulative since first sweep).
- ``asset_upload.py``: 394 → 718 LOC (helpers + docs).

### Testability win

``update_asset_execution_table`` is now testable with
``MagicMock`` — pre-extraction this code path could only be
exercised by spinning up a real catalog + workflow +
execution + uploaded assets. New unit tests run in 0.2s.

## Test plan

- [x] New ``TestUpdateAssetExecutionTable`` (5 pure-Python
      tests): dry-run skip, **Input branch (Asset_Role +
      Input_File tag)**, **Output branch (Asset_Role +
      Output_File tag + auto-add)**, Output no-duplicate,
      vocab-term decoupling.
- [x] ``tests/execution/test_asset_upload.py`` — 23/23 pass (~0.2s)
- [x] ``tests/execution/`` (existing integration coverage) —
      **407/407 pass** against live catalog (~6:45). This
      includes the 699-LOC ``test_asset_role_auto_tag.py``
      that pins both Input AND Output branches.
- [x] ``ruff check`` clean on touched code

Generated with Claude Code