### PR TITLE
fix(denormalize): warnings field on describe envelope (SC-01 / RB-01 / TC-09, recovers #234)

### DIFF
--- a/src/deriva_ml/local_db/denormalizer.py
+++ b/src/deriva_ml/local_db/denormalizer.py
@@ -637,16 +637,20 @@ class Denormalizer:
         row_per: str | None = None,
         via: list[str] | None = None,
     ) -> dict[str, Any]:
-        """Return a 12-key planning-metadata dict describing what a
+        """Return a 13-key planning-metadata dict describing what a
         corresponding :meth:`as_dataframe` call would do.
 
         **Dry-run invariant**: unlike :meth:`as_dataframe`, ``describe``
         never raises. Every failure mode (planner rule violation,
         catalog access error, network timeout) is swallowed and
         represented in the returned dict as ``None`` / ``[]`` / ``{}``
-        in the affected positions. Ambiguities are reported in the
-        ``ambiguities`` list so the caller can inspect before
-        committing to a real call.
+        in the affected positions. **Information-preservation
+        invariant**: whenever a broad-except site swallows an
+        exception, a short one-line diagnostic is appended to
+        ``plan["warnings"]`` so the caller can tell why a key is
+        empty (genuine empty result vs. a swallowed failure).
+        Ambiguities are reported in the ``ambiguities`` list so the
+        caller can inspect before committing to a real call.
 
         Args:
             include_tables: Tables whose columns would appear in the
@@ -695,6 +699,15 @@ class Denormalizer:
             - ``source``: ``"catalog"`` for live Datasets, ``"local"``
               for DatasetBags / canned fixtures, ``"slice"`` for
               attached slices.
+            - ``warnings``: ``list[str]`` — one short human-readable
+              entry per swallowed exception. Each entry names the
+              call that failed (``"_resolve_table_names"``,
+              ``"_find_sinks"``, etc.), what defaulted (``"reverted
+              to original include"``, ``"row_per_candidates is
+              empty"``), and the exception type plus a truncated
+              one-line message. Empty list means describe ran
+              clean. See spec §8.3.1 and audit findings SC-01 /
+              RB-01 / TC-09.
 
         Example::
 
@@ -716,6 +729,18 @@ class Denormalizer:
         original_include = list(include_tables)
         original_via = list(via or [])
 
+        # ── warnings accumulator ────────────────────────────────────────────
+        # Per spec §8.3.1 ("describe() return shape — warnings field"),
+        # every broad-except site below appends a short one-liner
+        # naming the call that failed, what defaulted, and the
+        # exception type + truncated message. This restores the
+        # information-preservation invariant (a caller can tell why a
+        # key is empty) without weakening the dry-run invariant
+        # (describe still never raises). Closes audit findings SC-01,
+        # RB-01, TC-09 in
+        # ``docs/audits/2026-05-26-denormalize-audit.md``.
+        warnings: list[str] = []
+
         # ── feature-name resolution ─────────────────────────────────────────
         # Translate feature names ("Image_Classification") to their
         # underlying feature-association tables
@@ -727,9 +752,13 @@ class Denormalizer:
         # surface the failure as empty fields in the returned dict.
         try:
             include, via_list, row_per = self._resolve_table_names(original_include, via=original_via, row_per=row_per)
-        except Exception:
+        except Exception as e:
             include = original_include
             via_list = original_via
+            warnings.append(
+                f"_resolve_table_names: {type(e).__name__} ({str(e)[:120]}); "
+                "reverted to original include/via"
+            )
 
         # ── row_per resolution ─────────────────────────────────────────────
         # Dry-run invariant: describe() never raises. Every call that could
@@ -740,8 +769,12 @@ class Denormalizer:
         row_per_source = "explicit" if row_per else "auto-inferred"
         try:
             row_per_candidates = self._model._planner._find_sinks(include, via_list)
-        except Exception:
+        except Exception as e:
             row_per_candidates = []
+            warnings.append(
+                f"_find_sinks: {type(e).__name__} ({str(e)[:120]}); "
+                "row_per_candidates is empty"
+            )
         try:
             resolved_row_per: str | None = self._model._planner._determine_row_per(
                 include_tables=include,
@@ -764,9 +797,13 @@ class Denormalizer:
                 via=via_list,
             )
             cols = [(denormalize_column_name(s, t, c, multi_schema), tp) for s, t, c, tp in column_specs]
-        except Exception:
+        except Exception as e:
             element_tables = {}
             cols = []
+            warnings.append(
+                f"_prepare_wide_table: {type(e).__name__} ({str(e)[:120]}); "
+                "element_tables and columns are empty"
+            )
 
         # ── ambiguities (reported, not raised) ─────────────────────────────
         ambiguities_raw: list[dict] = []
@@ -777,10 +814,14 @@ class Denormalizer:
                     include_tables=include,
                     via=via_list,
                 )
-            except Exception:
+            except Exception as e:
                 # If path enumeration fails (e.g., model access error),
                 # treat as "no ambiguities detected" rather than raising.
                 ambiguities_raw = []
+                warnings.append(
+                    f"_find_path_ambiguities: {type(e).__name__} ({str(e)[:120]}); "
+                    "ambiguities not detected"
+                )
         ambiguities = [
             {
                 "type": "multiple_paths",
@@ -820,8 +861,12 @@ class Denormalizer:
         # than raise.
         try:
             anchors = self._anchors_as_dict()
-        except Exception:
+        except Exception as e:
             anchors = {}
+            warnings.append(
+                f"_anchors_as_dict: {type(e).__name__} ({str(e)[:120]}); "
+                "anchors summary is empty"
+            )
         # RB-03: skip empty anchor sets, matching the ``if not rids: continue``
         # guard in :meth:`_classify_anchors`. ``list_dataset_members`` returns
         # ``{"File": []}`` for empty association tables; describe and run must
@@ -897,8 +942,11 @@ class Denormalizer:
                         "orphan_rows": orphan_count,
                         "total": at_row_per_count + orphan_count,
                     }
-            except Exception:
-                pass
+            except Exception as e:
+                warnings.append(
+                    f"estimated_row_count: {type(e).__name__} ({str(e)[:120]}); "
+                    "row-count estimate left as None"
+                )
 
         return {
             "row_per": resolved_row_per,
@@ -913,6 +961,7 @@ class Denormalizer:
             "estimated_row_count": estimated,
             "anchors": {"total": sum(anchors_by_type.values()), "by_type": anchors_by_type},
             "source": getattr(self, "_source", "local"),
+            "warnings": warnings,
         }
 
     def list_paths(

--- a/tests/local_db/test_denormalizer.py
+++ b/tests/local_db/test_denormalizer.py
@@ -478,7 +478,7 @@ class TestDescribe:
         ds = _FakeDataset(populated_denorm)
         d = Denormalizer(ds)
         plan = d.describe(["Image", "Subject"])
-        # Required keys per spec §5
+        # Required keys per spec §5 (+ §8.3.1 warnings envelope).
         for key in [
             "row_per",
             "row_per_source",
@@ -492,6 +492,7 @@ class TestDescribe:
             "estimated_row_count",
             "anchors",
             "source",
+            "warnings",
         ]:
             assert key in plan, f"plan missing key {key}: {list(plan.keys())}"
 
@@ -662,6 +663,9 @@ class TestFeatureNameResolution:
         df = d.as_dataframe(["Image", "ClassifiedAs"])
         # describe's column list shape matches the dataframe's columns.
         assert {name for name, _ in plan["columns"]} == set(df.columns)
+        # SC-01 / spec §8.3.1: when describe and run agree, warnings is empty
+        # — a populated list would mean describe silently swallowed an error.
+        assert plan["warnings"] == [], f"expected clean warnings, got {plan['warnings']}"
 
     def test_unknown_feature_name_distinguishes_from_unknown_table(self, populated_denorm) -> None:
         """Unknown feature name and unknown table produce different
@@ -1289,3 +1293,185 @@ class _FakeDataset:
 
     def list_dataset_children(self, **kwargs: Any) -> list:
         return []
+
+
+
+class TestDescribeWarningsFieldExists:
+    """``describe()`` always returns a ``warnings: list[str]`` key.
+
+    Per spec §8.3.1 ("describe() return shape — warnings field"), the
+    returned dict carries a 13th key whose value is a list of short
+    diagnostic strings — one per swallowed exception. On a clean run
+    the list is empty; the key is always present.
+    """
+
+    def test_warnings_key_present_on_clean_describe(self, populated_denorm) -> None:
+        """Happy path: warnings key exists and is an empty list."""
+        ds = _FakeDataset(populated_denorm)
+        d = Denormalizer(ds)
+        plan = d.describe(["Image", "Subject"])
+        assert "warnings" in plan, f"plan missing 'warnings' key: {list(plan.keys())}"
+        assert isinstance(plan["warnings"], list), (
+            f"plan['warnings'] is {type(plan['warnings'])}, expected list"
+        )
+        assert plan["warnings"] == [], (
+            f"clean describe should produce no warnings, got {plan['warnings']}"
+        )
+
+    def test_warnings_key_present_on_bad_row_per(self, populated_denorm) -> None:
+        """Even when describe's planner-rule paths fail, warnings is a list[str]."""
+        ds = _FakeDataset(populated_denorm)
+        d = Denormalizer(ds)
+        plan = d.describe(["Image"], row_per="Subject")
+        assert "warnings" in plan
+        assert isinstance(plan["warnings"], list)
+        for w in plan["warnings"]:
+            assert isinstance(w, str), f"warning entry not a string: {w!r}"
+
+    def test_warnings_key_present_on_diamond(self, populated_denorm_diamond) -> None:
+        """Ambiguity is a reported outcome, not a swallowed error — warnings stays empty."""
+        ds = _FakeDataset(populated_denorm_diamond)
+        d = Denormalizer(ds)
+        plan = d.describe(["Image", "Subject"])
+        assert "warnings" in plan
+        assert isinstance(plan["warnings"], list)
+
+
+class TestDescribeWarningsPopulated:
+    """Failing-planner-call scenarios produce non-empty ``warnings``.
+
+    Each broad-except site in ``describe()`` appends a one-liner naming
+    the call that failed and what defaulted. We construct a scenario
+    where ``_resolve_table_names`` raises (ambiguous feature name) and
+    verify the corresponding warning lands in ``plan["warnings"]``.
+    """
+
+    @staticmethod
+    def _stub_ambiguous_feature(model):
+        """Set up two synthetic Features with the same feature_name but
+        different target/feature tables, so ``_resolve_table_names``
+        raises ``DerivaMLDenormalizeError("ambiguous")`` per the
+        resolver's documented behavior."""
+
+        class _StubFeature:
+            def __init__(self, feature_name, feature_table, target_table):
+                self.feature_name = feature_name
+                self.feature_table = feature_table
+                self.target_table = target_table
+
+        feat_a = _StubFeature(
+            "AmbigName",
+            model.name_to_table("Subject"),
+            model.name_to_table("Image"),
+        )
+        feat_b = _StubFeature(
+            "AmbigName",
+            model.name_to_table("Image"),
+            model.name_to_table("Subject"),
+        )
+        model.find_features = lambda table=None: [feat_a, feat_b]
+
+    def test_warning_emitted_when_resolve_table_names_raises(
+        self, populated_denorm
+    ) -> None:
+        """Ambiguous feature name → ``_resolve_table_names`` raises →
+        warning appears in plan["warnings"] naming the failing call."""
+        ds = _FakeDataset(populated_denorm)
+        d = Denormalizer(ds)
+        self._stub_ambiguous_feature(populated_denorm["model"])
+
+        plan = d.describe(["Image", "AmbigName"])
+        assert len(plan["warnings"]) >= 1, (
+            f"expected at least one warning, got {plan['warnings']}"
+        )
+        # The first warning must name the call that failed so a caller can
+        # tell which envelope position is unreliable.
+        joined = " | ".join(plan["warnings"])
+        assert "_resolve_table_names" in joined, (
+            f"warnings should name _resolve_table_names, got {plan['warnings']}"
+        )
+
+    def test_warning_format_includes_exception_type_and_default(
+        self, populated_denorm
+    ) -> None:
+        """Each warning string carries the exception class name and a
+        short ``what defaulted`` clause so the user can diagnose without
+        consulting source."""
+        ds = _FakeDataset(populated_denorm)
+        d = Denormalizer(ds)
+        self._stub_ambiguous_feature(populated_denorm["model"])
+
+        plan = d.describe(["Image", "AmbigName"])
+        resolve_warnings = [w for w in plan["warnings"] if "_resolve_table_names" in w]
+        assert resolve_warnings, plan["warnings"]
+        w = resolve_warnings[0]
+        # Format: "<call>: <ExcType> (<msg>); <default-explanation>"
+        assert "DerivaMLDenormalizeError" in w, (
+            f"warning should name the exception type: {w!r}"
+        )
+        assert "reverted to original" in w, (
+            f"warning should describe what defaulted: {w!r}"
+        )
+
+
+class TestDescribeStillNeverRaises:
+    """The dry-run invariant: ``describe()`` never raises, even when
+    swallowed exceptions land in ``warnings``.
+
+    These tests guard against a regression where adding the warnings
+    envelope accidentally turns one of the broad-except sites into a
+    re-raise — the information-preservation invariant must not weaken
+    the dry-run invariant.
+    """
+
+    @staticmethod
+    def _stub_ambiguous_feature(model):
+        """See TestDescribeWarningsPopulated._stub_ambiguous_feature."""
+
+        class _StubFeature:
+            def __init__(self, feature_name, feature_table, target_table):
+                self.feature_name = feature_name
+                self.feature_table = feature_table
+                self.target_table = target_table
+
+        feat_a = _StubFeature(
+            "AmbigName",
+            model.name_to_table("Subject"),
+            model.name_to_table("Image"),
+        )
+        feat_b = _StubFeature(
+            "AmbigName",
+            model.name_to_table("Image"),
+            model.name_to_table("Subject"),
+        )
+        model.find_features = lambda table=None: [feat_a, feat_b]
+
+    def test_describe_does_not_raise_when_resolver_fails(
+        self, populated_denorm
+    ) -> None:
+        """Ambiguous feature name in include_tables: ``describe`` swallows,
+        the warning is appended, and the caller still gets a well-formed
+        dict instead of an exception."""
+        ds = _FakeDataset(populated_denorm)
+        d = Denormalizer(ds)
+        self._stub_ambiguous_feature(populated_denorm["model"])
+
+        # If this raises, the dry-run invariant has regressed.
+        plan = d.describe(["Image", "AmbigName"])
+        # All 13 spec keys should still be present even after a failure.
+        for key in [
+            "row_per",
+            "row_per_source",
+            "row_per_candidates",
+            "columns",
+            "include_tables",
+            "via",
+            "join_path",
+            "transparent_intermediates",
+            "ambiguities",
+            "estimated_row_count",
+            "anchors",
+            "source",
+            "warnings",
+        ]:
+            assert key in plan, f"plan missing key {key} after swallowed error"


### PR DESCRIPTION
## Summary

Recovers PR #234 (closed at 2026-05-26T22:53:19Z without merging) and rebases it onto current main. PR #234's base branch (#228 `_resolve_table_names`) has now landed on main, so this rebase drops the duplicated content and leaves only the warnings-envelope work.

Closes audit findings SC-01 + RB-01 + TC-09 (the "describe broad-except swallows diagnostic info" cluster) per the audit document at `docs/audits/2026-05-26-denormalize-audit.md` and spec PR #231 §8.3.1.

## What changed (vs the original #234)

Same content; only the parent commits from the squash-merged #228 are dropped from the branch history. Two trivial layout-only conflicts (RB-03 anchors filter + a single-line dict comprehension cosmetic) were resolved against the current main version — the warnings.append() call was layered on top of main's RB-03 anchor-filter fix, so both protections coexist. Functionally identical to #234 otherwise.

## Test plan

- [x] `uv run python -m pytest tests/local_db/test_denormalizer.py` — all 65 tests pass.

Closed predecessor: #234.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>