### PR TITLE
refactor(execution): extract public-API surface to asset_upload.py (audit P1 Ex-god, third sweep)

### DIFF
--- a/src/deriva_ml/execution/asset_upload.py
+++ b/src/deriva_ml/execution/asset_upload.py
@@ -17,23 +17,28 @@ were nearly free functions already
 ``save_runtime_environment``, ``upload_hydra_config_assets``,
 ``clean_folder_contents``).
 
-**Second sweep** (this PR): the catalog-writing orchestrators —
+**Second sweep**: the catalog-writing orchestrators —
 ``bag_commit_upload`` (transient bag build + load) and
 ``update_asset_execution_table`` (per-execution + per-type
-association rows). These have heavier ``self`` coupling
-(read ``execution_rid``, ``_model``, ``_ml_object``,
-``_working_dir``, ``_manifest_store``) but no state-machine
-touching — that stays on :class:`Execution`.
+association rows).
 
-Still on :class:`Execution` (public API + state-machine
-entanglement): ``upload_execution_outputs``,
-``download_asset``, ``asset_file_path``, ``metrics_file``.
-Future sweeps may continue the extraction once the
-state-machine and manifest-store types stabilize further.
+**Third sweep** (this PR): the public-API surface —
+``asset_file_path`` (manifest registration + flat staging
++ asset_type JSONL), ``metrics_file`` (thin sugar over
+``asset_file_path``), ``download_asset`` (hatrac fetch +
+cache + execution-link), and ``upload_execution_outputs``
+(state-machine bracketed bag-commit driver). These are
+public-API methods on :class:`Execution`; the body moves
+here but the class still exposes thin delegate methods so
+the public surface is unchanged.
 
 Pairs with ``bag_commit.py`` (the bag-build / bag-load
 pipeline). Together the two modules carry the bulk of the
 asset-upload work that ``Execution`` used to hold inline.
+After the third sweep ``execution.py`` is the lifecycle
+class — state-machine transitions, dataset attach, feature
+staging, nested-execution hierarchy — and ``asset_upload.py``
+owns the asset surface.
 """
 
 from __future__ import annotations
@@ -53,19 +58,26 @@ from deriva_ml.core.exceptions import DerivaMLException
 from deriva_ml.execution.environment import get_execution_environment
 
 if TYPE_CHECKING:
-    from deriva_ml.asset.aux_classes import AssetFilePath
+    from deriva.core.ermrest_model import Table
+
+    from deriva_ml.asset.aux_classes import AssetFilePath, AssetRecord
+    from deriva_ml.core.definitions import RID
     from deriva_ml.core.ermrest import UploadProgress
     from deriva_ml.execution.execution import Execution
 
 
 # Public symbols re-exported via ``Execution`` thin delegates.
 __all__ = [
+    "asset_file_path",
     "bag_commit_upload",
     "clean_folder_contents",
+    "download_asset",
     "get_metadata_description",
+    "metrics_file",
     "save_runtime_environment",
     "set_asset_descriptions",
     "update_asset_execution_table",
+    "upload_execution_outputs",
     "upload_hydra_config_assets",
 ]
 
@@ -730,3 +742,511 @@ def bag_commit_upload(
         sum(s.assets_attempted for s in report.table_stats.values()),
     )
     return asset_map
+
+
+# ---------------------------------------------------------------------------
+# Public-API surface (audit P1 Ex-god, third sweep)
+# ---------------------------------------------------------------------------
+
+
+def asset_file_path(
+    execution: "Execution",
+    asset_name: str,
+    file_name: "str | Path",
+    *,
+    asset_types: "list[str] | str | None" = None,
+    copy_file: bool = False,
+    rename_file: str | None = None,
+    metadata: "AssetRecord | dict[str, Any] | None" = None,
+    description: str | None = None,
+    asset_type_vocab_term: str,
+    flat_asset_dir_fn: Callable[..., Path],
+    asset_type_path_fn: Callable[..., Path],
+    legacy_kwargs: dict[str, Any] | None = None,
+) -> "AssetFilePath":
+    """Register a file for upload and return a path to write to.
+
+    Three modes depending on whether ``file_name`` refers to an existing file:
+
+    1. **New file** — ``file_name`` doesn't exist; returns a path to write to.
+    2. **Symlink** — ``file_name`` exists, ``copy_file=False``; symlinks into staging.
+    3. **Copy** — ``file_name`` exists, ``copy_file=True``; copies into staging.
+
+    Files land in a flat per-table directory
+    (``assets/{AssetTable}/``). Metadata is tracked in a
+    persistent JSON manifest for crash safety. Metadata can be
+    set at registration time via the ``metadata`` parameter (an
+    ``AssetRecord`` or dict) or incrementally after via the
+    returned ``AssetFilePath``'s ``metadata`` property.
+
+    Pre-extraction this was an :class:`Execution` method. The
+    extracted helper reads
+    ``execution._model.is_asset/name_to_table``,
+    ``execution._ml_object.lookup_term``,
+    ``execution._working_dir``, ``execution.execution_rid``,
+    and ``execution._get_manifest()`` — no state-machine
+    interaction. The enum-shaped args
+    (``asset_type_vocab_term``, ``flat_asset_dir_fn``,
+    ``asset_type_path_fn``) are threaded in so the helper
+    stays decoupled from ``MLVocab`` and
+    ``core.upload_layout`` imports.
+
+    Args:
+        execution: The bound :class:`Execution`.
+        asset_name: Name of the asset table. Must be a valid
+            asset table.
+        file_name: Name of file to be uploaded, or path to an
+            existing file.
+        asset_types: Asset type terms from Asset_Type
+            vocabulary. Defaults to ``asset_name`` if neither
+            this nor ``legacy_kwargs["Asset_Type"]`` is set.
+        copy_file: Whether to copy the file rather than
+            symlinking.
+        rename_file: If provided, rename the file during
+            staging.
+        metadata: An ``AssetRecord`` (uses ``model_dump``) or
+            dict of metadata column values.
+        description: Optional description for the asset record.
+        asset_type_vocab_term: The ``MLVocab.asset_type`` enum
+            value, threaded in to avoid the ``MLVocab`` import.
+        flat_asset_dir_fn: The ``flat_asset_dir`` callable from
+            ``core.upload_layout``.
+        asset_type_path_fn: The ``asset_type_path`` callable
+            from ``core.upload_layout``.
+        legacy_kwargs: Extra ``**kwargs`` passed through from
+            the delegate. Two roles: legacy ``Asset_Type``
+            fallback (consumed by the empty-asset_types
+            branch) and additional metadata column values
+            (merged into ``metadata``).
+
+    Returns:
+        :class:`AssetFilePath` bound to the manifest for
+        write-through metadata updates.
+
+    Raises:
+        DerivaMLException: If the asset table doesn't exist.
+        DerivaMLValidationError: If ``asset_types`` contains
+            invalid vocabulary terms.
+    """
+    from deriva_ml.asset.aux_classes import AssetFilePath
+    from deriva_ml.asset.manifest import AssetEntry
+
+    legacy_kwargs = legacy_kwargs or {}
+
+    if not execution._model.is_asset(asset_name):
+        raise DerivaMLException(f"Table {asset_name} is not an asset")
+
+    asset_table = execution._model.name_to_table(asset_name)
+    schema = asset_table.schema.name
+
+    # Validate and normalize asset types. Use ``is None`` rather
+    # than ``or`` so an explicit ``asset_types=[]`` (the user
+    # saying "no content tags") is honored as-is — the previous
+    # ``or`` chain collapsed an empty list to ``asset_name`` and
+    # then ``lookup_term`` would fail on the table name. The
+    # legacy ``Asset_Type`` kwarg keeps its fallback role.
+    if asset_types is None:
+        asset_types = legacy_kwargs.pop("Asset_Type", None)
+        if asset_types is None:
+            asset_types = asset_name
+    asset_types = [asset_types] if isinstance(asset_types, str) else asset_types
+    for t in asset_types:
+        execution._ml_object.lookup_term(asset_type_vocab_term, t)
+
+    # Resolve metadata from AssetRecord, dict, or kwargs.
+    metadata_dict: dict[str, Any] = {}
+    if metadata is not None:
+        if hasattr(metadata, "model_dump"):
+            metadata_dict = {
+                k: v for k, v in metadata.model_dump().items() if v is not None
+            }
+        else:
+            metadata_dict = dict(metadata)
+    # Merge any legacy_kwargs that aren't standard parameters.
+    metadata_dict.update(legacy_kwargs)
+
+    # Determine file name and path.
+    file_name = Path(file_name)
+    if file_name.name == "_implementations.log":
+        file_name = file_name.with_name("-implementations.log")
+
+    if not file_name.is_absolute():
+        file_name = file_name.resolve()
+
+    target_name = (
+        Path(rename_file) if file_name.exists() and rename_file else file_name
+    )
+
+    # Store file in flat per-table directory.
+    flat_dir = flat_asset_dir_fn(
+        execution._working_dir, execution.execution_rid, asset_name
+    )
+    flat_path = flat_dir / target_name.name
+
+    if file_name.exists():
+        if copy_file:
+            flat_path.write_bytes(file_name.read_bytes())
+        else:
+            try:
+                flat_path.symlink_to(file_name)
+            except (OSError, PermissionError):
+                flat_path.write_bytes(file_name.read_bytes())
+
+    # Register in manifest (write-through + fsync).
+    manifest = execution._get_manifest()
+    manifest_key = f"{asset_name}/{target_name.name}"
+    manifest.add_asset(
+        manifest_key,
+        AssetEntry(
+            asset_table=asset_name,
+            schema=schema,
+            asset_types=asset_types,
+            metadata=metadata_dict,
+            description=description,
+        ),
+    )
+
+    # Also write legacy asset-type JSONL for backward compatibility with upload.
+    with Path(
+        asset_type_path_fn(execution._working_dir, execution.execution_rid, asset_table)
+    ).open("a") as f:
+        f.write(json.dumps({target_name.name: asset_types}) + "\n")
+
+    result = AssetFilePath(
+        asset_path=flat_path,
+        asset_table=asset_name,
+        file_name=target_name.name,
+        asset_metadata=metadata_dict,
+        asset_types=asset_types,
+    )
+    result._bind_manifest(manifest, manifest_key)
+    return result
+
+
+def metrics_file(
+    execution: "Execution",
+    filename: str,
+    *,
+    execution_metadata_asset_name: Any,
+    metrics_file_asset_type: str,
+) -> "AssetFilePath":
+    """Return a path for writing training-metric records.
+
+    Thin sugar over :func:`asset_file_path` that stamps the
+    file with ``asset_types=Metrics_File`` so the catalog's
+    ``Execution_Metadata.Type`` honestly describes the file's
+    purpose. Repeated calls inside the same execution return
+    the same ``AssetFilePath`` (the manifest registers the
+    file once), so append-style writes across an epoch loop
+    are safe.
+
+    Pre-extraction this was a 5-line method on
+    :class:`Execution`. Moved here for symmetry with
+    :func:`asset_file_path` so the asset-staging API surface
+    lives in one place.
+
+    Args:
+        execution: The bound :class:`Execution`.
+        filename: Metrics filename inside Execution_Metadata.
+        execution_metadata_asset_name: ``MLAsset.execution_metadata``.
+        metrics_file_asset_type: ``ExecMetadataType.metrics_file.value``.
+
+    Returns:
+        :class:`AssetFilePath` for the metrics file.
+    """
+    return execution.asset_file_path(
+        execution_metadata_asset_name,
+        filename,
+        asset_types=metrics_file_asset_type,
+    )
+
+
+def download_asset(
+    execution: "Execution",
+    asset_rid: "RID",
+    dest_dir: Path,
+    *,
+    update_catalog: bool = True,
+    use_cache: bool = False,
+    _asset_table: "Table | None" = None,
+    asset_type_vocab_term: str,
+    check_overwrite_safe_fn: Callable[..., None],
+) -> "AssetFilePath":
+    """Download an asset from Hatrac and place it in a local directory.
+
+    Writes to ``dest_dir / asset_record["Filename"]``. Overwrites
+    any existing file at that path; a WARNING is logged when the
+    existing content is byte-different from the asset's expected
+    MD5 (via ``check_overwrite_safe_fn``). Idempotent
+    re-downloads (existing file's md5 matches catalog's recorded
+    MD5) log nothing.
+
+    Cache behaviour: with ``use_cache=True`` and a matching MD5,
+    the cached file is symlinked into ``dest_dir``. On a cache
+    miss the asset is downloaded to ``dest_dir``, then moved to
+    the cache directory and symlinked back so future
+    ``use_cache=True`` calls see a hit.
+
+    Pre-extraction this was an :class:`Execution` method.
+
+    Args:
+        execution: The bound :class:`Execution`.
+        asset_rid: RID of the asset.
+        dest_dir: Destination directory for the asset.
+        update_catalog: Whether to update the catalog execution
+            information after downloading (writes Input role
+            association rows via
+            :func:`update_asset_execution_table`).
+        use_cache: When ``True``, check ``cache_dir/assets/{rid}_{md5}/``
+            for a previously downloaded copy before fetching.
+        _asset_table: Internal — pre-resolved Table object for
+            this RID (skip the per-asset ``resolve_rid``
+            round-trip).
+        asset_type_vocab_term: The ``MLVocab.asset_type`` enum
+            value, threaded in to avoid the ``MLVocab`` import.
+        check_overwrite_safe_fn: The ``_check_overwrite_safe``
+            callable, threaded in to keep the helper free of
+            the module-private import.
+
+    Returns:
+        :class:`AssetFilePath` with the path to the downloaded
+        (or cached) asset file.
+
+    Raises:
+        DerivaMLException: If ``asset_rid`` does not refer to an
+            asset table.
+    """
+    # Local import — ``HatracStore`` carries network deps; keep
+    # it lazy so unit tests that mock the helper don't pay the
+    # cost.
+    from deriva.core.hatrac_store import HatracStore
+
+    from deriva_ml.asset.aux_classes import AssetFilePath
+
+    asset_table = (
+        _asset_table
+        if _asset_table is not None
+        else execution._ml_object.resolve_rid(asset_rid).table
+    )
+    if not execution._model.is_asset(asset_table):
+        raise DerivaMLException(f"RID {asset_rid}  is not for an asset table.")
+
+    asset_record = execution._ml_object._retrieve_rid(asset_rid)
+    asset_metadata = {
+        k: v
+        for k, v in asset_record.items()
+        if k in execution._model.asset_metadata(asset_table)
+    }
+    asset_url = asset_record["URL"]
+    asset_filename = dest_dir / asset_record["Filename"]
+    expected_md5 = asset_record.get("MD5")
+
+    # Check cache before downloading.
+    cache_hit = False
+    if use_cache:
+        md5 = expected_md5
+        if md5:
+            asset_cache_dir = execution._ml_object.cache_dir / "assets"
+            asset_cache_dir.mkdir(parents=True, exist_ok=True)
+            cache_key = f"{asset_rid}_{md5}"
+            cached_file = asset_cache_dir / cache_key / asset_record["Filename"]
+            if cached_file.exists():
+                # Cache hit — symlink from cache to destination. The
+                # cached file's bytes ARE the asset's expected bytes
+                # by construction (cache_key includes md5), so reuse
+                # ``expected_md5`` as the "about to be written" md5
+                # in the overwrite check.
+                check_overwrite_safe_fn(asset_filename, expected_md5, asset_rid)
+                execution._logger.info(
+                    f"Using cached asset {asset_rid} (MD5: {md5})"
+                )
+                if asset_filename.exists() or asset_filename.is_symlink():
+                    asset_filename.unlink()
+                asset_filename.symlink_to(cached_file)
+                cache_hit = True
+
+    if not cache_hit:
+        check_overwrite_safe_fn(asset_filename, expected_md5, asset_rid)
+        hs = HatracStore(
+            "https", execution._ml_object.host_name, execution._ml_object.credential
+        )
+        hs.get_obj(path=asset_url, destfilename=asset_filename.as_posix())
+
+        # Store in cache for future use.
+        if use_cache:
+            md5 = asset_record.get("MD5")
+            if md5:
+                asset_cache_dir = execution._ml_object.cache_dir / "assets"
+                asset_cache_dir.mkdir(parents=True, exist_ok=True)
+                cache_key = f"{asset_rid}_{md5}"
+                cache_entry_dir = asset_cache_dir / cache_key
+                cache_entry_dir.mkdir(parents=True, exist_ok=True)
+                cached_file = cache_entry_dir / asset_record["Filename"]
+                # Move file to cache, then symlink back.
+                shutil.move(str(asset_filename), str(cached_file))
+                asset_filename.symlink_to(cached_file)
+                execution._logger.info(f"Cached asset {asset_rid} (MD5: {md5})")
+
+    asset_type_table, _col_l, _col_r = execution._model.find_association(
+        asset_table, asset_type_vocab_term
+    )
+    type_path = execution._ml_object.pathBuilder().schemas[
+        asset_type_table.schema.name
+    ].tables[asset_type_table.name]
+    asset_types = [
+        asset_type[asset_type_vocab_term]
+        for asset_type in type_path.filter(
+            type_path.columns[asset_table.name] == asset_rid
+        )
+        .attributes(type_path.Asset_Type)
+        .fetch()
+    ]
+
+    asset_path = AssetFilePath(
+        file_name=asset_filename,
+        asset_rid=asset_rid,
+        asset_path=asset_filename,
+        asset_metadata=asset_metadata,
+        asset_table=asset_table.name,
+        asset_types=asset_types,
+    )
+
+    if update_catalog:
+        # Input role assignment — preserved by design (see
+        # ``update_asset_execution_table`` docstring on why the
+        # Output branch is also kept).
+        execution._update_asset_execution_table(
+            {f"{asset_table.schema.name}/{asset_table.name}": [asset_path]},
+            asset_role="Input",
+        )
+    return asset_path
+
+
+def upload_execution_outputs(
+    execution: "Execution",
+    *,
+    clean_folder: bool | None = None,
+    progress_callback: "Callable[[UploadProgress], None] | None" = None,
+    pending_upload_status: Any,
+    uploaded_status: Any,
+    failed_status: Any,
+    running_status: Any,
+    stopped_status: Any,
+    format_duration_fn: Callable[..., str],
+) -> dict[str, list["AssetFilePath"]]:
+    """Upload all registered output assets via the bag pipeline and bracket the state-machine.
+
+    Drives the upload workflow:
+
+    1. Returns ``{}`` for dry-run executions.
+    2. Auto-transitions ``Running → Stopped`` for callers that
+       bypassed the context manager.
+    3. Handles the ``Uploaded`` short-circuit (no pending work
+       → return the full ``uploaded_assets`` view).
+    4. Brackets the bag-commit + description-write phase with
+       ``Pending_Upload → Uploaded`` (success) or
+       ``Pending_Upload → Failed`` (exception) transitions.
+       Upload_Duration is written to SQLite **before** each
+       terminal transition so the state-machine PUT carries
+       the measurement.
+    5. Cleans the execution root on success when ``clean_folder``
+       is truthy.
+
+    Pre-extraction this was the public ``Execution`` method.
+    Extracted helper takes ``execution`` plus the
+    ``ExecutionStatus`` enum values + the ``_format_duration``
+    callable as explicit args so the helper stays decoupled
+    from the enum/utility imports.
+
+    Args:
+        execution: The bound :class:`Execution`.
+        clean_folder: Whether to delete execution-root folders
+            after upload. ``None`` uses
+            ``execution._ml_object.clean_execution_dir``.
+        progress_callback: Forwarded to ``bag_commit_upload``.
+        pending_upload_status, uploaded_status, failed_status,
+            running_status, stopped_status: The corresponding
+            ``ExecutionStatus`` enum values.
+        format_duration_fn: The ``_format_duration`` callable.
+
+    Returns:
+        ``{"{schema}/{table}": [AssetFilePath, ...]}`` per-call
+        subset of uploaded assets (matching the legacy contract).
+        ``{}`` for dry-run.
+
+    Raises:
+        Exception: Whatever the bag-commit raises; the state
+            machine transitions to ``Failed`` first.
+    """
+    from datetime import timezone
+
+    if execution._dry_run:
+        return {}
+
+    # Use DerivaML instance setting if not explicitly provided.
+    if clean_folder is None:
+        clean_folder = getattr(execution._ml_object, "clean_execution_dir", True)
+
+    # Auto-stop a still-Running execution. Notebook code paths
+    # and other imperative callers that don't use a ``with`` block
+    # reach this method with status=Running because no
+    # ``__exit__`` ever fired.
+    if execution.status is running_status:
+        execution.execution_stop()
+
+    # Additive upload path: the execution already finished a prior
+    # upload batch (status=Uploaded) and the caller has registered
+    # additional assets that need to ship. If there's nothing
+    # pending, treat the call as a no-op and return early.
+    if execution.status is uploaded_status:
+        manifest = execution._get_manifest()
+        if not manifest.pending_assets():
+            # Short-circuit: no new work. Return the full manifest
+            # view of what's been uploaded for this execution.
+            return execution.uploaded_assets
+        execution.update_status(pending_upload_status)
+
+    # Transition to Pending_Upload BEFORE starting the upload work
+    # so that an exception during _bag_commit_upload can legally
+    # transition to Failed (Stopped → Failed is not a legal
+    # transition, but Pending_Upload → Failed is).
+    if execution.status is stopped_status:
+        execution.update_status(pending_upload_status)
+
+    # Bracket the upload work with timestamps so Upload_Duration
+    # gets populated regardless of whether the call succeeds or
+    # raises. The write goes to SQLite *before* the terminal
+    # status transition so the state-machine PUT that follows
+    # carries the measurement.
+    _upload_start = datetime.now(timezone.utc)
+    try:
+        # ``_bag_commit_upload`` returns the per-call subset of
+        # uploaded assets. External callers depend on this
+        # per-call shape; the ``uploaded_assets`` property is the
+        # full-manifest view.
+        uploaded = execution._bag_commit_upload(progress_callback=progress_callback)
+        execution._set_asset_descriptions(uploaded)
+        # Record Upload_Duration just before the terminal transition
+        # so the catalog PUT for Pending_Upload → Uploaded carries
+        # the new value.
+        execution._ml_object.workspace.execution_state_store().update_execution(
+            execution.execution_rid,
+            upload_duration=format_duration_fn(_upload_start, datetime.now(timezone.utc)),
+        )
+        # Successful end of upload: Pending_Upload → Uploaded.
+        if execution.status is pending_upload_status:
+            execution.update_status(uploaded_status)
+        if clean_folder:
+            execution._clean_folder_contents(execution._execution_root)
+        return uploaded
+    except Exception as e:
+        # Capture partial upload duration before transitioning to
+        # Failed — same write-then-transition order so the failure
+        # PUT carries the partial measurement.
+        execution._ml_object.workspace.execution_state_store().update_execution(
+            execution.execution_rid,
+            upload_duration=format_duration_fn(_upload_start, datetime.now(timezone.utc)),
+        )
+        error = format_exception(e)
+        execution.update_status(failed_status, error=error)
+        raise e

--- a/src/deriva_ml/execution/execution.py
+++ b/src/deriva_ml/execution/execution.py
@@ -34,24 +34,20 @@ import hashlib
 import json
 import logging
 import os
-import shutil
 import sys
 from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Iterable, List
-
-from deriva.core import format_exception
 
 if TYPE_CHECKING:
     from deriva_ml.asset.asset import Asset
     from deriva_ml.execution.pending_summary import PendingSummary
     from deriva_ml.execution.upload_report import UploadReport
     from deriva_ml.local_db.manifest_store import ManifestStore
-from deriva.core.hatrac_store import HatracStore
 from pydantic import validate_call
 
 from deriva_ml.asset.aux_classes import AssetFilePath
-from deriva_ml.asset.manifest import AssetEntry, AssetManifest
+from deriva_ml.asset.manifest import AssetManifest
 from deriva_ml.core.base import DerivaML
 from deriva_ml.core.connection_mode import ConnectionMode
 from deriva_ml.core.definitions import (
@@ -1438,83 +1434,18 @@ class Execution:
             ``AssetFilePath.file_name`` is the canonical access path — read from it
             rather than hand-constructing a path from the asset table or filename.
         """
+        from deriva_ml.execution.asset_upload import download_asset as _download_asset
 
-        asset_table = _asset_table if _asset_table is not None else self._ml_object.resolve_rid(asset_rid).table
-        if not self._model.is_asset(asset_table):
-            raise DerivaMLException(f"RID {asset_rid}  is not for an asset table.")
-
-        asset_record = self._ml_object._retrieve_rid(asset_rid)
-        asset_metadata = {k: v for k, v in asset_record.items() if k in self._model.asset_metadata(asset_table)}
-        asset_url = asset_record["URL"]
-        asset_filename = dest_dir / asset_record["Filename"]
-        expected_md5 = asset_record.get("MD5")
-
-        # Check cache before downloading
-        cache_hit = False
-        if use_cache:
-            md5 = expected_md5
-            if md5:
-                asset_cache_dir = self._ml_object.cache_dir / "assets"
-                asset_cache_dir.mkdir(parents=True, exist_ok=True)
-                cache_key = f"{asset_rid}_{md5}"
-                cached_file = asset_cache_dir / cache_key / asset_record["Filename"]
-                if cached_file.exists():
-                    # Cache hit — symlink from cache to destination. The
-                    # cached file's bytes ARE the asset's expected bytes
-                    # by construction (cache_key includes md5), so reuse
-                    # ``expected_md5`` as the "about to be written" md5
-                    # in the overwrite check.
-                    _check_overwrite_safe(asset_filename, expected_md5, asset_rid)
-                    self._logger.info(f"Using cached asset {asset_rid} (MD5: {md5})")
-                    if asset_filename.exists() or asset_filename.is_symlink():
-                        asset_filename.unlink()
-                    asset_filename.symlink_to(cached_file)
-                    cache_hit = True
-
-        if not cache_hit:
-            _check_overwrite_safe(asset_filename, expected_md5, asset_rid)
-            hs = HatracStore("https", self._ml_object.host_name, self._ml_object.credential)
-            hs.get_obj(path=asset_url, destfilename=asset_filename.as_posix())
-
-            # Store in cache for future use
-            if use_cache:
-                md5 = asset_record.get("MD5")
-                if md5:
-                    asset_cache_dir = self._ml_object.cache_dir / "assets"
-                    asset_cache_dir.mkdir(parents=True, exist_ok=True)
-                    cache_key = f"{asset_rid}_{md5}"
-                    cache_entry_dir = asset_cache_dir / cache_key
-                    cache_entry_dir.mkdir(parents=True, exist_ok=True)
-                    cached_file = cache_entry_dir / asset_record["Filename"]
-                    # Move file to cache, then symlink back
-                    shutil.move(str(asset_filename), str(cached_file))
-                    asset_filename.symlink_to(cached_file)
-                    self._logger.info(f"Cached asset {asset_rid} (MD5: {md5})")
-
-        asset_type_table, _col_l, _col_r = self._model.find_association(asset_table, MLVocab.asset_type)
-        type_path = self._ml_object.pathBuilder().schemas[asset_type_table.schema.name].tables[asset_type_table.name]
-        asset_types = [
-            asset_type[MLVocab.asset_type.value]
-            for asset_type in type_path.filter(type_path.columns[asset_table.name] == asset_rid)
-            .attributes(type_path.Asset_Type)
-            .fetch()
-        ]
-
-        asset_path = AssetFilePath(
-            file_name=asset_filename,
-            asset_rid=asset_rid,
-            asset_path=asset_filename,
-            asset_metadata=asset_metadata,
-            asset_table=asset_table.name,
-            asset_types=asset_types,
+        return _download_asset(
+            self,
+            asset_rid,
+            dest_dir,
+            update_catalog=update_catalog,
+            use_cache=use_cache,
+            _asset_table=_asset_table,
+            asset_type_vocab_term=MLVocab.asset_type,
+            check_overwrite_safe_fn=_check_overwrite_safe,
         )
-
-        if update_catalog:
-            self._update_asset_execution_table(
-                {f"{asset_table.schema.name}/{asset_table.name}": [asset_path]},
-                asset_role="Input",
-            )
-        return asset_path
 
     @validate_call(config=VALIDATION_CONFIG)
     def upload_execution_outputs(
@@ -1554,98 +1485,21 @@ class Execution:
             ...     path = exe.asset_file_path("Model", "model.pt")  # doctest: +SKIP
             >>> uploaded = exe.upload_execution_outputs()  # doctest: +SKIP
         """
-        if self._dry_run:
-            return {}
+        from deriva_ml.execution.asset_upload import (
+            upload_execution_outputs as _upload_execution_outputs,
+        )
 
-        # Use DerivaML instance setting if not explicitly provided
-        if clean_folder is None:
-            clean_folder = getattr(self._ml_object, "clean_execution_dir", True)
-
-        # Auto-stop a still-Running execution. Notebook code paths
-        # (``run_notebook`` + per-cell user code) and other imperative
-        # callers that don't use a ``with`` block reach this method with
-        # status=Running because no ``__exit__`` ever fired — by the time
-        # they're calling ``upload_execution_outputs()`` they're done with
-        # work and just haven't transitioned. Convert that final
-        # transition into a single call instead of forcing every notebook
-        # cell to know about ``execution_stop()``.
-        if self.status is ExecutionStatus.Running:
-            self.execution_stop()
-
-        # Additive upload path: the execution already finished a prior
-        # upload batch (status=Uploaded) and the caller has registered
-        # additional assets that need to ship. If there's nothing
-        # pending, treat the call as a no-op and return early — the
-        # state machine has no Uploaded → Uploaded edge, and we shouldn't
-        # cycle Uploaded → Pending_Upload → Uploaded just to do nothing.
-        # Typical caller: the runner harness in run_notebook.py
-        # registering the Hydra job log after the kernel's own upload
-        # completed. See state_machine.ALLOWED_TRANSITIONS for the
-        # documented Uploaded → Pending_Upload edge.
-        if self.status is ExecutionStatus.Uploaded:
-            manifest = self._get_manifest()
-            if not manifest.pending_assets():
-                # Short-circuit: no new work. Return the full
-                # manifest view of what's been uploaded for this
-                # execution (the ``uploaded_assets`` property reads
-                # the manifest). Pre-Phase-3 this returned the
-                # most-recent call's subset; the manifest view is
-                # more useful for the typical caller ("what assets
-                # did this execution produce so far?").
-                return self.uploaded_assets
-            self.update_status(ExecutionStatus.Pending_Upload)
-
-        # Transition to Pending_Upload BEFORE starting the upload work. This
-        # ensures that an exception during _bag_commit_upload can legally
-        # transition to Failed (Stopped → Failed is not a legal transition,
-        # but Pending_Upload → Failed is; see state_machine.ALLOWED_TRANSITIONS).
-        if self.status is ExecutionStatus.Stopped:
-            self.update_status(ExecutionStatus.Pending_Upload)
-
-        # Bracket the upload work with timestamps so Upload_Duration
-        # gets populated regardless of whether the call succeeds or
-        # raises. The write goes to SQLite *before* the terminal status
-        # transition so the state-machine PUT that follows carries the
-        # measurement to the catalog. See
-        # docs/bugs/2026-05-19-execution-phase-durations-design.md.
-        from datetime import timezone
-
-        _upload_start = datetime.now(timezone.utc)
-        try:
-            # ``_bag_commit_upload`` returns the per-call subset of
-            # uploaded assets (see ``report_to_asset_map``). External
-            # callers of ``upload_execution_outputs`` depend on this
-            # per-call shape; the ``uploaded_assets`` property is the
-            # full-manifest view.
-            uploaded = self._bag_commit_upload(
-                progress_callback=progress_callback,
-            )
-            self._set_asset_descriptions(uploaded)
-            # Record Upload_Duration just before the terminal transition
-            # so the catalog PUT for Pending_Upload → Uploaded carries
-            # the new value (state machine reads the full SQLite row
-            # via _catalog_body_for_execution).
-            self._ml_object.workspace.execution_state_store().update_execution(
-                self.execution_rid,
-                upload_duration=_format_duration(_upload_start, datetime.now(timezone.utc)),
-            )
-            # Successful end of upload: Pending_Upload → Uploaded.
-            if self.status is ExecutionStatus.Pending_Upload:
-                self.update_status(ExecutionStatus.Uploaded)
-            if clean_folder:
-                self._clean_folder_contents(self._execution_root)
-            return uploaded
-        except Exception as e:
-            # Capture partial upload duration before transitioning to
-            # Failed — same write-then-transition order so the failure
-            # PUT carries the partial measurement.
-            self._ml_object.workspace.execution_state_store().update_execution(
-                self.execution_rid,
-                upload_duration=_format_duration(_upload_start, datetime.now(timezone.utc)),
-            )
-            error = format_exception(e)
-            self.update_status(ExecutionStatus.Failed, error=error)
-            raise e
+        return _upload_execution_outputs(
+            self,
+            clean_folder=clean_folder,
+            progress_callback=progress_callback,
+            pending_upload_status=ExecutionStatus.Pending_Upload,
+            uploaded_status=ExecutionStatus.Uploaded,
+            failed_status=ExecutionStatus.Failed,
+            running_status=ExecutionStatus.Running,
+            stopped_status=ExecutionStatus.Stopped,
+            format_duration_fn=_format_duration,
+        )
 
     def _bag_commit_upload(
         self,
@@ -1740,6 +1594,11 @@ class Execution:
         (an AssetRecord or dict) or incrementally after via the returned
         AssetFilePath's ``metadata`` property.
 
+        Thin delegate to ``asset_upload.asset_file_path``;
+        see that helper for the per-mode logic and the
+        ``asset_types is None`` vs explicit-empty-list
+        normalization.
+
         Args:
             asset_name: Name of the asset table. Must be a valid asset table.
             file_name: Name of file to be uploaded, or path to an existing file.
@@ -1757,86 +1616,22 @@ class Execution:
             DerivaMLException: If the asset table doesn't exist.
             DerivaMLValidationError: If asset_types contains invalid terms.
         """
-        if not self._model.is_asset(asset_name):
-            raise DerivaMLException(f"Table {asset_name} is not an asset")
+        from deriva_ml.execution.asset_upload import asset_file_path as _asset_file_path
 
-        asset_table = self._model.name_to_table(asset_name)
-        schema = asset_table.schema.name
-
-        # Validate and normalize asset types. Use ``is None`` rather
-        # than ``or`` so an explicit ``asset_types=[]`` (the user
-        # saying "no content tags") is honored as-is — the previous
-        # ``or`` chain collapsed an empty list to ``asset_name`` and
-        # then ``lookup_term`` would fail on the table name. The
-        # legacy ``Asset_Type`` kwarg keeps its fallback role.
-        if asset_types is None:
-            asset_types = kwargs.pop("Asset_Type", None)
-            if asset_types is None:
-                asset_types = asset_name
-        asset_types = [asset_types] if isinstance(asset_types, str) else asset_types
-        for t in asset_types:
-            self._ml_object.lookup_term(MLVocab.asset_type, t)
-
-        # Resolve metadata from AssetRecord, dict, or kwargs
-        metadata_dict: dict[str, Any] = {}
-        if metadata is not None:
-            if hasattr(metadata, "model_dump"):
-                metadata_dict = {k: v for k, v in metadata.model_dump().items() if v is not None}
-            else:
-                metadata_dict = dict(metadata)
-        # Merge any kwargs that aren't standard parameters
-        metadata_dict.update(kwargs)
-
-        # Determine file name and path
-        file_name = Path(file_name)
-        if file_name.name == "_implementations.log":
-            file_name = file_name.with_name("-implementations.log")
-
-        if not file_name.is_absolute():
-            file_name = file_name.resolve()
-
-        target_name = Path(rename_file) if file_name.exists() and rename_file else file_name
-
-        # Store file in flat per-table directory
-        flat_dir = flat_asset_dir(self._working_dir, self.execution_rid, asset_name)
-        flat_path = flat_dir / target_name.name
-
-        if file_name.exists():
-            if copy_file:
-                flat_path.write_bytes(file_name.read_bytes())
-            else:
-                try:
-                    flat_path.symlink_to(file_name)
-                except (OSError, PermissionError):
-                    flat_path.write_bytes(file_name.read_bytes())
-
-        # Register in manifest (write-through + fsync)
-        manifest = self._get_manifest()
-        manifest_key = f"{asset_name}/{target_name.name}"
-        manifest.add_asset(
-            manifest_key,
-            AssetEntry(
-                asset_table=asset_name,
-                schema=schema,
-                asset_types=asset_types,
-                metadata=metadata_dict,
-                description=description,
-            ),
-        )
-
-        # Also write legacy asset-type JSONL for backward compatibility with upload
-        with Path(asset_type_path(self._working_dir, self.execution_rid, asset_table)).open("a") as f:
-            f.write(json.dumps({target_name.name: asset_types}) + "\n")
-
-        result = AssetFilePath(
-            asset_path=flat_path,
-            asset_table=asset_name,
-            file_name=target_name.name,
-            asset_metadata=metadata_dict,
+        return _asset_file_path(
+            self,
+            asset_name,
+            file_name,
             asset_types=asset_types,
+            copy_file=copy_file,
+            rename_file=rename_file,
+            metadata=metadata,
+            description=description,
+            asset_type_vocab_term=MLVocab.asset_type,
+            flat_asset_dir_fn=flat_asset_dir,
+            asset_type_path_fn=asset_type_path,
+            legacy_kwargs=kwargs,
         )
-        result._bind_manifest(manifest, manifest_key)
-        return result
 
     def metrics_file(self, filename: str = "metrics.jsonl") -> AssetFilePath:
         """Return a path for writing training-metric records.
@@ -1909,10 +1704,13 @@ class Execution:
             ...         f.write("\\n")  # doctest: +SKIP
             >>> exe.upload_execution_outputs()  # doctest: +SKIP
         """
-        return self.asset_file_path(
-            MLAsset.execution_metadata,
+        from deriva_ml.execution.asset_upload import metrics_file as _metrics_file
+
+        return _metrics_file(
+            self,
             filename,
-            asset_types=ExecMetadataType.metrics_file.value,
+            execution_metadata_asset_name=MLAsset.execution_metadata,
+            metrics_file_asset_type=ExecMetadataType.metrics_file.value,
         )
 
     def _get_manifest(self) -> AssetManifest:

--- a/tests/execution/test_asset_upload.py
+++ b/tests/execution/test_asset_upload.py
@@ -1,4 +1,4 @@
-"""Unit tests for ``deriva_ml.execution.asset_upload`` (audit P1 Ex-god first + second sweeps).
+"""Unit tests for ``deriva_ml.execution.asset_upload`` (audit P1 Ex-god 1st/2nd/3rd sweeps).
 
 Pre-extraction these helpers lived on ``Execution`` as
 methods. Each could only be exercised by spinning up a real
@@ -19,9 +19,16 @@ Coverage layers:
    missing dir.
 5. ``clean_folder_contents`` — pure filesystem op with
    bounded retry.
-6. ``update_asset_execution_table`` (second sweep) — per-role
-   dispatch (Input vs Output), dry-run skip, Asset_Role
-   vocab lookup.
+6. ``update_asset_execution_table`` — per-role dispatch
+   (Input vs Output), dry-run skip, Asset_Role vocab lookup.
+7. ``asset_file_path`` — manifest registration, asset-type
+   JSONL writeback, empty-list-types preservation, metadata
+   normalization.
+8. ``metrics_file`` — thin sugar over ``asset_file_path``.
+9. ``upload_execution_outputs`` — state-machine bracketing
+   for dry-run, Running auto-stop, Uploaded short-circuit,
+   Stopped → Pending_Upload → Uploaded happy path,
+   Pending_Upload → Failed on exception.
 
 Pure-Python tests; no live catalog required.
 """
@@ -32,12 +39,17 @@ import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from deriva_ml.execution.asset_upload import (
+    asset_file_path,
     clean_folder_contents,
     get_metadata_description,
+    metrics_file,
     save_runtime_environment,
     set_asset_descriptions,
     update_asset_execution_table,
+    upload_execution_outputs,
     upload_hydra_config_assets,
 )
 
@@ -617,3 +629,415 @@ class TestUpdateAssetExecutionTable:
         )
 
         exe._ml_object.lookup_term.assert_called_once_with("My_Custom_Vocab", "Input")
+
+
+# ---------------------------------------------------------------------------
+# asset_file_path — third sweep
+# ---------------------------------------------------------------------------
+
+
+class TestAssetFilePath:
+    """Pin the asset-staging contract for the third sweep extraction."""
+
+    def _build_execution(self, tmp_path: Path):
+        """Build an ``Execution`` mock with the minimum surface the helper reads."""
+        exe = MagicMock()
+        exe._working_dir = str(tmp_path)
+        exe.execution_rid = "EX-1"
+
+        # Model: ``Image`` is the only asset table.
+        def is_asset(name):
+            return name in ("Image", "Execution_Metadata")
+
+        def name_to_table(name):
+            t = MagicMock()
+            t.name = name
+            t.schema.name = "deriva-ml"
+            return t
+
+        exe._model.is_asset.side_effect = is_asset
+        exe._model.name_to_table.side_effect = name_to_table
+
+        # Manifest mock: ``add_asset`` records the call.
+        manifest = MagicMock()
+        exe._get_manifest.return_value = manifest
+
+        return exe, manifest
+
+    def _flat_dir_fn(self, tmp_path: Path):
+        """Build a ``flat_asset_dir`` stand-in that mkdirs and returns a path."""
+        def _fn(working_dir, exec_rid, asset_name):
+            p = Path(working_dir) / "flat" / exec_rid / asset_name
+            p.mkdir(parents=True, exist_ok=True)
+            return p
+
+        return _fn
+
+    def _type_path_fn(self, tmp_path: Path):
+        """Build an ``asset_type_path`` stand-in that returns a writable JSONL path."""
+        def _fn(working_dir, exec_rid, asset_table):
+            p = Path(working_dir) / "type-jsonl" / exec_rid
+            p.mkdir(parents=True, exist_ok=True)
+            return p / f"{asset_table.name}.jsonl"
+
+        return _fn
+
+    def test_rejects_non_asset_table(self, tmp_path):
+        """Non-asset table → ``DerivaMLException``."""
+        from deriva_ml.core.exceptions import DerivaMLException
+
+        exe, _ = self._build_execution(tmp_path)
+        exe._model.is_asset.side_effect = lambda name: False
+
+        with pytest.raises(DerivaMLException, match="not an asset"):
+            asset_file_path(
+                exe,
+                "Subject",
+                "subj.csv",
+                asset_type_vocab_term="Asset_Type",
+                flat_asset_dir_fn=self._flat_dir_fn(tmp_path),
+                asset_type_path_fn=self._type_path_fn(tmp_path),
+            )
+
+    def test_defaults_asset_types_to_asset_name(self, tmp_path):
+        """``asset_types=None`` defaults to ``[asset_name]`` (with vocab lookup)."""
+        exe, manifest = self._build_execution(tmp_path)
+
+        asset_file_path(
+            exe,
+            "Image",
+            "photo.jpg",
+            asset_type_vocab_term="Asset_Type",
+            flat_asset_dir_fn=self._flat_dir_fn(tmp_path),
+            asset_type_path_fn=self._type_path_fn(tmp_path),
+        )
+
+        # Vocab lookup happened with the default.
+        exe._ml_object.lookup_term.assert_called_once_with("Asset_Type", "Image")
+
+    def test_empty_list_asset_types_preserved(self, tmp_path):
+        """Explicit ``asset_types=[]`` is honored — no fallback to asset_name.
+
+        Pre-fix the inline ``or`` chain collapsed an empty list
+        to ``asset_name`` and then ``lookup_term`` would fail on
+        the table name (audit P1 ``asset_file_path`` falsy bug).
+        Pin the ``is None`` semantic against future regressions.
+        """
+        exe, _ = self._build_execution(tmp_path)
+
+        asset_file_path(
+            exe,
+            "Image",
+            "photo.jpg",
+            asset_types=[],
+            asset_type_vocab_term="Asset_Type",
+            flat_asset_dir_fn=self._flat_dir_fn(tmp_path),
+            asset_type_path_fn=self._type_path_fn(tmp_path),
+        )
+
+        # No vocab lookup — empty list is honored.
+        exe._ml_object.lookup_term.assert_not_called()
+
+    def test_legacy_asset_type_kwarg_fallback(self, tmp_path):
+        """``legacy_kwargs={"Asset_Type": "X"}`` is used when ``asset_types`` is None."""
+        exe, _ = self._build_execution(tmp_path)
+
+        asset_file_path(
+            exe,
+            "Image",
+            "photo.jpg",
+            asset_type_vocab_term="Asset_Type",
+            flat_asset_dir_fn=self._flat_dir_fn(tmp_path),
+            asset_type_path_fn=self._type_path_fn(tmp_path),
+            legacy_kwargs={"Asset_Type": "Training_Data"},
+        )
+
+        exe._ml_object.lookup_term.assert_called_once_with("Asset_Type", "Training_Data")
+
+    def test_registers_in_manifest_with_correct_key(self, tmp_path):
+        """Manifest is keyed as ``{asset_name}/{target_name}``."""
+        exe, manifest = self._build_execution(tmp_path)
+
+        asset_file_path(
+            exe,
+            "Image",
+            "photo.jpg",
+            asset_type_vocab_term="Asset_Type",
+            flat_asset_dir_fn=self._flat_dir_fn(tmp_path),
+            asset_type_path_fn=self._type_path_fn(tmp_path),
+        )
+
+        assert manifest.add_asset.call_count == 1
+        manifest_key = manifest.add_asset.call_args.args[0]
+        assert manifest_key == "Image/photo.jpg"
+
+    def test_writes_asset_type_jsonl(self, tmp_path):
+        """The asset-type JSONL file gets a line per call (legacy upload contract)."""
+        exe, _ = self._build_execution(tmp_path)
+
+        asset_file_path(
+            exe,
+            "Image",
+            "photo.jpg",
+            asset_types=["Training_Data"],
+            asset_type_vocab_term="Asset_Type",
+            flat_asset_dir_fn=self._flat_dir_fn(tmp_path),
+            asset_type_path_fn=self._type_path_fn(tmp_path),
+        )
+
+        jsonl = tmp_path / "type-jsonl" / "EX-1" / "Image.jsonl"
+        assert jsonl.exists()
+        line = jsonl.read_text().strip()
+        # The JSONL maps target-filename to asset_types list.
+        parsed = json.loads(line)
+        assert parsed == {"photo.jpg": ["Training_Data"]}
+
+    def test_metadata_dict_passed_through(self, tmp_path):
+        """``metadata`` dict is merged with ``legacy_kwargs`` and stored."""
+        exe, manifest = self._build_execution(tmp_path)
+
+        asset_file_path(
+            exe,
+            "Image",
+            "photo.jpg",
+            asset_type_vocab_term="Asset_Type",
+            flat_asset_dir_fn=self._flat_dir_fn(tmp_path),
+            asset_type_path_fn=self._type_path_fn(tmp_path),
+            metadata={"Subject": "2-DEF"},
+            legacy_kwargs={"Acquisition_Date": "2026-01-15"},
+        )
+
+        # The AssetEntry passed to manifest.add_asset has both keys.
+        entry = manifest.add_asset.call_args.args[1]
+        assert entry.metadata == {
+            "Subject": "2-DEF",
+            "Acquisition_Date": "2026-01-15",
+        }
+
+    def test_asset_record_model_dump_normalized(self, tmp_path):
+        """A Pydantic AssetRecord's ``model_dump()`` is used, ``None`` values stripped."""
+        exe, manifest = self._build_execution(tmp_path)
+
+        record = MagicMock()
+        record.model_dump.return_value = {
+            "Subject": "2-DEF",
+            "Acquisition_Date": None,  # stripped
+        }
+
+        asset_file_path(
+            exe,
+            "Image",
+            "photo.jpg",
+            asset_type_vocab_term="Asset_Type",
+            flat_asset_dir_fn=self._flat_dir_fn(tmp_path),
+            asset_type_path_fn=self._type_path_fn(tmp_path),
+            metadata=record,
+        )
+
+        entry = manifest.add_asset.call_args.args[1]
+        assert entry.metadata == {"Subject": "2-DEF"}
+
+
+# ---------------------------------------------------------------------------
+# metrics_file — thin sugar over asset_file_path
+# ---------------------------------------------------------------------------
+
+
+class TestMetricsFile:
+    def test_delegates_with_correct_asset_type(self):
+        """``metrics_file(filename)`` calls
+        ``execution.asset_file_path(execution_metadata, filename,
+        asset_types=metrics_file_tag)``."""
+        exe = MagicMock()
+        exe.asset_file_path.return_value = "<AssetFilePath>"
+
+        result = metrics_file(
+            exe,
+            "metrics.jsonl",
+            execution_metadata_asset_name="Execution_Metadata",
+            metrics_file_asset_type="Metrics_File",
+        )
+
+        assert result == "<AssetFilePath>"
+        exe.asset_file_path.assert_called_once_with(
+            "Execution_Metadata",
+            "metrics.jsonl",
+            asset_types="Metrics_File",
+        )
+
+
+# ---------------------------------------------------------------------------
+# upload_execution_outputs — state-machine bracketing
+# ---------------------------------------------------------------------------
+
+
+class TestUploadExecutionOutputs:
+    """Pin the state-machine transitions around the upload work."""
+
+    def _build_execution(
+        self,
+        *,
+        status,
+        dry_run: bool = False,
+        pending: dict | None = None,
+    ):
+        """Build an ``Execution`` mock for the upload orchestrator."""
+        exe = MagicMock()
+        exe._dry_run = dry_run
+        exe.execution_rid = "EX-1"
+        exe.status = status
+
+        manifest = MagicMock()
+        manifest.pending_assets.return_value = pending if pending is not None else {"K": "v"}
+        exe._get_manifest.return_value = manifest
+
+        exe._bag_commit_upload.return_value = {"schema/Image": []}
+        return exe
+
+    def _statuses(self):
+        """Use sentinel enum-like objects so ``is`` comparisons work."""
+        class _StatusSentinel:
+            def __init__(self, name):
+                self.name = name
+
+            def __repr__(self):
+                return f"<Status.{self.name}>"
+
+        return {
+            "Running": _StatusSentinel("Running"),
+            "Stopped": _StatusSentinel("Stopped"),
+            "Pending_Upload": _StatusSentinel("Pending_Upload"),
+            "Uploaded": _StatusSentinel("Uploaded"),
+            "Failed": _StatusSentinel("Failed"),
+        }
+
+    def test_dry_run_returns_empty(self):
+        """Dry-run executions short-circuit to ``{}``."""
+        s = self._statuses()
+        exe = self._build_execution(status=s["Stopped"], dry_run=True)
+
+        result = upload_execution_outputs(
+            exe,
+            pending_upload_status=s["Pending_Upload"],
+            uploaded_status=s["Uploaded"],
+            failed_status=s["Failed"],
+            running_status=s["Running"],
+            stopped_status=s["Stopped"],
+            format_duration_fn=lambda a, b: "0s",
+        )
+        assert result == {}
+        # No state transitions, no bag-commit calls.
+        exe._bag_commit_upload.assert_not_called()
+        exe.update_status.assert_not_called()
+
+    def test_uploaded_short_circuit_when_no_pending(self):
+        """``status=Uploaded`` + no pending → return ``uploaded_assets``, no transition."""
+        s = self._statuses()
+        exe = self._build_execution(status=s["Uploaded"], pending={})
+        exe.uploaded_assets = {"schema/Image": []}
+
+        result = upload_execution_outputs(
+            exe,
+            pending_upload_status=s["Pending_Upload"],
+            uploaded_status=s["Uploaded"],
+            failed_status=s["Failed"],
+            running_status=s["Running"],
+            stopped_status=s["Stopped"],
+            format_duration_fn=lambda a, b: "0s",
+        )
+        assert result == {"schema/Image": []}
+        exe._bag_commit_upload.assert_not_called()
+        exe.update_status.assert_not_called()
+
+    def test_running_auto_stops(self):
+        """``status=Running`` → auto-call ``execution_stop()`` before upload."""
+        s = self._statuses()
+        # After execution_stop, status transitions to Stopped (and then
+        # Pending_Upload, then Uploaded). We simulate by toggling the
+        # status attribute via a side_effect on execution_stop.
+        exe = self._build_execution(status=s["Running"])
+
+        def _stop_fn():
+            exe.status = s["Stopped"]
+
+        exe.execution_stop.side_effect = _stop_fn
+
+        # After update_status(Pending_Upload), status becomes Pending_Upload.
+        # After the successful upload, the helper transitions to Uploaded.
+        update_calls = []
+
+        def _update_fn(target, **kwargs):
+            update_calls.append(target)
+            exe.status = target
+
+        exe.update_status.side_effect = _update_fn
+
+        upload_execution_outputs(
+            exe,
+            pending_upload_status=s["Pending_Upload"],
+            uploaded_status=s["Uploaded"],
+            failed_status=s["Failed"],
+            running_status=s["Running"],
+            stopped_status=s["Stopped"],
+            format_duration_fn=lambda a, b: "0s",
+        )
+
+        # execution_stop was called once.
+        assert exe.execution_stop.call_count == 1
+        # Status transitions: Pending_Upload, then Uploaded.
+        assert update_calls == [s["Pending_Upload"], s["Uploaded"]]
+
+    def test_failure_transitions_to_failed(self):
+        """``_bag_commit_upload`` raises → ``Pending_Upload → Failed``."""
+        s = self._statuses()
+        exe = self._build_execution(status=s["Stopped"])
+
+        exe._bag_commit_upload.side_effect = RuntimeError("bag-load failed")
+
+        update_calls = []
+
+        def _update_fn(target, **kwargs):
+            update_calls.append((target, kwargs))
+            exe.status = target
+
+        exe.update_status.side_effect = _update_fn
+
+        with pytest.raises(RuntimeError, match="bag-load failed"):
+            upload_execution_outputs(
+                exe,
+                pending_upload_status=s["Pending_Upload"],
+                uploaded_status=s["Uploaded"],
+                failed_status=s["Failed"],
+                running_status=s["Running"],
+                stopped_status=s["Stopped"],
+                format_duration_fn=lambda a, b: "0s",
+            )
+
+        # Status transitions: Pending_Upload (pre-upload bracket),
+        # then Failed (catch handler).
+        assert [c[0] for c in update_calls] == [s["Pending_Upload"], s["Failed"]]
+        # Failed transition carried an error= kwarg.
+        assert "error" in update_calls[1][1]
+
+    def test_happy_path_clean_folder_runs(self):
+        """Successful upload with ``clean_folder=True`` cleans the execution root."""
+        s = self._statuses()
+        exe = self._build_execution(status=s["Stopped"])
+
+        def _update_fn(target, **kwargs):
+            exe.status = target
+
+        exe.update_status.side_effect = _update_fn
+
+        upload_execution_outputs(
+            exe,
+            clean_folder=True,
+            pending_upload_status=s["Pending_Upload"],
+            uploaded_status=s["Uploaded"],
+            failed_status=s["Failed"],
+            running_status=s["Running"],
+            stopped_status=s["Stopped"],
+            format_duration_fn=lambda a, b: "0s",
+        )
+
+        exe._clean_folder_contents.assert_called_once_with(exe._execution_root)


### PR DESCRIPTION
## Summary

Third — and final — sweep on audit P1 Ex-god. Completes the
movement of asset-staging + upload methods from ``Execution``
into ``asset_upload.py``.

### Extracted

- ``asset_file_path`` — manifest registration + flat staging
  + asset_type JSONL writeback.
- ``metrics_file`` — thin sugar over ``asset_file_path``.
- ``download_asset`` — hatrac fetch + cache + execution-link
  via ``update_asset_execution_table(asset_role="Input")``.
- ``upload_execution_outputs`` — state-machine bracketed
  bag-commit driver (Stopped → Pending_Upload → Uploaded
  or → Failed). The state-machine transitions still go
  through ``execution.update_status`` / ``execution_stop``;
  only the body moves.

The four corresponding ``Execution`` methods are now thin
delegates so the public API is unchanged. Enum-shaped args
threaded through so the helpers stay decoupled from the
heavy import graph.

### Asset_Role Input/Output preservation (continues)

``download_asset`` still calls
``_update_asset_execution_table(..., asset_role="Input")``;
the Input role assignment is **preserved** as part of the
public-API contract. See PR #217 for the broader
explanation of why the Output branch is also retained
(audit's "drop the dead branch" recommendation rejected).
The 419/419 integration tests (which include the 699-LOC
``test_asset_role_auto_tag.py``) confirm both Input and
Output role assignment work correctly through the
extracted code.

### Sizes

- ``execution.py``: 2,387 → 2,291 LOC (-96 this sweep;
  **-401 cumulative across all three sweeps** from the
  pre-Ex-god 2,692 baseline).
- ``asset_upload.py``: 718 → 1,252 LOC.

Drive-by: dropped 4 newly-unused top-level imports from
``execution.py`` (``shutil``, ``format_exception``,
``HatracStore``, ``AssetEntry``).

### Audit posture after three sweeps

- **Lifecycle on Execution**: state-machine transitions,
  ``__enter__``/``__exit__``, ``abort``, ``execute``.
- **Asset surface in asset_upload.py**: staging, hatrac
  download, bag-commit driver, association-row writes,
  description metadata, env snapshot, Hydra config,
  folder cleanup.
- **Dataset/feature surface still on Execution**:
  ``download_dataset_bag``, ``create_dataset``,
  ``add_features``, ``add_nested_execution`` — these are
  deeper concerns (dataset materialization, execution
  hierarchy) not part of the asset-upload theme.

### Testability win

The four public-API methods are now testable with
``MagicMock``. New unit tests:

- ``TestAssetFilePath`` (7): non-asset rejection, default
  asset_types, **explicit empty-list preserved (pins the
  audit P1 falsy bug)**, legacy ``Asset_Type`` kwarg
  fallback, manifest key shape, JSONL writeback,
  AssetRecord None-stripping.
- ``TestMetricsFile`` (1): delegates correctly.
- ``TestUploadExecutionOutputs`` (5): dry-run, Uploaded
  short-circuit, Running auto-stop, Pending_Upload →
  Failed on exception, clean_folder=True happy path.

## Test plan

- [x] ``tests/execution/test_asset_upload.py`` — 37/37 pass (~0.22s)
- [x] ``tests/execution/`` (existing integration coverage) —
      **419/419 pass** against live catalog (~6:22). Confirms
      Input/Output role assignment + asset staging + hatrac
      download + upload bracketing all work through the
      extracted code.
- [x] ``ruff check`` clean on touched code

Generated with Claude Code