### PR TITLE
fix(local_db): chunk-loop oversized GET requests so no RIDs are silently dropped

### DIFF
--- a/src/deriva_ml/local_db/paged_fetcher.py
+++ b/src/deriva_ml/local_db/paged_fetcher.py
@@ -325,26 +325,106 @@ class PagedFetcher:
         rids: list[str],
         max_url_bytes: int,
     ) -> list[dict[str, Any]]:
-        attempt = list(rids)
-        while attempt:
-            estimated = 128 + 13 * len(attempt)
+        """Fetch rows for *rids* via GET, shrinking + chunking if URL too long.
+
+        Strategy, designed to preserve the row-completeness invariant
+        (every RID in ``rids`` is requested exactly once across one or
+        more HTTP calls, and every response row is returned):
+
+        1. Try GET with the full list. If the estimated URL fits under
+           ``max_url_bytes`` and the server accepts it, return the rows.
+        2. If the URL is too long (either by local estimate or by a
+           runtime "URL too long" error), shrink to the largest prefix
+           that does fit and request *that* prefix via GET — then
+           recurse on the remaining suffix, accumulating rows.
+        3. If even a single-RID URL exceeds the limit (impossible in
+           practice, but defensive), fall back to a POST request with
+           the full original ``rids`` list.
+
+        The earlier implementation shrunk to the first prefix that fit
+        and returned the result, silently dropping the suffix — a SC-06
+        row-completeness violation at the fetcher layer. The chunk-loop
+        below preserves the "always POST as a last resort" fallback for
+        clients without POST while guaranteeing every RID is requested.
+
+        Args:
+            table: Qualified table name (``"schema:table"``).
+            column: Column to filter on.
+            rids: RIDs to request.
+            max_url_bytes: URL-length guard threshold.
+
+        Returns:
+            All rows from the server for *rids*, concatenated.
+        """
+        remaining = list(rids)
+        out: list[dict[str, Any]] = []
+        while remaining:
+            estimated = 128 + 13 * len(remaining)
             if estimated <= max_url_bytes:
+                # URL should fit — try GET on the entire remaining set.
                 try:
-                    return self._client.fetch_rid_batch(table=table, column=column, rids=attempt, method="GET")
+                    out.extend(
+                        self._client.fetch_rid_batch(
+                            table=table, column=column, rids=remaining, method="GET"
+                        )
+                    )
+                    return out
                 except RuntimeError as exc:
                     if "too long" not in str(exc).lower():
                         raise
-            half = len(attempt) // 2
-            if half == 0:
+                    # Local estimate was optimistic — fall through to
+                    # shrink-and-chunk.
+
+            # Find the largest prefix that fits under the URL guard.
+            # Solve 128 + 13 * k <= max_url_bytes for k.
+            fits = (max_url_bytes - 128) // 13
+            if fits <= 0:
+                # max_url_bytes is so small that even one RID doesn't
+                # fit — last-resort POST with the original rids list.
                 logger.debug(
                     "POST fallback for table=%s column=%s rids=%d",
                     table,
                     column,
                     len(rids),
                 )
-                return self._client.fetch_rid_batch(table=table, column=column, rids=rids, method="POST")
-            attempt = attempt[:half]
-        return []
+                return self._client.fetch_rid_batch(
+                    table=table, column=column, rids=rids, method="POST"
+                )
+            chunk = remaining[:fits]
+            try:
+                out.extend(
+                    self._client.fetch_rid_batch(
+                        table=table, column=column, rids=chunk, method="GET"
+                    )
+                )
+            except RuntimeError as exc:
+                if "too long" not in str(exc).lower():
+                    raise
+                # Local estimate was wrong even for this chunk size.
+                # Halve and retry once; if that also rejects, POST is
+                # the only remaining option.
+                half = max(1, len(chunk) // 2)
+                chunk = chunk[:half]
+                try:
+                    out.extend(
+                        self._client.fetch_rid_batch(
+                            table=table, column=column, rids=chunk, method="GET"
+                        )
+                    )
+                except RuntimeError as exc2:
+                    if "too long" not in str(exc2).lower():
+                        raise
+                    logger.debug(
+                        "POST fallback after GET-shrink rejected: table=%s column=%s rids=%d",
+                        table,
+                        column,
+                        len(rids),
+                    )
+                    return self._client.fetch_rid_batch(
+                        table=table, column=column, rids=rids, method="POST"
+                    )
+            remaining = remaining[len(chunk) :]
+        return out
 
     def fetch_by_rids_or_predicate(
         self,

--- a/tests/local_db/test_paged_fetcher.py
+++ b/tests/local_db/test_paged_fetcher.py
@@ -282,6 +282,70 @@ class TestFetchByRids:
         assert len(get_requests) == 2
         assert len(post_requests) == 0
 
+    def test_oversized_get_chunk_loops_until_all_rids_fetched(self, engine):
+        """500-RID batch above the URL guard → chunk-loop fetches all 500.
+
+        2026-05-27 regression: the prior shrink-on-URL-too-long path
+        returned after the first prefix that fit, silently dropping
+        the suffix. With 500 RIDs and a max_url_bytes that fits ~462
+        RIDs, the old code returned 462 rows and never fetched the
+        remaining ~38. This test pins the row-completeness invariant
+        at the fetcher layer: every RID requested must be present
+        in the local DB after the call.
+        """
+        rows = _make_rows(500)
+        # 128 + 13*462 = 6134 fits; 128 + 13*500 = 6628 doesn't.
+        threshold = 6144
+        client = FakePagedClient(rows_by_table={"Image": rows}, max_get_bytes=threshold)
+        table = _make_target_table(engine, "Image")
+        fetcher = PagedFetcher(client=client, engine=engine)
+        rids = [r["RID"] for r in rows]
+
+        fetcher.fetch_by_rids("Image", rids, table, batch_size=500, max_url_bytes=threshold)
+
+        # All 500 rows landed in the local DB.
+        assert _rows_count(engine, table) == 500
+
+        # Two GET requests (one fits-the-limit chunk + one remainder)
+        # and no POST fallback for this case.
+        batch_requests = [r for r in client.requests if r[0] == "fetch_rid_batch"]
+        get_requests = [r for r in batch_requests if r[1]["method"] == "GET"]
+        post_requests = [r for r in batch_requests if r[1]["method"] == "POST"]
+        # The first GET is the largest prefix that fits (~462 rids);
+        # the second GET is the remainder (~38 rids).
+        assert len(get_requests) == 2
+        assert len(post_requests) == 0
+        # Sanity-check the chunk split adds up to all rids.
+        total_requested = sum(len(r[1]["rids"]) for r in get_requests)
+        assert total_requested == 500
+
+    def test_oversized_get_eventually_falls_back_to_post(self, engine):
+        """When even a single-RID URL won't fit, fall back to POST.
+
+        Defensive path: the chunk-loop's first iteration computes
+        ``fits = (max_url_bytes - 128) // 13``; if that yields 0,
+        no chunk can be sent via GET and the method falls back to
+        POST with the full original RID list. Pins this behaviour
+        so a future "simplify the loop" refactor doesn't drop the
+        last-resort path.
+        """
+        rows = _make_rows(50)
+        # max_url_bytes < 128 + 13 = 141 means even one RID can't be
+        # sent via GET. The fake client also rejects GETs of any size.
+        client = FakePagedClient(rows_by_table={"Image": rows}, max_get_bytes=1)
+        table = _make_target_table(engine, "Image")
+        fetcher = PagedFetcher(client=client, engine=engine)
+        rids = [r["RID"] for r in rows]
+
+        fetcher.fetch_by_rids("Image", rids, table, batch_size=50, max_url_bytes=1)
+
+        assert _rows_count(engine, table) == 50
+        post_requests = [
+            r for r in client.requests
+            if r[0] == "fetch_rid_batch" and r[1]["method"] == "POST"
+        ]
+        assert len(post_requests) >= 1, "POST fallback should have fired"
+
     def test_empty_rid_set_returns_zero(self, engine):
         """Empty rids list → 0 returned, no requests issued."""
         client = FakePagedClient(rows_by_table={"Image": _make_rows(10)})


### PR DESCRIPTION
## Summary

`PagedFetcher._fetch_rid_batch_with_fallback` had a row-completeness bug at the HTTP layer: when an outer fetch batch produced a URL longer than `max_url_bytes`, the shrink loop would halve the RID list to a prefix that fit, fetch *only that prefix*, and return those rows. The remaining RIDs were silently dropped.

## How it surfaced

2026-05-27 e2e run, P0 step 7 (load-cifar10 --phase datasets) failed creating the labeled split with:

```
ValueError: Column 'Execution_Image_Image_Classification.Image_Class' has 250 missing values (50.0% of 500 rows).
```

Underlying catalog state was clean: 1500 features, all non-null Image_Class. But the denormalize join for a 750-Image training dataset produced 500 rows where 250 had a feature and 250 were orphan-style nulls. Tracing through `PagedFetcher`:

```
fetch_by_rids(Image, 500 RIDs requested) → 250 rows landed
fetch_by_rids(Execution_Image_Image_Classification, 500 RIDs from Image) → 250 rows landed
```

The 500-RID Image batch estimated at 6628 bytes > 6144 max → shrink path → returned 250 rows for the prefix, dropped the other 250.

## Why the audit thread missed it

SC-06 (PR #230) fixed the same shape of bug at the *planner* layer (the dedup tuple). The fetcher's variant was a separate site that no test covered. The existing `test_shrinks_batch_before_post` exercised 200 RIDs split into two outer batches of 100, each fitting GET — so the inner shrink-loop never ran.

## Fix

Replace the shrink-and-return path with a chunk-loop that accumulates rows:

```python
remaining = list(rids)
out = []
while remaining:
    # Try GET on the full remaining set if it fits.
    if estimated_url_bytes <= max_url_bytes:
        try: GET(remaining); return out
        except "too long": fall through

    # Otherwise GET the largest prefix that fits, advance to the suffix.
    fits = (max_url_bytes - 128) // 13
    if fits <= 0:
        return POST(rids)              # defensive: even 1 RID too big
    chunk = remaining[:fits]
    try: out.extend(GET(chunk))
    except "too long": halve and retry once; if still too long, POST(rids)
    remaining = remaining[len(chunk):]
return out
```

POST is reserved for genuinely degenerate cases (max_url_bytes < single-RID URL, or server rejects a single-RID GET the client thought would fit). The common case is a clean chunk-loop of GETs.

## Tests

- `TestFetchByRids::test_oversized_get_chunk_loops_until_all_rids_fetched` — pins the regression. 500 RIDs over URL guard → two GET requests (largest-fits-prefix + remainder), 500 rows in local DB, zero POSTs.
- `TestFetchByRids::test_oversized_get_eventually_falls_back_to_post` — pins the defensive single-RID-too-long path so a future refactor doesn't drop it.

Verified end-to-end against the live catalog 92 that triggered the regression:
- Before fix: 500 rows, 250 null Image_Class
- After fix:  750 rows, 0 null Image_Class

## Test plan
- [x] `uv run python -m pytest tests/local_db/ -m 'not integration'` — 301 passed
- [x] `uv run ruff check src/deriva_ml/local_db/paged_fetcher.py tests/local_db/test_paged_fetcher.py` — clean
- [x] Live-catalog reproduction (catalog 92) now returns the full 750-row dataframe

🤖 Generated with [Claude Code](https://claude.com/claude-code)