### PR TITLE
fix(denormalize): enforce row-completeness invariant in _populate_from_catalog_inner

### DIFF
--- a/docs/design/denormalization.md
+++ b/docs/design/denormalization.md
@@ -283,7 +283,7 @@ deletion/update freshness cases until we decide to fix.
 | **F2** | Re-denormalize silently drops rows | `_get_seen` (v1.37.2) hydrated a dedup map from the engine keyed by the caller's `rid_column`. For FK columns with N rows per value, this collapsed the fetch to one row per FK. | Fixed by removing the engine-hydrated seen-set entirely. The fetcher does not dedup based on engine state; conflict handling belongs at INSERT. Originally surfaced as 2026-05-21 finding A01. |
 | F3 | Stale local data when server mutates between calls (deletes, updates) | Cache is write-through, never invalidated. | Documented as a known limitation. See §6. Test cases marked `xfail`. |
 | F4 | `_collect_fk_values` walks "values currently present in the engine" to decide what to fetch from the server. If a parent table's membership was updated server-side after the engine cached it, downstream fetches use the stale parent set. | Same root cause as F3. | Same status — known limitation, tracked. |
-| F5 | Path-walk order silently determines which rows get loaded when two element tables share intermediate tables | `_populate_from_catalog_inner` walks `join_tables` in dict iteration order; the order isn't part of the documented contract. | Not currently a bug, because every fetch must visit each (table, rid_column, rid) tuple at least once. Pin to the test matrix in §8 so a regression here would be caught. |
+| **F5** | Path-walk order silently determines which rows get loaded when two element tables share intermediate tables | The contract (§6 step 3) requires the local cache to contain the union of rows every path's `(table, rid_column, rids)` tuple would fetch — the *row-completeness invariant*. Until 2026-05-26 `_populate_from_catalog_inner` keyed its `processed` set on table name only, which only *coincidentally* satisfied the invariant under the current planner's output. A future planner change (new element type, FK refactor, split datasets) could silently break the invariant without any code in `_populate_from_catalog_inner` changing. | **Fixed** (2026-05-26): the dedup key is now `(table_name, rid_column, frozenset(rids))`, which implements the invariant directly — each distinct parametrization fires its own fetch; only true duplicates are deduped. Regression test pinned at §8 row D.3 / C.8. Originally surfaced as 2026-05-26 audit finding SC-06 / RB-02. |
 | **F6** | `describe()` / `preflight_count` reports `estimated_row_count.total = 0` while the actual fetch returns rows | The estimator counted anchors whose table literally equals `row_per`. When `row_per` is downstream of the anchor table (the common feature-table case), no anchor matches and the sum is silently 0. Mathematically the cardinality is N rows per anchor for an unknown-from-anchor-data N. | Fixed by honest "unknown" semantics: when anchors are downstream of `row_per`, `in_scope_row_per_rows` and `total` return `None` and a `reason` field tells the caller why. The case-1 path (anchor == row_per) still returns an exact integer. Originally surfaced as 2026-05-21 finding A02 (Analyst arc). |
 
 ---
@@ -333,6 +333,7 @@ are marked `unit`.
 | C.5x | Mutation → re-denormalize. **Deletion or update** server-side between calls. | live, `xfail` | freshness limitation — see §6 |
 | C.6 | `split_dataset` then live denormalize of the parent | live | parent's feature rows visible |
 | C.7 | Live denormalize a Split parent containing children | live | members from children appear |
+| **C.8** | **Two element paths converge on the same target table with disjoint rid sets (F5 / SC-06)** | unit | **every Image RID reachable via either path is fetched; local cache equals the union (covered by `tests/local_db/test_denormalize_impl.py::TestRowCompletenessInvariant`)** |
 
 ### Layer E — `describe()` / preflight estimated_row_count
 
@@ -349,6 +350,7 @@ are marked `unit`.
 |---|---|---|---|
 | D.1 | Same dataset, same include_tables/row_per, fetched via DatasetBag (source="local") AND Dataset (source="catalog") | live | identical row count and column set |
 | D.2 | Same as D.1 but with multi-feature-per-anchor data (A01 shape) | live | identical row count |
+| **D.3** | **Same as D.1 but with two element paths converging on one table (F5 / SC-06 shape)** | live | **identical row count and column set; both sources see every reachable row** |
 
 Coverage status as of 2026-05-21:
 

--- a/src/deriva_ml/local_db/denormalize.py
+++ b/src/deriva_ml/local_db/denormalize.py
@@ -505,9 +505,7 @@ def _populate_from_catalog_inner(
     # fires its own fetch, and only true duplicates (same table, same rid
     # column, same rid set) are skipped. The pre-seeded entry covers Step 1's
     # Dataset fetch so we don't redundantly re-issue it in the loop.
-    processed: set[tuple[str, str, frozenset[str]]] = {
-        ("Dataset", "RID", frozenset(str(r) for r in dataset_rid_list))
-    }
+    processed: set[tuple[str, str, frozenset[str]]] = {("Dataset", "RID", frozenset(str(r) for r in dataset_rid_list))}
 
     for _key, (path, join_conditions, _join_types) in join_tables.items():
         # Walk in order — each table depends on rows loaded by the previous.

--- a/src/deriva_ml/local_db/denormalize.py
+++ b/src/deriva_ml/local_db/denormalize.py
@@ -492,32 +492,34 @@ def _populate_from_catalog_inner(
     )
 
     # --- Step 2: Walk each join path, fetching each table in turn ----------
-    # We process tables in the order they appear along each path. Already-
-    # walked tables are skipped via the ``processed`` set so we don't issue
-    # redundant fetches. PagedFetcher itself is stateless about prior fetches
-    # (see paged_fetcher.py and docs/design/denormalization.md §4); the
-    # dedup that matters is between this for-loop's iterations, not between
-    # PagedFetcher instances.
-    processed: set[str] = {"Dataset"}
+    # The row-completeness invariant (spec §6 step 3, audit SC-06): the local
+    # cache must contain the union of rows every path's
+    # ``(table, rid_column, rids)`` tuple would fetch. Two element paths can
+    # reach the same table via different intermediate routes — e.g. one path
+    # hits ``Image`` with ``rid_column="RID"`` and one rid set, another hits
+    # ``Image`` with ``rid_column="Image"`` (a FK) and a different rid set.
+    # The first walk's narrower fetch must NOT shadow the second's.
+    #
+    # We dedup on the full ``(table, rid_column, frozenset(rids))`` tuple,
+    # which implements the invariant directly: each distinct parametrization
+    # fires its own fetch, and only true duplicates (same table, same rid
+    # column, same rid set) are skipped. The pre-seeded entry covers Step 1's
+    # Dataset fetch so we don't redundantly re-issue it in the loop.
+    processed: set[tuple[str, str, frozenset[str]]] = {
+        ("Dataset", "RID", frozenset(str(r) for r in dataset_rid_list))
+    }
 
     for _key, (path, join_conditions, _join_types) in join_tables.items():
         # Walk in order — each table depends on rows loaded by the previous.
-        prior_tables_in_path: list[str] = ["Dataset"]
         for table_name in path[1:]:
-            if table_name in processed:
-                prior_tables_in_path.append(table_name)
-                continue
-
             target_orm = orm_resolver(table_name)
             if target_orm is None:
                 logger.warning("Skipping fetch for %s: no ORM class resolved", table_name)
-                prior_tables_in_path.append(table_name)
                 continue
 
             target_schema = table_to_schema.get(table_name)
             if target_schema is None:
                 logger.warning("Skipping fetch for %s: no schema known", table_name)
-                prior_tables_in_path.append(table_name)
                 continue
 
             qualified = f"{target_schema}:{table_name}"
@@ -542,16 +544,23 @@ def _populate_from_catalog_inner(
                 # strings since PagedFetcher's Iterable[str] contract expects
                 # stringified RID values.
                 str_rids = [str(r) for r in rids_to_fetch if r is not None]
-                if str_rids:
-                    fetcher.fetch_by_rids(
-                        table=qualified,
-                        rids=str_rids,
-                        target_table=target_orm.__table__,
-                        rid_column=fk_column_on_target,
-                    )
+                if not str_rids:
+                    continue
 
-            processed.add(table_name)
-            prior_tables_in_path.append(table_name)
+                # Dedup on the full (table, rid_column, frozenset(rids)) tuple
+                # — see the comment block above for why the prior table-name
+                # key was wrong.
+                fetch_key = (table_name, fk_column_on_target, frozenset(str_rids))
+                if fetch_key in processed:
+                    continue
+
+                fetcher.fetch_by_rids(
+                    table=qualified,
+                    rids=str_rids,
+                    target_table=target_orm.__table__,
+                    rid_column=fk_column_on_target,
+                )
+                processed.add(fetch_key)
 
 
 def _collect_fk_values(

--- a/tests/local_db/conftest.py
+++ b/tests/local_db/conftest.py
@@ -688,6 +688,25 @@ def denorm_feature_deriva_model(denorm_feature_model: Model) -> DerivaModel:
     )
 
 
+@pytest.fixture
+def denorm_local_schema_feature(denorm_feature_model: Model, tmp_path: Path) -> LocalSchema:
+    """LocalSchema built from the feature-association fixture.
+
+    Same shape as :func:`denorm_local_schema`, but against the schema
+    that includes ``Execution``, ``Image_Classification``, and the
+    ``Execution_Image_Image_Classification`` feature-association table.
+    Used by the row-completeness invariant tests (SC-06 / RB-02) that
+    need two element paths converging on ``Image``.
+    """
+    db_path = tmp_path / "denorm_feature_db"
+    db_path.mkdir()
+    return LocalSchema.build(
+        model=denorm_feature_model,
+        schemas=["isa", "deriva-ml"],
+        database_path=db_path,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Shared helpers
 # ---------------------------------------------------------------------------

--- a/tests/local_db/test_denormalize_impl.py
+++ b/tests/local_db/test_denormalize_impl.py
@@ -340,6 +340,323 @@ class TestDatasetOrmGuard:
             )
 
 
+class TestRowCompletenessInvariant:
+    """SC-06 / RB-02 / TC-03 regression: same table, two paths, two parametrizations.
+
+    Spec §6 step 3 requires the local cache to contain the union of rows
+    every path's ``(table, rid_column, rids)`` tuple would fetch — the
+    *row-completeness invariant*. Before the fix, ``_populate_from_catalog_inner``
+    keyed its ``processed`` set on table name only, so the second walk's
+    fetch was silently skipped when two element paths converged on the
+    same table.
+
+    These tests pin the invariant by hand-constructing a two-path
+    ``join_tables`` dict and asserting both fetches actually fire (and
+    that the resulting Image set is the union of what each path
+    legitimately asks for).
+    """
+
+    def _build_two_path_scenario(
+        self,
+        denorm_feature_deriva_model: Any,
+        denorm_local_schema_feature: Any,
+    ) -> dict[str, Any]:
+        """Set up a fixture where two element paths converge on Image.
+
+        The pre-populated state is what ``_collect_fk_values`` will read
+        from the engine to decide which Image RIDs each path needs.
+
+        Path A: ``Dataset → Dataset_Image → Image`` — pulls IMG-A1, IMG-A2.
+        Path B: ``Dataset → Execution_Image_Image_Classification → Image``
+            — pulls IMG-B1, IMG-B2 (a disjoint set; this is what makes
+            the bug visible).
+
+        Returns a dict carrying everything the test needs: the
+        hand-crafted ``join_tables``, the engine, the resolver, the
+        ``FakePagedClient`` (preloaded with rows for *all* Image RIDs so
+        a correct walk pulls the union; a buggy walk pulls only one
+        path's worth).
+        """
+        from sqlalchemy.orm import Session
+
+        from tests.local_db.test_paged_fetcher import FakePagedClient
+
+        ls = denorm_local_schema_feature
+        model = denorm_feature_deriva_model
+
+        ds_rid = "DS-001"
+        path_a_image_rids = ["IMG-A1", "IMG-A2"]
+        path_b_image_rids = ["IMG-B1", "IMG-B2"]
+        exec_rid = "EXE-1"
+        cls_rid = "CLS-cat"
+
+        # Pre-populate the engine with the "prior tables" each path
+        # reads to derive its target RIDs. Path A reads Dataset_Image;
+        # path B reads Execution_Image_Image_Classification.
+        with Session(ls.engine) as session:
+            ds_cls = ls.get_orm_class("Dataset")
+            session.add(ds_cls(RID=ds_rid, Description="t"))
+
+            di_cls = ls.get_orm_class("Dataset_Image")
+            for img in path_a_image_rids:
+                session.add(di_cls(RID=f"DI-{img}", Dataset=ds_rid, Image=img))
+
+            exe_cls = ls.get_orm_class("Execution")
+            session.add(exe_cls(RID=exec_rid, Description="run"))
+
+            cls_cls = ls.get_orm_class("Image_Classification")
+            session.add(cls_cls(RID=cls_rid, Name="cat"))
+
+            feat_cls = ls.get_orm_class("Execution_Image_Image_Classification")
+            for img in path_b_image_rids:
+                session.add(
+                    feat_cls(
+                        RID=f"EIIC-{img}",
+                        Feature_Name="default",
+                        Image=img,
+                        Execution=exec_rid,
+                        Image_Classification=cls_rid,
+                    )
+                )
+            session.commit()
+
+        # Look up the actual ERMrest Column objects so we can build
+        # join_conditions whose `.table.name` / `.name` match what
+        # ``_collect_fk_values`` and ``_col_table_name`` expect.
+        image_tbl = model.name_to_table("Image")
+        dataset_tbl = model.name_to_table("Dataset")
+        dataset_image_tbl = model.name_to_table("Dataset_Image")
+        exec_tbl = model.name_to_table("Execution")
+        feat_tbl = model.name_to_table("Execution_Image_Image_Classification")
+
+        image_rid_col = image_tbl.columns["RID"]
+        dataset_rid_col = dataset_tbl.columns["RID"]
+        di_image_col = dataset_image_tbl.columns["Image"]
+        di_dataset_col = dataset_image_tbl.columns["Dataset"]
+        feat_image_col = feat_tbl.columns["Image"]
+        exec_rid_col = exec_tbl.columns["RID"]
+        feat_exec_col = feat_tbl.columns["Execution"]
+
+        # Hand-crafted join_tables: two element paths both ending at
+        # Image, but reaching it via different intermediate tables.
+        # ``_collect_fk_values`` will read Dataset_Image for path A and
+        # Execution_Image_Image_Classification for path B, producing
+        # disjoint Image RID sets.
+        join_tables = {
+            "Image_via_DatasetImage": (
+                ["Dataset", "Dataset_Image", "Image"],
+                {
+                    "Dataset_Image": {(di_dataset_col, dataset_rid_col)},
+                    "Image": {(di_image_col, image_rid_col)},
+                },
+                {"Dataset_Image": "inner", "Image": "inner"},
+            ),
+            "Image_via_Feature": (
+                ["Dataset", "Execution", "Execution_Image_Image_Classification", "Image"],
+                {
+                    # Synthetic edge: planner-internal, we don't need Dataset→Execution
+                    # FK conditions here because the test calls the *inner* walk
+                    # directly and only the table-targeted conditions matter.
+                    "Execution": set(),
+                    "Execution_Image_Image_Classification": {(feat_exec_col, exec_rid_col)},
+                    "Image": {(feat_image_col, image_rid_col)},
+                },
+                {
+                    "Execution": "inner",
+                    "Execution_Image_Image_Classification": "inner",
+                    "Image": "inner",
+                },
+            ),
+        }
+
+        # FakePagedClient with rows for the union — a correct walk will
+        # pull all four; a buggy walk (today) pulls only path A's two.
+        all_images = path_a_image_rids + path_b_image_rids
+        fake = FakePagedClient(
+            rows_by_table={
+                "deriva-ml:Dataset": [{"RID": ds_rid, "Description": "t"}],
+                "isa:Image": [{"RID": r, "Filename": f"{r}.png", "Subject": None} for r in all_images],
+                # Path A's prior table (Dataset_Image) is already in engine — fetcher
+                # will still issue a fetch for it; provide rows so the call doesn't
+                # crash. The same applies to path B's intermediate tables.
+                "deriva-ml:Dataset_Image": [
+                    {"RID": f"DI-{r}", "Dataset": ds_rid, "Image": r} for r in path_a_image_rids
+                ],
+                "deriva-ml:Execution": [{"RID": exec_rid, "Description": "run"}],
+                "deriva-ml:Execution_Image_Image_Classification": [
+                    {
+                        "RID": f"EIIC-{r}",
+                        "Feature_Name": "default",
+                        "Image": r,
+                        "Execution": exec_rid,
+                        "Image_Classification": cls_rid,
+                    }
+                    for r in path_b_image_rids
+                ],
+            }
+        )
+
+        return {
+            "model": model,
+            "engine": ls.engine,
+            "orm_resolver": ls.get_orm_class,
+            "join_tables": join_tables,
+            "fake_client": fake,
+            "dataset_rid": ds_rid,
+            "path_a_image_rids": path_a_image_rids,
+            "path_b_image_rids": path_b_image_rids,
+            "local_schema": ls,
+        }
+
+    def test_two_paths_both_fetch_their_target_rids(
+        self,
+        denorm_feature_deriva_model: Any,
+        denorm_local_schema_feature: Any,
+    ) -> None:
+        """Both element paths' Image fetches must fire (row-completeness invariant).
+
+        With the bug, ``processed`` adds ``"Image"`` after path A's fetch
+        and path B's fetch is silently skipped. The Image RIDs only
+        reachable via path B are absent from the local cache.
+
+        With the fix, the dedup key is ``(table, rid_column, frozenset(rids))``,
+        so the two paths' distinct parametrizations both issue a fetch.
+
+        The assertion that fails on main is the final
+        ``image_rids_in_engine == set(union)`` — IMG-B1/IMG-B2 are missing
+        because path B's fetch never ran.
+        """
+        from sqlalchemy import select as sa_select
+
+        from deriva_ml.local_db.denormalize import (
+            _foreign_keys_off,
+            _populate_from_catalog_inner,
+        )
+        from deriva_ml.local_db.paged_fetcher import PagedFetcher
+
+        scenario = self._build_two_path_scenario(
+            denorm_feature_deriva_model, denorm_local_schema_feature
+        )
+
+        fetcher = PagedFetcher(client=scenario["fake_client"], engine=scenario["engine"])
+
+        table_to_schema = {
+            "Dataset": "deriva-ml",
+            "Dataset_Image": "deriva-ml",
+            "Image": "isa",
+            "Execution": "deriva-ml",
+            "Execution_Image_Image_Classification": "deriva-ml",
+        }
+
+        with _foreign_keys_off(scenario["engine"]):
+            _populate_from_catalog_inner(
+                fetcher=fetcher,
+                engine=scenario["engine"],
+                orm_resolver=scenario["orm_resolver"],
+                table_to_schema=table_to_schema,
+                join_tables=scenario["join_tables"],
+                dataset_rid_list=[scenario["dataset_rid"]],
+            )
+
+        # Collect all Image fetches the fake client saw.
+        image_fetch_rids: list[set[str]] = []
+        for kind, params in scenario["fake_client"].requests:
+            if kind == "fetch_rid_batch" and params["table"] == "isa:Image":
+                image_fetch_rids.append(set(params["rids"]))
+
+        union_requested = set().union(*image_fetch_rids) if image_fetch_rids else set()
+        expected_union = set(scenario["path_a_image_rids"] + scenario["path_b_image_rids"])
+
+        # The invariant: every (table, rid_column, rids) tuple in the
+        # plan must have its rows in the local cache. The cheapest way
+        # to surface this is: the union of all Image fetches must
+        # include every Image RID either path's parametrization
+        # legitimately asks for.
+        assert union_requested == expected_union, (
+            f"Row-completeness invariant violated: path B's Image fetch was "
+            f"skipped. Image RIDs requested across all fetches: {union_requested}. "
+            f"Expected union of both paths: {expected_union}. "
+            f"Missing: {expected_union - union_requested}."
+        )
+
+        # And the engine must end up holding the union.
+        image_orm = scenario["orm_resolver"]("Image")
+        with scenario["engine"].connect() as conn:
+            image_rids_in_engine = {
+                row[0] for row in conn.execute(sa_select(image_orm.__table__.columns["RID"])).fetchall()
+            }
+        assert image_rids_in_engine == expected_union, (
+            f"Local cache missing rows: engine has {image_rids_in_engine}, "
+            f"expected union {expected_union}."
+        )
+
+    def test_duplicate_parametrization_is_still_deduped(
+        self,
+        denorm_feature_deriva_model: Any,
+        denorm_local_schema_feature: Any,
+    ) -> None:
+        """Two paths with the SAME (table, rid_column, rids) tuple → one fetch.
+
+        The fix preserves the optimization for true duplicates — if both
+        paths converge on Image via the same rid_column with the same
+        rid set, only one fetch should fire. This pins the dedup half of
+        the contract (the other half being row-completeness).
+        """
+        from deriva_ml.local_db.denormalize import (
+            _foreign_keys_off,
+            _populate_from_catalog_inner,
+        )
+        from deriva_ml.local_db.paged_fetcher import PagedFetcher
+
+        scenario = self._build_two_path_scenario(
+            denorm_feature_deriva_model, denorm_local_schema_feature
+        )
+
+        # Replace path B's join_conditions[Image] with an identical
+        # parametrization to path A's — same (rid_column, source) so
+        # _collect_fk_values returns the same (rid_column, rids).
+        model = scenario["model"]
+        image_rid_col = model.name_to_table("Image").columns["RID"]
+        di_image_col = model.name_to_table("Dataset_Image").columns["Image"]
+
+        # Rewire path B's Image conditions to point at Dataset_Image too
+        # (artificial — the point is just that both paths produce the
+        # same (rid_column, frozenset(rids)) tuple for Image).
+        path_b = scenario["join_tables"]["Image_via_Feature"]
+        path_b[1]["Image"] = {(di_image_col, image_rid_col)}
+
+        fetcher = PagedFetcher(client=scenario["fake_client"], engine=scenario["engine"])
+        table_to_schema = {
+            "Dataset": "deriva-ml",
+            "Dataset_Image": "deriva-ml",
+            "Image": "isa",
+            "Execution": "deriva-ml",
+            "Execution_Image_Image_Classification": "deriva-ml",
+        }
+
+        with _foreign_keys_off(scenario["engine"]):
+            _populate_from_catalog_inner(
+                fetcher=fetcher,
+                engine=scenario["engine"],
+                orm_resolver=scenario["orm_resolver"],
+                table_to_schema=table_to_schema,
+                join_tables=scenario["join_tables"],
+                dataset_rid_list=[scenario["dataset_rid"]],
+            )
+
+        image_fetches = [
+            params
+            for kind, params in scenario["fake_client"].requests
+            if kind == "fetch_rid_batch" and params["table"] == "isa:Image"
+        ]
+        # Exactly one Image fetch: the two paths produced an identical
+        # (rid_column, rids) tuple and the second is correctly deduped.
+        assert len(image_fetches) == 1, (
+            f"Expected 1 Image fetch for identical parametrizations, got "
+            f"{len(image_fetches)}: {image_fetches}"
+        )
+
+
 def test_denormalize_result_extend() -> None:
     """DenormalizeResult.extend appends rows and updates row_count."""
     from deriva_ml.local_db.denormalize import DenormalizeResult

--- a/tests/local_db/test_denormalize_impl.py
+++ b/tests/local_db/test_denormalize_impl.py
@@ -534,9 +534,7 @@ class TestRowCompletenessInvariant:
         )
         from deriva_ml.local_db.paged_fetcher import PagedFetcher
 
-        scenario = self._build_two_path_scenario(
-            denorm_feature_deriva_model, denorm_local_schema_feature
-        )
+        scenario = self._build_two_path_scenario(denorm_feature_deriva_model, denorm_local_schema_feature)
 
         fetcher = PagedFetcher(client=scenario["fake_client"], engine=scenario["engine"])
 
@@ -586,8 +584,7 @@ class TestRowCompletenessInvariant:
                 row[0] for row in conn.execute(sa_select(image_orm.__table__.columns["RID"])).fetchall()
             }
         assert image_rids_in_engine == expected_union, (
-            f"Local cache missing rows: engine has {image_rids_in_engine}, "
-            f"expected union {expected_union}."
+            f"Local cache missing rows: engine has {image_rids_in_engine}, expected union {expected_union}."
         )
 
     def test_duplicate_parametrization_is_still_deduped(
@@ -608,9 +605,7 @@ class TestRowCompletenessInvariant:
         )
         from deriva_ml.local_db.paged_fetcher import PagedFetcher
 
-        scenario = self._build_two_path_scenario(
-            denorm_feature_deriva_model, denorm_local_schema_feature
-        )
+        scenario = self._build_two_path_scenario(denorm_feature_deriva_model, denorm_local_schema_feature)
 
         # Replace path B's join_conditions[Image] with an identical
         # parametrization to path A's — same (rid_column, source) so
@@ -652,8 +647,7 @@ class TestRowCompletenessInvariant:
         # Exactly one Image fetch: the two paths produced an identical
         # (rid_column, rids) tuple and the second is correctly deduped.
         assert len(image_fetches) == 1, (
-            f"Expected 1 Image fetch for identical parametrizations, got "
-            f"{len(image_fetches)}: {image_fetches}"
+            f"Expected 1 Image fetch for identical parametrizations, got {len(image_fetches)}: {image_fetches}"
         )
 
 


### PR DESCRIPTION
## Summary

Closes audit findings **SC-06 / RB-02** (with regression tests for **TC-01 / TC-03**) from `docs/audits/2026-05-26-denormalize-audit.md`. The audit's highest-stakes finding: silent row loss on any plan where two element paths converge on the same target table with different parametrizations.

`_populate_from_catalog_inner` keyed its `processed` set on table name only. When the same table appears on two join paths with different `rid_column` and/or `rids`, the second walk's fetch was silently skipped. The first walk's narrower fetch won, and rows reachable only via the second path were absent from the local cache — the SQL JOIN then produced fewer rows than reality without raising.

Spec §6 step 3 already required the local cache to contain the union of rows every path's `(table, rid_column, rids)` tuple would fetch — the **row-completeness invariant**. The fix implements it directly:

```python
processed: set[tuple[str, str, frozenset[str]]] = {
    ("Dataset", "RID", frozenset(str(r) for r in dataset_rid_list))
}
...
fetch_key = (table_name, fk_column_on_target, frozenset(str_rids))
if fetch_key in processed:
    continue
fetcher.fetch_by_rids(...)
processed.add(fetch_key)
```

The subsumption optimization (skipping a later tuple whose rids are a subset of an earlier tuple's) is deliberately omitted — `INSERT-OR-IGNORE` already makes the HTTP layer cheap on redundant rids, and adding subsumption detection complicates the code for marginal payoff. Implement the invariant strictly; let the storage layer dedup rows.

## Failing-test-first

Commit `d8f6838b` adds the regression test (`TestRowCompletenessInvariant`) **before** the fix. On main, it fails with:

```
AssertionError: Row-completeness invariant violated: path B's Image fetch was
skipped. Image RIDs requested across all fetches: {'IMG-A1', 'IMG-A2'}.
Expected union of both paths: {'IMG-A1', 'IMG-A2', 'IMG-B1', 'IMG-B2'}.
Missing: {'IMG-B1', 'IMG-B2'}.
```

Commit `9810074f` applies the fix; commit `a970c695` updates spec §7 F5 and §8 to name the invariant and pin the regression.

## Changes

- `src/deriva_ml/local_db/denormalize.py` — dedup key in `_populate_from_catalog_inner` changed from `set[str]` to `set[tuple[str, str, frozenset[str]]]`. Step 1's Dataset fetch is pre-seeded with the matching tuple shape.
- `tests/local_db/test_denormalize_impl.py` — new `TestRowCompletenessInvariant` class with two cases: (1) two paths with distinct parametrizations both fetch their target rids; (2) two paths with identical parametrizations still dedup to one fetch.
- `tests/local_db/conftest.py` — new `denorm_local_schema_feature` fixture (LocalSchema built from the existing feature-association schema).
- `docs/design/denormalization.md` — §7 F5 reworded to distinguish the invariant from the planner-output coincidence; §8 gets new rows C.8 (unit) and D.3 (live, tracked for future) for the two-path-on-one-table contract.

## Test plan

- [x] New `TestRowCompletenessInvariant` tests fail on main, pass after the fix.
- [x] `uv run python -m pytest tests/local_db/` — 258 passed (was 256; +2 new), 3 skipped, unchanged from main otherwise.
- [x] `uv run python -m pytest tests/local_db/test_planner_rules.py` — 24 passed, no regressions.
- [ ] `uv run python -m pytest tests/dataset/test_denormalize.py` — requires live catalog; run locally with `DERIVA_ML_ALLOW_DIRTY=true` against `localhost`. Pre-existing dirty-workflow setup errors block unrelated runs; this PR doesn't introduce any new failures in that suite.