### PR TITLE
refactor(planner): delegate FK walk to deriva.bag.path_walker.SchemaPathWalker

### DIFF
--- a/docs/design/denormalization.md
+++ b/docs/design/denormalization.md
@@ -77,6 +77,11 @@ iterator.
                          ├─ _prepare_wide_table(...)               ← src/deriva_ml/model/denormalize_planner.py
                          │    pure model code; no I/O
                          │    returns:  join_tables, column_specs, multi_schema
+                         │    FK-graph walking delegated to
+                         │      deriva.bag.path_walker.SchemaPathWalker
+                         │      (shared with deriva-py's CatalogBagBuilder;
+                         │       DerivaML layers skip-tables + nested-dataset
+                         │       loopback as an edge_filter hook)
                          │
                          ├─ if source == "catalog":
                          │    _populate_from_catalog(...)
@@ -314,7 +319,12 @@ ignore_unrelated_anchors)`:
 - **Behavior.**
   1. Resolves source mode from the dataset type (see §6.1).
   2. Plans the join via `_prepare_wide_table` (planner is pure;
-     no I/O — see §2).
+     no I/O — see §2). The FK-graph walker is
+     `deriva.bag.path_walker.SchemaPathWalker`, shared with
+     deriva-py's `CatalogBagBuilder`; DerivaML-specific rules (the
+     default `Dataset_Dataset` / `Execution` skip set and the
+     nested-dataset loopback guard) plug in via the walker's
+     `edge_filter` hook so the generic walker stays domain-free.
   3. If `source="catalog"`: populates the local SQLite via
      `_populate_from_catalog`. This step issues catalog fetches and
      must satisfy the **row-completeness invariant** (§6.3): when

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ requires-python = ">=3.12"
 dependencies = [
     "bump-my-version",
     "bdbag @ git+https://github.com/fair-research/bdbag@1.9.0-dev",
-    "deriva @ git+https://github.com/informatics-isi-edu/deriva-py@deriva-ml",
+    "deriva @ git+https://github.com/informatics-isi-edu/deriva-py@feat/schema-walker-public-api",
     "deepdiff",
     "nbconvert",
     "pandas",
@@ -53,7 +53,7 @@ build-backend = "setuptools.build_meta"
 python-preference = "only-managed"
 
 [tool.uv.sources]
-deriva = { git = "https://github.com/informatics-isi-edu/deriva-py", branch = "deriva-ml" }
+deriva = { git = "https://github.com/informatics-isi-edu/deriva-py", branch = "feat/schema-walker-public-api" }
 
 
 [tool.setuptools.package-data]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ requires-python = ">=3.12"
 dependencies = [
     "bump-my-version",
     "bdbag @ git+https://github.com/fair-research/bdbag@1.9.0-dev",
-    "deriva @ git+https://github.com/informatics-isi-edu/deriva-py@feat/schema-walker-public-api",
+    "deriva @ git+https://github.com/informatics-isi-edu/deriva-py@deriva-ml",
     "deepdiff",
     "nbconvert",
     "pandas",
@@ -53,7 +53,7 @@ build-backend = "setuptools.build_meta"
 python-preference = "only-managed"
 
 [tool.uv.sources]
-deriva = { git = "https://github.com/informatics-isi-edu/deriva-py", branch = "feat/schema-walker-public-api" }
+deriva = { git = "https://github.com/informatics-isi-edu/deriva-py", branch = "deriva-ml" }
 
 
 [tool.setuptools.package-data]

--- a/src/deriva_ml/dataset/dataset_bag.py
+++ b/src/deriva_ml/dataset/dataset_bag.py
@@ -328,7 +328,7 @@ class DatasetBag:
         dataset_rids = [self.dataset_rid] + [c.dataset_rid for c in self.list_dataset_children(recurse=True)]
 
         # Find all paths from Dataset to the target table
-        paths = [[t.name for t in p] for p in self.model._schema_to_paths() if p[-1].name == table]
+        paths = [[t.name for t in p] for p in self.model._planner._schema_to_paths() if p[-1].name == table]
 
         # Build a SELECT query for each path and UNION them together
         sql_cmds = []

--- a/src/deriva_ml/model/catalog.py
+++ b/src/deriva_ml/model/catalog.py
@@ -925,11 +925,6 @@ class DerivaModel:
     # underscore-prefixed because the planner is internal to the
     # denormalization subsystem; the user-facing API is
     # :class:`local_db.denormalize.Denormalizer`.
-    #
-    # The :meth:`_schema_to_paths` forwarder below exists because
-    # ``dataset/dataset_bag.py:381`` still reaches into the model's FK
-    # traversal directly. A follow-up cleanup will migrate that caller
-    # to ``model._planner._schema_to_paths`` and drop the forwarder.
     # ------------------------------------------------------------------
 
     @property
@@ -951,30 +946,6 @@ class DerivaModel:
         if not hasattr(self, "_planner_cache"):
             self._planner_cache = DenormalizePlanner(self)
         return self._planner_cache
-
-    def _schema_to_paths(
-        self,
-        root: "Table | None" = None,
-        path: "list[Table] | None" = None,
-        exclude_tables: "set[str] | None" = None,
-        skip_tables: "frozenset[str] | None" = None,
-        max_depth: int | None = None,
-        stop_at: str | None = None,
-    ) -> "list[list[Table]]":
-        """Forwarder to :meth:`DenormalizePlanner._schema_to_paths`.
-
-        Kept on ``DerivaModel`` because ``dataset/dataset_bag.py:381``
-        still calls it on the model. New code should use
-        ``model._planner._schema_to_paths``.
-        """
-        return self._planner._schema_to_paths(
-            root=root,
-            path=path,
-            exclude_tables=exclude_tables,
-            skip_tables=skip_tables,
-            max_depth=max_depth,
-            stop_at=stop_at,
-        )
 
     def create_table(self, table_def: TableDefinition, schema: str | None = None) -> Table:
         """Create a new table from TableDefinition.

--- a/src/deriva_ml/model/denormalize_planner.py
+++ b/src/deriva_ml/model/denormalize_planner.py
@@ -790,122 +790,111 @@ class DenormalizePlanner:
     def _schema_to_paths(
         self,
         root: Table | None = None,
-        path: list[Table] | None = None,
         exclude_tables: set[str] | None = None,
         skip_tables: frozenset[str] | None = None,
         max_depth: int | None = None,
         stop_at: str | None = None,
     ) -> list[list[Table]]:
-        """Discover all FK paths through the schema graph via depth-first traversal.
+        """Discover all FK paths through the schema graph (DFS, every-prefix).
 
-        Used by the denormalization machinery (_prepare_wide_table)
-        to enumerate joinable paths through the schema. Bag export
-        no longer routes through this method — the bag pipeline
-        (:class:`deriva.bag.catalog_builder.CatalogBagBuilder`) has
-        its own walker, anchored at user-supplied :class:`Anchor`s
-        rather than the Dataset table.
+        Delegates the FK walk to deriva-py's
+        :class:`~deriva.bag.path_walker.SchemaPathWalker` and layers
+        the DerivaML-specific rules on top via the walker's
+        ``edge_filter`` hook:
 
-        Traversal rules:
-        - Follows both outbound FKs (table.foreign_keys) and inbound FKs (table.referenced_by)
-        - Only traverses tables in valid schemas (domain + ML)
-        - Terminates at vocabulary tables (paths go INTO vocabs but not OUT)
-        - Skips tables in exclude_tables and skip_tables
-        - Detects and skips cycles (same table appearing twice in a path)
-        - Prevents dataset element loopback (traversing back to Dataset via element associations)
-        - When multiple FKs exist between the same two domain tables, deduplicates
-          arcs to avoid redundant paths (keeps one arc per target table)
+        - Default skip tables (``Dataset_Dataset``, ``Execution``).
+        - Nested-dataset loopback prevention
+          (``Subject → Dataset_Subject → Dataset`` is blocked).
+
+        The generic walker handles the rest: bidirectional FK walk,
+        vocabulary-as-leaf, multi-FK edge deduplication, simple-path
+        cycle guarding, schema allow-list, and depth bounding.
 
         Args:
-            root: Starting table. Defaults to the Dataset table in the ML schema.
-            path: Current path being built (used during recursion).
-            exclude_tables: Caller-specified table names to skip. These tables and
-                all paths through them are pruned from the result.
-            skip_tables: Infrastructure table names to skip. Defaults to
-                _DEFAULT_SKIP_TABLES (Dataset_Dataset, Execution). Override to
-                customize which ML schema tables are excluded from traversal.
-            max_depth: Maximum path length (number of tables). None = unlimited.
-                Use to protect against pathological schemas with deep chains.
-            stop_at: If given, return only paths whose final table's name equals
-                ``stop_at``. The root-only path ``[root]`` is excluded unless
-                ``root.name == stop_at``. Default ``None`` returns all prefixes
-                (the original behavior).
+            root: Starting table. Defaults to the ML schema's
+                ``Dataset`` table.
+            exclude_tables: Caller-specified table names to skip.
+                Pruned along with all paths through them.
+            skip_tables: Infrastructure table names to skip. Defaults
+                to ``_DEFAULT_SKIP_TABLES``
+                (``{"Dataset_Dataset", "Execution"}``). Override to
+                customize which ML-schema tables are excluded.
+            max_depth: Maximum path length (number of tables). ``None``
+                means unbounded.
+            stop_at: If supplied, return only paths whose last table
+                has this name. The full-prefix DFS still runs; this
+                is a post-filter on the result.
 
         Returns:
-            List of paths, where each path is a list of Table objects starting
-            from root. Every prefix of a path is also included (e.g., if
-            [Dataset, A, B, C] is a path, then [Dataset], [Dataset, A], and
-            [Dataset, A, B] are also in the result).
+            Every walked prefix as a list of :class:`Table` objects.
+            If ``[Dataset, A, B, C]`` is walked, ``[Dataset]``,
+            ``[Dataset, A]``, ``[Dataset, A, B]`` are all in the
+            result too.
         """
-        exclude_tables = exclude_tables or set()
-        skip_tables = skip_tables if skip_tables is not None else _DEFAULT_SKIP_TABLES
+        from deriva.bag.path_walker import SchemaPathWalker
+        from deriva.bag.traversal import FKTraversalPolicy
 
-        root = root or self.model.model.schemas[self.model.ml_schema].tables["Dataset"]
-        path = path.copy() if path else []
-        parent = path[-1] if path else None  # Table we are coming from.
-        path.append(root)
-        paths = [path]
+        # Resolve defaults.
+        exclude_names = exclude_tables or set()
+        skip_names = (
+            skip_tables if skip_tables is not None else _DEFAULT_SKIP_TABLES
+        )
+        if root is None:
+            root = self.model.model.schemas[self.model.ml_schema].tables[
+                "Dataset"
+            ]
 
-        # Depth limit check
-        if max_depth is not None and len(path) >= max_depth:
-            if stop_at is not None:
-                return [p for p in paths if p and p[-1].name == stop_at]
-            return paths
+        # Scope to the domain schemas plus the ML schema — the same
+        # filter the legacy ``_fk_neighbors`` enforced.
+        valid_schemas = self.model.domain_schemas | {self.model.ml_schema}
 
-        def is_nested_dataset_loopback(n1: Table, n2: Table) -> bool:
-            """Check if traversal would loop back to Dataset via an element association.
+        # The DerivaML edge filter implements the two domain-specific
+        # rules: skip-table exclusion (Dataset_Dataset / Execution by
+        # default), caller-supplied exclude_tables, and nested-dataset
+        # loopback prevention.
+        dataset_table = (
+            self.model.model.schemas[self.model.ml_schema].tables["Dataset"]
+        )
 
-            Prevents: Subject -> Dataset_Subject -> Dataset (looping back to root).
-            Allows: Dataset -> Dataset_Subject -> Subject (the intended direction).
-
-            Uses :meth:`is_topological_association` (FK-arity topology) rather
-            than ermrest's ``find_associations(pure=True)`` so that non-
-            pure association tables — bridges that carry user metadata
-            like ``Image_Dataset_Legacy`` — are ALSO recognized as
-            dataset-element associations and excluded from upstream
-            traversal. Without this, walking Image → Image_Dataset_Legacy →
-            Dataset creates a phantom "hub" path that spuriously connects
-            Image to any other dataset-member table (e.g. Subject,
-            Observation) through a different Dataset_X association,
-            producing false Rule-6 ambiguities.
-            """
-            dataset_table = self.model.model.schemas[self.model.ml_schema].tables["Dataset"]
-            if n1 == dataset_table:
-                # Outbound from Dataset → Dataset_X is always fine.
+        def edge_filter(src: Table, tgt: Table) -> bool:
+            # Schema scope is handled by the walker (via policy.schemas),
+            # but skip_tables / exclude_tables / loopback are domain
+            # rules — keep them here.
+            if tgt.name in skip_names:
                 return False
-            # Is n2 an association table that points at Dataset (i.e. one
-            # of its FK targets is the Dataset root)?
-            if not self._is_topological_association(n2):
+            if tgt.name in exclude_names:
                 return False
-            for fk in n2.foreign_keys:
-                if fk.pk_table == dataset_table:
-                    return True
-            return False
+            # Nested-dataset loopback: block ``X → assoc → Dataset``
+            # when X is not Dataset itself. Allows
+            # ``Dataset → Dataset_X → ...`` (the intended outbound
+            # direction) but prevents the inverse walk back to the
+            # root through an element association.
+            if (
+                src is not dataset_table
+                and self._is_topological_association(tgt)
+            ):
+                for fk in tgt.foreign_keys:
+                    if fk.pk_table is dataset_table:
+                        return False
+            return True
 
-        # Vocabulary tables are terminal — traverse INTO but not OUT.
-        if self.model.is_vocabulary(root):
-            if stop_at is not None:
-                return [p for p in paths if p and p[-1].name == stop_at]
-            return paths
+        policy = FKTraversalPolicy(schemas=valid_schemas)
+        walker = SchemaPathWalker(
+            model=self.model.model,
+            policy=policy,
+            edge_filter=edge_filter,
+        )
 
-        for child in self._fk_neighbors(root):
-            if child.name in skip_tables:
-                continue
-            if child.name in exclude_tables:
-                continue
-            if child == parent:
-                # Don't loop back to immediate parent via referenced_by
-                continue
-            if is_nested_dataset_loopback(root, child):
-                continue
-            if child in path:
-                # Cycle detected — skip to avoid infinite recursion.
-                logger.warning(f"Cycle in schema path: {child.name} path:{[p.name for p in path]}, skipping")
-                continue
+        prefixes = walker.walk_all_prefixes(
+            root=root, max_depth=max_depth, stop_at=stop_at
+        )
 
-            paths.extend(self._schema_to_paths(child, path, exclude_tables, skip_tables, max_depth, stop_at))
+        # Convert tuples to lists for compatibility with existing
+        # callers (they iterate and slice freely).
+        result: list[list[Table]] = [list(p) for p in prefixes]
         if stop_at is not None:
-            return [p for p in paths if p and p[-1].name == stop_at]
-        return paths
+            return [p for p in result if p and p[-1].name == stop_at]
+        return result
 
     def _table_relationship(
         self,

--- a/tests/dataset/test_denormalize.py
+++ b/tests/dataset/test_denormalize.py
@@ -251,7 +251,7 @@ class TestDenormalizeSchemaGraph:
         bag = dataset_description.dataset.download_dataset_bag(current_version, use_minid=False)
 
         # The _schema_to_paths method should return paths through the schema
-        paths = bag.model._schema_to_paths()
+        paths = bag.model._planner._schema_to_paths()
 
         # Should have paths to various tables
         assert len(paths) > 0, "Expected schema paths"
@@ -275,7 +275,7 @@ class TestDenormalizeSchemaGraph:
         bag = dataset_description.dataset.download_dataset_bag(current_version, use_minid=False)
 
         # Get all paths without exclusion
-        all_paths = bag.model._schema_to_paths()
+        all_paths = bag.model._planner._schema_to_paths()
 
         # Find a table name that appears in at least one path (not Dataset itself)
         table_names_in_paths = {table.name for path in all_paths for table in path if table.name != "Dataset"}
@@ -283,7 +283,7 @@ class TestDenormalizeSchemaGraph:
 
         # Pick a table to exclude
         exclude_name = next(iter(table_names_in_paths))
-        excluded_paths = bag.model._schema_to_paths(exclude_tables={exclude_name})
+        excluded_paths = bag.model._planner._schema_to_paths(exclude_tables={exclude_name})
 
         # Excluded table should not appear in any path (except if it's the root)
         for path in excluded_paths:

--- a/tests/dataset/test_realworld_patterns.py
+++ b/tests/dataset/test_realworld_patterns.py
@@ -141,12 +141,12 @@ class TestDeepFKChains:
 
         # Without depth limit, should find paths reaching ChainF
         # Path: Dataset → Dataset_ChainA → ChainA → ChainB → ... → ChainF (8 hops)
-        all_paths = test_ml.model._schema_to_paths()
+        all_paths = test_ml.model._planner._schema_to_paths()
         deep_sigs = {" -> ".join(t.name for t in p) for p in all_paths if any(t.name == "ChainF" for t in p)}
         assert len(deep_sigs) > 0, "Should find paths to ChainF without depth limit"
 
         # With max_depth=4, should NOT reach ChainF (needs 8 hops from Dataset)
-        shallow_paths = test_ml.model._schema_to_paths(max_depth=4)
+        shallow_paths = test_ml.model._planner._schema_to_paths(max_depth=4)
         shallow_sigs = {" -> ".join(t.name for t in p) for p in shallow_paths if any(t.name == "ChainF" for t in p)}
         assert len(shallow_sigs) == 0, "max_depth=4 should not reach ChainF"
 
@@ -500,7 +500,7 @@ class TestSelfReferentialFK:
 
         # Should complete without hanging. The cycle detection in
         # _schema_to_paths prevents infinite recursion.
-        paths = test_ml.model._schema_to_paths()
+        paths = test_ml.model._planner._schema_to_paths()
         assert len(paths) > 0
 
     def test_self_referential_denormalize(self, test_ml: DerivaML, tmp_path):
@@ -565,7 +565,7 @@ class TestWideSchema:
         self._create_wide_schema(test_ml, n_tables=8)
         test_ml.model.refresh_model()
 
-        paths = test_ml.model._schema_to_paths()
+        paths = test_ml.model._planner._schema_to_paths()
         # Should complete. The star topology has bounded paths:
         # Dataset → assoc → Hub, Dataset → assoc → Hub → Spoke_i
         # Not exponential.

--- a/tests/dataset/test_schema_paths.py
+++ b/tests/dataset/test_schema_paths.py
@@ -67,7 +67,7 @@ class TestSchemaToPathsBenchmark:
         bag = dataset_description.dataset.download_dataset_bag(
             dataset_description.dataset.current_version, use_minid=False
         )
-        paths = bag.model._schema_to_paths()
+        paths = bag.model._planner._schema_to_paths()
         sigs = path_signatures(paths)
 
         # Core domain paths through Dataset_Image
@@ -90,7 +90,7 @@ class TestSchemaToPathsBenchmark:
         bag = dataset_description.dataset.download_dataset_bag(
             dataset_description.dataset.current_version, use_minid=False
         )
-        paths = bag.model._schema_to_paths()
+        paths = bag.model._planner._schema_to_paths()
         sigs = path_signatures(paths)
 
         # Core domain paths through Dataset_Subject
@@ -109,7 +109,7 @@ class TestSchemaToPathsBenchmark:
         bag = dataset_description.dataset.download_dataset_bag(
             dataset_description.dataset.current_version, use_minid=False
         )
-        paths = bag.model._schema_to_paths()
+        paths = bag.model._planner._schema_to_paths()
         sigs = path_signatures(paths)
 
         # Legacy association paths mirror Dataset_Image paths
@@ -127,7 +127,7 @@ class TestSchemaToPathsBenchmark:
         bag = dataset_description.dataset.download_dataset_bag(
             dataset_description.dataset.current_version, use_minid=False
         )
-        paths = bag.model._schema_to_paths()
+        paths = bag.model._planner._schema_to_paths()
         sigs = path_signatures(paths)
 
         # Image features (via Dataset_Image)
@@ -149,7 +149,7 @@ class TestSchemaToPathsBenchmark:
         bag = dataset_description.dataset.download_dataset_bag(
             dataset_description.dataset.current_version, use_minid=False
         )
-        paths = bag.model._schema_to_paths()
+        paths = bag.model._planner._schema_to_paths()
         sigs = path_signatures(paths)
 
         # ML schema paths
@@ -171,7 +171,7 @@ class TestSchemaToPathsBenchmark:
         bag = dataset_description.dataset.download_dataset_bag(
             dataset_description.dataset.current_version, use_minid=False
         )
-        paths = bag.model._schema_to_paths()
+        paths = bag.model._planner._schema_to_paths()
 
         vocab_tables = {
             "Dataset_Type",
@@ -197,7 +197,7 @@ class TestSchemaToPathsBenchmark:
         bag = dataset_description.dataset.download_dataset_bag(
             dataset_description.dataset.current_version, use_minid=False
         )
-        paths = bag.model._schema_to_paths()
+        paths = bag.model._planner._schema_to_paths()
         sigs = path_signatures(paths)
 
         # ClinicalRecord is only reachable via ClinicalRecord_Observation (M:N)
@@ -224,7 +224,7 @@ class TestSchemaToPathsBenchmark:
         bag = dataset_description.dataset.download_dataset_bag(
             dataset_description.dataset.current_version, use_minid=False
         )
-        paths = bag.model._schema_to_paths()
+        paths = bag.model._planner._schema_to_paths()
         sigs = path_signatures(paths)
 
         # Direct path: Image → Subject
@@ -238,7 +238,7 @@ class TestSchemaToPathsBenchmark:
         bag = dataset_description.dataset.download_dataset_bag(
             dataset_description.dataset.current_version, use_minid=False
         )
-        paths = bag.model._schema_to_paths()
+        paths = bag.model._planner._schema_to_paths()
 
         for p in paths:
             names = [t.name for t in p]
@@ -257,8 +257,8 @@ class TestSchemaToPathsBenchmark:
             dataset_description.dataset.current_version, use_minid=False
         )
 
-        all_paths = bag.model._schema_to_paths()
-        excluded_paths = bag.model._schema_to_paths(exclude_tables={"Observation"})
+        all_paths = bag.model._planner._schema_to_paths()
+        excluded_paths = bag.model._planner._schema_to_paths(exclude_tables={"Observation"})
 
         all_sigs = path_signatures(all_paths)
         excluded_sigs = path_signatures(excluded_paths)
@@ -287,7 +287,7 @@ class TestSchemaToPathsBenchmark:
         bag = dataset_description.dataset.download_dataset_bag(
             dataset_description.dataset.current_version, use_minid=False
         )
-        paths = bag.model._schema_to_paths()
+        paths = bag.model._planner._schema_to_paths()
 
         # The demo schema with features produces ~115 paths.
         # Allow some tolerance for minor schema changes.
@@ -300,7 +300,7 @@ class TestSchemaToPathsBenchmark:
         bag = dataset_description.dataset.download_dataset_bag(
             dataset_description.dataset.current_version, use_minid=False
         )
-        paths = bag.model._schema_to_paths()
+        paths = bag.model._planner._schema_to_paths()
         sigs = [path_signature(p) for p in paths]
 
         assert len(sigs) == len(set(sigs)), f"Duplicate paths found: {[s for s in sigs if sigs.count(s) > 1]}"
@@ -311,7 +311,7 @@ class TestSchemaToPathsBenchmark:
         bag = dataset_description.dataset.download_dataset_bag(
             dataset_description.dataset.current_version, use_minid=False
         )
-        paths = bag.model._schema_to_paths()
+        paths = bag.model._planner._schema_to_paths()
         sigs = path_signatures(paths)
 
         # Image asset type association

--- a/uv.lock
+++ b/uv.lock
@@ -838,7 +838,7 @@ wheels = [
 [[package]]
 name = "deriva"
 version = "2.0.0.dev0"
-source = { git = "https://github.com/informatics-isi-edu/deriva-py?branch=feat%2Fschema-walker-public-api#f40069aaa4d6b34b48c8287b6c23a69991386684" }
+source = { git = "https://github.com/informatics-isi-edu/deriva-py?branch=deriva-ml#ce2124c44905147f8a707c280e833b763a622a1d" }
 dependencies = [
     { name = "bdbag" },
     { name = "fair-identifiers-client" },
@@ -910,7 +910,7 @@ requires-dist = [
     { name = "bdbag", git = "https://github.com/fair-research/bdbag?rev=1.9.0-dev" },
     { name = "bump-my-version" },
     { name = "deepdiff" },
-    { name = "deriva", git = "https://github.com/informatics-isi-edu/deriva-py?branch=feat%2Fschema-walker-public-api" },
+    { name = "deriva", git = "https://github.com/informatics-isi-edu/deriva-py?branch=deriva-ml" },
     { name = "hydra-zen" },
     { name = "nbconvert" },
     { name = "nbstripout" },

--- a/uv.lock
+++ b/uv.lock
@@ -838,7 +838,7 @@ wheels = [
 [[package]]
 name = "deriva"
 version = "2.0.0.dev0"
-source = { git = "https://github.com/informatics-isi-edu/deriva-py?branch=deriva-ml#ed5ee69c9f65a383f85acc57d9513757a6d0a96e" }
+source = { git = "https://github.com/informatics-isi-edu/deriva-py?branch=feat%2Fschema-walker-public-api#f40069aaa4d6b34b48c8287b6c23a69991386684" }
 dependencies = [
     { name = "bdbag" },
     { name = "fair-identifiers-client" },
@@ -910,7 +910,7 @@ requires-dist = [
     { name = "bdbag", git = "https://github.com/fair-research/bdbag?rev=1.9.0-dev" },
     { name = "bump-my-version" },
     { name = "deepdiff" },
-    { name = "deriva", git = "https://github.com/informatics-isi-edu/deriva-py?branch=deriva-ml" },
+    { name = "deriva", git = "https://github.com/informatics-isi-edu/deriva-py?branch=feat%2Fschema-walker-public-api" },
     { name = "hydra-zen" },
     { name = "nbconvert" },
     { name = "nbstripout" },


### PR DESCRIPTION
## Summary

Consolidates the FK-graph walker that was duplicated between deriva-ml's
`DenormalizePlanner._schema_to_paths` and deriva-py's
`CatalogBagBuilder._compute_reached_tables`. The shared primitive is now
`deriva.bag.path_walker.SchemaPathWalker`, contributed in
informatics-isi-edu/deriva-py#263.

Companion PR: **informatics-isi-edu/deriva-py#263** — must land first.
This PR's `pyproject.toml` and `uv.lock` pin to that branch
(`feat/schema-walker-public-api`); once the deriva-py PR merges into
the `deriva-ml` branch, this PR's pin should flip back to that branch.

## What changes

- `DenormalizePlanner._schema_to_paths`: 120-line hand-rolled DFS body
  replaced by a 30-line wrapper around `SchemaPathWalker.walk_all_prefixes`.
- DerivaML-specific rules plug in via the walker's `edge_filter` hook:
  - default skip-tables (`Dataset_Dataset`, `Execution`),
  - nested-dataset loopback prevention.
- `DerivaModel._schema_to_paths` forwarder: **deleted**. Callers reach
  the planner directly (the one production caller in
  `dataset/dataset_bag.py:331` and the three test files that used the
  forwarder are all ported to `model._planner._schema_to_paths`).
- Spec update: `docs/design/denormalization.md` §2 (ASCII flow) and §6
  step 2 now name the shared walker and explain the
  edge_filter-driven DerivaML rules.

## What does NOT change

The reachability-and-paths helpers (`_outbound_reachable`,
`_outbound_reachable_strict`, `_enumerate_paths`) stay in the planner.
They are direction- and transparency-aware DerivaML semantics with no
deriva-py counterpart. Folding them into a generic walker would hurt
both abstractions — the bag walker is BFS-from-anchors with finite
per-target routes, while denormalize's reachability is a directional
transparent-bridge walk that doesn't need to emit paths at all. See
the audit's "two-walker" finding for the full reasoning.

## Backwards-incompatible changes

- `DerivaModel._schema_to_paths` (the forwarder) is gone. New code
  should use `model._planner._schema_to_paths`. Internal-only API
  (single underscore on a class only the planner subsystem touches);
  no public callers in this repo, deriva-ml-model-template, or the
  deriva-ml-mcp surface.
- `DenormalizePlanner._schema_to_paths(path=...)` — the recursive
  internal `path` argument was removed (it was an implementation
  detail of the DFS recursion, never useful to call sites). No
  external caller passed it.

## Test plan

- [x] `uv run python -m pytest tests/local_db/` — **266 passed, 3 skipped**.
- [x] `uv run python -m pytest tests/model/` (with `DERIVA_ML_ALLOW_DIRTY=true` for the live-catalog tests) — **passes**.
- [x] `uv run python -m pytest tests/dataset/test_schema_paths.py::...` (live catalog) — sampled 3 representative tests, all pass:
  - `test_domain_paths_via_dataset_image`
  - `test_total_path_count` (validates ~115 paths from the demo schema — exact same count as pre-refactor)
  - `test_exclude_tables`
- [ ] Full `tests/dataset/test_schema_paths.py` run (live catalog) takes ~5 minutes; sampled tests cover the key path-shape invariants.
- [ ] CI to run the full suite once the deriva-py pin resolves.

## Refs

- Audit: `docs/audits/2026-05-26-denormalize-audit.md` (consolidates the "two walkers" finding).
- Companion: informatics-isi-edu/deriva-py#263.

🤖 Generated with [Claude Code](https://claude.com/claude-code)