### PR TITLE
feat: address 2026-05-25 e2e findings (curator/01, developer/01, setup/06)

### DIFF
--- a/src/deriva_ml/__init__.py
+++ b/src/deriva_ml/__init__.py
@@ -54,6 +54,26 @@ def __getattr__(name: str) -> type:
         from deriva_ml.execution.execution import Execution
 
         return Execution
+    elif name == "ExecutionConfiguration":
+        from deriva_ml.execution.execution_configuration import ExecutionConfiguration
+
+        return ExecutionConfiguration
+    elif name == "Workflow":
+        from deriva_ml.execution.workflow import Workflow
+
+        return Workflow
+    elif name == "Dataset":
+        from deriva_ml.dataset.dataset import Dataset
+
+        return Dataset
+    elif name == "DatasetSpec":
+        from deriva_ml.dataset.aux_classes import DatasetSpec
+
+        return DatasetSpec
+    elif name == "DatasetSpecConfig":
+        from deriva_ml.dataset.aux_classes import DatasetSpecConfig
+
+        return DatasetSpecConfig
     elif name == "Asset":
         from deriva_ml.asset.asset import Asset
 
@@ -101,6 +121,14 @@ __all__ = [
     "DerivaML",  # Lazy-loaded
     "DerivaMLConfig",
     "ConnectionMode",
+    # Execution-authoring surface (lazy-loaded)
+    "Execution",
+    "ExecutionConfiguration",
+    "Workflow",
+    # Dataset classes (lazy-loaded)
+    "Dataset",
+    "DatasetSpec",
+    "DatasetSpecConfig",
     # Asset classes (lazy-loaded)
     "Asset",
     "AssetFilePath",

--- a/src/deriva_ml/asset/asset.py
+++ b/src/deriva_ml/asset/asset.py
@@ -139,7 +139,7 @@ class Asset:
     def __repr__(self) -> str:
         """Return a string representation of the Asset for debugging."""
         return (
-            f"<deriva_ml.Asset at {hex(id(self))}: rid='{self.asset_rid}', "
+            f"<deriva_ml.Asset at {hex(id(self))}: asset_rid='{self.asset_rid}', "
             f"table='{self.asset_table}', file='{self.filename}', types={self._asset_types}>"
         )
 

--- a/src/deriva_ml/config/ast_walker.py
+++ b/src/deriva_ml/config/ast_walker.py
@@ -9,7 +9,7 @@ The four recognized constructor names:
 
 - ``DatasetSpecConfig`` -- dataset entries; ``rid=`` and ``version=`` kwargs
 - ``AssetSpecConfig`` -- asset entries; ``rid=`` (and optional ``cache=``)
-- ``Workflow`` -- workflow entries; ``rid=`` kwarg
+- ``Workflow`` -- workflow entries; ``workflow_rid=`` kwarg
 - ``DerivaMLConfig`` -- connection entries; ``hostname=`` and ``catalog_id=``
 
 Edge cases the walker handles:
@@ -266,7 +266,12 @@ class _CallVisitor(ast.NodeVisitor):
     ) -> ConfigEntry | None:
         """Pull the kwargs off a known constructor call into a :class:`ConfigEntry`."""
         kwargs = _kwarg_map(call)
-        rid = self._resolve_str_value(kwargs.get("rid"))
+        # Workflow uses the scoped name `workflow_rid=`; everything else uses
+        # `rid=`. See the deriva-ml typed-record naming convention (scoped names
+        # across Workflow, Dataset, Execution, Asset; Workflow aligned to this
+        # convention in 2026-05-25 e2e developer/01 finding).
+        rid_kw = "workflow_rid" if kind == "Workflow" else "rid"
+        rid = self._resolve_str_value(kwargs.get(rid_kw))
         version = self._resolve_str_value(kwargs.get("version"))
         hostname = self._resolve_str_value(kwargs.get("hostname"))
 

--- a/src/deriva_ml/config/bootstrap.py
+++ b/src/deriva_ml/config/bootstrap.py
@@ -176,8 +176,8 @@ def _format_asset_spec(rid: str, *, cache: bool = False) -> str:
 
 
 def _format_workflow_spec(rid: str) -> str:
-    """Format a ``Workflow(rid=...)`` line."""
-    return f'Workflow(rid="{rid}")'
+    """Format a ``Workflow(workflow_rid=...)`` line."""
+    return f'Workflow(workflow_rid="{rid}")'
 
 
 def _format_deriva_ml_spec(hostname: str, catalog_id: str) -> str:

--- a/src/deriva_ml/core/mixins/dataset.py
+++ b/src/deriva_ml/core/mixins/dataset.py
@@ -722,8 +722,8 @@ class DatasetMixin:
 
         # Workflow.
         workflow_result: WorkflowSpecResult | None
-        if config.workflow is not None and config.workflow.rid is not None:
-            workflow_result = self._validate_workflow_rid(config.workflow.rid)
+        if config.workflow is not None and config.workflow.workflow_rid is not None:
+            workflow_result = self._validate_workflow_rid(config.workflow.workflow_rid)
         else:
             workflow_result = None
 
@@ -1087,7 +1087,7 @@ class DatasetMixin:
         if "workflow" in requested_kinds:
             workflows = self.find_workflows()  # type: ignore[attr-defined]
             for wf in workflows:
-                wf_rid = getattr(wf, "rid", None)
+                wf_rid = getattr(wf, "workflow_rid", None)
                 if wf_rid is None:
                     continue  # in-memory Workflow without a catalog row
                 wf_name = getattr(wf, "name", "") or ""

--- a/src/deriva_ml/core/mixins/execution.py
+++ b/src/deriva_ml/core/mixins/execution.py
@@ -620,7 +620,7 @@ class ExecutionMixin:
 
         # Filter by specific workflow
         if workflow:
-            workflow_rid = workflow.rid if isinstance(workflow, WorkflowClass) else workflow
+            workflow_rid = workflow.workflow_rid if isinstance(workflow, WorkflowClass) else workflow
             filtered_path = filtered_path.filter(execution_path.Workflow == workflow_rid)
 
         # Filter by workflow type - find workflows with matching type, then filter executions
@@ -1150,9 +1150,9 @@ class ExecutionMixin:
 
         try:
             wf_summary: "WorkflowSummary | None" = None
-            if record.workflow is not None and record.workflow.rid is not None:
+            if record.workflow is not None and record.workflow.workflow_rid is not None:
                 wf_summary = WorkflowSummary(
-                    rid=record.workflow.rid,
+                    rid=record.workflow.workflow_rid,
                     name=record.workflow.name,
                 )
 

--- a/src/deriva_ml/core/mixins/feature.py
+++ b/src/deriva_ml/core/mixins/feature.py
@@ -466,7 +466,7 @@ class FeatureMixin:
                 >>> # ... or by Workflow RID, when you need a specific run:
                 >>> workflow = ml.lookup_workflow("Glaucoma_Training_v2")  # doctest: +SKIP
                 >>> sel = FeatureRecord.select_by_workflow(  # doctest: +SKIP
-                ...     workflow.rid, container=ml,
+                ...     workflow.workflow_rid, container=ml,
                 ... )
                 >>> labels = [r.Glaucoma for r in ml.feature_values(  # doctest: +SKIP
                 ...     "Image", "Glaucoma", selector=sel,

--- a/src/deriva_ml/execution/execution_record.py
+++ b/src/deriva_ml/execution/execution_record.py
@@ -200,7 +200,7 @@ class ExecutionRecord(BaseModel):
         Returns:
             The workflow RID, or None if no workflow is associated.
         """
-        return self._workflow.rid if self._workflow else None
+        return self._workflow.workflow_rid if self._workflow else None
 
     @property
     def status(self) -> ExecutionStatus:

--- a/src/deriva_ml/execution/workflow.py
+++ b/src/deriva_ml/execution/workflow.py
@@ -62,7 +62,7 @@ class Workflow(BaseModel):
         description (str | None): Description of workflow purpose and behavior.
             When the workflow is bound to a writable catalog, setting this property
             will update the catalog record.
-        rid (RID | None): Resource Identifier if registered in catalog.
+        workflow_rid (RID | None): Resource Identifier if registered in catalog.
         checksum (str | None): Git hash of workflow source code.
         is_notebook (bool): Whether workflow is a Jupyter notebook.
 
@@ -116,7 +116,7 @@ class Workflow(BaseModel):
     description: str | None = None
     url: str | None = None
     version: str | None = None
-    rid: RID | None = None
+    workflow_rid: RID | None = None
     checksum: str | None = None
     is_notebook: bool = False
     git_root: Path | None = None
@@ -193,7 +193,7 @@ class Workflow(BaseModel):
         from deriva_ml.execution._helpers import check_writable_catalog
 
         check_writable_catalog(
-            rid=self.rid,
+            rid=self.workflow_rid,
             ml_instance=self._ml_instance,
             entity_label="Workflow",
             operation=operation,
@@ -216,7 +216,7 @@ class Workflow(BaseModel):
 
         self._check_writable_catalog("update description")
         update_field_in_catalog(
-            rid=self.rid,
+            rid=self.workflow_rid,
             ml_instance=self._ml_instance,
             table_name="Workflow",
             updates={"Description": new_description},
@@ -249,7 +249,7 @@ class Workflow(BaseModel):
         if self._ml_instance is not None:
             _, atable_path = self._get_workflow_type_association_table()
             wt_types = (
-                atable_path.filter(atable_path.Workflow == self.rid).attributes(atable_path.Workflow_Type).fetch()
+                atable_path.filter(atable_path.Workflow == self.workflow_rid).attributes(atable_path.Workflow_Type).fetch()
             )
             return [wt[MLVocab.workflow_type] for wt in wt_types]
         return list(self.workflow_type)
@@ -278,7 +278,7 @@ class Workflow(BaseModel):
             return
 
         _, atable_path = self._get_workflow_type_association_table()
-        atable_path.insert([{MLVocab.workflow_type: vocab_term.name, "Workflow": self.rid}])
+        atable_path.insert([{MLVocab.workflow_type: vocab_term.name, "Workflow": self.workflow_rid}])
 
     def remove_workflow_type(self, workflow_type: str | VocabularyTerm) -> None:
         """Remove a workflow type from this workflow.
@@ -303,7 +303,7 @@ class Workflow(BaseModel):
             return
 
         _, atable_path = self._get_workflow_type_association_table()
-        atable_path.filter((atable_path.Workflow == self.rid) & (atable_path.Workflow_Type == vocab_term.name)).delete()
+        atable_path.filter((atable_path.Workflow == self.workflow_rid) & (atable_path.Workflow_Type == vocab_term.name)).delete()
 
     def add_workflow_types(self, workflow_types: str | VocabularyTerm | list[str | VocabularyTerm]) -> None:
         """Add one or more workflow types to this workflow.
@@ -343,11 +343,11 @@ class Workflow(BaseModel):
 
         # Delete all existing type associations
         _, atable_path = self._get_workflow_type_association_table()
-        atable_path.filter(atable_path.Workflow == self.rid).delete()
+        atable_path.filter(atable_path.Workflow == self.workflow_rid).delete()
 
         # Insert new type associations
         if new_workflow_types:
-            atable_path.insert([{MLVocab.workflow_type: wt, "Workflow": self.rid} for wt in new_workflow_types])
+            atable_path.insert([{MLVocab.workflow_type: wt, "Workflow": self.workflow_rid} for wt in new_workflow_types])
 
     @model_validator(mode="after")
     def setup_url_checksum(self) -> "Workflow":

--- a/src/deriva_ml/schema/__init__.py
+++ b/src/deriva_ml/schema/__init__.py
@@ -1,7 +1,13 @@
-from deriva_ml.schema.create_schema import create_ml_catalog, create_ml_schema, initialize_ml_schema
+from deriva_ml.schema.create_schema import (
+    create_ml_catalog,
+    create_ml_schema,
+    create_or_retarget_ml_catalog,
+    initialize_ml_schema,
+)
 
 __all__ = [
     "create_ml_catalog",
+    "create_or_retarget_ml_catalog",
     "create_ml_schema",
     "initialize_ml_schema",
 ]

--- a/src/deriva_ml/schema/create_schema.py
+++ b/src/deriva_ml/schema/create_schema.py
@@ -709,8 +709,74 @@ def create_ml_catalog(
     return catalog
 
 
+def create_or_retarget_ml_catalog(
+    hostname: str,
+    project_name: str,
+    *,
+    alias: str | None = None,
+) -> ErmrestCatalog:
+    """Create a new ML catalog and point ``alias`` at it.
+
+    Idempotent on ``alias``: re-running with the same alias always yields a
+    *fresh* catalog reachable via that alias. The previously-aliased catalog
+    (if any) is left in place — its numeric id is preserved, but the alias
+    no longer resolves to it. Callers who want the orphan deleted must do so
+    explicitly (e.g. via ``server.delete_ermrest_catalog(old_id)``).
+
+    Compare with :func:`create_ml_catalog`, which always creates a new alias
+    and refuses if one with the same name exists. ``create_or_retarget_ml_catalog``
+    is the right call when the alias is a *stable handle* for "the current
+    catalog of project X" rather than a one-shot decoration.
+
+    Args:
+        hostname: Server hostname (e.g., "localhost", "www.eye-ai.org").
+        project_name: Name for the project, becomes the domain schema name.
+        alias: Optional alias name. When given, retargets the alias if it
+            already exists, otherwise creates a new one. When ``None``,
+            behaves identically to :func:`create_ml_catalog` with no alias
+            (the caller must track the numeric id themselves).
+
+    Returns:
+        The created ``ErmrestCatalog`` instance. Callers can read
+        ``catalog.catalog_id`` for the numeric id. The alias (if any) points
+        to this catalog after the call returns.
+
+    Example:
+        >>> # Re-run after a successful run that lost track of the id:
+        >>> catalog = create_or_retarget_ml_catalog(  # doctest: +SKIP
+        ...     "localhost", "my_project", alias="my-project-dev"
+        ... )
+        >>> # The old catalog at the old id still exists; the alias now
+        >>> # resolves to the new catalog. Delete the orphan separately
+        >>> # if desired.
+    """
+    # Always create a new catalog first.
+    new_catalog = create_ml_catalog(hostname, project_name, catalog_alias=None)
+
+    if alias is None:
+        return new_catalog
+
+    # Look up the alias. If it exists, retarget. If not, create.
+    server = new_catalog.deriva_server
+    try:
+        existing_alias = server.connect_ermrest_alias(alias)
+        # Retarget to the new catalog.
+        existing_alias.update(alias_target=str(new_catalog.catalog_id))
+    except Exception:
+        # Alias doesn't exist; create it.
+        server.create_ermrest_alias(
+            id=alias,
+            alias_target=new_catalog.catalog_id,
+            name=project_name,
+            description=f"Alias for {project_name} catalog (ID: {new_catalog.catalog_id})",
+        )
+
+    return new_catalog
+
+
 __all__ = [
     "create_ml_catalog",
+    "create_or_retarget_ml_catalog",
     "create_ml_schema",
     "initialize_ml_schema",
 ]

--- a/tests/config/test_ast_walker.py
+++ b/tests/config/test_ast_walker.py
@@ -72,7 +72,7 @@ def test_bare_workflow(tmp_path: Path) -> None:
     path = _write(
         tmp_path,
         """
-workflow_store(name="t", spec=Workflow(rid="1-CCCC"))
+workflow_store(name="t", spec=Workflow(workflow_rid="1-CCCC"))
 """,
     )
     entries, err = parse_config_file(path)
@@ -114,12 +114,12 @@ datasets_store(
 
 
 def test_builds_with_known_class(tmp_path: Path) -> None:
-    """``builds(Workflow, rid=...)`` is treated as the Workflow class."""
+    """``builds(Workflow, workflow_rid=...)`` is treated as the Workflow class."""
     path = _write(
         tmp_path,
         """
 from hydra_zen import builds
-workflow_store(name="t", spec=builds(Workflow, rid="1-DDDD"))
+workflow_store(name="t", spec=builds(Workflow, workflow_rid="1-DDDD"))
 """,
     )
     entries, err = parse_config_file(path)

--- a/tests/config/test_bootstrap.py
+++ b/tests/config/test_bootstrap.py
@@ -43,7 +43,7 @@ class _StubAssetTable:
 
 @dataclass
 class _StubWorkflow:
-    rid: str
+    workflow_rid: str
     name: str = ""
 
 
@@ -103,7 +103,7 @@ def test_bootstrap_returns_one_per_kind_minimum() -> None:
         assets_by_table={
             "Image": [_StubAsset(asset_rid="1-BBBB", filename="model_weights.pt")],
         },
-        workflows=[_StubWorkflow(rid="1-CCCC", name="train_cifar10")],
+        workflows=[_StubWorkflow(workflow_rid="1-CCCC", name="train_cifar10")],
     )
     report = ml.bootstrap_config()
 
@@ -231,7 +231,7 @@ def test_kinds_gates_what_is_returned() -> None:
         datasets=[_StubDataset(dataset_rid="1-AA", dataset_types=["Training"])],
         asset_tables=[_StubAssetTable(name="Image")],
         assets_by_table={"Image": [_StubAsset(asset_rid="1-BB")]},
-        workflows=[_StubWorkflow(rid="1-CC")],
+        workflows=[_StubWorkflow(workflow_rid="1-CC")],
     )
     report = ml.bootstrap_config(kinds=["datasets"])
     assert {s.kind for s in report.suggestions} == {"datasets"}
@@ -285,8 +285,8 @@ def test_workflow_with_no_rid_is_silently_dropped() -> None:
     """An in-memory Workflow without a catalog RID isn't suggested."""
     ml = _StubMixin(
         workflows=[
-            _StubWorkflow(rid="1-AA", name="trainer"),
-            _StubWorkflow(rid=None, name="just-in-memory"),  # type: ignore[arg-type]
+            _StubWorkflow(workflow_rid="1-AA", name="trainer"),
+            _StubWorkflow(workflow_rid=None, name="just-in-memory"),  # type: ignore[arg-type]
         ],
     )
     report = ml.bootstrap_config(kinds=["workflow"])
@@ -355,10 +355,10 @@ def test_asset_spec_string_is_ready_to_paste() -> None:
 
 
 def test_workflow_spec_string_is_ready_to_paste() -> None:
-    ml = _StubMixin(workflows=[_StubWorkflow(rid="1-CC")])
+    ml = _StubMixin(workflows=[_StubWorkflow(workflow_rid="1-CC")])
     report = ml.bootstrap_config(kinds=["workflow"])
     s = report.suggestions[0]
-    assert s.spec_string == 'Workflow(rid="1-CC")'
+    assert s.spec_string == 'Workflow(workflow_rid="1-CC")'
 
 
 def test_deriva_ml_spec_string_uses_connection_state() -> None:

--- a/tests/config/test_validate_config_file.py
+++ b/tests/config/test_validate_config_file.py
@@ -132,7 +132,7 @@ def test_clean_config_returns_all_valid(tmp_path: Path) -> None:
     src = """
 datasets_store(name="train", spec=DatasetSpecConfig(rid="1-AAAA", version="0.1.0"))
 assets_store(name="w", spec=AssetSpecConfig(rid="1-BBBB", cache=True))
-workflow_store(name="t", spec=Workflow(rid="1-CCCC"))
+workflow_store(name="t", spec=Workflow(workflow_rid="1-CCCC"))
 deriva_store(DerivaMLConfig, hostname="data.example.org", catalog_id="42")
 """
     path = _write(tmp_path, src)
@@ -302,7 +302,7 @@ def test_asset_not_found(tmp_path: Path) -> None:
 
 
 def test_workflow_not_a_workflow(tmp_path: Path) -> None:
-    src = 'workflow_store(name="t", spec=Workflow(rid="1-WRNG"))\n'
+    src = 'workflow_store(name="t", spec=Workflow(workflow_rid="1-WRNG"))\n'
     path = _write(tmp_path, src)
     ml = _StubMixin(
         workflow_results_by_rid={

--- a/tests/core/test_hydra_zen_config.py
+++ b/tests/core/test_hydra_zen_config.py
@@ -215,7 +215,7 @@ class TestHydraZenExecutionConfiguration:
             name="Test Workflow",
             workflow_type="python_script",
             description="Test workflow description",
-            rid="WXYZ",
+            workflow_rid="WXYZ",
         )
 
         exec_config = ExecutionConfiguration(
@@ -224,7 +224,7 @@ class TestHydraZenExecutionConfiguration:
         )
 
         assert exec_config.workflow is workflow
-        assert exec_config.workflow.rid == "WXYZ"
+        assert exec_config.workflow.workflow_rid == "WXYZ"
         assert exec_config.workflow.name == "Test Workflow"
 
     def test_make_config_for_custom_execution(self):

--- a/tests/dataset/test_validate_specs_live.py
+++ b/tests/dataset/test_validate_specs_live.py
@@ -113,9 +113,9 @@ def test_validate_execution_configuration_live_workflow_rid_is_dataset(test_ml):
         workflow_type="Validate Test",
         description="composite smoke",
     )
-    # Mutate the wf object so its rid points at the dataset (no catalog
-    # round-trip — composite validator only reads config.workflow.rid).
-    wf_swapped = wf.model_copy(update={"rid": rid})
+    # Mutate the wf object so its workflow_rid points at the dataset (no catalog
+    # round-trip — composite validator only reads config.workflow.workflow_rid).
+    wf_swapped = wf.model_copy(update={"workflow_rid": rid})
     config = ExecutionConfiguration(workflow=wf_swapped)
     report = test_ml.validate_execution_configuration(config)
     assert report.all_valid is False

--- a/tests/execution/test_execution.py
+++ b/tests/execution/test_execution.py
@@ -150,12 +150,12 @@ class TestWorkflow:
 
         # Verify lookup_workflow_by_url returns the workflow
         looked_up_workflow = ml_instance.lookup_workflow_by_url(workflow_url)
-        assert looked_up_workflow.rid == workflow_rid
+        assert looked_up_workflow.workflow_rid == workflow_rid
         assert looked_up_workflow.url == workflow_url
 
         # Verify lookup_workflow works with RID
         looked_up_workflow_by_rid = ml_instance.lookup_workflow(workflow_rid)
-        assert looked_up_workflow_by_rid.rid == workflow_rid
+        assert looked_up_workflow_by_rid.workflow_rid == workflow_rid
         assert looked_up_workflow_by_rid.url == workflow_url
 
         # Verify running again doesn't duplicate

--- a/tests/experiment/test_experiment.py
+++ b/tests/experiment/test_experiment.py
@@ -487,7 +487,7 @@ class TestExperimentFinder:
         ml = execution_with_hydra_config._ml_object
 
         # Find experiments by workflow RID
-        experiments = list(ml.find_experiments(workflow_rid=test_workflow.rid))
+        experiments = list(ml.find_experiments(workflow_rid=test_workflow.workflow_rid))
 
         # The execution with hydra config was created with test_workflow
         experiment_rids = [e.execution_rid for e in experiments]
@@ -526,7 +526,7 @@ class TestExperimentFinder:
         # Find uploaded experiments for the specific workflow
         experiments = list(
             ml.find_experiments(
-                workflow_rid=test_workflow.rid,
+                workflow_rid=test_workflow.workflow_rid,
                 status=ExecutionStatus.Uploaded,
             )
         )


### PR DESCRIPTION
## Summary

Three findings from the 2026-05-25 multipersona e2e run, landed in one PR. All pure additive or breaking-rename work; no behavior changes to existing happy paths.

### curator/01 — Broader top-level re-exports (Low)

Add to `deriva_ml/__init__.py` lazy `__getattr__` + `__all__`:
- `ExecutionConfiguration`, `Workflow`
- `Dataset`, `DatasetSpec`, `DatasetSpecConfig`

Symmetric with already-exposed Asset family (`Asset`, `AssetSpec`, `AssetSpecConfig`, `AssetFilePath`). Now every class users name in a hydra-zen config or bootstrap script imports from the package root — eliminates the friction the Curator hit when `from deriva_ml import ExecutionConfiguration` failed.

### developer/01 — `Workflow.rid` → `Workflow.workflow_rid`; Asset repr fix (Low)

The DerivaML typed-record naming convention is **scoped names**: `dataset_rid`, `execution_rid`, `asset_rid`. Workflow was the outlier with bare `rid`. Renamed for consistency — **clean rename, no alias, no deprecation cycle**.

Touched: `workflow.py` (model field + docstring), all internal call sites (mixins/{dataset,execution,feature}.py, execution_record.py, ast_walker.py, bootstrap.py emitter, walker's kwarg lookup), 5 test files (incl. `_StubWorkflow`).

Also fixed: `Asset.__repr__` printed `rid='…'` while the actual attribute is `asset_rid`. Now shows `asset_rid='…'` so "type what you see" works.

**Breaking:** any external caller using `w.rid` on a `Workflow` instance will break. Per user direction, no compat shim.

### setup/06 — New `create_or_retarget_ml_catalog` helper (Medium)

New library helper in `deriva_ml.schema`:

```python
create_or_retarget_ml_catalog(hostname, project_name, *, alias=None)
```

Always creates a fresh catalog. If `alias` is given:
- Existing alias: retarget to new catalog (old one orphaned, not deleted)
- No existing alias: create one

Makes `--create-catalog NAME` (in the model template) idempotent on NAME from the user's perspective: NAME always resolves to a fresh catalog. The previously-aliased catalog is left in place — callers delete explicitly if needed.

Uses `ErmrestAlias.update(alias_target=...)` for the retarget (confirmed available in deriva-py).

## Test plan

- [x] `DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/config tests/core` — 251 passed, 11 skipped
- [x] Smoke-test: all 11 top-level package exports import cleanly
- [x] Smoke-test: `Workflow(workflow_rid=...)` constructs; `Workflow(rid=...)` rejected by pydantic
- [x] Smoke-test: `from deriva_ml.schema import create_or_retarget_ml_catalog` works
- [ ] Reviewer: full test sweep (`uv run pytest tests/`) before merge

## Companion PR

deriva-ml-model-template will switch `_cifar10_schema.create_or_connect_catalog` to call `create_or_retarget_ml_catalog` once this lands and releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)