### PR TITLE
fix(cli): diagnostic error for bare positional args on deriva-ml-run* CLIs

### DIFF
--- a/src/deriva_ml/cli/hydra_overrides.py
+++ b/src/deriva_ml/cli/hydra_overrides.py
@@ -1,0 +1,103 @@
+"""Validation helpers for Hydra-zen override arguments on deriva-ml CLIs.
+
+Both ``deriva-ml-run`` and ``deriva-ml-run-notebook`` collect trailing
+positional arguments and forward them to Hydra-zen as configuration
+overrides. Hydra's override grammar is strict: every token must be of
+the form ``key=value`` (or one of the prefixed forms ``+key=value``,
+``++key=value``, ``~key``, ``~key=value``).
+
+A bare positional token like ``roc_analysis`` slips past ``argparse``
+(which is happy with ``nargs="*"``) and only fails deep inside Hydra's
+ANTLR-based override parser with::
+
+    LexerNoViableAltException: missing EQUAL at '<EOF>'
+
+The error is technically correct but unhelpful -- it doesn't name the
+offending token and it doesn't suggest the fix. This module provides
+``validate_hydra_overrides`` which inspects the override list upfront
+and raises a diagnostic :class:`ValueError` pointing at the bad token.
+
+Example:
+    >>> from deriva_ml.cli.hydra_overrides import validate_hydra_overrides
+    >>> validate_hydra_overrides(["assets=roc_analysis"])  # OK
+    >>> validate_hydra_overrides(["roc_analysis"])
+    Traceback (most recent call last):
+        ...
+    ValueError: 'roc_analysis' looks like a positional argument, ...
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+
+def _looks_like_override(token: str) -> bool:
+    """Return True if ``token`` parses as a Hydra-style override.
+
+    Hydra accepts the following forms (see Hydra override grammar):
+
+    - ``key=value`` (override an existing key)
+    - ``+key=value`` (append a new key)
+    - ``++key=value`` (force-add a key)
+    - ``~key`` or ``~key=value`` (delete a key)
+    - ``key@package=value`` (override with package directive)
+
+    Anything else -- most commonly a bare positional like ``roc_analysis`` --
+    is rejected.
+
+    Args:
+        token: A single CLI argument intended as a Hydra override.
+
+    Returns:
+        True if ``token`` has Hydra-override shape, False otherwise.
+    """
+    if not token:
+        return False
+    # ~key (delete) is the only valid form that does not require '='.
+    if token.startswith("~"):
+        return True
+    return "=" in token
+
+
+def validate_hydra_overrides(overrides: Iterable[str], *, cli_name: str = "deriva-ml-run-notebook") -> None:
+    """Validate that every override looks like a Hydra ``key=value`` token.
+
+    Hydra's own parser produces a cryptic ANTLR ``missing EQUAL at '<EOF>'``
+    error when a bare positional argument is passed. This helper catches
+    that case before Hydra runs and raises a diagnostic :class:`ValueError`
+    that names the offending token and suggests the typical fixes.
+
+    Args:
+        overrides: Iterable of CLI tokens collected as positional Hydra
+            overrides (e.g. ``args.hydra_overrides`` from ``argparse``).
+        cli_name: Name of the calling CLI for use in the error message.
+            Defaults to ``"deriva-ml-run-notebook"``.
+
+    Raises:
+        ValueError: If any token does not look like a Hydra override. The
+            message names the bad token and shows the two canonical fixes
+            (``group=value`` and ``+experiment=value``).
+
+    Example:
+        >>> validate_hydra_overrides(["assets=roc_quick_probabilities"])
+        >>> validate_hydra_overrides(["+experiment=cifar10_quick"])
+        >>> validate_hydra_overrides(["~deriva_ml.catalog_id"])
+        >>> validate_hydra_overrides(["roc_analysis"])
+        Traceback (most recent call last):
+            ...
+        ValueError: 'roc_analysis' looks like a positional argument, ...
+    """
+    for token in overrides:
+        if _looks_like_override(token):
+            continue
+        raise ValueError(
+            f"{token!r} looks like a positional argument, but "
+            f"{cli_name} expects Hydra overrides in key=value form.\n"
+            f"Did you mean:\n"
+            f"  {cli_name} ... assets={token}\n"
+            f"or\n"
+            f"  {cli_name} ... +experiment={token}\n"
+            f"?\n"
+            f"Run '{cli_name} --info' to list available config groups, "
+            f"or see the project README / CLAUDE.md for examples."
+        )

--- a/src/deriva_ml/run_model.py
+++ b/src/deriva_ml/run_model.py
@@ -29,6 +29,7 @@ from pathlib import Path
 from deriva.core import BaseCLI
 from hydra_zen import store, zen
 
+from deriva_ml.cli.hydra_overrides import validate_hydra_overrides
 from deriva_ml.core.exceptions import DerivaMLDirtyWorkflowError
 from deriva_ml.execution import (
     get_all_multirun_configs,
@@ -135,6 +136,16 @@ class DerivaMLRunCLI(BaseCLI):
             Exit code (0 for success, 1 for failure).
         """
         args = self.parse_cli()
+
+        # Pre-validate Hydra overrides before any work happens, so bare
+        # positional args (e.g. 'cifar10_quick' instead of
+        # '+experiment=cifar10_quick') produce a diagnostic error rather
+        # than the cryptic ANTLR "missing EQUAL at '<EOF>'" from Hydra.
+        try:
+            validate_hydra_overrides(args.hydra_overrides, cli_name="deriva-ml-run")
+        except ValueError as e:
+            print(f"Error: {e}", file=sys.stderr)
+            return 1
 
         # Resolve config directory
         config_dir = args.config_dir.resolve()

--- a/src/deriva_ml/run_notebook.py
+++ b/src/deriva_ml/run_notebook.py
@@ -58,6 +58,7 @@ from jupyter_client.kernelspec import KernelSpecManager
 from nbconvert import MarkdownExporter
 
 from deriva_ml import DerivaML, ExecAssetType, MLAsset
+from deriva_ml.cli.hydra_overrides import validate_hydra_overrides
 from deriva_ml.core.constants import DRY_RUN_RID
 from deriva_ml.core.enums import ExecMetadataType
 from deriva_ml.core.exceptions import DerivaMLDirtyWorkflowError
@@ -371,6 +372,16 @@ class DerivaMLRunNotebookCLI(BaseCLI):
         args = self.parse_cli()
         notebook_file: Path = args.notebook_file
         parameter_file = args.file
+
+        # Pre-validate Hydra overrides before any work happens, so bare
+        # positional args (e.g. 'roc_analysis' instead of
+        # 'assets=roc_analysis') produce a diagnostic error rather than the
+        # cryptic ANTLR "missing EQUAL at '<EOF>'" from Hydra's parser.
+        try:
+            validate_hydra_overrides(args.hydra_overrides, cli_name="deriva-ml-run-notebook")
+        except ValueError as e:
+            print(f"Error: {e}", file=sys.stderr)
+            exit(1)
 
         # Build parameters dict from command-line -p/--parameter flags
         # args.parameter is a list of [KEY, VALUE] lists, e.g. [['timeout', '30'], ...]

--- a/tests/cli/test_hydra_overrides.py
+++ b/tests/cli/test_hydra_overrides.py
@@ -1,0 +1,145 @@
+"""Tests for Hydra override validation on the deriva-ml CLIs.
+
+The CLIs ``deriva-ml-run`` and ``deriva-ml-run-notebook`` accept Hydra
+overrides as trailing positional arguments. A bare positional token
+(no ``=``) used to slip past ``argparse`` and only fail deep inside
+Hydra's ANTLR parser with ``missing EQUAL at '<EOF>'``. These tests
+lock in the friendlier upfront error message.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+
+from deriva_ml.cli.hydra_overrides import (
+    _looks_like_override,
+    validate_hydra_overrides,
+)
+
+
+class TestLooksLikeOverride:
+    """Unit tests for the override-shape predicate."""
+
+    @pytest.mark.parametrize(
+        "token",
+        [
+            "key=value",
+            "+experiment=cifar10_quick",
+            "++force.add=1",
+            "assets=roc_quick_probabilities",
+            "~deriva_ml.catalog_id",
+            "~deriva_ml.catalog_id=42",
+            "deriva_ml.hostname=host.example.org",
+            "key@package=value",
+        ],
+    )
+    def test_accepts_valid_hydra_forms(self, token: str) -> None:
+        """Every documented Hydra override shape passes the check."""
+        assert _looks_like_override(token) is True
+
+    @pytest.mark.parametrize(
+        "token",
+        [
+            "roc_analysis",
+            "cifar10_quick",
+            "my_experiment",
+            "",
+        ],
+    )
+    def test_rejects_bare_positional(self, token: str) -> None:
+        """Bare positional tokens (no '=' and no '~') are rejected."""
+        assert _looks_like_override(token) is False
+
+
+class TestValidateHydraOverrides:
+    """Unit tests for the public validator."""
+
+    def test_accepts_empty_list(self) -> None:
+        """An empty override list is valid (no overrides supplied)."""
+        validate_hydra_overrides([])
+
+    def test_accepts_all_valid_overrides(self) -> None:
+        """A mix of all valid override forms passes."""
+        validate_hydra_overrides(
+            [
+                "assets=roc_quick_probabilities",
+                "+experiment=cifar10_quick",
+                "~deriva_ml.catalog_id",
+                "++force.flag=true",
+            ]
+        )
+
+    def test_rejects_bare_positional_with_diagnostic(self) -> None:
+        """A bare positional triggers ValueError naming the bad token."""
+        with pytest.raises(ValueError) as excinfo:
+            validate_hydra_overrides(["roc_analysis"])
+
+        msg = str(excinfo.value)
+        # Names the offending token
+        assert "'roc_analysis'" in msg
+        # Mentions the expected form
+        assert "key=value" in msg
+        # Offers the canonical suggestions
+        assert "assets=roc_analysis" in msg
+        assert "+experiment=roc_analysis" in msg
+
+    def test_rejects_first_bad_token_in_mixed_list(self) -> None:
+        """When valid and invalid tokens are mixed, the invalid one is reported."""
+        with pytest.raises(ValueError, match=r"'cifar10_quick'"):
+            validate_hydra_overrides(
+                [
+                    "assets=roc_quick_probabilities",
+                    "cifar10_quick",  # bare positional
+                    "+experiment=other",
+                ]
+            )
+
+    def test_cli_name_appears_in_message(self) -> None:
+        """The cli_name kwarg is reflected in the suggestion text."""
+        with pytest.raises(ValueError) as excinfo:
+            validate_hydra_overrides(["foo"], cli_name="deriva-ml-run")
+        assert "deriva-ml-run" in str(excinfo.value)
+        # Suggestions should also use the custom name
+        assert "deriva-ml-run ... assets=foo" in str(excinfo.value)
+
+
+class TestEndToEndCLIErrorMessage:
+    """End-to-end check that ``deriva-ml-run`` surfaces the friendly error."""
+
+    def test_run_model_cli_rejects_bare_positional(self, tmp_path) -> None:
+        """Running ``deriva-ml-run roc_analysis`` exits non-zero with the helper text.
+
+        We invoke ``deriva-ml-run`` as a subprocess against a minimal
+        configs directory so we don't depend on any specific project
+        layout. The validator runs BEFORE config loading, so even an
+        empty configs dir is fine -- but we still need ``--config-dir``
+        to point somewhere that exists.
+        """
+        # Minimal valid config dir for the CLI's early existence check.
+        configs_dir = tmp_path / "configs"
+        configs_dir.mkdir()
+        (configs_dir / "__init__.py").write_text("")
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "deriva_ml.run_model",
+                "--config-dir",
+                str(configs_dir),
+                "roc_analysis",  # the offending bare positional
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
+        assert result.returncode != 0
+        combined = result.stdout + result.stderr
+        assert "'roc_analysis'" in combined
+        assert "key=value" in combined
+        # Ensure we did NOT leak the cryptic ANTLR error
+        assert "missing EQUAL" not in combined


### PR DESCRIPTION
## Summary

- Both ``deriva-ml-run`` and ``deriva-ml-run-notebook`` collect trailing positional args and forward them to Hydra-zen. A bare token like ``roc_analysis`` used to slip past ``argparse`` and surface as Hydra's cryptic ANTLR ``missing EQUAL at '<EOF>'`` -- correct but unhelpful, and consistently hit by users who imitate the CLI examples without the ``key=`` prefix (it bit both the Modeler and Analyst personas in the 2026-05-27d e2e run).
- Added a shared validator at ``src/deriva_ml/cli/hydra_overrides.py`` that runs before Hydra is invoked, accepts every documented Hydra override shape (``k=v``, ``+k=v``, ``++k=v``, ``~k``, ``~k=v``, ``k@pkg=v``), and otherwise raises a ``ValueError`` naming the bad token and suggesting both ``assets=<value>`` and ``+experiment=<value>`` fixes. Wired into both ``run_notebook.py`` and ``run_model.py`` right after ``argparse`` finishes.
- New test file ``tests/cli/test_hydra_overrides.py`` (18 tests): parametrized unit tests on the predicate, behavioural tests on the validator (empty list, mixed valid/invalid, ``cli_name`` propagation, message contents), and an end-to-end subprocess test that invokes ``deriva-ml-run`` with a bare positional and asserts the friendly error is surfaced while the cryptic ANTLR string is **not** leaked.

## Test plan

- [x] ``uv run python -m pytest tests/cli/test_hydra_overrides.py -v`` -- 18 passed
- [x] ``uv run python -m pytest tests/cli tests/execution/test_base_config.py tests/execution/test_find_caller.py`` -- 63 passed (no regressions in the existing CLI / config tests)
- [x] ``uv run ruff check`` + ``uv run ruff format --check`` clean on touched files
- [ ] Manual sanity: try ``deriva-ml-run-notebook nb.ipynb roc_analysis`` against the model template and confirm the new message fires (will be covered by the model-template-side update that removes the workaround note from ``CLAUDE.md``)

🤖 Generated with [Claude Code](https://claude.com/claude-code)