### PR TITLE
fix(run_notebook): auto-derive config_name under headless deriva-ml-run-notebook

### DIFF
--- a/src/deriva_ml/execution/base_config.py
+++ b/src/deriva_ml/execution/base_config.py
@@ -491,24 +491,30 @@ def _derive_config_name_from_notebook() -> str:
 
     Resolution strategy, in order:
 
-    1. **Papermill execution.** When the notebook is executed via
-       ``deriva-ml-run-notebook`` (which uses papermill under the hood),
-       papermill sets the ``PAPERMILL_INPUT_PATH`` env var to the notebook
-       being executed. This is the most reliable signal because it survives
-       Jupyter's globals-namespace abstractions.
-    2. **Interactive Jupyter / VS Code.** Walk the call stack looking for a
+    1. **Papermill CLI execution.** When papermill is invoked via its
+       command-line entry point (``papermill <input.ipynb> <output.ipynb>``),
+       it sets the ``PAPERMILL_INPUT_PATH`` env var to the notebook being
+       executed. Note that ``papermill.execute_notebook()`` (the Python API)
+       does *not* set this var -- only the CLI does.
+    2. **deriva-ml-run-notebook (headless).** The project's headless runner
+       drives papermill via ``pm.execute_notebook(...)`` (the Python API),
+       so ``PAPERMILL_INPUT_PATH`` is unset on that path. To bridge the gap,
+       the runner exports ``DERIVA_ML_NOTEBOOK_PATH`` with the notebook path
+       before invoking papermill; this helper consults that env var as a
+       second-priority source.
+    3. **Interactive Jupyter / VS Code.** Walk the call stack looking for a
        frame whose ``__file__`` (or filename in ``f_code``) ends in
        ``.ipynb``. Jupyter and VS Code both surface the notebook path on the
        caller frame this way.
 
-    In both cases the returned name is ``Path(notebook_path).stem``.
+    In all cases the returned name is ``Path(notebook_path).stem``.
 
     Returns:
         The notebook's filename stem, suitable for passing as a Hydra
         ``config_name``.
 
     Raises:
-        ValueError: If neither signal yields a notebook path -- typically
+        ValueError: If no signal yields a notebook path -- typically
             because :func:`run_notebook` was called from a plain ``.py``
             script rather than a notebook. The caller should either invoke
             this function from a notebook or pass ``config_name`` explicitly.
@@ -517,11 +523,20 @@ def _derive_config_name_from_notebook() -> str:
         Called inside ``notebooks/roc_analysis.ipynb`` (via papermill or
         interactively), this returns ``"roc_analysis"``.
     """
-    # Papermill path. PAPERMILL_INPUT_PATH is set by papermill.execute_notebook
-    # to the absolute path of the notebook being executed.
+    # Papermill CLI path. PAPERMILL_INPUT_PATH is set by the papermill
+    # command-line entry point to the absolute path of the notebook being
+    # executed. It is NOT set by pm.execute_notebook() (the Python API).
     papermill_path = os.environ.get("PAPERMILL_INPUT_PATH")
     if papermill_path:
         return Path(papermill_path).stem
+
+    # deriva-ml-run-notebook (headless) path. Because the project's runner
+    # uses pm.execute_notebook() rather than the papermill CLI, it sets
+    # DERIVA_ML_NOTEBOOK_PATH itself before invoking papermill so this
+    # helper still has a signal to work with.
+    deriva_notebook_path = os.environ.get("DERIVA_ML_NOTEBOOK_PATH")
+    if deriva_notebook_path:
+        return Path(deriva_notebook_path).stem
 
     # Interactive (Jupyter / VS Code) path. Walk back through the stack and
     # pick up the first frame whose source file is an .ipynb. Jupyter

--- a/tests/execution/test_base_config.py
+++ b/tests/execution/test_base_config.py
@@ -436,8 +436,9 @@ class TestDeriveConfigNameFromNotebook:
 
     @pytest.fixture(autouse=True)
     def _clean_papermill_env(self, monkeypatch):
-        """Ensure PAPERMILL_INPUT_PATH never leaks between tests."""
+        """Ensure notebook-path env vars never leak between tests."""
         monkeypatch.delenv("PAPERMILL_INPUT_PATH", raising=False)
+        monkeypatch.delenv("DERIVA_ML_NOTEBOOK_PATH", raising=False)
         yield
 
     def test_derives_from_papermill_env_var(self, monkeypatch):
@@ -453,6 +454,31 @@ class TestDeriveConfigNameFromNotebook:
         """
         monkeypatch.setenv("PAPERMILL_INPUT_PATH", "/tmp/work/from_env.ipynb")
         assert _derive_config_name_from_notebook() == "from_env"
+
+    def test_derives_from_deriva_ml_notebook_path_env_var(self, monkeypatch):
+        """When DERIVA_ML_NOTEBOOK_PATH is set (and PAPERMILL_INPUT_PATH is not),
+        return the stem of the path it points at.
+
+        This is the headless-runner code path: ``deriva-ml-run-notebook``
+        drives papermill via ``pm.execute_notebook()`` (the Python API), which
+        does not set ``PAPERMILL_INPUT_PATH``. The runner exports
+        ``DERIVA_ML_NOTEBOOK_PATH`` before invoking papermill so this helper
+        has a signal to work with.
+        """
+        monkeypatch.delenv("PAPERMILL_INPUT_PATH", raising=False)
+        monkeypatch.setenv("DERIVA_ML_NOTEBOOK_PATH", "/tmp/work/roc_analysis.ipynb")
+        assert _derive_config_name_from_notebook() == "roc_analysis"
+
+    def test_papermill_env_takes_precedence_over_deriva_ml_notebook_path(self, monkeypatch):
+        """When both env vars are set, PAPERMILL_INPUT_PATH wins.
+
+        Both vars can legitimately be set at the same time (the papermill CLI
+        sets the former while the project's runner also sets the latter, e.g.
+        if someone wraps the CLI). The papermill-native signal is preferred.
+        """
+        monkeypatch.setenv("PAPERMILL_INPUT_PATH", "/tmp/work/from_papermill.ipynb")
+        monkeypatch.setenv("DERIVA_ML_NOTEBOOK_PATH", "/tmp/work/from_deriva_ml.ipynb")
+        assert _derive_config_name_from_notebook() == "from_papermill"
 
     def test_stack_frame_with_ipynb_filename(self, monkeypatch):
         """A frame whose filename ends in .ipynb yields its stem."""
@@ -509,6 +535,7 @@ class TestRunNotebookConfigNameAutoDerive:
         """Reset env vars that might leak between tests."""
         monkeypatch.delenv("DERIVA_ML_HYDRA_OVERRIDES", raising=False)
         monkeypatch.delenv("PAPERMILL_INPUT_PATH", raising=False)
+        monkeypatch.delenv("DERIVA_ML_NOTEBOOK_PATH", raising=False)
         yield
 
     def _patch_catalog_io(self):


### PR DESCRIPTION
## Observation

PR #248 (merged today, commit `6ed68d08`) added `_derive_config_name_from_notebook()` in `src/deriva_ml/execution/base_config.py` so callers of `run_notebook()` don't have to repeat the notebook stem as a string. The first auto-derive strategy reads `os.environ["PAPERMILL_INPUT_PATH"]`.

That env var is set by the papermill **CLI** (`papermill <input.ipynb> <output.ipynb>`). It is **not** set by `papermill.execute_notebook()` (the Python API). The project's only headless runner — `deriva-ml-run-notebook` (`src/deriva_ml/run_notebook.py:633`) — drives papermill via `pm.execute_notebook(...)`, so the env var is unset on that path. The stack-walk fallback also fails because papermill's kernel-side frames don't expose the notebook path. The helper raises `ValueError` and every notebook in the template repo that omits `config_name=` becomes unrunnable through `deriva-ml-run-notebook`.

The runner already exports `DERIVA_ML_NOTEBOOK_PATH` to the notebook path (`run_notebook.py:618`) for other consumers — it just isn't consulted by the auto-derive helper.

## Why High severity

- It's a correctness regression in code that **just shipped today** (PR #248). The default invocation path of the headline ergonomic does not work under the only headless runner the project ships.
- The interactive Jupyter path still works, so the bug doesn't surface in interactive testing — only in headless / CI / end-to-end contexts.
- The workaround (passing `config_name` as a positional arg in every notebook) pollutes every notebook in the template repo with exactly the boilerplate PR #248 was designed to eliminate.

## The fix

Teach `_derive_config_name_from_notebook()` to consult `DERIVA_ML_NOTEBOOK_PATH` as a second-priority source — sitting between the papermill-CLI signal and the interactive stack walk:

1. `PAPERMILL_INPUT_PATH` (papermill CLI)
2. `DERIVA_ML_NOTEBOOK_PATH` (set by `deriva-ml-run-notebook` before `pm.execute_notebook()`)
3. Stack walk for `.ipynb` filename (interactive Jupyter / VS Code)

The docstring is also updated to call out that `PAPERMILL_INPUT_PATH` is only set by papermill's CLI (not by the Python API the project's runner uses), so a future reader doesn't draw the wrong conclusion about why the function fails.

## Test added

`tests/execution/test_base_config.py::TestDeriveConfigNameFromNotebook`:

- `test_derives_from_deriva_ml_notebook_path_env_var` — sets `DERIVA_ML_NOTEBOOK_PATH` only (with `PAPERMILL_INPUT_PATH` explicitly unset) and confirms the helper returns the path's stem.
- `test_papermill_env_takes_precedence_over_deriva_ml_notebook_path` — sets both and confirms `PAPERMILL_INPUT_PATH` still wins (CLI runs would set both).

Existing tests continue to pass (29 tests, all green) and the lint check passes on the modified files.

## Reference

The evaluator finding from the 2026-05-27 multi-persona e2e run that caught this regression: `findings/evaluator/01-run-notebook-config-derivation-regression-confirmed.md` (path inside the e2e worktree at `deriva-ml-model-template-e2e/`; the branch is not public).

## Test plan

- [x] `uv run ruff check src/deriva_ml/execution/base_config.py tests/execution/test_base_config.py`
- [x] `uv run python -m pytest tests/execution/test_base_config.py -v` (29 passed)
- [ ] After merge: pick up the new pin in `deriva-ml-model-template` and re-run `deriva-ml-run-notebook notebooks/roc_analysis.ipynb` end-to-end to confirm the headless path now auto-derives.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>