### PR TITLE
docs: walk back v2.0.0 to v1.39.0

### DIFF
--- a/docs/adr/0009-unified-commit-output-assets.md
+++ b/docs/adr/0009-unified-commit-output-assets.md
@@ -129,11 +129,14 @@ around this method.
 | `DerivaML.upload_pending(...)` | `DerivaML.commit_pending_executions(...)` |
 | `retry_failed=` kwarg (everywhere) | Removed — was already a documented no-op under the bag pipeline |
 
-**No deprecation shims.** The breaking change ships as **v2.0.0**
-with a migration table in the release notes. Internal callers
-(10 source files) migrate in the same PR. External Python
-consumers (`deriva-mcp`, `deriva-ml-model-template`) migrate in
-coordinated companion PRs.
+**No deprecation shims.** The breaking change ships as **v1.39.0**
+— a minor bump that carries an API-incompatible change. Major-
+version (`v2.0.0`) is intentionally deferred until the unified
+surface has more bake time; landing the rename at v1.39 keeps the
+v2.0 marker free for a future release we are more confident in.
+Internal callers (10 source files) migrate in the same PR.
+External Python consumers (`deriva-mcp`,
+`deriva-ml-model-template`) migrate in coordinated companion PRs.
 
 ### Why no shims
 
@@ -192,7 +195,7 @@ session.
 **Negative:**
 
 - Breaking change. Every external Python caller of the four
-  removed methods must migrate at v2.0.0 upgrade. No shim.
+  removed methods must migrate at v1.39.0 upgrade. No shim.
 - Internal-caller migration is in the same PR as the rename —
   the PR is larger than a minimum-viable behavior fix would have
   been.
@@ -250,18 +253,31 @@ otherwise commit a half-done execution.
 
 ### Deprecation shims for one minor cycle
 
-Standard semver hygiene — ship v2.0.0 with shims that warn,
-remove in v3.0.0.
+Standard semver hygiene — ship with shims that warn, remove a
+minor cycle later.
 
 Rejected by the user: shims extend the period during which both
 names are in use. The blast radius is small enough that a single
 coordinated PR session resolves all known external consumers.
 Shims would have kept the broken methods reachable in any pinned
-v2.x environment.
+v1.39+ environment.
+
+### Ship as v2.0.0
+
+Initial intent — semver-honest. A breaking API change is what
+v2.0 numerals signal.
+
+Rejected by the user **after** the initial v2.0.0 tag was pushed:
+v2.0 should mark a release we are confident enough in to stand
+behind for years; the unified surface needs bake time before it
+earns that marker. The v2.0.0 tag was deleted from origin and
+this commit was re-tagged as v1.39.0. The release notes call out
+that v1.39.0 carries an API-incompatible change despite the minor
+version number; consumers must read them before upgrading.
 
 ## References
 
-- Release notes for v2.0.0 — migration table.
+- Release notes for v1.39.0 — migration table.
 - `tests/execution/test_commit_lifecycle.py` — the contract test.
 - `docs/user-guide/executions.md` §"Committing output assets" —
   user-facing documentation of the unified surface.

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,6 +1,6 @@
-Version 2.0.0
+Version 1.39.0
 
-**Breaking change: unified upload API.** The four ways to upload execution outputs (`Execution.upload_execution_outputs`, `Execution.upload_outputs`, `ExecutionSnapshot.upload_outputs`, `DerivaML.upload_pending`) collapse into one per-execution method and one batch method. See ADR-0009 for the rationale and the two latent bugs fixed.
+**Breaking-API change shipped as a minor bump.** The four ways to upload execution outputs (`Execution.upload_execution_outputs`, `Execution.upload_outputs`, `ExecutionSnapshot.upload_outputs`, `DerivaML.upload_pending`) collapse into one per-execution method and one batch method. Callers of the removed methods must migrate at upgrade — there are no deprecation shims. Major-version (`v2.0.0`) is deferred until the unified surface has more bake time. See ADR-0009 for the rationale and the two latent bugs fixed.
 
 Migration table:
 
@@ -17,9 +17,9 @@ Migration table:
 - CLI-uploaded executions now correctly transition to `Uploaded` status (were stuck `Stopped`).
 - `exe.upload_outputs()` callers now get asset descriptions written and Upload_Duration recorded (were silently skipped).
 
-Both bugs were present in v1.37.x but only reachable via the legacy methods that v2.0.0 removes.
+Both bugs were present in v1.37.x but only reachable via the legacy methods that v1.39.0 removes.
 
-**Also in this release** (post-v1.37.14, folded into v2.0):
+**Also in this release** (post-v1.37.14, folded into v1.39):
 
 - **`feat(asset,dataset)`: write-through description setters** (#221, closes #70). `Asset.description` and `Dataset.description` now use a `@property` / `@setter` pair that persists assignments to the catalog row, mirroring the symmetric pattern already in place on `Workflow` and `ExecutionRecord`. `update_field_in_catalog` in `execution/_helpers.py` gained an optional `schema_name` parameter so the same helper now serves both ML-schema (Workflow / Execution / Dataset) and domain-schema (Asset) callers.
 - **`fix(execution)`: Output_File directional tag + Execution_Execution exclusion** (#220). `bag_commit._add_asset_rows_to_bag` now auto-adds the `Output_File` directional Asset_Type to every asset uploaded after an execution — restores the public-API contract that every execution-linked asset carries an Input or Output role. `find_asset_execution_tables` excludes `Execution_Execution` (which is an execution-to-execution association, not an asset). Adds a "How execution-asset roles work" section to `docs/user-guide/executions.md` and a 5-test `test_asset_role_contract.py` regression suite.


### PR DESCRIPTION
## Summary

The v2.0.0 tag was premature — per request, the unified
\`commit_output_assets\` surface needs more bake time before
earning the major-version marker. v2.0 should mark a release
we're confident enough in to stand behind for years.

## Walkback already done out-of-band

- Local v2.0.0 tag deleted (\`git tag -d v2.0.0\`)
- Remote v2.0.0 tag deleted (\`git push origin :refs/tags/v2.0.0\`)
- Same commit (\`8d109372\`) re-tagged as v1.39.0
- Tag pushed to origin

## This PR

Docs-only follow-up to match the new tag:

| File | Change |
|---|---|
| \`docs/release-notes.md\` | Header \"Version 2.0.0\" → \"Version 1.39.0\"; inline \"v2.0.0 removes\" / \"folded into v2.0\" references updated |
| \`docs/adr/0009-unified-commit-output-assets.md\` | Three explicit v2.0.0 references updated to v1.39.0. New \"Ship as v2.0.0\" alternative-considered subsection captures the walkback rationale. |

## Downstream impact

**None.** Sibling repos (\`deriva-mcp\` PR #15, \`deriva-ml-model-template\` PR #20) merged against the **same commit** (\`8d109372\`). Their lockfiles record:

\`\`\`
source = { git = \"https://github.com/informatics-isi-edu/deriva-ml.git#8d109372...\" }
\`\`\`

The lockfile pins are by commit hash, not by tag label, so renaming the tag doesn't break their resolution. The sibling-side \`pyproject.toml\` pins (\`deriva-ml >=2.0,<3.0\`) **will not match v1.39.0** if they relock from scratch — but their existing lockfiles continue to resolve to the right commit, so they'll keep working. **Separate follow-up PRs to relax those pins to \`>=1.39,<2.0\` are needed before either repo can do a fresh \`uv sync --refresh\`.**

## Test plan

- [x] No code changes
- [x] No references to v2.0.0 in deriva-ml package itself (other unrelated \`2.0.0\` hits in \`bump_version.py\` / \`upload_layout.py\` / dataset version examples are intentional)
- [x] ADR-0009 captures the rationale for future readers

🤖 Generated with [Claude Code](https://claude.com/claude-code)