### PR TITLE
fix(denormalize): resolve feature names in include_tables to feature tables

### DIFF
--- a/src/deriva_ml/local_db/denormalizer.py
+++ b/src/deriva_ml/local_db/denormalizer.py
@@ -528,6 +528,13 @@ class Denormalizer:
         """
         from deriva_ml.model.catalog import denormalize_column_name
 
+        # Translate feature names to feature-association table names so
+        # ``columns`` accepts the same caller-friendly inputs as
+        # ``as_dataframe`` (the symmetry is half the point of this
+        # method — preview the run's column list cheaply).
+        include_resolved, via_resolved, row_per_resolved = self._resolve_table_names(
+            list(include_tables), via=via, row_per=row_per
+        )
         # Invoke the planner on the model alone. _prepare_wide_table runs
         # the Rule 2/5/6 guards and returns the column spec list. Walking
         # that list with denormalize_column_name gives us the final
@@ -535,9 +542,9 @@ class Denormalizer:
         element_tables, column_specs, multi_schema = self._model._planner._prepare_wide_table(
             self._dataset,
             self._dataset_rid,
-            list(include_tables),
-            row_per=row_per,
-            via=via,
+            include_resolved,
+            row_per=row_per_resolved,
+            via=via_resolved,
         )
         return [(denormalize_column_name(s, t, c, multi_schema), tp) for s, t, c, tp in column_specs]
 
@@ -624,8 +631,23 @@ class Denormalizer:
         from deriva_ml.core.exceptions import DerivaMLDenormalizeError
         from deriva_ml.model.catalog import denormalize_column_name
 
-        include = list(include_tables)
-        via_list = list(via or [])
+        original_include = list(include_tables)
+        original_via = list(via or [])
+
+        # ── feature-name resolution ─────────────────────────────────────────
+        # Translate feature names ("Image_Classification") to their
+        # underlying feature-association tables
+        # ("Execution_Image_Image_Classification") so describe and
+        # ``as_dataframe`` agree on what's a valid ``include_tables``
+        # entry. The dry-run invariant says describe never raises, so
+        # any resolution failure (typo, ambiguous feature) collapses
+        # to the original inputs and the downstream planner calls
+        # surface the failure as empty fields in the returned dict.
+        try:
+            include, via_list, row_per = self._resolve_table_names(original_include, via=original_via, row_per=row_per)
+        except Exception:
+            include = original_include
+            via_list = original_via
 
         # ── row_per resolution ─────────────────────────────────────────────
         # Dry-run invariant: describe() never raises. Every call that could
@@ -759,13 +781,9 @@ class Denormalizer:
                 # (case 1, exact contribution) and "anchors elsewhere
                 # but reaching row_per via FK chain" (case 2, unknown
                 # fan-out).
-                at_row_per_count = sum(
-                    len(rids) for table, rids in scoping.items() if table == resolved_row_per
-                )
+                at_row_per_count = sum(len(rids) for table, rids in scoping.items() if table == resolved_row_per)
                 downstream_anchor_tables = [
-                    table
-                    for table, rids in scoping.items()
-                    if table != resolved_row_per and rids
+                    table for table, rids in scoping.items() if table != resolved_row_per and rids
                 ]
                 orphan_count = sum(len(rids) for rids in orphans.values())
 
@@ -937,6 +955,146 @@ class Denormalizer:
     # Private helpers
     # ------------------------------------------------------------------
 
+    def _resolve_table_names(
+        self,
+        include_tables: list[str],
+        *,
+        via: list[str] | None = None,
+        row_per: str | None = None,
+    ) -> tuple[list[str], list[str], str | None]:
+        """Translate caller-supplied names into canonical table names.
+
+        Both :meth:`describe` and :meth:`as_dataframe` accept tables in
+        ``include_tables`` / ``via`` / ``row_per`` by name. The natural
+        mental model — confirmed by the rest of the DerivaML surface
+        (:meth:`find_features`, :meth:`feature_values`,
+        :meth:`lookup_feature`) — uses the **feature name** (e.g.
+        ``"Image_Classification"``) rather than the underlying
+        feature-association table name (e.g.
+        ``"Execution_Image_Image_Classification"``). This helper
+        accepts either form: real table names pass through unchanged;
+        feature names are silently substituted for their backing
+        association table.
+
+        Resolution algorithm for each name:
+
+        1. If ``name_to_table(t)`` succeeds → keep ``t`` as-is.
+        2. Otherwise consult :meth:`DerivaModel.find_features` and look
+           for a feature whose ``feature_name == t``. If exactly one
+           match → substitute with ``feature.feature_table.name``. If
+           multiple matches across different target tables → raise
+           :class:`DerivaMLDenormalizeError` (ambiguous — caller should
+           name the feature table directly).
+        3. If neither path works → raise
+           :class:`DerivaMLTableNotFound`. When the name doesn't match
+           any feature either, the error makes clear that no table or
+           feature with that name exists, so the user can tell whether
+           they typo'd a feature name or pointed at the wrong feature.
+
+        Args:
+            include_tables: Caller's ``include_tables`` (mixed table
+                names and feature names allowed).
+            via: Caller's ``via`` argument.
+            row_per: Caller's ``row_per`` argument.
+
+        Returns:
+            Tuple of ``(resolved_include_tables, resolved_via,
+            resolved_row_per)`` — all canonical table names that
+            ``name_to_table`` will accept.
+
+        Raises:
+            DerivaMLTableNotFound: A name doesn't match any catalog
+                table and isn't a known feature name either. The
+                error message names the offending entry so the user
+                knows whether to fix a typo or pick a different
+                feature.
+            DerivaMLDenormalizeError: A feature name matches multiple
+                features on different target tables — the helper
+                can't disambiguate so the caller must pass the
+                feature-association table name directly.
+
+        Example::
+
+            # Feature name silently resolves to the feature-association table.
+            d._resolve_table_names(["Image", "Image_Classification"])
+            # (["Image", "Execution_Image_Image_Classification"], [], None)
+
+            # Real table names pass through untouched.
+            d._resolve_table_names(["Image", "Subject"])
+            # (["Image", "Subject"], [], None)
+        """
+        from deriva_ml.core.exceptions import (
+            DerivaMLDenormalizeError,
+            DerivaMLException,
+            DerivaMLTableNotFound,
+        )
+
+        # The model may be None on minimal fixtures; in that case we
+        # have no way to resolve names, so return inputs unchanged and
+        # let downstream planner validation produce its own error.
+        if self._model is None:
+            return list(include_tables), list(via or []), row_per
+
+        # Build the {feature_name: [feature]} index once per call.
+        # ``find_features()`` walks every association in the catalog
+        # so we don't want to re-run it for each name in the inputs.
+        # Failures (no find_features, network errors) collapse to an
+        # empty index — the helper then falls through to the
+        # table-not-found branch and the caller gets the original
+        # error.
+        feature_index: dict[str, list[Any]] = {}
+        find_feats = getattr(self._model, "find_features", None)
+        if callable(find_feats):
+            try:
+                for f in find_feats():
+                    fname = getattr(f, "feature_name", None)
+                    if fname:
+                        feature_index.setdefault(fname, []).append(f)
+            except Exception:
+                feature_index = {}
+
+        def _resolve_one(t: str) -> str:
+            """Return canonical table name for ``t`` or raise."""
+            try:
+                self._model.name_to_table(t)
+                return t
+            except DerivaMLException:
+                pass
+            # Not a table — try the feature index.
+            matches = feature_index.get(t, [])
+            if len(matches) == 1:
+                resolved_name = matches[0].feature_table.name
+                logger.info(
+                    "Denormalizer: resolved feature name %r to feature table %r",
+                    t,
+                    resolved_name,
+                )
+                return resolved_name
+            if len(matches) > 1:
+                target_tables = sorted({m.target_table.name for m in matches})
+                feature_tables = sorted({m.feature_table.name for m in matches})
+                raise DerivaMLDenormalizeError(
+                    f"Feature name {t!r} is ambiguous — it is defined on "
+                    f"multiple target tables ({target_tables}). Pass the "
+                    f"feature-association table name directly instead: "
+                    f"one of {feature_tables}."
+                )
+            # Not a table and not a feature name. Distinguish the
+            # error so the user knows it isn't a near-miss for a
+            # feature they typed badly.
+            known_features = sorted(feature_index.keys())
+            if known_features:
+                raise DerivaMLTableNotFound(
+                    t,
+                    msg=(f"No table or feature named {t!r} exists. Known feature names: {known_features}"),
+                )
+            raise DerivaMLTableNotFound(t)
+
+        resolved_include = [_resolve_one(t) for t in include_tables]
+        resolved_via = [_resolve_one(t) for t in (via or [])]
+        resolved_row_per = _resolve_one(row_per) if row_per is not None else None
+        return resolved_include, resolved_via, resolved_row_per
+
     def _run(
         self,
         include_tables: list[str],
@@ -978,6 +1136,19 @@ class Denormalizer:
             The final :class:`DenormalizeResult` — main SQL rows plus
             any orphan rows appended.
         """
+        # Step 0: translate feature names to feature-association table
+        # names so the caller can pass either form. This is what makes
+        # ``include_tables=["Image", "Image_Classification"]`` work
+        # symmetrically with the rest of the DerivaML surface
+        # (``find_features``, ``feature_values``, ``lookup_feature``) —
+        # see ``_resolve_table_names`` for the algorithm. Validation
+        # errors (typo'd name, ambiguous feature) surface here, before
+        # any planner work.
+        include_tables, via_resolved, row_per = self._resolve_table_names(
+            list(include_tables), via=via, row_per=row_per
+        )
+        via = via_resolved
+
         # Step 1: planner decisions (row_per, ambiguity checks).
         # _determine_row_per either validates an explicit row_per
         # (raising DownstreamLeaf if a downstream table is in

--- a/tests/local_db/test_denormalizer.py
+++ b/tests/local_db/test_denormalizer.py
@@ -542,6 +542,176 @@ class TestDescribe:
         assert plan["row_per"] is None
 
 
+class TestFeatureNameResolution:
+    """``_resolve_table_names`` translates feature names to feature tables.
+
+    Both ``describe_denormalized`` and ``get_denormalized_as_dataframe``
+    accept feature names (e.g. ``"Image_Classification"``) in
+    ``include_tables`` even though the underlying catalog entity is a
+    feature-association table (e.g.
+    ``"Execution_Image_Image_Classification"``). The shared resolver
+    silently substitutes feature names for their backing tables so the
+    two methods agree on what's a valid ``include_tables`` entry.
+
+    These tests stub ``find_features`` on the canned model so we don't
+    have to spin up a feature-aware bag fixture — the resolver only
+    needs the index ``{feature_name: [Feature]}`` to operate.
+    """
+
+    @staticmethod
+    def _stub_find_features(model, mapping):
+        """Monkey-patch ``model.find_features`` to return synthetic features.
+
+        Args:
+            model: The DerivaModel under test.
+            mapping: ``{feature_name: feature_table_name}`` — each entry
+                produces a synthetic Feature wrapping the named tables
+                from ``model.name_to_table``.
+        """
+
+        class _StubFeature:
+            def __init__(self, feature_name, feature_table, target_table):
+                self.feature_name = feature_name
+                self.feature_table = feature_table
+                self.target_table = target_table
+
+        features = []
+        for fname, table_name in mapping.items():
+            tbl = model.name_to_table(table_name)
+            # Pick a deterministic target — the Image table is the
+            # universal sink in the canned fixture.
+            target = model.name_to_table("Image")
+            features.append(_StubFeature(fname, tbl, target))
+        model.find_features = lambda table=None: features
+
+    def test_run_accepts_feature_name_as_include_table(self, populated_denorm) -> None:
+        """``as_dataframe(include_tables=[feature_name])`` runs the same
+        as if the user had passed the feature-association table name.
+
+        Pre-fix: ``name_to_table("Image_Classification")`` would raise
+        because the catalog only has ``Execution_Image_Image_Classification``.
+        Post-fix: the resolver substitutes silently.
+        """
+        # In the canned fixture, Subject is a plain table — we stub
+        # the model so the planner sees a feature called "ClassifiedAs"
+        # backed by the existing "Subject" table. The data is the same;
+        # we just verify the substitution wires through end-to-end.
+        ds = _FakeDataset(populated_denorm)
+        d = Denormalizer(ds)
+        self._stub_find_features(populated_denorm["model"], {"ClassifiedAs": "Subject"})
+
+        df_via_feature = d.as_dataframe(["Image", "ClassifiedAs"])
+        df_via_table = d.as_dataframe(["Image", "Subject"])
+        # Same shape — the feature name was resolved to Subject before
+        # the planner ran.
+        assert len(df_via_feature) == len(df_via_table)
+        assert list(df_via_feature.columns) == list(df_via_table.columns)
+
+    def test_describe_accepts_feature_name(self, populated_denorm) -> None:
+        """``describe(include_tables=[feature_name])`` produces a plan
+        whose ``row_per_candidates`` reflects the resolved table — not
+        the raw feature name, so describe and run agree."""
+        ds = _FakeDataset(populated_denorm)
+        d = Denormalizer(ds)
+        self._stub_find_features(populated_denorm["model"], {"ClassifiedAs": "Subject"})
+
+        plan = d.describe(["Image", "ClassifiedAs"])
+        # Resolved name, not the raw feature name.
+        assert "Subject" in plan["include_tables"]
+        assert "ClassifiedAs" not in plan["include_tables"]
+        # The plan agrees with what run would produce.
+        assert plan["row_per"] == "Image"
+
+    def test_describe_and_run_agree(self, populated_denorm) -> None:
+        """The Analyst's preferred-fix invariant: describe and run agree
+        on what's a valid ``include_tables`` entry.
+
+        Originally surfaced in the 2026-05-26 multipersona e2e —
+        ``describe_denormalized(include_tables=["Image",
+        "Image_Classification"])`` succeeded but the corresponding
+        ``get_denormalized_as_dataframe`` call raised
+        ``DerivaMLException: The table Image_Classification doesn't
+        exist``. After the fix both calls succeed and produce
+        consistent shapes.
+        """
+        ds = _FakeDataset(populated_denorm)
+        d = Denormalizer(ds)
+        self._stub_find_features(populated_denorm["model"], {"ClassifiedAs": "Subject"})
+
+        plan = d.describe(["Image", "ClassifiedAs"])
+        df = d.as_dataframe(["Image", "ClassifiedAs"])
+        # describe's column list shape matches the dataframe's columns.
+        assert {name for name, _ in plan["columns"]} == set(df.columns)
+
+    def test_unknown_feature_name_distinguishes_from_unknown_table(self, populated_denorm) -> None:
+        """Unknown feature name and unknown table produce different
+        error messages so the user knows whether to typo-correct a
+        feature name or pick a different table."""
+        from deriva_ml.core.exceptions import DerivaMLTableNotFound
+
+        ds = _FakeDataset(populated_denorm)
+        d = Denormalizer(ds)
+        # Stub find_features so the error message lists known features.
+        self._stub_find_features(populated_denorm["model"], {"ClassifiedAs": "Subject"})
+
+        # Bogus name with no feature match → error mentions known features.
+        with pytest.raises(DerivaMLTableNotFound) as exc_info_feature:
+            d.as_dataframe(["Image", "TotallyUnknownThing"])
+        msg_with_features = str(exc_info_feature.value)
+        assert "TotallyUnknownThing" in msg_with_features
+        assert "ClassifiedAs" in msg_with_features
+        assert "Known feature names" in msg_with_features
+
+        # Same bogus name, but with no features defined at all →
+        # plain table-not-found, no "Known feature names" suggestion.
+        populated_denorm["model"].find_features = lambda table=None: []
+        with pytest.raises(DerivaMLTableNotFound) as exc_info_plain:
+            d.as_dataframe(["Image", "TotallyUnknownThing"])
+        msg_plain = str(exc_info_plain.value)
+        assert "TotallyUnknownThing" in msg_plain
+        assert "Known feature names" not in msg_plain
+
+    def test_unknown_table_still_raises_table_not_found(self, populated_denorm) -> None:
+        """Pre-fix behavior preserved: a genuinely-unknown table name
+        still raises ``DerivaMLTableNotFound`` — the resolver doesn't
+        accidentally accept invalid inputs."""
+        from deriva_ml.core.exceptions import DerivaMLTableNotFound
+
+        ds = _FakeDataset(populated_denorm)
+        d = Denormalizer(ds)
+        # No find_features stub: the resolver's feature index is empty
+        # and a bogus table name falls through to TableNotFound.
+        with pytest.raises(DerivaMLTableNotFound):
+            d.as_dataframe(["Image", "DefinitelyDoesNotExist"])
+
+    def test_ambiguous_feature_name_raises(self, populated_denorm) -> None:
+        """A feature name defined on multiple target tables is
+        ambiguous — the resolver refuses to guess."""
+        from deriva_ml.core.exceptions import DerivaMLDenormalizeError
+
+        ds = _FakeDataset(populated_denorm)
+        d = Denormalizer(ds)
+
+        # Two synthetic Features sharing the same feature_name but
+        # backed by different feature_tables.
+        model = populated_denorm["model"]
+
+        class _StubFeature:
+            def __init__(self, feature_name, feature_table, target_table):
+                self.feature_name = feature_name
+                self.feature_table = feature_table
+                self.target_table = target_table
+
+        subj = model.name_to_table("Subject")
+        img = model.name_to_table("Image")
+        model.find_features = lambda table=None: [
+            _StubFeature("Shared", subj, img),
+            _StubFeature("Shared", img, subj),
+        ]
+        with pytest.raises(DerivaMLDenormalizeError, match="ambiguous"):
+            d.as_dataframe(["Image", "Shared"])
+
+
 class TestListPaths:
     """list_paths describes the FK graph from the dataset's anchor types."""
 


### PR DESCRIPTION
## Summary

- Add `Denormalizer._resolve_table_names` helper that translates feature names (e.g. `"Image_Classification"`) to the underlying feature-association table (e.g. `"Execution_Image_Image_Classification"`) before either dry-run or run path hits the planner.
- Wire it into `as_dataframe` / `as_dict` / `columns` / `describe` so they all share the same `include_tables` validation — describe and run now agree on what's a valid entry.
- Distinguish "feature name not found" (lists known feature names) from "table not found" so the user knows whether to fix a typo or pick a different feature.

## Rationale

From the 2026-05-26 multipersona Analyst arc finding (`deriva-ml-model-template-e2e/findings/analyst/01-describe-vs-run-include-tables.md`):

> The Analyst's first reach was to pass the **feature name** in `include_tables` because that's the name used everywhere else in the API (`find_features()`, `feature_values()`, `lookup_feature()`).
>
> `describe_denormalized` accepts `"Image_Classification"` as a valid `include_tables` entry AND lists it as a candidate `row_per`. The preview is internally consistent — anchors, estimated row count, join path, all populated.
>
> Then the same call to the actual runner fails: `DerivaMLException: The table Image_Classification doesn't exist.`
>
> Option 2 [the friendlier user experience] — Loosen `get_denormalized_as_dataframe` so it resolves feature names to their feature table at call time. Symmetric with how `feature_values('Image', 'Image_Classification')` already works.

The planner already understood feature names through `find_features(target_table).by_name(feature_name)`; the runner just needed to do the substitution silently. This PR implements that.

## What the actual asymmetry was

Looking at the code, the inconsistency was more subtle than "describe validates, run doesn't." Both paths went through `DenormalizePlanner._prepare_wide_table`, which validated each name with `model.name_to_table(t)`. The difference was that `describe()` wraps that call in a broad `try/except` (the dry-run invariant — never raise), so when `name_to_table("Image_Classification")` failed for a feature name, `element_tables = {}` and `cols = []`, but the other parts of the dict (`row_per_candidates`, `anchors`, `estimated_row_count`) still populated because they walked their own primitives (`_find_sinks`, `_anchors_as_dict`) that silently caught the failure too. The user saw a "consistent" plan that was actually empty in the parts they didn't notice.

After this PR, both paths share `_resolve_table_names`, which:
1. Tries `name_to_table(t)` — keeps the name if it succeeds (no behavior change for real table names, including vocab tables like `Image_Classification` that happen to exist in the catalog).
2. Falls back to scanning `find_features()` for a feature whose `feature_name == t`. Single match → substitute the feature-table name silently; multiple matches → raise `DerivaMLDenormalizeError` with the candidate tables.
3. Raises `DerivaMLTableNotFound` with a "Known feature names: [...]" hint when no match is found and features are defined; plain `DerivaMLTableNotFound` when no features exist.

`describe` wraps the resolver in a `try/except` to preserve the dry-run invariant — if resolution itself fails, it falls back to the original inputs and the downstream planner calls swallow the failure as before.

## Test plan

- [x] 6 new tests in `tests/local_db/test_denormalizer.py::TestFeatureNameResolution` cover:
  - `as_dataframe(include_tables=[<feature_name>])` succeeds and produces the same shape as the equivalent table-name call.
  - `describe(include_tables=[<feature_name>])` produces a plan whose `include_tables` echoes the resolved table — so describe and run agree.
  - Unknown feature name vs unknown table name produce distinct error messages.
  - Genuinely-unknown table names still raise `DerivaMLTableNotFound`.
  - Ambiguous feature names (defined on multiple target tables) raise `DerivaMLDenormalizeError`.
- [x] `uv run python -m pytest tests/local_db/` — 262 passed, 3 skipped (no regressions).
- [x] `uv run python -m pytest tests/local_db/ tests/model/` with `DERIVA_ML_ALLOW_DIRTY=true` — 364 passed.
- [x] `uv run ruff check` and `uv run ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)