### PR TITLE
denormalize: close-out RB-07, docstring paths, audit dispositions

### DIFF
--- a/docs/audits/2026-05-26-denormalize-audit.md
+++ b/docs/audits/2026-05-26-denormalize-audit.md
@@ -29,37 +29,39 @@ either confirmed, demoted, dropped, or fixed each finding. Inline
 | Finding | PR | Notes |
 |---|---|---|
 | SC-04, SC-05, SC-08, RB-09 | informatics-isi-edu/deriva-ml#231 | Doc-rot fixed in the spec rewrite, or finding determined not-a-bug after grilling. |
+| Single-source-of-record consolidation | informatics-isi-edu/deriva-ml#242 | Design spec, recovered user guide, and semantics companion merged into `docs/user-guide/denormalization.md` (Mechanism D, 1,712 lines). Old paths removed: `docs/design/denormalization.md`, `docs/concepts/denormalization.md` (was a stub), `docs/superpowers/specs/2026-04-17-denormalization-semantics-design.md`. mkdocs nav + cross-refs updated. |
 
 **Deferred — code work that the spec rewrite calls out:**
 
-| Finding | What the spec says now | Code TODO |
-|---|---|---|
-| SC-01 / RB-01 / TC-09 | §8.3 names a `warnings: list[str]` envelope field on `describe()` | implement the field; route every swallowed exception through it. |
-| SC-02 / TC-05 | §8.1 says `from_rids(dataset_rid=None)` must reject against live catalog (or surface a `reason`) | implement the guard. |
-| SC-03 | §6 Freshness caveat says `DenormalizeResult` should carry a freshness signal | add `cache_age_seconds: float \| None`. |
-| SC-07 / TC-06 | §8.2 declares `as_dict` does NOT stream (matches today's eager materialisation) but flags streaming as the better implementation. | Pick A (correct the docstring — already aligned by spec) or B (implement streaming). Spec is honest either way. |
+| Finding | What the spec says now | Code TODO | Status |
+|---|---|---|---|
+| SC-01 / RB-01 / TC-09 | §8.3 names a `warnings: list[str]` envelope field on `describe()` | implement the field; route every swallowed exception through it. | **Closed** by informatics-isi-edu/deriva-ml#239 — 13-key envelope with `warnings`, 6 broad-except sites instrumented. |
+| SC-02 / TC-05 | §8.1 says `from_rids(dataset_rid=None)` must reject against live catalog (or surface a `reason`) | implement the guard. | **Closed** by informatics-isi-edu/deriva-ml#236 — `from_rids` rejects `dataset_rid=None` against live catalog with `ValueError`. |
+| SC-03 | §6 Freshness caveat says `DenormalizeResult` should carry a freshness signal | add `cache_age_seconds: float \| None`. | **Closed** by informatics-isi-edu/deriva-ml#240 — field landed on `DenormalizeResult`. |
+| SC-07 / TC-06 | §8.2 declares `as_dict` does NOT stream (matches today's eager materialisation) but flags streaming as the better implementation. | Pick A (correct the docstring — already aligned by spec) or B (implement streaming). Spec is honest either way. | **Closed (Pick A)** by informatics-isi-edu/deriva-ml#233 — docstring corrected to admit eager materialisation. Streaming remains a future enhancement. |
 
 **Confirmed remaining test gaps:**
 
-| Finding | Severity (post-grill) | Disposition |
-|---|---|---|
-| TC-01 | Medium (was Blocker) | demoted — the load-bearing role TC-01 played for SC-06 is now covered by `TestRowCompletenessInvariant`. The cross-channel parity test is still worth writing; spec §9 D.2 marks it as "planned, not yet written." |
-| TC-02 | Medium (was High) | demoted — per-key describe-vs-run parity test still worth writing for the 11 keys analyst/01's `test_describe_and_run_agree` doesn't cover. |
-| TC-04 | Medium (unchanged) | §8 C.5x xfail test for server-side delete still missing; spec rewrite reconciled it to "planned." |
-| TC-07 | Medium (unchanged) | live-catalog resolver test still missing. |
-| TC-08 | Medium (unchanged) | `_collect_fk_values` partial-engine-state behavior unpinned. |
-| TC-10 | Low (unchanged) | catalog↔bag parity test for A01-shape data — cheap extension of `test_feature_table_multiple_rows_per_anchor`. |
+| Finding | Severity (post-grill) | Disposition | Status |
+|---|---|---|---|
+| TC-01 | Medium (was Blocker) | demoted — the load-bearing role TC-01 played for SC-06 is now covered by `TestRowCompletenessInvariant`. The cross-channel parity test is still worth writing; spec §9 D.2 marks it as "planned, not yet written." | **Closed** by informatics-isi-edu/deriva-ml#241 (cross-channel parity D.3 added). |
+| TC-02 | Medium (was High) | demoted — per-key describe-vs-run parity test still worth writing for the 11 keys analyst/01's `test_describe_and_run_agree` doesn't cover. | **Closed** by informatics-isi-edu/deriva-ml#241 (`TestDescribeKeyParity` covers the remaining keys). |
+| TC-04 | Medium (unchanged) | §8 C.5x xfail test for server-side delete still missing; spec rewrite reconciled it to "planned." | **Closed** by informatics-isi-edu/deriva-ml#241 (C.5x xfail test added). |
+| TC-07 | Medium (unchanged) | live-catalog resolver test still missing. | **Closed** by informatics-isi-edu/deriva-ml#241 (`test_resolve_table_names_live_feature` added). |
+| TC-08 | Medium (unchanged) | `_collect_fk_values` partial-engine-state behavior unpinned. | **Closed** by informatics-isi-edu/deriva-ml#241 (partial-engine-state coverage added). |
+| TC-10 | Low (unchanged) | catalog↔bag parity test for A01-shape data — cheap extension of `test_feature_table_multiple_rows_per_anchor`. | **Closed** by informatics-isi-edu/deriva-ml#241 (parity assertion added). |
 
 **Confirmed remaining robustness one-liners (code TODOs):**
 
-| Finding | Severity | One-line fix |
-|---|---|---|
-| RB-03 | Low | `if not rids: continue` filter in describe at line 721 (mirror `_classify_anchors` skip). |
-| RB-04 | Low | Multi-schema label hazard in `_run`'s per-RID orphan scan; use `denormalize_column_name` or assert single-schema. |
-| RB-05 | Medium | `Denormalizer.__init__` silent fallback to `source="local"` should log WARNING + attach `_init_warning`. |
-| RB-06 | Medium | `list_dataset_children` silent fallback to root-only should warn for `source="catalog"`. |
-| RB-08 | Medium | `_collect_fk_values` composite-FK assumption — AND conditions or document single-column FK requirement. |
-| RB-10 | Low | Remove unused `model` parameter from `_populate_from_catalog`. |
+| Finding | Severity | One-line fix | Status |
+|---|---|---|---|
+| RB-03 | Low | `if not rids: continue` filter in describe at line 721 (mirror `_classify_anchors` skip). | Pending. |
+| RB-04 | Low | Multi-schema label hazard in `_run`'s per-RID orphan scan; use `denormalize_column_name` or assert single-schema. | Pending. |
+| RB-05 | Medium | `Denormalizer.__init__` silent fallback to `source="local"` should log WARNING + attach `_init_warning`. | Pending. |
+| RB-06 | Medium | `list_dataset_children` silent fallback to root-only should warn for `source="catalog"`. | Pending. |
+| RB-07 | Low | Resolver should dedup after feature-name substitution so `["Image_Classification", "Execution_Image_Image_Classification"]` collapses to one entry. | **Closed** (post-PR-241 follow-up, this branch) — `_resolve_table_names` now dedups resolved `include_tables` / `via` in first-seen order, with `test_resolver_dedupes_after_feature_substitution` as regression. |
+| RB-08 | Medium | `_collect_fk_values` composite-FK assumption — AND conditions or document single-column FK requirement. | **Closed** by informatics-isi-edu/deriva-ml#238 — `_collect_fk_values` raises `NotImplementedError` on composite FK rather than silently mis-fetching. |
+| RB-10 | Low | Remove unused `model` parameter from `_populate_from_catalog`. | Pending. |
 
 **Dropped after grilling:**
 

--- a/src/deriva_ml/local_db/__init__.py
+++ b/src/deriva_ml/local_db/__init__.py
@@ -20,14 +20,14 @@ tracking.  Key public symbols:
 - :class:`ManifestStore`: crash-safe SQLite replacement for the old
   ``asset-manifest.json`` file.
 
-See ``docs/design/denormalization.md`` for the current architecture,
-state model, fetcher/INSERT contract, fragility map, and test matrix.
+See ``docs/user-guide/denormalization.md`` — the single source of
+record for the current architecture, state model, fetcher/INSERT
+contract, the nine semantic Rules, fragility map, and test matrix.
 The older Phase 1 / Phase 2 design specs under
 ``docs/superpowers/specs/`` remain authoritative for the workspace
-layout (ATTACH'd schema files, ``main.db`` registries) and the
-``Denormalizer`` class semantic Rules 1–8 respectively, but are
-superseded by ``docs/design/denormalization.md`` wherever they
-overlap on fetcher/INSERT-side behavior.
+layout (ATTACH'd schema files, ``main.db`` registries) but are
+superseded by the user guide wherever they overlap on
+fetcher/INSERT-side behaviour or Denormalizer semantics.
 
 See ``README.md`` in this directory for a short orientation.
 """

--- a/src/deriva_ml/local_db/denormalize.py
+++ b/src/deriva_ml/local_db/denormalize.py
@@ -115,8 +115,8 @@ class DenormalizeResult:
             long-lived process can use this to detect that results draw
             on cached data older than they're comfortable with — the
             local SQLite cache is write-through and does NOT observe
-            server-side deletions or updates (see ``docs/design/denormalization.md``
-            §6 and §7 F3/F4).
+            server-side deletions or updates (see ``docs/user-guide/denormalization.md``
+            §6.5 freshness caveat and §7 F3/F4).
 
     Example::
 

--- a/src/deriva_ml/local_db/denormalizer.py
+++ b/src/deriva_ml/local_db/denormalizer.py
@@ -4,14 +4,12 @@ Wraps the lower-level ``_denormalize_impl`` primitive in a class-based API
 with support for auto-inferred ``row_per``, explicit ``via`` path routing,
 orphan-row handling, and arbitrary RID anchor sets.
 
-Architecture, state model, fetcher/INSERT contract, fragility map, and
-test matrix:
-    ``docs/design/denormalization.md``
-
-The semantic Rules 1–8 implemented here (auto-inferred ``row_per``,
+Architecture, state model, fetcher/INSERT contract, fragility map,
+the nine semantic Rules implemented here (auto-inferred ``row_per``,
 downstream-leaf rejection, ambiguity detection, orphan emission,
-unrelated-anchor handling, etc.) live in:
-    ``docs/superpowers/specs/2026-04-17-denormalization-semantics-design.md``
+unrelated-anchor handling, etc.), and the full test matrix all live in
+the single source of record:
+    ``docs/user-guide/denormalization.md``
 """
 
 from __future__ import annotations
@@ -530,7 +528,7 @@ class Denormalizer:
         results.
 
         True row-by-row streaming over the cursor is a known gap (audit
-        finding SC-07; see ``docs/design/denormalization.md`` §8.2 for
+        finding SC-07; see ``docs/user-guide/denormalization.md`` §8.2 for
         the design discussion). Until that gap is closed, treat
         ``as_dict`` as "iteration interface, materialised internals."
 
@@ -692,7 +690,7 @@ class Denormalizer:
               tables. ``orphan_rows`` is always exact (an orphan
               contributes exactly one row regardless of ``row_per``
               cardinality). Originally surfaced as 2026-05-21 finding
-              A02; documented in ``docs/design/denormalization.md`` §7
+              A02; documented in ``docs/user-guide/denormalization.md`` §7
               row F6.
             - ``anchors``: ``{total, by_type}`` — counts of anchor RIDs
               grouped by table.
@@ -875,7 +873,7 @@ class Denormalizer:
 
         # ── estimated row count (anchor-based; honest about unknowns) ───────
         #
-        # Three cases (see ``docs/design/denormalization.md`` §6 freshness
+        # Three cases (see ``docs/user-guide/denormalization.md`` §6.5 freshness
         # caveat and the 2026-05-21 finding A02 history):
         #
         # 1. Anchor table == row_per → in_scope is exact (1 row per anchor).
@@ -1225,8 +1223,24 @@ class Denormalizer:
                 )
             raise DerivaMLTableNotFound(t)
 
-        resolved_include = [_resolve_one(t) for t in include_tables]
-        resolved_via = [_resolve_one(t) for t in (via or [])]
+        # RB-07: feature-name substitution can collapse two distinct
+        # caller-supplied names onto the same canonical table (e.g.
+        # ["Image_Classification", "Execution_Image_Image_Classification"]
+        # both resolve to the feature-association table). Dedup the
+        # resolved lists in first-seen order so the planner doesn't get
+        # the same table twice — duplicates would trigger spurious
+        # ambiguity/cardinality errors downstream.
+        def _dedup(seq: list[str]) -> list[str]:
+            seen: set[str] = set()
+            out: list[str] = []
+            for x in seq:
+                if x not in seen:
+                    seen.add(x)
+                    out.append(x)
+            return out
+
+        resolved_include = _dedup([_resolve_one(t) for t in include_tables])
+        resolved_via = _dedup([_resolve_one(t) for t in (via or [])])
         resolved_row_per = _resolve_one(row_per) if row_per is not None else None
         return resolved_include, resolved_via, resolved_row_per
 

--- a/src/deriva_ml/local_db/paged_fetcher.py
+++ b/src/deriva_ml/local_db/paged_fetcher.py
@@ -17,7 +17,7 @@ exists in the target table are skipped, not overwritten, not raised on).
 request — the server is the authority for what rows match a query, and
 the database's UNIQUE constraint is the authority for insert collisions.
 
-See ``docs/design/denormalization.md`` for the full pipeline architecture,
+See ``docs/user-guide/denormalization.md`` for the full pipeline architecture,
 state model, and contract. The 2026-05-21 model-template e2e run
 documented two failure modes this design closes (finding 05: re-INSERT
 crash; finding A01: silent row-drop on FK-column fetch).
@@ -115,7 +115,7 @@ class PagedFetcher:
     - :meth:`fetch_by_rids_or_predicate`: automatically routes between the two
       strategies based on ``|rids| / table_row_count`` cardinality ratio.
 
-    Statelessness contract (``docs/design/denormalization.md`` §4):
+    Statelessness contract (``docs/user-guide/denormalization.md`` §4):
 
     - **No engine-derived dedup.** ``fetch_by_rids``/``fetch_predicate`` do
       not consult the engine to decide what to request. The server is the
@@ -440,7 +440,7 @@ class PagedFetcher:
     def _insert_rows(self, target_table: Table, rows: list[dict[str, Any]]) -> int:
         """Insert *rows* into *target_table* using INSERT-OR-IGNORE.
 
-        Contract (``docs/design/denormalization.md`` §5):
+        Contract (``docs/user-guide/denormalization.md`` §5):
 
         - For each row: if a row with the same RID already exists in
           ``target_table``, skip (do not update, do not crash).

--- a/src/deriva_ml/model/denormalize_planner.py
+++ b/src/deriva_ml/model/denormalize_planner.py
@@ -65,12 +65,11 @@ What is intentionally **not** transparent:
 **This module is internal.** The user-facing API for denormalization
 is :class:`local_db.denormalize.Denormalizer`. The semantic Rules
 this planner enforces (auto-inferred ``row_per``, downstream-leaf
-rejection, ambiguity detection, orphan emission, …) live in
-``docs/superpowers/specs/2026-04-17-denormalization-semantics-design.md``.
-The full pipeline (planner → row-population → SQL emission), the
-state-ownership model, and the fragility map for the denormalize
-subsystem live in ``docs/design/denormalization.md`` — start there
-when touching anything in this module. All methods are
+rejection, ambiguity detection, orphan emission, …), the full pipeline
+(planner → row-population → SQL emission), the state-ownership model,
+and the fragility map for the denormalize subsystem all live in
+``docs/user-guide/denormalization.md`` — start there when touching
+anything in this module. All methods are
 underscore-prefixed because they are private from the user's
 perspective.
 

--- a/tests/local_db/test_denormalizer.py
+++ b/tests/local_db/test_denormalizer.py
@@ -735,6 +735,35 @@ class TestFeatureNameResolution:
         with pytest.raises(DerivaMLDenormalizeError, match="ambiguous"):
             d.as_dataframe(["Image", "Shared"])
 
+    def test_resolver_dedupes_after_feature_substitution(self, populated_denorm) -> None:
+        """RB-07: caller passes both the feature name and the underlying
+        feature-association table name in ``include_tables``. After
+        substitution they collapse onto the same canonical table — the
+        resolver must dedup so the planner sees the table only once.
+
+        Pre-fix: ``include_tables`` came back with the same table twice
+        and downstream planner logic would either emit a duplicate
+        column or trip a cardinality check. Post-fix: first-seen-order
+        dedup yields a single canonical entry.
+        """
+        ds = _FakeDataset(populated_denorm)
+        d = Denormalizer(ds)
+        # Synthetic feature ``ClassifiedAs`` backed by ``Subject`` — same
+        # stub the other tests in this class use.
+        self._stub_find_features(populated_denorm["model"], {"ClassifiedAs": "Subject"})
+
+        # Both names resolve to ``Subject``.
+        include_resolved, via_resolved, row_per_resolved = d._resolve_table_names(
+            ["Image", "ClassifiedAs", "Subject"],
+            via=["ClassifiedAs", "Subject"],
+            row_per=None,
+        )
+        # ``Image`` and ``Subject`` survive; the feature-name duplicate
+        # is removed, preserving first-seen order.
+        assert include_resolved == ["Image", "Subject"]
+        assert via_resolved == ["Subject"]
+        assert row_per_resolved is None
+
 
 class TestDescribeKeyParity:
     """Per-key describe-vs-run parity (audit finding TC-02 / spec §8.3).


### PR DESCRIPTION
## Summary

Closes the remaining audit-thread items after PRs #230–#242 landed:

- **RB-07** (post-grill follow-up) — `_resolve_table_names` now dedups resolved `include_tables` and `via` in first-seen order, so `["Image_Classification", "Execution_Image_Image_Classification"]` (or any duplicate after feature-name substitution) collapses to one canonical entry. Regression test `test_resolver_dedupes_after_feature_substitution`.
- **Source docstring paths** — 11 references across `local_db/__init__.py`, `local_db/denormalize.py`, `local_db/denormalizer.py`, `local_db/paged_fetcher.py`, and `model/denormalize_planner.py` migrated from the deleted `docs/design/denormalization.md` to the consolidated `docs/user-guide/denormalization.md` (single source of record from #242). Section anchors preserved.
- **Audit-doc dispositions** — `docs/audits/2026-05-26-denormalize-audit.md` now carries a Status column on each finding row pointing at the PR that closed it. RB-03/04/05/06/10 are explicitly marked Pending (small one-liners not in this cycle).

Three commits, kept separate so each is independently reviewable:

1. `fix(denormalize): dedup resolved include_tables/via after feature substitution`
2. `docs(denormalize): migrate remaining src docstring refs to user-guide path`
3. `docs(audit): stamp denormalize audit findings closed by PRs #236-#242`

## Test plan
- [x] `uv run python -m pytest tests/local_db/test_denormalizer.py::TestFeatureNameResolution -x` — 7 passed (6 pre-existing + 1 new).
- [x] `uv run python -m pytest tests/local_db/ -m 'not integration'` — 97 passed.
- [x] `uv run ruff check src/deriva_ml/local_db/ src/deriva_ml/model/denormalize_planner.py` — clean.
- [x] `grep -r "docs/design/denormalization\|docs/concepts/denormalization" src/` — empty (egg-info excluded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)