### PR TITLE
docs(audit): RB items already closed by #237 — correct dispositions

### DIFF
--- a/docs/audits/2026-05-26-denormalize-audit.md
+++ b/docs/audits/2026-05-26-denormalize-audit.md
@@ -23,6 +23,8 @@ either confirmed, demoted, dropped, or fixed each finding. Inline
 | Finding | PR | Notes |
 |---|---|---|
 | SC-06 / RB-02 / TC-03 | informatics-isi-edu/deriva-ml#230 | row-completeness invariant in `_populate_from_catalog_inner`; hermetic unit test `TestRowCompletenessInvariant` written failing-first, then fix; spec §7 F5 rewritten in the same PR to distinguish invariant from planner-output coincidence. |
+| RB-03 / RB-04 / RB-05 / RB-06 / RB-08 / RB-10 + SC-05 | informatics-isi-edu/deriva-ml#237 | Defensive one-liners batch: empty-anchor guard in `describe`, schema-qualified orphan labels, `_init_warning` for catalog-client build failure, narrowed `list_dataset_children` exception handling, composite-FK `NotImplementedError`, dead `model` param removal. Eight regression tests landed alongside. |
+| RB-07 | informatics-isi-edu/deriva-ml#243 | Post-grill follow-up: `_resolve_table_names` dedups resolved `include_tables` / `via` in first-seen order so feature-name + feature-table-name in one call collapses to one entry. |
 
 **Closed (spec rewrite):**
 
@@ -51,17 +53,17 @@ either confirmed, demoted, dropped, or fixed each finding. Inline
 | TC-08 | Medium (unchanged) | `_collect_fk_values` partial-engine-state behavior unpinned. | **Closed** by informatics-isi-edu/deriva-ml#241 (partial-engine-state coverage added). |
 | TC-10 | Low (unchanged) | catalog↔bag parity test for A01-shape data — cheap extension of `test_feature_table_multiple_rows_per_anchor`. | **Closed** by informatics-isi-edu/deriva-ml#241 (parity assertion added). |
 
-**Confirmed remaining robustness one-liners (code TODOs):**
+**Robustness one-liners — all closed:**
 
 | Finding | Severity | One-line fix | Status |
 |---|---|---|---|
-| RB-03 | Low | `if not rids: continue` filter in describe at line 721 (mirror `_classify_anchors` skip). | Pending. |
-| RB-04 | Low | Multi-schema label hazard in `_run`'s per-RID orphan scan; use `denormalize_column_name` or assert single-schema. | Pending. |
-| RB-05 | Medium | `Denormalizer.__init__` silent fallback to `source="local"` should log WARNING + attach `_init_warning`. | Pending. |
-| RB-06 | Medium | `list_dataset_children` silent fallback to root-only should warn for `source="catalog"`. | Pending. |
-| RB-07 | Low | Resolver should dedup after feature-name substitution so `["Image_Classification", "Execution_Image_Image_Classification"]` collapses to one entry. | **Closed** (post-PR-241 follow-up, this branch) — `_resolve_table_names` now dedups resolved `include_tables` / `via` in first-seen order, with `test_resolver_dedupes_after_feature_substitution` as regression. |
-| RB-08 | Medium | `_collect_fk_values` composite-FK assumption — AND conditions or document single-column FK requirement. | **Closed** by informatics-isi-edu/deriva-ml#238 — `_collect_fk_values` raises `NotImplementedError` on composite FK rather than silently mis-fetching. |
-| RB-10 | Low | Remove unused `model` parameter from `_populate_from_catalog`. | Pending. |
+| RB-03 | Low | `if not rids: continue` filter in describe at line 721 (mirror `_classify_anchors` skip). | **Closed** by informatics-isi-edu/deriva-ml#237 — `describe`'s `anchors.by_type` skips empty anchor sets, matching the `_classify_anchors` guard. |
+| RB-04 | Low | Multi-schema label hazard in `_run`'s per-RID orphan scan; use `denormalize_column_name` or assert single-schema. | **Closed** by informatics-isi-edu/deriva-ml#237 — per-RID orphan scan builds labels via `denormalize_column_name`, so multi-schema datasets produce schema-qualified RID columns. |
+| RB-05 | Medium | `Denormalizer.__init__` silent fallback to `source="local"` should log WARNING + attach `_init_warning`. | **Closed** by informatics-isi-edu/deriva-ml#237 — `ErmrestPagedClient` build failure logs WARNING and stashes a single-line diagnostic on `Denormalizer._init_warning`; routed through the `describe()` warnings envelope from #239. |
+| RB-06 | Medium | `list_dataset_children` silent fallback to root-only should warn for `source="catalog"`. | **Closed** by informatics-isi-edu/deriva-ml#237 — exception handling narrowed to `AttributeError`/`TypeError` for fixture compatibility; other exceptions emit a WARNING under `source="catalog"` instead of falling back silently. |
+| RB-07 | Low | Resolver should dedup after feature-name substitution so `["Image_Classification", "Execution_Image_Image_Classification"]` collapses to one entry. | **Closed** by informatics-isi-edu/deriva-ml#243 — `_resolve_table_names` now dedups resolved `include_tables` / `via` in first-seen order, with `test_resolver_dedupes_after_feature_substitution` as regression. |
+| RB-08 | Medium | `_collect_fk_values` composite-FK assumption — AND conditions or document single-column FK requirement. | **Closed** by informatics-isi-edu/deriva-ml#237 — `_collect_fk_values` raises `NotImplementedError` on composite FK rather than silently returning the first under-scoped match; single-column FK path unchanged. |
+| RB-10 | Low | Remove unused `model` parameter from `_populate_from_catalog`. | **Closed** by informatics-isi-edu/deriva-ml#237 — dead `model` parameter removed from `_populate_from_catalog` and inner walker; `TestRB10DeadModelParameter` pins the signature. |
 
 **Dropped after grilling:**
 


### PR DESCRIPTION
## Summary

Docs-only follow-up to PR #243. Investigating RB-03/04/05/06/10 to close them out, I found they had already shipped in PR #237 (\"defensive one-liners\") back when the audit was active. The audit document hadn't been updated to reflect that, and #243's status table inherited the stale \"Pending\" rows. #243 also mis-attributed RB-08 to #238 (the path-walker refactor) when in fact #237 fixed it too.

This PR corrects the audit document:

- Adds an explicit row for #237 to the top \"Closed (fix landed)\" summary table, listing the six RB items + SC-05 that landed together with eight regression tests.
- Adds a row for #243 (RB-07) to the same summary.
- Rewrites the \"Robustness one-liners\" detail table — all seven entries now point at the correct PR (#237 for RB-03/04/05/06/08/10, #243 for RB-07).
- Renames the section from \"Confirmed remaining robustness one-liners\" to \"Robustness one-liners — all closed\" so the reading order doesn't suggest pending work.

No source code or tests changed.

## Test plan
- [x] `grep -n \"RB-0\\|RB-10\\|_init_warning\\|denormalize_column_name\"` in `src/deriva_ml/local_db/denormalizer.py` confirms each fix is present.
- [x] `uv run python -m pytest tests/local_db/test_denormalizer.py -k \"RB03 or RB04 or RB05 or RB06 or RB10\"` — 8 passed (the regression tests #237 landed).
- [x] `git log --grep=RB-08` shows #237 (not #238) carried that fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)