### PR TITLE
fix(denormalize): reject from_rids without dataset_rid against live catalog (SC-02 / TC-05)

### DIFF
--- a/src/deriva_ml/local_db/denormalizer.py
+++ b/src/deriva_ml/local_db/denormalizer.py
@@ -217,12 +217,10 @@ class Denormalizer:
         The current ``_denormalize_impl`` primitive scopes its SQL query by
         ``Dataset.RID IN (dataset_rid)`` — that is, it always traverses from
         the Dataset root. ``from_rids`` therefore requires a real dataset
-        RID against which the anchors are linked. When ``dataset_rid`` is
-        given, it is used as the scoping root; when omitted, the first
-        anchor's RID is used as a pseudo-scope (which will currently return
-        zero rows against a production catalog — a known limitation that
-        will be addressed when ``_denormalize_impl`` gains an anchor-scoped
-        SQL mode).
+        RID against which the anchors are linked. Pass an explicit
+        ``dataset_rid=<RID>`` that contains the anchor RIDs, or use the
+        :class:`Denormalizer` constructor with a :class:`Dataset` so the
+        parent dataset's RID is used automatically.
 
         Per-call behavior flags (``row_per``, ``via``,
         ``ignore_unrelated_anchors``) are supplied to the public methods
@@ -234,9 +232,13 @@ class Denormalizer:
             ml: Convenience: pass a DerivaML instance. catalog/workspace/model
                 are derived from it.
             catalog, workspace, model, engine, orm_resolver: Explicit deps.
-            dataset_rid: Optional real dataset RID to scope the SQL by. If
-                None, uses the first anchor's RID as a placeholder (see
-                note above).
+            dataset_rid: Real dataset RID to scope the SQL by. Required
+                against a live catalog — otherwise the SQL ``Dataset.RID
+                IN (dataset_rid, ...)`` predicate matches nothing and the
+                caller gets a silent empty DataFrame (SC-02 / TC-05). May
+                be omitted in fixture/local-only contexts where the engine
+                has been pre-populated with arbitrary RIDs; a warning is
+                logged in that path.
 
         Returns:
             A :class:`Denormalizer` bound to the given anchor set.
@@ -244,8 +246,11 @@ class Denormalizer:
         Raises:
             ValueError: if neither ``ml`` nor ``model`` is provided; if a
                 bare RID is passed without a catalog for lookup; if a bare
-                RID cannot be resolved; or if a tuple anchor does not have
-                exactly two elements.
+                RID cannot be resolved; if a tuple anchor does not have
+                exactly two elements; or if ``dataset_rid`` is ``None``
+                against a live catalog (pass an explicit ``dataset_rid``
+                or use the :class:`Denormalizer` constructor with a
+                :class:`Dataset` instead).
         """
         # Derive deps from ml if given.
         if ml is not None:
@@ -261,6 +266,44 @@ class Denormalizer:
 
         if model is None:
             raise ValueError("Denormalizer.from_rids requires either ml= or an explicit model=")
+
+        # SC-02 / TC-05 guard: dataset_rid is None against a live catalog
+        # is a silent-zero failure mode. _denormalize_impl scopes by
+        # ``Dataset.RID IN (dataset_rid, ...)`` and no real dataset has
+        # the placeholder RID, so the result is an empty DataFrame with
+        # no diagnostic. Probe whether the catalog passed in is a real
+        # live one (i.e., one ErmrestPagedClient can wrap) and refuse
+        # the call there. Fixture/local contexts (no catalog, or a
+        # mock that can't be wrapped) keep working with a warning —
+        # those flows pre-populate the engine and the RID acts as an
+        # opaque scoping key the in-memory SQL will match if rows exist.
+        if dataset_rid is None:
+            live_catalog = False
+            if catalog is not None:
+                try:
+                    from deriva_ml.local_db.paged_fetcher_ermrest import ErmrestPagedClient
+
+                    ErmrestPagedClient(catalog=catalog)
+                    live_catalog = True
+                except Exception:
+                    # Catalog can't be wrapped (mock, offline) — treat
+                    # as local mode; warn but don't raise.
+                    live_catalog = False
+            if live_catalog:
+                raise ValueError(
+                    "Denormalizer.from_rids() requires an explicit dataset_rid against "
+                    "a live catalog because the SQL primitive scopes by "
+                    "Dataset.RID IN (dataset_rid, ...). Pass dataset_rid=<existing "
+                    "dataset RID> that contains the anchor RIDs, or use "
+                    "Denormalizer(dataset) where the parent Dataset's RID is "
+                    "used automatically."
+                )
+            logger.warning(
+                "Denormalizer.from_rids() called with dataset_rid=None in "
+                "local/fixture mode; falling back to the first anchor's RID "
+                "as a placeholder scope. This will return zero rows against "
+                "a live catalog — pass dataset_rid=<RID> for production use."
+            )
 
         # Normalize anchors to (table, RID) pairs. Validate tuple arity so
         # a 3-tuple (or 1-tuple) surfaces as a clear ValueError here rather
@@ -313,8 +356,9 @@ class Denormalizer:
             anchors_by_table.setdefault(table, []).append(rid)
 
         # Effective dataset RID used by _denormalize_impl's WHERE clause.
-        # If caller supplied one, use it; otherwise fall back to the first
-        # anchor's RID (placeholder — see docstring for caveat).
+        # If caller supplied one, use it; otherwise (local/fixture mode
+        # only — live-catalog callers were rejected above) fall back to
+        # the first anchor's RID as a placeholder scope.
         effective_dataset_rid = dataset_rid if dataset_rid is not None else (resolved[0][1] if resolved else "")
 
         # Create a pseudo-dataset that exposes the anchors dict as members.
@@ -759,13 +803,9 @@ class Denormalizer:
                 # (case 1, exact contribution) and "anchors elsewhere
                 # but reaching row_per via FK chain" (case 2, unknown
                 # fan-out).
-                at_row_per_count = sum(
-                    len(rids) for table, rids in scoping.items() if table == resolved_row_per
-                )
+                at_row_per_count = sum(len(rids) for table, rids in scoping.items() if table == resolved_row_per)
                 downstream_anchor_tables = [
-                    table
-                    for table, rids in scoping.items()
-                    if table != resolved_row_per and rids
+                    table for table, rids in scoping.items() if table != resolved_row_per and rids
                 ]
                 orphan_count = sum(len(rids) for rids in orphans.values())
 

--- a/tests/local_db/test_denormalizer.py
+++ b/tests/local_db/test_denormalizer.py
@@ -668,6 +668,72 @@ class TestFromRids:
                 dataset_rid=populated_denorm["dataset_rid"],
             )
 
+    # ── SC-02 / TC-05: from_rids(dataset_rid=None) silent-zero guard ──────
+
+    def test_from_rids_rejects_no_dataset_rid_against_live_catalog(self, populated_denorm) -> None:
+        """SC-02 / TC-05: live catalog + dataset_rid=None must raise.
+
+        The SQL primitive scopes by ``Dataset.RID IN (dataset_rid, ...)``;
+        with no real dataset RID, the result is silently empty against a
+        production catalog. ``from_rids`` rejects the call up front rather
+        than letting the user discover the silent-zero failure mode.
+        """
+        ml = _FakeMl(populated_denorm)
+        # Simulate a live catalog: presence of ``catalog_id`` is what makes
+        # ErmrestPagedClient(catalog=catalog) succeed in from_rids' probe.
+        ml.catalog = _LiveShapedCatalog(catalog_id="42")
+        with pytest.raises(
+            ValueError,
+            match=r"requires an explicit dataset_rid against a live catalog",
+        ):
+            Denormalizer.from_rids(
+                [("Image", r) for r in populated_denorm["image_rids"]],
+                ml=ml,
+                # dataset_rid intentionally omitted
+            )
+
+    def test_from_rids_with_explicit_dataset_rid_succeeds(self, populated_denorm) -> None:
+        """Control case: live-shaped catalog + explicit dataset_rid is fine.
+
+        Confirms the guard's discriminator is ``dataset_rid is None``,
+        not the presence of a live catalog. Constructing with an explicit
+        dataset_rid against a live-shaped catalog works as before.
+        """
+        ml = _FakeMl(populated_denorm)
+        ml.catalog = _LiveShapedCatalog(catalog_id="42")
+        # Should NOT raise.
+        d = Denormalizer.from_rids(
+            [("Image", r) for r in populated_denorm["image_rids"]],
+            ml=ml,
+            dataset_rid=populated_denorm["dataset_rid"],
+        )
+        # And the underlying query still works (fixture mode against the
+        # in-memory engine — the live catalog is never actually contacted
+        # because from_rids hard-pins source="local").
+        df = d.as_dataframe(["Image", "Subject"])
+        assert len(df) == 3
+
+    def test_from_rids_no_dataset_rid_local_mode_works(self, populated_denorm, caplog) -> None:
+        """Fixture/local mode still works without dataset_rid — warns, no raise.
+
+        The catalog passed in here can't be wrapped by ``ErmrestPagedClient``
+        (no ``catalog_id``), so the probe falls into the local branch. The
+        constructor logs a warning but returns a usable Denormalizer.
+        """
+        ml = _FakeMl(populated_denorm)  # ml.catalog is None — local mode
+        with caplog.at_level("WARNING", logger="deriva_ml.local_db.denormalizer"):
+            d = Denormalizer.from_rids(
+                [("Image", r) for r in populated_denorm["image_rids"]],
+                ml=ml,
+                dataset_rid=None,
+            )
+        # Warning surfaced.
+        assert any("dataset_rid=None" in rec.message and "local" in rec.message.lower() for rec in caplog.records), (
+            f"expected local-mode warning; got: {[r.message for r in caplog.records]}"
+        )
+        # And the Denormalizer is usable in local mode.
+        assert d is not None
+
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -689,6 +755,19 @@ class _FakeMl:
 
         self.workspace = _WS(populated_denorm["local_schema"])
         self.catalog = None  # bare-RID lookup not needed for tuple anchors
+
+
+class _LiveShapedCatalog:
+    """Catalog shim that ``ErmrestPagedClient(catalog=...)`` accepts.
+
+    Exposes ``catalog_id`` (the only attribute ``ErmrestPagedClient.__init__``
+    reads with no default), which is enough to make the from_rids probe
+    classify this as a "live catalog" without actually wiring up the HTTP
+    layer. Used to drive SC-02 / TC-05 rejection tests.
+    """
+
+    def __init__(self, catalog_id: str):
+        self.catalog_id = catalog_id
 
 
 class _FakeCatalog:


### PR DESCRIPTION
## Summary

Closes the SC-02 / TC-05 silent-zero failure mode in
`Denormalizer.from_rids()`. Previously, calling with `ml=` bound to a
live catalog but no `dataset_rid=` returned an empty DataFrame with no
diagnostic — `_denormalize_impl` scopes by
`Dataset.RID IN (dataset_rid, ...)` and the first-anchor-RID
placeholder fallback matches no real dataset on a production catalog,
so the result was silently empty.

The fix:

- `from_rids()` now probes whether the catalog passed in is a real live
  one (by attempting `ErmrestPagedClient(catalog=catalog)` construction)
  when `dataset_rid is None`. If the probe succeeds, the call is
  rejected with a `ValueError` that names the workaround.
- Fixture/local-only contexts where the catalog can't be wrapped (no
  catalog, or a mock) keep working with a `logger.warning(...)`. Those
  flows pre-populate the engine with arbitrary RIDs and the placeholder
  scoping key matches in-memory SQL when rows exist.
- Updates the docstring to remove the "currently returns zero rows"
  caveat and document the new contract.
- Adds three regression tests against the canned-fixture suite (no live
  catalog needed): the live-catalog-rejection case, the
  explicit-dataset_rid control case, and the local-mode-warns case.

## References

- Audit: `docs/audits/2026-05-26-denormalize-audit.md` — SC-02 + TC-05
- Spec (declares the contract): PR #231 / branch
  `docs/denormalize-spec-completeness-pass`, §8.1 known-limitation block
  in `docs/design/denormalization.md`

## Test plan

- [x] `uv run python -m pytest tests/local_db/test_denormalizer.py` — 42 passed (was 39)
- [x] `uv run ruff check src tests`
- [x] `uv run ruff format src tests`

🤖 Generated with [Claude Code](https://claude.com/claude-code)