### PR TITLE
fix(denormalize): align as_dict docstring with eager implementation (SC-07)

### DIFF
--- a/src/deriva_ml/local_db/denormalizer.py
+++ b/src/deriva_ml/local_db/denormalizer.py
@@ -62,8 +62,11 @@ class Denormalizer:
 
     - :meth:`as_dataframe` — materialize the wide table as a
       :class:`pandas.DataFrame`.
-    - :meth:`as_dict` — stream rows as ``dict[str, Any]`` (memory-efficient
-      for large results).
+    - :meth:`as_dict` — yield rows as ``dict[str, Any]`` one at a time.
+      Convenience for row-by-row iteration; the full result is still
+      materialised internally before the first row is yielded, so this
+      is *not* a memory-efficient alternative to :meth:`as_dataframe`
+      (see the method's own docstring and audit finding SC-07).
     - :meth:`columns` — preview ``(column_name, column_type)`` pairs
       without fetching data (model-only).
     - :meth:`describe` — dry-run: returns a 12-key plan dict (spec §5);
@@ -445,13 +448,27 @@ class Denormalizer:
         via: list[str] | None = None,
         ignore_unrelated_anchors: bool = False,
     ) -> Generator[dict[str, Any], None, None]:
-        """Stream the denormalized table row-by-row as dicts.
+        """Convert the denormalized table to dicts and yield row-by-row.
 
         Same planner, same rules, same exceptions as :meth:`as_dataframe` —
         but yields one ``dict[str, Any]`` per row (keyed by the
         ``Table.column`` / ``schema.Table.column`` label) rather than
-        materializing a DataFrame. Use this when the result set won't fit
-        in memory or when downstream code processes rows one at a time.
+        materializing a DataFrame.
+
+        **The full result is materialised before the first row is
+        yielded.** This method is memory-equivalent to
+        :meth:`as_dataframe`, not a streaming alternative — peak memory
+        scales with the full result set, because ``_denormalize_impl``
+        eagerly drains the SQLAlchemy cursor into a Python list before
+        :meth:`as_dict` iterates it. Use this when downstream code
+        processes rows one at a time but does not need DataFrame
+        indexing; do **not** rely on it to bound memory for very large
+        results.
+
+        True row-by-row streaming over the cursor is a known gap (audit
+        finding SC-07; see ``docs/design/denormalization.md`` §8.2 for
+        the design discussion). Until that gap is closed, treat
+        ``as_dict`` as "iteration interface, materialised internals."
 
         Args:
             include_tables: Tables whose columns appear in the output.
@@ -468,8 +485,9 @@ class Denormalizer:
 
         Raises:
             Same as :meth:`as_dataframe`. Exceptions surface on the first
-            ``next()`` — all planner validation runs before any row is
-            yielded, since the pipeline builds the full result up front.
+            ``next()`` — all planner validation and the full SQL execution
+            run before any row is yielded, since the pipeline builds the
+            full result up front.
 
         Example::
 
@@ -759,13 +777,9 @@ class Denormalizer:
                 # (case 1, exact contribution) and "anchors elsewhere
                 # but reaching row_per via FK chain" (case 2, unknown
                 # fan-out).
-                at_row_per_count = sum(
-                    len(rids) for table, rids in scoping.items() if table == resolved_row_per
-                )
+                at_row_per_count = sum(len(rids) for table, rids in scoping.items() if table == resolved_row_per)
                 downstream_anchor_tables = [
-                    table
-                    for table, rids in scoping.items()
-                    if table != resolved_row_per and rids
+                    table for table, rids in scoping.items() if table != resolved_row_per and rids
                 ]
                 orphan_count = sum(len(rids) for rids in orphans.values())
 

--- a/tests/local_db/test_denormalizer.py
+++ b/tests/local_db/test_denormalizer.py
@@ -54,7 +54,7 @@ class TestAsDataframe:
 
 
 class TestAsDict:
-    """Denormalizer.as_dict streams rows as dicts."""
+    """Denormalizer.as_dict yields rows as dicts (eager materialisation)."""
 
     def test_yields_dicts(self, populated_denorm) -> None:
         ds = _FakeDataset(populated_denorm)
@@ -63,6 +63,26 @@ class TestAsDict:
         assert len(rows) == 3
         for r in rows:
             assert isinstance(r, dict)
+
+    def test_as_dict_docstring_admits_eager(self) -> None:
+        """as_dict's docstring must admit eager materialisation (SC-07 / TC-06).
+
+        The previous docstring claimed ``as_dict`` streams "when the
+        result set won't fit in memory" — false: ``_denormalize_impl``
+        drains the SQLAlchemy cursor into a Python list before any row
+        is yielded. This meta-test keeps the docstring honest under
+        future edits: any return to "streams"/"memory-efficient" framing
+        must come with an actual streaming implementation (and this
+        test should then be updated to assert the new contract).
+        """
+        doc = Denormalizer.as_dict.__doc__
+        assert doc is not None, "as_dict must keep its docstring"
+        lowered = doc.lower()
+        assert "materialised" in lowered or "materialized" in lowered, (
+            "as_dict docstring must admit eager materialisation (SC-07). "
+            "If true streaming has been implemented, update this test to "
+            "assert the new contract instead."
+        )
 
 
 class TestColumns:


### PR DESCRIPTION
## Summary

- `Denormalizer.as_dict()` advertised row-by-row streaming ("Use this when the result set won't fit in memory") while admitting eager materialisation a few lines later in the Raises: block. The implementation has always been eager: `_denormalize_impl` drains the SQLAlchemy cursor into a Python list before `as_dict` yields a single row.
- This PR picks **Option A** from audit finding SC-07 (and the spec PR #231 §8.2 framing): correct the docstring to match the implementation. True streaming is left as a future change.
- The fix touches both the method docstring AND the class-level methods summary (which independently called `as_dict` "memory-efficient for large results"), and adds a meta-test (TC-06) that keeps the docstring honest under future edits.

Audit refs: `docs/audits/2026-05-26-denormalize-audit.md` SC-07 (Medium → High in grill) and TC-06. Spec ref: `docs/design/denormalization.md` §8.2.

## Why Option A

- The spec already declares eager materialisation as the current contract (`docs/design/denormalization.md` §8.2 — "Materialization, not streaming — known doc-rot").
- Audit explicitly notes either path is a valid resolution; recommendation defaults to A.
- Real streaming requires careful SQLAlchemy cursor-lifetime management (the orphan-emission step in `_run` re-iterates the full result and the `with Session(...)` block bounds the connection), making Option B a 4-6 hour change with subtle bug risk. Worth doing later, but separately.

## Changes

- `src/deriva_ml/local_db/denormalizer.py`:
  - Rewrite `as_dict` docstring. The result is materialised up front; this method is memory-equivalent to `as_dataframe`, not a streaming alternative. Use it when iterating row-by-row is more ergonomic than DataFrame indexing, but not to bound memory.
  - Update the class-level methods summary entry for `as_dict` to drop the "memory-efficient" claim and call out the materialised-internals reality.
  - Both docstrings now point readers at audit finding SC-07 and `docs/design/denormalization.md` §8.2.
- `tests/local_db/test_denormalizer.py`:
  - Add `test_as_dict_docstring_admits_eager` (TC-06). A meta-test that asserts the docstring contains "materialised"/"materialized" — cheap defensive check so a future edit can't quietly reintroduce the streaming lie without also implementing streaming.
  - Update the `TestAsDict` class docstring to match the new contract.

## Test plan

- [x] `uv run python -m pytest tests/local_db/test_denormalizer.py -v` — 40 passed (1 new test).
- [x] `uv run python -m pytest tests/local_db/` — 257 passed, 3 skipped (no regressions).
- [x] `uv run ruff check src/deriva_ml/local_db/denormalizer.py tests/local_db/test_denormalizer.py` — clean.
- [x] `uv run ruff format` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)