### PR TITLE
feat(denormalize): cache_age_seconds freshness signal on DenormalizeResult (SC-03, recovers #235)

### DIFF
--- a/src/deriva_ml/local_db/denormalize.py
+++ b/src/deriva_ml/local_db/denormalize.py
@@ -34,6 +34,7 @@ The ``source`` parameter controls how rows get into the local SQLite engine:
 
 from __future__ import annotations
 
+import time
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from typing import Any, Callable, Generator
@@ -102,6 +103,20 @@ class DenormalizeResult:
             names use ``Table.Column`` dot notation (or
             ``schema.Table.Column`` when multi-schema).
         row_count: Number of rows in the result (``len(_rows)``).
+        cache_age_seconds: Caller-visible freshness signal (SC-03, spec §6
+            "Freshness caveat"). The wall-clock time delta, in seconds,
+            between the start of this denormalize call and the *earliest*
+            catalog fetch that participated in the SQL JOIN that built this
+            result. ``None`` when no live catalog fetch happened
+            (``source='bag'`` / ``source='local'`` / ``source='slice'``, or
+            ``source='catalog'`` with all keys already deduped against
+            cache — though in practice the dataset-row fetch always
+            stamps the ledger). A user re-running denormalize in a
+            long-lived process can use this to detect that results draw
+            on cached data older than they're comfortable with — the
+            local SQLite cache is write-through and does NOT observe
+            server-side deletions or updates (see ``docs/design/denormalization.md``
+            §6 and §7 F3/F4).
 
     Example::
 
@@ -110,11 +125,14 @@ class DenormalizeResult:
         df = result.to_dataframe()       # full DataFrame
         for row in result.iter_rows():   # streaming
             process(row)
+        if result.cache_age_seconds is not None and result.cache_age_seconds > 600:
+            warn("denormalize result built from cache >10min old")
     """
 
     columns: list[tuple[str, str]]
     row_count: int
     _rows: list[dict[str, Any]] = field(repr=False)
+    cache_age_seconds: float | None = None
 
     def to_dataframe(self) -> pd.DataFrame:
         """Convert the result to a :class:`pandas.DataFrame`.
@@ -170,6 +188,7 @@ class DenormalizeResult:
             columns=self.columns,
             row_count=self.row_count + len(rows),
             _rows=list(self._rows) + list(rows),
+            cache_age_seconds=self.cache_age_seconds,
         )
 
 
@@ -342,8 +361,16 @@ def _denormalize_impl(
     # Step 3b: If source='catalog', fetch rows into the engine's tables
     # before we run the SQL join. Without this step, the join runs against
     # an empty working DB and returns zero rows.
+    #
+    # The returned fetcher carries its freshness ledger
+    # (``fetcher.fetch_ledger``) — a map of ``(table, rid_column, frozenset(rids))``
+    # to the ``time.monotonic()`` of the first fetch attempt for that key.
+    # We use the oldest timestamp in the ledger to compute
+    # :attr:`DenormalizeResult.cache_age_seconds` after the SQL JOIN
+    # materializes (SC-03; spec §6 freshness caveat).
+    fetcher: PagedFetcher | None = None
     if source == "catalog":
-        _populate_from_catalog(
+        fetcher = _populate_from_catalog(
             paged_client=paged_client,
             engine=engine,
             orm_resolver=orm_resolver,
@@ -374,8 +401,22 @@ def _denormalize_impl(
 
         sql_statements.append(stmt)
 
+    # Compute the freshness signal (SC-03). `cache_age_seconds` is the
+    # wall-clock delta between *now* (just before we hand back the result)
+    # and the earliest fetch timestamp in the fetcher's ledger. `None`
+    # when no live catalog fetch happened (`source != "catalog"`, or
+    # `source == "catalog"` but no fetches were recorded — empty join
+    # plan, etc.). See :attr:`DenormalizeResult.cache_age_seconds` for
+    # the user-facing contract.
+    cache_age_seconds = _compute_cache_age_seconds(fetcher)
+
     if not sql_statements:
-        return DenormalizeResult(columns=output_columns, row_count=0, _rows=[])
+        return DenormalizeResult(
+            columns=output_columns,
+            row_count=0,
+            _rows=[],
+            cache_age_seconds=cache_age_seconds,
+        )
 
     # Step 5: Execute.
     final_query = union(*sql_statements) if len(sql_statements) > 1 else sql_statements[0]
@@ -384,7 +425,44 @@ def _denormalize_impl(
         result = session.execute(final_query)
         rows = [dict(row._mapping) for row in result]
 
-    return DenormalizeResult(columns=output_columns, row_count=len(rows), _rows=rows)
+    return DenormalizeResult(
+        columns=output_columns,
+        row_count=len(rows),
+        _rows=rows,
+        cache_age_seconds=cache_age_seconds,
+    )
+
+
+def _compute_cache_age_seconds(fetcher: PagedFetcher | None) -> float | None:
+    """Compute the freshness signal from a fetcher's ledger.
+
+    The contract (SC-03, spec §6 freshness caveat): the wall-clock time
+    delta between *now* and the *earliest* fetch attempt the fetcher
+    recorded. Returns ``None`` when no fetch happened (``fetcher is
+    None`` — bag/local/slice sources don't construct a fetcher) or when
+    the ledger is empty (catalog source with an empty join plan or a
+    no-op call).
+
+    Args:
+        fetcher: The :class:`PagedFetcher` that populated rows for this
+            denormalize call, or ``None`` if no live fetch happened.
+
+    Returns:
+        Wall-clock age in seconds of the oldest participating fetch, or
+        ``None`` if no fetch was recorded.
+
+    Example::
+
+        cache_age = _compute_cache_age_seconds(fetcher)
+        # cache_age >= 0 if at least one fetch happened
+        # cache_age is None for source != "catalog"
+    """
+    if fetcher is None:
+        return None
+    ledger = fetcher.fetch_ledger
+    if not ledger:
+        return None
+    return time.monotonic() - min(ledger.values())
 
 
 def _populate_from_catalog(
@@ -395,7 +473,7 @@ def _populate_from_catalog(
     table_to_schema: dict[str, str],
     join_tables: dict,
     dataset_rid_list: list[str],
-) -> None:
+) -> PagedFetcher:
     """Fetch rows from a live catalog into the engine's local tables.
 
     Data-dependency order: each table's fetch needs RID values that come
@@ -424,6 +502,12 @@ def _populate_from_catalog(
             with "Dataset".
         dataset_rid_list: RIDs to scope the denormalization to (the root
             dataset plus any children from recursive traversal).
+
+    Returns:
+        The :class:`PagedFetcher` used for the catalog fetches. The
+        caller reads its :attr:`PagedFetcher.fetch_ledger` to compute
+        :attr:`DenormalizeResult.cache_age_seconds` (SC-03; spec §6
+        freshness caveat).
     """
     fetcher = PagedFetcher(client=paged_client, engine=engine)
 
@@ -438,6 +522,8 @@ def _populate_from_catalog(
             join_tables=join_tables,
             dataset_rid_list=dataset_rid_list,
         )
+
+    return fetcher
 
 
 def _populate_from_catalog_inner(
@@ -459,6 +545,11 @@ def _populate_from_catalog_inner(
     # rows during the SQL join.
     dataset_orm = orm_resolver("Dataset")
     dataset_schema = table_to_schema.get("Dataset", "deriva-ml")
+    # Stamp the freshness ledger BEFORE the fetch so the timestamp is the
+    # fetch *start*, not the end (SC-03). The ledger key uses the
+    # unqualified table name to match the dedup-processed key shape used
+    # in Step 2 below — see the row-completeness invariant block.
+    fetcher.record_fetch_start("Dataset", "RID", dataset_rid_list)
     fetcher.fetch_by_rids(
         table=f"{dataset_schema}:Dataset",
         rids=dataset_rid_list,
@@ -527,6 +618,13 @@ def _populate_from_catalog_inner(
                 if fetch_key in processed:
                     continue
 
+                # Stamp the freshness ledger BEFORE the fetch (SC-03).
+                # ``record_fetch_start`` is idempotent on key — though the
+                # dedup check above already guarantees we won't restamp,
+                # the idempotence is what makes the ledger report the
+                # *first* fetch's timestamp rather than the most-recent
+                # restamp.
+                fetcher.record_fetch_start(table_name, fk_column_on_target, str_rids)
                 fetcher.fetch_by_rids(
                     table=qualified,
                     rids=str_rids,

--- a/src/deriva_ml/local_db/paged_fetcher.py
+++ b/src/deriva_ml/local_db/paged_fetcher.py
@@ -29,6 +29,7 @@ in tests for the exact interface contract.
 
 from __future__ import annotations
 
+import time
 from typing import Any, Iterable, Protocol
 
 from sqlalchemy import Table, select
@@ -157,6 +158,68 @@ class PagedFetcher:
         # its own lifetime, and it survives only the one denormalize call
         # that built the fetcher.
         self._counts: dict[str, int] = {}
+        # Freshness ledger: ``time.monotonic()`` of the first fetch attempt
+        # for each ``(table, rid_column, frozenset(rids))`` tuple. Used by
+        # the denormalize layer to compute
+        # :attr:`DenormalizeResult.cache_age_seconds` — the wall-clock age of
+        # the *oldest* fetch that participated in this fetcher's lifetime
+        # (SC-03, spec §6 "Freshness caveat" caller-visible freshness signal).
+        # Recorded once per distinct key: a cache-hit re-visit by the
+        # dedup-processed set in ``_populate_from_catalog_inner`` does NOT
+        # overwrite an existing timestamp, so the ledger reports "when did
+        # we first fetch this key", not "when was it most recently touched."
+        self._fetch_ledger: dict[tuple[str, str, frozenset[str]], float] = {}
+
+    def record_fetch_start(self, table: str, rid_column: str, rids: Iterable[str]) -> None:
+        """Record the start time of a fetch attempt in the freshness ledger.
+
+        Idempotent on key — if the same ``(table, rid_column, frozenset(rids))``
+        tuple was already recorded, the existing timestamp is preserved. This
+        is the contract that makes :attr:`DenormalizeResult.cache_age_seconds`
+        report "wall-clock age of the *first* fetch that participated", not
+        "the most recent re-touch."
+
+        Callers in :func:`_populate_from_catalog_inner` invoke this
+        immediately before :meth:`fetch_by_rids` for each distinct fetch
+        key, so the ledger reflects fetch *attempts*, not cache hits. A
+        cache-hit re-visit (where the key is already in the dedup
+        ``processed`` set) does not call this and does not pollute the ledger.
+
+        Args:
+            table: Qualified table name (``"schema:table"``) — the same form
+                passed to :meth:`fetch_by_rids`.
+            rid_column: Column on *table* to filter on.
+            rids: RID values being fetched. Stringified and frozen for use
+                as the ledger key.
+
+        Example::
+
+            fetcher.record_fetch_start("isa:Image", "RID", ["IMG-1", "IMG-2"])
+            fetcher.fetch_by_rids(
+                table="isa:Image",
+                rids=["IMG-1", "IMG-2"],
+                target_table=image_t,
+                rid_column="RID",
+            )
+        """
+        key = (table, rid_column, frozenset(str(r) for r in rids))
+        if key not in self._fetch_ledger:
+            self._fetch_ledger[key] = time.monotonic()
+
+    @property
+    def fetch_ledger(self) -> dict[tuple[str, str, frozenset[str]], float]:
+        """Read-only view of the freshness ledger.
+
+        Maps ``(table, rid_column, frozenset(rids))`` to the
+        ``time.monotonic()`` of the first fetch attempt for that key.
+        Used by :func:`_denormalize_impl` to compute
+        :attr:`DenormalizeResult.cache_age_seconds`.
+
+        Returns:
+            The ledger dict. Mutating the returned dict will mutate the
+            fetcher's internal state; treat as read-only.
+        """
+        return self._fetch_ledger
 
     def fetch_predicate(
         self,

--- a/tests/local_db/test_denormalize_impl.py
+++ b/tests/local_db/test_denormalize_impl.py
@@ -666,3 +666,190 @@ def test_denormalize_result_extend() -> None:
     assert [r["A.RID"] for r in extended.iter_rows()] == ["1-A", "1-B", "1-C", "1-D"]
     # Does not mutate the original
     assert base.row_count == 2
+
+
+class TestCacheAgeSeconds:
+    """SC-03 / spec §6 freshness caveat: ``DenormalizeResult.cache_age_seconds``.
+
+    The contract (PR #231 §6): ``DenormalizeResult`` carries
+    ``cache_age_seconds: float | None``:
+
+    - ``None`` for ``source != "catalog"`` (no live fetch happened).
+    - For ``source == "catalog"``: the wall-clock delta between the
+      denormalize call's completion and the *earliest* fetch in the
+      local cache that participated in this result's SQL JOIN.
+
+    These tests pin the contract at the ``_denormalize_impl`` boundary.
+    """
+
+    def test_denormalize_result_carries_cache_age_seconds(
+        self,
+        denorm_deriva_model: Any,
+        denorm_local_schema: Any,
+    ) -> None:
+        """A successful catalog fetch produces a non-negative cache_age_seconds."""
+        from tests.local_db.test_paged_fetcher import FakePagedClient
+
+        ls = denorm_local_schema
+        model = denorm_deriva_model
+        ds_rid = "DS-CA-001"
+
+        fake = FakePagedClient(
+            rows_by_table={
+                "deriva-ml:Dataset": [{"RID": ds_rid, "Description": "t"}],
+                "deriva-ml:Dataset_Image": [
+                    {"RID": "DI-1", "Dataset": ds_rid, "Image": "IMG-A"},
+                ],
+                "isa:Image": [
+                    {"RID": "IMG-A", "Filename": "a.png", "Subject": "S-1"},
+                ],
+                "isa:Subject": [
+                    {"RID": "S-1", "Name": "Alice"},
+                ],
+            }
+        )
+
+        result = _denormalize_impl(
+            model=model,
+            engine=ls.engine,
+            orm_resolver=ls.get_orm_class,
+            dataset_rid=ds_rid,
+            include_tables=["Image", "Subject"],
+            source="catalog",
+            paged_client=fake,
+        )
+
+        assert result.cache_age_seconds is not None, (
+            "source='catalog' with non-empty join plan must surface a freshness signal"
+        )
+        assert result.cache_age_seconds >= 0, f"cache_age_seconds must be non-negative, got {result.cache_age_seconds}"
+
+    def test_denormalize_result_cache_age_is_none_for_local_source(
+        self,
+        populated_denorm: dict[str, Any],
+    ) -> None:
+        """source='local' (no live fetch) reports cache_age_seconds=None.
+
+        The spec carve-out (PR #231 §6): ``None`` for ``source='bag'``
+        (no live fetch happened). ``source='local'`` is the in-tree
+        equivalent — rows are pre-populated, no PagedFetcher is
+        constructed, no ledger exists.
+        """
+        result = _denormalize_impl(
+            model=populated_denorm["model"],
+            engine=populated_denorm["local_schema"].engine,
+            orm_resolver=populated_denorm["local_schema"].get_orm_class,
+            dataset_rid=populated_denorm["dataset_rid"],
+            include_tables=["Image", "Subject"],
+            source="local",
+        )
+
+        assert result.cache_age_seconds is None, (
+            "source='local' must not produce a cache_age_seconds — no live fetch happened"
+        )
+
+    def test_denormalize_result_cache_age_is_none_for_slice_source(
+        self,
+        populated_denorm: dict[str, Any],
+    ) -> None:
+        """source='slice' also produces cache_age_seconds=None (no live fetch).
+
+        Spec PR #231 §6 names ``source='bag'`` explicitly. ``source='slice'``
+        is the production equivalent that ``DatasetBag.get_denormalized_as_dataframe``
+        uses; same carve-out applies.
+        """
+        result = _denormalize_impl(
+            model=populated_denorm["model"],
+            engine=populated_denorm["local_schema"].engine,
+            orm_resolver=populated_denorm["local_schema"].get_orm_class,
+            dataset_rid=populated_denorm["dataset_rid"],
+            include_tables=["Image"],
+            source="slice",
+        )
+
+        assert result.cache_age_seconds is None, (
+            "source='slice' must not produce a cache_age_seconds — no live fetch happened"
+        )
+
+    def test_denormalize_result_cache_age_reflects_oldest_fetch(
+        self,
+        denorm_deriva_model: Any,
+        denorm_local_schema: Any,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """cache_age_seconds reports age of the *oldest* participating fetch.
+
+        Scenario: simulate two fetches in the same call separated by N
+        seconds of wall-clock time. The reported ``cache_age_seconds``
+        must be at least N (the delta from the first fetch to "now"),
+        not the delta from the most recent fetch.
+
+        We drive this deterministically by monkey-patching
+        ``time.monotonic`` in the paged_fetcher and denormalize modules
+        to return successive values from a controlled list — no actual
+        ``sleep`` calls (which would slow the suite and add jitter).
+        """
+        from tests.local_db.test_paged_fetcher import FakePagedClient
+
+        ls = denorm_local_schema
+        model = denorm_deriva_model
+        ds_rid = "DS-CA-AGE-001"
+
+        fake = FakePagedClient(
+            rows_by_table={
+                "deriva-ml:Dataset": [{"RID": ds_rid, "Description": "t"}],
+                "deriva-ml:Dataset_Image": [
+                    {"RID": "DI-1", "Dataset": ds_rid, "Image": "IMG-A"},
+                ],
+                "isa:Image": [
+                    {"RID": "IMG-A", "Filename": "a.png", "Subject": "S-1"},
+                ],
+                "isa:Subject": [
+                    {"RID": "S-1", "Name": "Alice"},
+                ],
+            }
+        )
+
+        # Monkey-patched clock: each call returns the next value in the
+        # sequence. The fetcher calls ``time.monotonic`` once per distinct
+        # ``record_fetch_start``; ``_denormalize_impl`` calls it once at
+        # the end via ``_compute_cache_age_seconds``. We pin those reads
+        # to a deterministic sequence so the assertion below is exact.
+        # Sequence: 100 (Dataset fetch), 110 (Dataset_Image), 120 (Image),
+        # 130 (Subject), then 145 for the final "now" — i.e. the oldest
+        # fetch is 45s in the past at the time of result construction.
+        clock_values = iter([100.0, 110.0, 120.0, 130.0, 145.0])
+
+        def _fake_monotonic() -> float:
+            return next(clock_values)
+
+        # Patch where ``time.monotonic`` is actually called — once in
+        # paged_fetcher.PagedFetcher.record_fetch_start, once in
+        # denormalize._compute_cache_age_seconds. Patching the underlying
+        # ``time`` module on both module surfaces is the cleanest seam.
+        from deriva_ml.local_db import denormalize as denorm_mod
+        from deriva_ml.local_db import paged_fetcher as pf_mod
+
+        monkeypatch.setattr(pf_mod.time, "monotonic", _fake_monotonic)
+        monkeypatch.setattr(denorm_mod.time, "monotonic", _fake_monotonic)
+
+        result = _denormalize_impl(
+            model=model,
+            engine=ls.engine,
+            orm_resolver=ls.get_orm_class,
+            dataset_rid=ds_rid,
+            include_tables=["Image", "Subject"],
+            source="catalog",
+            paged_client=fake,
+        )
+
+        # Oldest fetch at t=100, "now" at t=145 → age = 45s exactly.
+        # The implementation does at most 4 ``record_fetch_start`` calls
+        # (Dataset, Dataset_Image, Image, Subject) plus one final
+        # ``time.monotonic()`` read for the cache_age_seconds computation —
+        # 5 total reads, matching our 5-value sequence. If the planner
+        # ever changes shape, this test will surface it as a StopIteration
+        # from the iterator (a clear signal the contract needs an update).
+        assert result.cache_age_seconds == 45.0, (
+            f"Expected cache_age_seconds reporting oldest fetch age (45.0), got {result.cache_age_seconds}"
+        )


### PR DESCRIPTION
## Summary

Recovers PR #235 (closed at 2026-05-26T22:53:14Z without merging) and rebases it onto current main. PR #235's base branch (#230 SC-06 row-completeness invariant) has now landed on main, so this rebase drops the duplicated SC-06 content and leaves only the SC-03 cache_age_seconds work.

Closes audit finding SC-03 (the "no caller-visible freshness signal" finding) per `docs/audits/2026-05-26-denormalize-audit.md` and spec PR #231 §6 (Freshness caveat).

## What changed

Adds a `cache_age_seconds: float | None` field on `DenormalizeResult` reporting the wall-clock age of the *oldest* catalog fetch that participated in this result's SQL JOIN. `None` for `source='local'` and `source='slice'` (no live fetch). Implementation plumbs a `PagedFetcher._fetch_ledger` keyed on the same `(table, rid_column, frozenset(rids))` tuple as the SC-06 dedup set, with a `record_fetch_start` helper called immediately before each `fetch_by_rids`. The ledger is idempotent on key so cache-hit re-visits don't restamp.

## What changed (vs the original #235)

Same content; the four SC-06 commits at the base of the original branch are dropped (their content is now on main via #230). One trivial signature-overlap conflict in `_populate_from_catalog`: the original branch was authored against a parent where the function had an unused `model: DerivaModel` parameter that didn't make it to main; dropped that param from the recovered version. Otherwise functionally identical to #235.

## Test plan

- [x] `uv run python -m pytest tests/local_db/test_denormalize_impl.py` — all 21 tests pass.

Closed predecessor: #235.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>