### PR TITLE
fix(denormalize): defensive one-liners (RB-03/04/05/06/08/10 + SC-05)

### DIFF
--- a/src/deriva_ml/local_db/denormalize.py
+++ b/src/deriva_ml/local_db/denormalize.py
@@ -350,7 +350,6 @@ def _denormalize_impl(
             table_to_schema=table_to_schema,
             join_tables=join_tables,
             dataset_rid_list=dataset_rid_list,
-            model=model,
         )
 
     # Step 4: Build SQL for each element path.
@@ -396,36 +395,20 @@ def _populate_from_catalog(
     table_to_schema: dict[str, str],
     join_tables: dict,
     dataset_rid_list: list[str],
-    model: DerivaModel,
 ) -> None:
     """Fetch rows from a live catalog into the engine's local tables.
 
-    Two ordering concerns run in parallel:
+    Data-dependency order: each table's fetch needs RID values that come
+    from rows we've already loaded (e.g., to fetch ``Image`` we read
+    ``Dataset_Image.Image`` from the local DB). The join-path walk gives
+    us this naturally — we walk each path's tables in join order and
+    fetch each table once.
 
-    1. **Data-dependency order** — each table's fetch needs RID values
-       that come from rows we've already loaded (e.g., to fetch
-       ``Image`` we read ``Dataset_Image.Image`` from the local DB).
-       This is what the join-path walk gives us naturally.
-    2. **FK-dependency order** — each ``INSERT`` must come after the
-       row it references, because the local SQLite engine has
-       ``foreign_keys=ON`` (set by ``create_wal_engine``). A naive
-       join-path walk inserts ``Dataset_Image`` before ``Image``, and
-       SQLite refuses with ``IntegrityError: FOREIGN KEY constraint
-       failed``.
-
-    Both orderings agree on the parent-before-child arrows, but a
-    single join path can visit a referencing table before its referent
-    (the path ``Dataset → Dataset_Image → Image`` references both
-    backwards-FKs and forwards-FKs).  The fix:
-
-    - Step 1: fetch every table's RIDs in *join-path* order so each
-      table can read FK values from already-loaded prior tables.
-    - Step 2: actually insert each table's rows in *FK-dependency*
-      order — referents before referencers — so SQLite is happy.
-
-    We accomplish both with a single rewrite: walk the join paths once
-    to determine *which RIDs to fetch for each table*, then issue the
-    fetches in FK-safe order.
+    FK enforcement is disabled for the duration of the load via
+    :func:`_foreign_keys_off`, so a join path that visits a referencing
+    table before its referent (e.g. ``Dataset → Dataset_Image → Image``,
+    which inserts ``Dataset_Image`` before ``Image``) does not raise on
+    SQLite. The constraint is re-enabled on exit.
 
     Args:
         paged_client: The client used for all catalog HTTP calls.
@@ -441,15 +424,7 @@ def _populate_from_catalog(
             with "Dataset".
         dataset_rid_list: RIDs to scope the denormalization to (the root
             dataset plus any children from recursive traversal).
-        model: The DerivaModel — used to read FK metadata for the FK-safe
-            insertion order over the tables we're about to populate.
     """
-    # ``model`` is part of the signature for future FK-aware insert
-    # ordering (see :func:`_foreign_keys_off` docstring). It's not
-    # consumed in the body today; mark it referenced to keep lint
-    # quiet without losing the API surface.
-    _ = model
-
     fetcher = PagedFetcher(client=paged_client, engine=engine)
 
     # FK enforcement is off for the whole load — see
@@ -574,7 +549,22 @@ def _collect_fk_values(
     Returns ``(values, column_name)`` where ``column_name`` is the name of the
     filter column on *target_table_name*, or ``(empty, None)`` if no workable
     condition is found.
+
+    **Single-column FK assumption (RB-08).** This routine currently
+    handles only **single-column** foreign keys. When the planner emits
+    a join condition for a **composite** FK (multiple ``(fk_col, pk_col)``
+    pairs all targeting *target_table_name*), the legacy implementation
+    silently returned the first pair's values, producing an under-scoped
+    fetch. The implementation now raises ``NotImplementedError`` when
+    more than one workable condition is found, so the limitation
+    surfaces loudly the day a schema introduces a composite FK rather
+    than producing wrong join results.
+
+    DerivaML schemas in active use today (CSA, CFDE, GPCR) all use
+    single-column RID-based FKs, so this guard is latent and only fires
+    against a future schema that breaks the assumption.
     """
+    workable: list[tuple[list[Any], str]] = []
     for fk_col, pk_col in conditions:
         # Each pair has one column that belongs to target_table_name (the
         # "far side" for this join) and one that belongs to an already-loaded
@@ -615,8 +605,21 @@ def _collect_fk_values(
             values = [row[0] for row in conn.execute(stmt).fetchall() if row[0] is not None]
 
         if values:
-            return values, filter_col_on_target
+            workable.append((values, filter_col_on_target))
 
+    if len(workable) > 1:
+        # RB-08: surface composite FKs loudly so a future schema breaking
+        # the single-column assumption produces an actionable error
+        # rather than a silently under-scoped fetch.
+        filter_cols = sorted({fc for _, fc in workable})
+        raise NotImplementedError(
+            f"_collect_fk_values: composite FK on {target_table_name!r} is "
+            f"not yet supported; got {len(workable)} workable conditions on "
+            f"filter columns {filter_cols}. Single-column FKs only — see "
+            f"function docstring for context."
+        )
+    if workable:
+        return workable[0]
     return [], None
 
 

--- a/src/deriva_ml/local_db/denormalizer.py
+++ b/src/deriva_ml/local_db/denormalizer.py
@@ -160,6 +160,13 @@ class Denormalizer:
         self._orm_resolver = getattr(dataset, "_orm_resolver", None)
         self._paged_client: Any = None
         self._source = "local"
+        # RB-05: diagnostic for the silent-fallback-to-local case. When
+        # ErmrestPagedClient construction fails on a live-catalog path,
+        # this gets populated with a single-line description so the
+        # describe() envelope can surface it (planned: SC-01 warnings
+        # envelope appends this to plan["warnings"]). Empty string means
+        # "no fallback occurred."
+        self._init_warning: str = ""
 
         if ml_instance is not None:
             workspace = getattr(ml_instance, "workspace", None)
@@ -182,11 +189,24 @@ class Denormalizer:
 
                     self._paged_client = ErmrestPagedClient(catalog=catalog)
                     self._source = "catalog"
-                except Exception:
-                    # If the client can't be built (offline tests, mock
-                    # catalog), fall back to local mode silently.
+                except Exception as e:
+                    # RB-05: If the client can't be built (offline tests,
+                    # mock catalog, transient auth race), fall back to
+                    # local mode — but log at WARNING and stash an
+                    # `_init_warning` so describe() can surface the
+                    # fallback to callers. Previously this was silent
+                    # and produced zero-row results on auth/network
+                    # setup races with no diagnostic.
                     self._paged_client = None
                     self._source = "local"
+                    self._init_warning = (
+                        f"ErmrestPagedClient construction failed "
+                        f"({type(e).__name__}: {e}); fell back to "
+                        f"source='local'. Live-catalog fetches are "
+                        f"disabled — results will reflect whatever is "
+                        f"already in the local engine."
+                    )
+                    logger.warning("Denormalizer init: %s", self._init_warning)
 
         if self._orm_resolver is None and self._model is not None:
             # Last resort — model-level ORM resolver.
@@ -718,7 +738,11 @@ class Denormalizer:
             anchors = self._anchors_as_dict()
         except Exception:
             anchors = {}
-        anchors_by_type = {t: len(rids) for t, rids in anchors.items()}
+        # RB-03: skip empty anchor sets, matching the ``if not rids: continue``
+        # guard in :meth:`_classify_anchors`. ``list_dataset_members`` returns
+        # ``{"File": []}`` for empty association tables; describe and run must
+        # agree on the resulting anchor count.
+        anchors_by_type = {t: len(rids) for t, rids in anchors.items() if rids}
 
         # ── estimated row count (anchor-based; honest about unknowns) ───────
         #
@@ -1039,10 +1063,26 @@ class Denormalizer:
                 dataset_children_rids = [
                     getattr(c, "dataset_rid", None) for c in children if getattr(c, "dataset_rid", None)
                 ] or None
-            except Exception:
-                # Fixture-shaped datasets or unusual DatasetLike
+            except (AttributeError, TypeError):
+                # RB-06: Fixture-shaped datasets or unusual DatasetLike
                 # implementations may not support recurse; silently fall
                 # back to root-only scoping rather than break denormalize.
+                dataset_children_rids = None
+            except Exception as e:
+                # RB-06: For a live catalog source, a transient failure
+                # (network, permissions) silently dropping to root-only
+                # produces the silent-zero pattern on nested datasets.
+                # Surface the failure as a WARNING log so operators can
+                # see why their nested-member rows are missing. Fixtures
+                # are caught by the narrow except above, so reaching here
+                # against ``source='catalog'`` is a real catalog issue.
+                if self._source == "catalog":
+                    logger.warning(
+                        "list_dataset_children failed on live catalog: %s; "
+                        "falling back to root-only scoping (nested-dataset "
+                        "members will be absent from the result).",
+                        e,
+                    )
                 dataset_children_rids = None
 
         main_result = _denormalize_impl(
@@ -1071,9 +1111,28 @@ class Denormalizer:
         }
         seen_by_table: dict[str, set[str]] = {t: set() for t in upstream_anchors}
         if upstream_anchors:
+            # RB-04: Build per-anchor RID labels via ``denormalize_column_name``
+            # so multi-schema datasets resolve to ``schema.Table.RID`` rather
+            # than the bare ``Table.RID`` form. Previously this loop assumed
+            # single-schema and would silently fail to match any row on
+            # multi-schema datasets, marking every anchor RID as orphan.
+            from deriva_ml.model.catalog import denormalize_column_name
+
+            _, _column_specs, _multi_schema = self._model._planner._prepare_wide_table(
+                self._dataset,
+                self._dataset_rid,
+                list(include_tables),
+                row_per=resolved_row_per,
+                via=list(via or []) or None,
+            )
+            table_to_schema: dict[str, str] = {t: s for s, t, _c, _tp in _column_specs}
+            rid_label_by_anchor: dict[str, str] = {
+                t: denormalize_column_name(table_to_schema.get(t, ""), t, "RID", _multi_schema)
+                for t in seen_by_table
+            }
             for row in main_result.iter_rows():
                 for t, seen in seen_by_table.items():
-                    val = row.get(f"{t}.RID")
+                    val = row.get(rid_label_by_anchor[t])
                     if val is not None:
                         seen.add(val)
         per_rid_orphans: dict[str, list[str]] = {}

--- a/src/deriva_ml/local_db/denormalizer.py
+++ b/src/deriva_ml/local_db/denormalizer.py
@@ -783,13 +783,9 @@ class Denormalizer:
                 # (case 1, exact contribution) and "anchors elsewhere
                 # but reaching row_per via FK chain" (case 2, unknown
                 # fan-out).
-                at_row_per_count = sum(
-                    len(rids) for table, rids in scoping.items() if table == resolved_row_per
-                )
+                at_row_per_count = sum(len(rids) for table, rids in scoping.items() if table == resolved_row_per)
                 downstream_anchor_tables = [
-                    table
-                    for table, rids in scoping.items()
-                    if table != resolved_row_per and rids
+                    table for table, rids in scoping.items() if table != resolved_row_per and rids
                 ]
                 orphan_count = sum(len(rids) for rids in orphans.values())
 
@@ -1127,8 +1123,7 @@ class Denormalizer:
             )
             table_to_schema: dict[str, str] = {t: s for s, t, _c, _tp in _column_specs}
             rid_label_by_anchor: dict[str, str] = {
-                t: denormalize_column_name(table_to_schema.get(t, ""), t, "RID", _multi_schema)
-                for t in seen_by_table
+                t: denormalize_column_name(table_to_schema.get(t, ""), t, "RID", _multi_schema) for t in seen_by_table
             }
             for row in main_result.iter_rows():
                 for t, seen in seen_by_table.items():

--- a/src/deriva_ml/local_db/paged_fetcher.py
+++ b/src/deriva_ml/local_db/paged_fetcher.py
@@ -395,6 +395,17 @@ class PagedFetcher:
         """
         if not rows:
             return 0
+        # SC-05: explicit guard — rows arriving without a ``RID`` key are
+        # a programming error. The legacy contract relied on SQLite's
+        # NOT NULL constraint to surface this (every supported engine
+        # declares ``RID`` as the PK, and PKs are implicitly NOT NULL),
+        # which produced an opaque ``IntegrityError`` from deep in the
+        # dialect layer. Raise a clear ``ValueError`` instead so the
+        # caller sees the bad row, and the contract is no longer
+        # dialect-coupled.
+        for r in rows:
+            if "RID" not in r:
+                raise ValueError(f"_insert_rows: row missing RID — programming error: {r!r}")
         cols = {c.name for c in target_table.columns}
         projected = [{k: v for k, v in r.items() if k in cols} for r in rows]
         if not projected:

--- a/tests/local_db/test_denormalizer.py
+++ b/tests/local_db/test_denormalizer.py
@@ -669,6 +669,264 @@ class TestFromRids:
             )
 
 
+class TestRB03EmptyAnchorInDescribe:
+    """RB-03: describe's anchor count must skip empty anchor sets to match
+    ``_classify_anchors``' ``if not rids: continue`` guard.
+
+    Without this, ``list_dataset_members`` returns ``{"File": []}`` for
+    empty association tables and the describe envelope reports
+    ``anchors.by_type["File"] == 0`` even though ``_run`` skips it
+    entirely — a cosmetic mismatch that confuses careful readers.
+    """
+
+    def test_empty_anchor_skipped_in_describe_by_type(self, populated_denorm) -> None:
+        """A ``list_dataset_members`` entry with an empty list is dropped."""
+
+        class _DSWithEmptyFile(_FakeDataset):
+            def list_dataset_members(self, **kwargs: Any) -> dict[str, list[dict]]:
+                members = super().list_dataset_members(**kwargs)
+                members["File"] = []
+                return members
+
+        ds = _DSWithEmptyFile(populated_denorm)
+        d = Denormalizer(ds)
+        plan = d.describe(["Image", "Subject"])
+        by_type = plan["anchors"]["by_type"]
+        assert "File" not in by_type, (
+            f"Empty anchors should be skipped to match _classify_anchors; got by_type={by_type}"
+        )
+        assert by_type.get("Image") == 3
+
+
+class TestRB04PerRidOrphanScanLabel:
+    """RB-04: the per-RID orphan scan in ``_run`` must label anchor RID
+    columns via ``denormalize_column_name`` rather than the bare
+    ``f"{t}.RID"`` shape, so multi-schema datasets don't silently mark
+    every anchor RID as orphan.
+    """
+
+    def test_label_construction_uses_denormalize_column_name(self) -> None:
+        """Direct: ``denormalize_column_name`` produces the schema-qualified
+        form when ``multi_schema=True`` and the bare form otherwise."""
+        from deriva_ml.model.catalog import denormalize_column_name
+
+        assert denormalize_column_name("isa", "Image", "RID", False) == "Image.RID"
+        assert denormalize_column_name("isa", "Image", "RID", True) == "isa.Image.RID"
+
+    def test_per_rid_scan_still_works_on_single_schema(self, populated_denorm) -> None:
+        """End-to-end: orphan detection works on a single-schema dataset.
+
+        Pin the behavior that the per-RID orphan scan continues to work
+        for single-schema fixtures after the routing change.
+        """
+        ds = _FakeDataset(populated_denorm)
+        d = Denormalizer(ds)
+        df = d.as_dataframe(["Image", "Subject"])
+        assert len(df) >= 3
+
+
+class TestRB05InitWarning:
+    """RB-05: ErmrestPagedClient construction failure on a live-catalog
+    path must surface as an ``_init_warning`` plus a WARNING log, not a
+    silent fallback to ``source='local'``.
+    """
+
+    def test_init_warning_set_on_paged_client_failure(self, populated_denorm, caplog) -> None:
+        """A bad catalog forces fallback; verify diagnostic + log fire."""
+        import logging
+
+        class _BadCatalog:
+            pass
+
+        class _FakeMlForInit:
+            def __init__(self, pd):
+                self.model = pd["model"]
+                ls = pd["local_schema"]
+                self.workspace = type("WS", (), {"engine": ls.engine, "local_schema": ls})()
+                self.catalog = _BadCatalog()
+
+        class _DSWithMl(_FakeDataset):
+            @property
+            def _ml_instance(self):
+                return self._fake_ml
+
+        ds = _DSWithMl(populated_denorm)
+        ds._fake_ml = _FakeMlForInit(populated_denorm)
+
+        with caplog.at_level(logging.WARNING, logger="deriva_ml.local_db.denormalizer"):
+            d = Denormalizer(ds)
+
+        assert d._source == "local"
+        assert d._init_warning, "Expected _init_warning to be populated after fallback"
+        assert "ErmrestPagedClient construction failed" in d._init_warning
+        assert any("Denormalizer init" in rec.message for rec in caplog.records), (
+            f"Expected WARNING log for init fallback; got {[r.message for r in caplog.records]}"
+        )
+
+    def test_init_warning_empty_on_success(self, populated_denorm) -> None:
+        """No fallback → ``_init_warning`` stays empty (the default sentinel)."""
+        ds = _FakeDataset(populated_denorm)
+        d = Denormalizer(ds)
+        assert d._init_warning == ""
+
+
+class TestRB06ListChildrenWarning:
+    """RB-06: ``_run``'s ``list_dataset_children`` exception handling must
+    log a WARNING when the source is ``"catalog"`` (a real catalog
+    failure) and stay silent on AttributeError/TypeError from fixture-
+    shaped datasets that simply don't implement recurse.
+    """
+
+    def test_real_exception_warns_under_catalog_source(self, populated_denorm, caplog, monkeypatch) -> None:
+        """Generic exception + source='catalog' → WARNING log.
+
+        Mock out ``_denormalize_impl`` so the test doesn't trip
+        ``_denormalize_impl``'s ``paged_client is required when source='catalog'``
+        validation — we're testing the upstream exception-handling
+        branch, not the SQL executor.
+        """
+        import logging
+
+        from deriva_ml.local_db import denormalizer as denorm_mod
+
+        class _DSRaisesGeneric(_FakeDataset):
+            def list_dataset_children(self, **kwargs: Any) -> list:
+                raise RuntimeError("network blip")
+
+        ds = _DSRaisesGeneric(populated_denorm)
+        d = Denormalizer(ds)
+        d._source = "catalog"
+
+        # Replace the SQL executor with a stub that returns an empty
+        # result — we just need _run's try/except to execute.
+        def _stub_impl(**kwargs: Any) -> Any:
+            from deriva_ml.local_db.denormalize import DenormalizeResult
+
+            return DenormalizeResult(columns=[], row_count=0, _rows=[])
+
+        monkeypatch.setattr(denorm_mod, "_denormalize_impl", _stub_impl)
+
+        with caplog.at_level(logging.WARNING, logger="deriva_ml.local_db.denormalizer"):
+            df = d.as_dataframe(["Image", "Subject"])
+        # Result returned (graceful fallback to root-only scoping).
+        assert len(df) >= 0
+        # Warning emitted because source='catalog' and a non-attr error
+        # was raised.
+        assert any("list_dataset_children failed" in rec.message for rec in caplog.records), (
+            f"Expected WARNING for catalog-source failure; got {[r.message for r in caplog.records]}"
+        )
+
+    def test_attribute_error_silent_for_fixture(self, populated_denorm, caplog) -> None:
+        """AttributeError from a fixture-shaped dataset must NOT warn."""
+        import logging
+
+        class _DSRaisesAttr(_FakeDataset):
+            def list_dataset_children(self, **kwargs: Any) -> list:
+                raise AttributeError("no recurse on this DatasetLike")
+
+        ds = _DSRaisesAttr(populated_denorm)
+        d = Denormalizer(ds)
+        with caplog.at_level(logging.WARNING, logger="deriva_ml.local_db.denormalizer"):
+            df = d.as_dataframe(["Image", "Subject"])
+        assert len(df) >= 0
+        assert not any("list_dataset_children" in rec.message for rec in caplog.records)
+
+
+class TestRB10DeadModelParameter:
+    """RB-10: ``_populate_from_catalog`` no longer accepts a ``model``
+    parameter — it was dead code marked with ``_ = model``.
+    """
+
+    def test_signature_has_no_model_parameter(self) -> None:
+        """Inspect the function signature to pin the parameter removal."""
+        import inspect
+
+        from deriva_ml.local_db.denormalize import _populate_from_catalog
+
+        sig = inspect.signature(_populate_from_catalog)
+        assert "model" not in sig.parameters, (
+            f"_populate_from_catalog should no longer take a 'model' kwarg; got {list(sig.parameters)}"
+        )
+
+
+class TestRB08CompositeFKAssertion:
+    """RB-08: ``_collect_fk_values`` must raise ``NotImplementedError``
+    when more than one workable condition is found, instead of silently
+    returning the first one (under-scoped fetch).
+    """
+
+    def test_composite_fk_raises_not_implemented(self, populated_denorm) -> None:
+        """Two workable conditions, same target table → NotImplementedError."""
+        from sqlalchemy import Column, MetaData, String, Table
+
+        from deriva_ml.local_db.denormalize import _collect_fk_values
+
+        engine = populated_denorm["local_schema"].engine
+        md = MetaData()
+        a = Table("RB08_OtherA", md, Column("RID", String, primary_key=True), Column("FilterCol", String))
+        b = Table("RB08_OtherB", md, Column("RID", String, primary_key=True), Column("FilterCol", String))
+        md.create_all(engine)
+        with engine.begin() as conn:
+            conn.execute(a.insert(), [{"RID": "X1", "FilterCol": "v1"}])
+            conn.execute(b.insert(), [{"RID": "Y1", "FilterCol": "v2"}])
+
+        class _OrmA:
+            __table__ = a
+
+        class _OrmB:
+            __table__ = b
+
+        def resolver(name: str) -> Any:
+            return {"RB08_OtherA": _OrmA, "RB08_OtherB": _OrmB}.get(name)
+
+        def _col(table_name: str, col_name: str) -> Any:
+            t = type("T", (), {"name": table_name})()
+            return type("C", (), {"table": t, "name": col_name})()
+
+        cond_pair_1 = (_col("RB08_OtherA", "FilterCol"), _col("Target", "RID"))
+        cond_pair_2 = (_col("RB08_OtherB", "FilterCol"), _col("Target", "RID"))
+
+        with pytest.raises(NotImplementedError, match="composite FK"):
+            _collect_fk_values(
+                engine=engine,
+                orm_resolver=resolver,
+                conditions={cond_pair_1, cond_pair_2},
+                target_table_name="Target",
+            )
+
+    def test_single_workable_condition_still_returns(self, populated_denorm) -> None:
+        """A single non-empty condition still returns its values."""
+        from sqlalchemy import Column, MetaData, String, Table
+
+        from deriva_ml.local_db.denormalize import _collect_fk_values
+
+        engine = populated_denorm["local_schema"].engine
+        md = MetaData()
+        a = Table("RB08_Only", md, Column("RID", String, primary_key=True), Column("FilterCol", String))
+        md.create_all(engine)
+        with engine.begin() as conn:
+            conn.execute(a.insert(), [{"RID": "X1", "FilterCol": "v1"}])
+
+        class _OrmA:
+            __table__ = a
+
+        def resolver(name: str) -> Any:
+            return _OrmA if name == "RB08_Only" else None
+
+        def _col(table_name: str, col_name: str) -> Any:
+            t = type("T", (), {"name": table_name})()
+            return type("C", (), {"table": t, "name": col_name})()
+
+        values, filter_col = _collect_fk_values(
+            engine=engine,
+            orm_resolver=resolver,
+            conditions={(_col("RB08_Only", "FilterCol"), _col("Target", "RID"))},
+            target_table_name="Target",
+        )
+        assert values == ["v1"]
+        assert filter_col == "RID"
+
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------

--- a/tests/local_db/test_paged_fetcher.py
+++ b/tests/local_db/test_paged_fetcher.py
@@ -506,21 +506,22 @@ class TestFetchByRids:
         """A.4 in the test matrix: insert behavior when an incoming row
         has no ``RID`` column.
 
-        Pin the behavior: INSERT-OR-IGNORE relies on RID being the
-        conflict-target column. A row without RID violates the table's
-        NOT-NULL primary-key constraint and the engine raises. This is
-        the right behavior — rows from ermrest always carry RID, so a
-        missing RID is a programming error worth surfacing.
+        Post-SC-05: the explicit guard at the top of ``_insert_rows``
+        raises a clear ``ValueError`` naming the offending row, so the
+        dialect-coupled ``IntegrityError`` from SQLite's NOT NULL
+        constraint never fires. Rows from ermrest always carry RID, so
+        a missing RID is a programming error worth surfacing — the
+        explicit message makes the failure actionable instead of a
+        deep-engine traceback.
         """
-        from sqlalchemy.exc import IntegrityError
-
         engine = create_engine(f"sqlite:///{tmp_path / 'wd.sqlite'}", future=True)
         target = _make_target_table(engine)
         client = FakePagedClient(rows_by_table={"Image": []})
         fetcher = PagedFetcher(client=client, engine=engine)
 
-        # Calling _insert_rows directly with a bad row should raise.
-        with pytest.raises(IntegrityError):
+        # Calling _insert_rows directly with a bad row should raise
+        # ValueError (SC-05 explicit guard), not IntegrityError.
+        with pytest.raises(ValueError, match="missing RID"):
             fetcher._insert_rows(target, [{"Filename": "x", "Subject": "y"}])
 
     def test_predicate_against_pre_populated_engine(self, engine):


### PR DESCRIPTION
## Summary

Batch of small defensive fixes from the [2026-05-26 denormalize audit](https://github.com/informatics-isi-edu/deriva-ml/blob/docs/denormalize-audit-grill-verdicts/docs/audits/2026-05-26-denormalize-audit.md) targeting RB-class robustness findings with grill verdict ≤ Medium severity and the optional SC-05 explicit guard.

## Per-finding fix summary

- **RB-03**: `describe`'s `anchors.by_type` skips empty anchor sets to match `_classify_anchors`' `if not rids: continue` guard — describe and run now agree on anchor counts.
- **RB-04**: per-RID orphan scan in `_run` uses `denormalize_column_name(...)` to build `Table.RID` / `schema.Table.RID` labels — multi-schema datasets no longer mark every anchor RID as orphan.
- **RB-05**: `ErmrestPagedClient` construction failure logs WARNING and stashes a single-line diagnostic on `Denormalizer._init_warning`. A future SC-01 warnings envelope (PR #228 on `fix/describe-warnings-envelope`) can append this directly into `plan["warnings"]`.
- **RB-06**: `_run`'s `list_dataset_children` exception handling narrows to `AttributeError`/`TypeError` for fixture compatibility; other exceptions emit a WARNING when `self._source == "catalog"` so live-catalog transient failures surface instead of silently dropping to root-only scoping.
- **RB-08**: `_collect_fk_values` raises `NotImplementedError` on composite FKs (multiple workable conditions) instead of silently returning the first under-scoped match. Documents the single-column FK assumption in the docstring.
- **RB-10**: Remove dead `model` parameter from `_populate_from_catalog` and prune the stale "future FK-aware insert ordering" comment.
- **SC-05**: `_insert_rows` raises an explicit `ValueError` on missing-RID rows instead of relying on SQLite's NOT NULL constraint — actionable error message, decoupled from the dialect.

## Peeled out

- **RB-07** (resolver dedup-after-substitution) **peeled out**: it targets `_resolve_table_names`, which is introduced by `fix/denormalize-resolve-feature-names` (PR not yet merged to main). Will land separately on top of that branch.

## Coordination

`_init_warning` (RB-05) is set but not yet surfaced. The parallel `fix/describe-warnings-envelope` branch is implementing the warnings envelope; once it lands it should consume `self._init_warning` from this PR.

## Files touched

- `src/deriva_ml/local_db/denormalize.py` — RB-08, RB-10.
- `src/deriva_ml/local_db/denormalizer.py` — RB-03, RB-04, RB-05, RB-06.
- `src/deriva_ml/local_db/paged_fetcher.py` — SC-05.
- `tests/local_db/test_denormalizer.py` — +10 tests across 6 new TestRB* classes.
- `tests/local_db/test_paged_fetcher.py` — update existing test for SC-05 `ValueError` instead of `IntegrityError`.

## Test plan

- [x] `uv run python -m pytest tests/local_db/` — **266 passed, 3 skipped** (was 256 + 3 before this batch — net +10 tests).
- [x] `uv run ruff check src tests` — all checks pass.
- [x] `uv run ruff format src tests` — clean.

## Audit reference

- `docs/audits/2026-05-26-denormalize-audit.md` (on `docs/denormalize-audit-grill-verdicts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)