### PR TITLE
docs: add 'experiments are GitHub repositories' framing

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,20 @@ using a deriva catalog.
 
 Complete on-line documentation for DerivaML can be found [here](https://informatics-isi-edu.github.io/deriva-ml/)
 
-To get started using DerivaML, you can clone the [model template repository](https://github.com/informatics-isi-edu/deriva-ml-model-template), and modify it to suite your requirements.
+## Experiments
+
+DerivaML organizes ML activities into **experiments**. An experiment is a
+**GitHub repository** that holds the *executable* and *human-readable* sides
+of a research project — model code, hydra-zen configurations, and a
+`tacit-knowledge.md` capturing the *why* behind project decisions. The catalog
+stores the *what* (data, RIDs, lineage); the experiment repository stores
+the *how* and the *why*. Every execution from the repo records the git commit
+hash on its Workflow row, so a result traces to the exact code that produced
+it.
+
+To bootstrap a new experiment, clone the
+[deriva-ml-model-template repository](https://github.com/informatics-isi-edu/deriva-ml-model-template)
+and modify it to suit your requirements.
 
 ## API verb conventions
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -48,22 +48,42 @@ Weaker fit:
 See also: _Deriva-ML: A Continuous FAIRness Approach to Reproducible
 Machine Learning Models_ (Li et al., 2024, IEEE e-Science).
 
-## Starting a new project
+## Experiments
 
-To start a new deriva-ml project, use the
+DerivaML organizes ML activities into **experiments**. An experiment is a
+**GitHub repository** that holds the *executable* and *human-readable*
+sides of a research project; the catalog stores the *what* (data, RIDs,
+lineage), the experiment repository stores the *how* and the *why*:
+
+- **Code** — model implementations, data-loading scripts, notebooks.
+- **Configuration** — hydra-zen configs (Python, not YAML) declaring
+  which catalog, which datasets, which workflow, which hyperparameters.
+- **Tacit knowledge** — `tacit-knowledge.md` at the repo root, capturing
+  the *why* behind decisions, dead ends explored, and the project's
+  conventions.
+- **Provenance link** — every execution from this repo records the git
+  commit hash on the `Workflow` row, so a result can be traced to the
+  exact code that produced it.
+
+### Starting a new experiment
+
+Bootstrap a new experiment from the
 [deriva-ml-model-template repository](https://github.com/informatics-isi-edu/deriva-ml-model-template).
 It provides:
 
 - Hydra-zen configuration scaffolding
 - CLI entry points (`deriva-ml-run`, `deriva-ml-run-notebook`)
 - GitHub Actions for versioning and documentation deployment
-- An example model (CIFAR-10) with config variants
+- An example model (CIFAR-10) with config variants you can replace with
+  your own
+- A `tacit-knowledge.md` skeleton ready for your project's first entry
 
 These docs cover the deriva-ml library itself, for developers who already
-have a project and want to understand the library's concepts and APIs.
-Start with the [User Guide](user-guide/exploring.md) for a task-oriented
-walkthrough, or jump to the [API Reference](api-reference/deriva_ml_base.md)
-for per-method documentation.
+have an experiment repository and want to understand the library's
+concepts and APIs. Start with the [User Guide](user-guide/exploring.md)
+for a task-oriented walkthrough, or jump to the
+[API Reference](api-reference/deriva_ml_base.md) for per-method
+documentation.
 
 ## Further reading
 


### PR DESCRIPTION
## Summary

Adds the missing high-level framing: **DerivaML organizes ML activities into *experiments*. An experiment is a GitHub repository.** Updates `README.md` and `docs/index.md`.

The catalog stores the *what* (data, RIDs, lineage); the experiment repository stores the *how* (code + hydra-zen configs) and the *why* (`tacit-knowledge.md`). Every execution records the git commit hash on its Workflow row, so a result traces to the exact code that produced it.

This was implicit in everything DerivaML does but never named in the project's own docs. The 2026-05-25 e2e revealed that persona agents had to infer it from implementation details.

## What changed

### `docs/index.md`

Replaced "Starting a new project" section with two sections:
- **Experiments**: names the concept; lists the four things an experiment repo contains (code, configuration, tacit knowledge, provenance link)
- **Starting a new experiment**: retains the model-template bootstrap text with one new bullet — "A tacit-knowledge.md skeleton ready for your project's first entry"

### `README.md`

Replaced the one-liner about the model template with a "Experiments" section that names the concept + bootstrap path. Sits above the existing "API verb conventions" section.

## Companion PR

`deriva-ml-skills/feat/experiment-framing-in-context` adds the same framing to the `deriva-ml-context` skill (always-loaded), so agents working in any deriva-ml session have the framing in context.

## Test plan

- [ ] Read `docs/index.md` top-to-bottom; does the new section ordering read naturally?
- [ ] Read `README.md`; does the new section sit well between the docs link and the API verb conventions?
- [ ] Is the "GitHub repository" framing accurate — are there any deriva-ml uses where an experiment is *not* a github repo (e.g., a notebook-only workflow)?

🤖 Generated with [Claude Code](https://claude.com/claude-code)