### PR TITLE
feat(asset,dataset): write-through description setters (closes #70)

### DIFF
--- a/src/deriva_ml/asset/asset.py
+++ b/src/deriva_ml/asset/asset.py
@@ -35,11 +35,12 @@ from deriva_ml.core.exceptions import NoAssociationException
 
 if TYPE_CHECKING:
     from deriva_ml.execution.execution_record import ExecutionRecord
-    from deriva_ml.feature import Feature, FeatureRecord
+    from deriva_ml.feature import Feature
     from deriva_ml.interfaces import DerivaMLCatalog
 
 # Deriva imports - use importlib to avoid shadowing by local 'deriva.py' files
 import importlib
+
 from deriva_ml.core.logging_config import get_logger
 
 _ermrest_model = importlib.import_module("deriva.core.ermrest_model")
@@ -89,7 +90,7 @@ class Asset:
         url: str = "",
         length: int = 0,
         md5: str = "",
-        description: str = "",
+        description: str | None = "",
         asset_types: list[str] | None = None,
         execution_rid: RID | None = None,
     ):
@@ -122,7 +123,11 @@ class Asset:
         self.url = url
         self.length = length
         self.md5 = md5
-        self.description = description
+        # ``description`` is exposed via a @property/@setter (below)
+        # for write-through to the catalog. Store the underlying
+        # value in ``_description`` so the setter has somewhere
+        # to write without invoking itself.
+        self._description = description
         self._asset_types = asset_types or []
         self._execution_rid = execution_rid
         # Lazy cache for ``_asset_type_path``. ``self.asset_table``
@@ -136,6 +141,82 @@ class Asset:
         return (
             f"<deriva_ml.Asset at {hex(id(self))}: rid='{self.asset_rid}', "
             f"table='{self.asset_table}', file='{self.filename}', types={self._asset_types}>"
+        )
+
+    @property
+    def description(self) -> str | None:
+        """The asset's human-readable description.
+
+        Read returns the cached in-memory value. Write performs a
+        **write-through** update: assigning
+        ``asset.description = "new"`` updates both the in-memory
+        attribute and the ``Description`` column on the asset's
+        catalog row.
+
+        This is the symmetric counterpart of
+        :attr:`Workflow.description` and
+        :attr:`ExecutionRecord.description` — every typed-entity
+        class with a catalog-backed description now writes
+        through on assignment. Issue #70.
+
+        Returns:
+            The description string, or ``None`` when the
+            catalog ``Description`` column is NULL.
+
+        Example:
+            >>> asset = ml.lookup_asset("3JSE")  # doctest: +SKIP
+            >>> asset.description = "Refined OCT scan, July 2026"  # doctest: +SKIP
+            >>> # Catalog ``Asset.Description`` is now updated;
+            >>> # ``asset.description`` reads "Refined OCT scan, July 2026".
+        """
+        return self._description
+
+    @description.setter
+    def description(self, value: str | None) -> None:
+        """Update the asset description in the catalog and in memory.
+
+        Args:
+            value: The new description text.
+
+        Raises:
+            DerivaMLException: If the asset is bound to a
+                read-only catalog snapshot or the catalog
+                connection is missing.
+        """
+        if self._ml_instance is not None:
+            self._update_description_in_catalog(value)
+        self._description = value
+
+    def _update_description_in_catalog(self, new_description: str | None) -> None:
+        """Write the description to the asset's catalog row.
+
+        Pulls the schema name from
+        ``model.name_to_table(self.asset_table).schema.name`` so
+        the helper picks up asset tables in any domain schema —
+        Asset tables aren't always in the ML schema (unlike
+        Workflow, Execution, Dataset which are).
+
+        Raises:
+            DerivaMLException: If the catalog is unwritable.
+        """
+        from deriva_ml.execution._helpers import (
+            check_writable_catalog,
+            update_field_in_catalog,
+        )
+
+        check_writable_catalog(
+            rid=self.asset_rid,
+            ml_instance=self._ml_instance,
+            entity_label="Asset",
+            operation="update description",
+        )
+        asset_table_obj = self._ml_instance.model.name_to_table(self.asset_table)
+        update_field_in_catalog(
+            rid=self.asset_rid,
+            ml_instance=self._ml_instance,
+            table_name=self.asset_table,
+            updates={"Description": new_description},
+            schema_name=asset_table_obj.schema.name,
         )
 
     def _asset_type_path(self) -> tuple[Any, str]:

--- a/src/deriva_ml/dataset/dataset.py
+++ b/src/deriva_ml/dataset/dataset.py
@@ -136,7 +136,84 @@ class Dataset:
         self.dataset_rid = dataset_rid
         self.execution_rid = execution_rid
         self._ml_instance = catalog
-        self.description = description
+        # ``description`` is exposed via a @property/@setter (below)
+        # for write-through to the catalog. Store the underlying
+        # value in ``_description`` so the setter has somewhere
+        # to write without invoking itself.
+        self._description = description
+
+    @property
+    def description(self) -> str:
+        """The dataset's human-readable description.
+
+        Read returns the cached in-memory value. Write performs a
+        **write-through** update: assigning
+        ``dataset.description = "new"`` updates both the in-memory
+        attribute and the ``Description`` column on the
+        ``Dataset`` catalog row.
+
+        This is the symmetric counterpart of
+        :attr:`Workflow.description` and
+        :attr:`ExecutionRecord.description` — every typed-entity
+        class with a catalog-backed description now writes
+        through on assignment. Issue #70.
+
+        Returns:
+            The description string, or empty string when none
+            was set.
+
+        Example:
+            >>> ds = ml.lookup_dataset("4HM")  # doctest: +SKIP
+            >>> ds.description = "Curated 2026-05 release"  # doctest: +SKIP
+            >>> # Catalog ``Dataset.Description`` is now updated;
+            >>> # ``ds.description`` reads "Curated 2026-05 release".
+        """
+        return self._description
+
+    @description.setter
+    def description(self, value: str) -> None:
+        """Update the dataset description in the catalog and in memory.
+
+        Args:
+            value: The new description text.
+
+        Raises:
+            DerivaMLException: If the dataset is bound to a
+                read-only catalog snapshot or the catalog
+                connection is missing.
+        """
+        if self._ml_instance is not None:
+            self._update_description_in_catalog(value)
+        self._description = value
+
+    def _update_description_in_catalog(self, new_description: str) -> None:
+        """Write the description to the ``Dataset`` catalog row.
+
+        Dataset rows live in the ML schema, so the helper uses
+        ``ml_instance.ml_schema`` (the default) — no schema-name
+        threading needed (unlike :meth:`Asset._update_description_in_catalog`,
+        whose asset tables may live in domain schemas).
+
+        Raises:
+            DerivaMLException: If the catalog is unwritable.
+        """
+        from deriva_ml.execution._helpers import (
+            check_writable_catalog,
+            update_field_in_catalog,
+        )
+
+        check_writable_catalog(
+            rid=self.dataset_rid,
+            ml_instance=self._ml_instance,
+            entity_label="Dataset",
+            operation="update description",
+        )
+        update_field_in_catalog(
+            rid=self.dataset_rid,
+            ml_instance=self._ml_instance,
+            table_name="Dataset",
+            updates={"Description": new_description},
+        )
 
     def __repr__(self) -> str:
         """Return a string representation of the Dataset for debugging."""

--- a/src/deriva_ml/execution/_helpers.py
+++ b/src/deriva_ml/execution/_helpers.py
@@ -104,6 +104,7 @@ def update_field_in_catalog(
     ml_instance: Any,
     table_name: str,
     updates: dict[str, Any],
+    schema_name: str | None = None,
 ) -> None:
     """Write column updates to one RID-keyed catalog row.
 
@@ -116,19 +117,28 @@ def update_field_in_catalog(
         rid: The row's RID.
         ml_instance: The bound :class:`DerivaML` instance — used
             to reach the pathBuilder + schema.
-        table_name: The table to update under
+        table_name: The table to update. Looked up under
+            ``schema_name`` if given, otherwise
             ``ml_instance.ml_schema``. Examples: ``"Execution"``,
-            ``"Workflow"``.
+            ``"Workflow"``, ``"Dataset"`` (all in the ML schema);
+            ``"Image"``, ``"Subject"`` (in a domain schema —
+            require ``schema_name``).
         updates: Column → value dict. The ``"RID"`` key is added
             automatically; callers pass the per-column updates
             only.
+        schema_name: Optional explicit schema. When ``None``
+            (default), uses ``ml_instance.ml_schema`` — the
+            common case for the ML-schema tables. Pass an
+            explicit name for Asset rows that live in domain
+            schemas.
 
     Raises:
         DerivaMLException: If ``ml_instance`` is None, ``rid`` is
             empty, or the catalog rejects the update.
     """
     pb = ml_instance.pathBuilder()
-    table_path = pb.schemas[ml_instance.ml_schema].tables[table_name]
+    schema = schema_name if schema_name is not None else ml_instance.ml_schema
+    table_path = pb.schemas[schema].tables[table_name]
     payload = {"RID": rid, **updates}
     table_path.update([payload])
 

--- a/tests/asset/test_asset.py
+++ b/tests/asset/test_asset.py
@@ -326,6 +326,69 @@ class TestAssetMetadata:
 
 
 # =============================================================================
+# TestAssetDescriptionSetter - write-through description (issue #70)
+# =============================================================================
+
+
+class TestAssetDescriptionSetter:
+    """Pin the write-through description setter on Asset.
+
+    Pre-issue-#70, ``asset.description = "new"`` only updated the
+    in-memory attribute; the catalog row was unchanged. The
+    setter now writes both, mirroring the pattern already in
+    place on :class:`Workflow` and :class:`ExecutionRecord`.
+    """
+
+    def test_description_assignment_writes_to_catalog(self, basic_execution):
+        """``asset.description = "new"`` persists to the catalog row."""
+        ml = basic_execution._ml_object
+
+        with basic_execution.execute() as execution:
+            create_test_asset(execution, "desc_write.txt", "x")
+        uploaded = basic_execution.upload_execution_outputs()
+        asset_rid = uploaded["deriva-ml/Execution_Asset"][0].asset_rid
+
+        asset = ml.lookup_asset(asset_rid)
+        new_desc = "Updated via setter — issue #70"
+
+        # Write-through assignment.
+        asset.description = new_desc
+
+        # In-memory side updated.
+        assert asset.description == new_desc
+
+        # Catalog round-trip: a fresh lookup sees the new value.
+        refreshed = ml.lookup_asset(asset_rid)
+        assert refreshed.description == new_desc
+
+    def test_description_read_returns_initial_value(self, basic_execution):
+        """The getter returns whatever was passed at construction (no catalog read).
+
+        For a freshly uploaded asset with no description set, the
+        catalog ``Description`` column is NULL, so the getter
+        returns None. Once written via the setter, the getter
+        returns the written value.
+        """
+        ml = basic_execution._ml_object
+
+        with basic_execution.execute() as execution:
+            create_test_asset(execution, "desc_read.txt", "x")
+        uploaded = basic_execution.upload_execution_outputs()
+        asset_rid = uploaded["deriva-ml/Execution_Asset"][0].asset_rid
+
+        asset = ml.lookup_asset(asset_rid)
+        # No description was ever written to this asset's row — the
+        # getter mirrors what ``lookup_asset`` populated (None or "").
+        initial = asset.description
+        assert initial is None or isinstance(initial, str)
+
+        # After a write, the getter reflects the written value
+        # without re-reading the catalog.
+        asset.description = "set via setter"
+        assert asset.description == "set via setter"
+
+
+# =============================================================================
 # TestAssetDownload - bare-bytes download primitive (audit P1 A3)
 # =============================================================================
 

--- a/tests/dataset/test_datasets.py
+++ b/tests/dataset/test_datasets.py
@@ -77,6 +77,46 @@ class TestDataset:
         assert new_dataset.description == "Dataset for testing"
         assert new_dataset.dataset_types == ["Testing"]
 
+    def test_dataset_description_setter_writes_to_catalog(self, deriva_catalog, tmp_path):
+        """``dataset.description = "new"`` writes through to the catalog row.
+
+        Pins the issue #70 contract: Asset and Dataset now have
+        write-through description setters mirroring the
+        Workflow + ExecutionRecord pattern. Pre-fix this would
+        only update the in-memory attribute; the catalog row
+        was unchanged.
+        """
+        ml_instance = DerivaML(
+            deriva_catalog.hostname,
+            deriva_catalog.catalog_id,
+            working_dir=tmp_path,
+            use_minid=False,
+        )
+        ml_instance.add_term(MLVocab.dataset_type, "Testing", description="A test dataset", exists_ok=True)
+        ml_instance.add_term(
+            MLVocab.workflow_type, "Manual Workflow", description="A manual workflow", exists_ok=True
+        )
+        workflow = ml_instance.create_workflow(
+            name="Description Setter Test Workflow",
+            workflow_type="Manual Workflow",
+            description="Workflow for testing description setter",
+        )
+        execution = ml_instance.create_execution(
+            ExecutionConfiguration(description="Test Execution", workflow=workflow)
+        )
+        dataset = execution.create_dataset(description="Initial description", dataset_types=["Testing"])
+
+        # Write-through assignment.
+        new_desc = "Updated via setter — issue #70"
+        dataset.description = new_desc
+
+        # In-memory side updated.
+        assert dataset.description == new_desc
+
+        # Catalog round-trip: a fresh lookup sees the new value.
+        refreshed = ml_instance.lookup_dataset(dataset.dataset_rid)
+        assert refreshed.description == new_desc
+
     def test_nested_datasets(self, dataset_test, tmp_path):
         """Test finding datasets."""
         # Find all datasets


### PR DESCRIPTION
## Summary

Issue #70: Asset and Dataset gain symmetric write-through
description setters, matching the pattern already in place on
``Workflow`` and ``ExecutionRecord``.

Before this change, assigning to ``asset.description`` or
``dataset.description`` only updated the in-memory attribute;
the catalog row was unchanged and the next
``lookup_asset``/``lookup_dataset`` call would see the old
value. Now both layers are kept consistent.

## Implementation

- Store the description in ``_description`` (private) so the
  setter can write without invoking itself; expose via a typed
  ``@property`` returning ``str | None``.
- New per-class ``_update_description_in_catalog`` helper —
  ``Asset`` threads the per-table schema name through (Asset
  tables live in domain schemas); ``Dataset`` uses the default
  ML schema.
- Extend ``execution/_helpers.update_field_in_catalog`` with an
  optional ``schema_name`` parameter so the same helper now
  serves both ML-schema (Workflow / Execution / Dataset) and
  domain-schema (Asset) callers, without breaking the existing
  three callers.

## Test plan

- [x] ``TestAssetDescriptionSetter::test_description_assignment_writes_to_catalog``
      — write-through round-trip via fresh ``lookup_asset``
- [x] ``TestAssetDescriptionSetter::test_description_read_returns_initial_value``
      — getter sanity check that acknowledges a freshly uploaded
      asset has a NULL description, plus post-set read
- [x] ``TestDataset.test_dataset_description_setter_writes_to_catalog``
      — write-through round-trip via fresh ``lookup_dataset``
- [x] All three pass against live catalog (``DERIVA_HOST=localhost``)
- [x] Existing fast-test suite still green (446 passed, 8 skipped)

Closes #70.

🤖 Generated with [Claude Code](https://claude.com/claude-code)