### PR TITLE
fix(run_model): compose Execution.description from Hydra overrides

### DIFF
--- a/src/deriva_ml/execution/runner.py
+++ b/src/deriva_ml/execution/runner.py
@@ -471,6 +471,7 @@ def run_model(
     # Import here to avoid circular imports
     from deriva_ml import DerivaML
     from deriva_ml.execution import ExecutionConfiguration
+    from deriva_ml.execution.base_config import _format_description_with_overrides
 
     # ---------------------------------------------------------------------------
     # Clear hydra's logging configuration
@@ -536,17 +537,34 @@ def run_model(
         _create_parent_execution(ml_instance, workflow, description, dry_run)
 
     # ---------------------------------------------------------------------------
-    # Capture Hydra runtime choices for provenance
+    # Capture Hydra runtime choices and overrides for provenance
     # ---------------------------------------------------------------------------
     # The choices dict maps config group names to the selected config names
     # e.g., {"model_config": "cifar10_quick", "datasets": "cifar10_training"}
-    # Filter out None values (some Hydra internal groups have None choices)
+    # Filter out None values (some Hydra internal groups have None choices).
+    #
+    # The overrides list is the resolved Hydra task-override list (the same
+    # list Hydra echoes at the top of every run). It feeds into the Execution
+    # description so the catalog row reflects what actually ran -- mirroring
+    # the run_notebook pattern. Without this, a sweep that differs only in a
+    # group/parameter override is indistinguishable from a default run when
+    # browsing executions.
     config_choices: dict[str, str] = {}
+    task_overrides: list[str] = []
     try:
         hydra_cfg = HydraConfig.get()
         config_choices = {k: v for k, v in hydra_cfg.runtime.choices.items() if v is not None}
+        task_overrides = list(hydra_cfg.overrides.task)
     except Exception as e:
         logger.debug(f"HydraConfig not available (not in Hydra context): {e}")
+
+    # The CLI synthesises a ``description='...'`` override in multirun mode
+    # (see DerivaMLRunCLI.main). Including it inside the formatted
+    # ``[overrides: ...]`` clause would recursively quote the base description
+    # back into itself, so drop self-references on the description parameter
+    # before composing. All other overrides (groups, parameters, package
+    # specs) pass through verbatim, matching run_notebook's behaviour.
+    description_overrides = [o for o in task_overrides if not o.startswith("description=")]
 
     # ---------------------------------------------------------------------------
     # Create the execution context
@@ -554,11 +572,18 @@ def run_model(
     # The ExecutionConfiguration bundles together all the inputs for this run:
     # which datasets to use, which assets (model weights, etc.), and metadata.
 
+    # Compose the description from the resolved Hydra overrides so the
+    # catalog Execution row reflects what actually ran, not just the
+    # registration-time default. This is symmetric with run_notebook
+    # (see base_config.run_notebook), and the two entry points share
+    # the same ``_format_description_with_overrides`` helper.
+    composed_description = _format_description_with_overrides(description, description_overrides)
+
     # In multirun mode, enhance the description with job info
-    job_description = description
+    job_description = composed_description
     if is_multirun:
         job_num = _get_job_num()
-        job_description = f"[Job {job_num}] {description}"
+        job_description = f"[Job {job_num}] {composed_description}"
 
     execution_config = ExecutionConfiguration(
         datasets=datasets,

--- a/tests/execution/test_runner.py
+++ b/tests/execution/test_runner.py
@@ -6,7 +6,6 @@ from unittest.mock import MagicMock, Mock, patch
 import pytest
 
 from deriva_ml.core.constants import DRY_RUN_RID
-from deriva_ml.execution.upload_report import UploadReport
 from deriva_ml.core.exceptions import DerivaMLStateInconsistency
 from deriva_ml.execution.runner import (
     _complete_parent_execution,
@@ -17,6 +16,7 @@ from deriva_ml.execution.runner import (
     reset_multirun_state,
     run_model,
 )
+from deriva_ml.execution.upload_report import UploadReport
 
 
 class TestMultirunDetection:
@@ -318,6 +318,159 @@ class TestRunModelWithMocks:
 
         # Verify custom class was used for instantiation
         mock_custom_class.instantiate.assert_called_once_with(mock_config)
+
+
+class TestRunModelDescriptionFromOverrides:
+    """run_model must compose Execution.description from Hydra overrides.
+
+    Symmetric with run_notebook (see
+    tests/execution/test_base_config.py::TestRunNotebookDescriptionFromResolvedConfig):
+    the sister entry point already composes a description with an
+    ``[overrides: ...]`` clause via ``_format_description_with_overrides``, so
+    a sweep that differs only in a group or parameter override is
+    distinguishable when browsing executions. run_model previously dropped
+    overrides silently because composition lived in a model-template wrapper
+    that ``zen(run_model).hydra_main(...)`` bypassed. This test pins the fix:
+    composition now lives inside ``run_model`` itself.
+    """
+
+    @pytest.fixture(autouse=True)
+    def reset_state(self):
+        """Reset multirun state before each test."""
+        reset_multirun_state()
+        yield
+        reset_multirun_state()
+
+    @patch("deriva_ml.execution.runner._is_multirun")
+    @patch("deriva_ml.execution.runner.HydraConfig")
+    def test_description_includes_resolved_overrides(self, mock_hydra_config, mock_is_multirun):
+        """Overrides resolved by Hydra must appear in Execution.description."""
+        mock_is_multirun.return_value = False
+
+        mock_hydra_cfg = MagicMock()
+        mock_hydra_cfg.runtime.choices.items.return_value = [
+            ("model_config", "foo"),
+            ("datasets", "bar"),
+        ]
+        mock_hydra_cfg.overrides.task = [
+            "model_config=foo",
+            "datasets=bar",
+            "seed=7",
+        ]
+        mock_hydra_config.get.return_value = mock_hydra_cfg
+
+        mock_ml_class = MagicMock()
+        mock_ml_instance = MagicMock()
+        mock_ml_class.instantiate.return_value = mock_ml_instance
+
+        mock_execution = MagicMock()
+        mock_execution.execute.return_value.__enter__ = Mock(return_value=mock_execution)
+        mock_execution.execute.return_value.__exit__ = Mock(return_value=False)
+        mock_execution.commit_output_assets.return_value = UploadReport(
+            execution_rids=[], total_uploaded=0, total_failed=0, per_table={}, errors=[]
+        )
+        mock_ml_instance.create_execution.return_value = mock_execution
+
+        run_model(
+            deriva_ml=MagicMock(),
+            datasets=[],
+            assets=[],
+            description="Simple model run",
+            workflow=MagicMock(),
+            model_config=Mock(),
+            dry_run=False,
+            ml_class=mock_ml_class,
+        )
+
+        # Inspect the description that landed in ExecutionConfiguration.
+        call_kwargs = mock_ml_instance.create_execution.call_args.kwargs
+        exec_config = mock_ml_instance.create_execution.call_args.args[0]
+        assert exec_config.description == ("Simple model run [overrides: model_config=foo, datasets=bar, seed=7]")
+        assert "workflow" in call_kwargs  # sanity check on the call shape
+
+    @patch("deriva_ml.execution.runner._is_multirun")
+    @patch("deriva_ml.execution.runner.HydraConfig")
+    def test_description_unchanged_when_no_overrides(self, mock_hydra_config, mock_is_multirun):
+        """Empty override list must leave the description untouched -- no bracket clutter."""
+        mock_is_multirun.return_value = False
+
+        mock_hydra_cfg = MagicMock()
+        mock_hydra_cfg.runtime.choices.items.return_value = []
+        mock_hydra_cfg.overrides.task = []
+        mock_hydra_config.get.return_value = mock_hydra_cfg
+
+        mock_ml_class = MagicMock()
+        mock_ml_instance = MagicMock()
+        mock_ml_class.instantiate.return_value = mock_ml_instance
+
+        mock_execution = MagicMock()
+        mock_execution.execute.return_value.__enter__ = Mock(return_value=mock_execution)
+        mock_execution.execute.return_value.__exit__ = Mock(return_value=False)
+        mock_execution.commit_output_assets.return_value = UploadReport(
+            execution_rids=[], total_uploaded=0, total_failed=0, per_table={}, errors=[]
+        )
+        mock_ml_instance.create_execution.return_value = mock_execution
+
+        run_model(
+            deriva_ml=MagicMock(),
+            datasets=[],
+            assets=[],
+            description="Simple model run",
+            workflow=MagicMock(),
+            model_config=Mock(),
+            dry_run=False,
+            ml_class=mock_ml_class,
+        )
+
+        exec_config = mock_ml_instance.create_execution.call_args.args[0]
+        assert exec_config.description == "Simple model run"
+        assert "[overrides:" not in exec_config.description
+
+    @patch("deriva_ml.execution.runner._is_multirun")
+    @patch("deriva_ml.execution.runner.HydraConfig")
+    def test_synthetic_description_override_is_filtered(self, mock_hydra_config, mock_is_multirun):
+        """A ``description='...'`` override (synthesised by the multirun CLI path)
+        must be dropped from the formatted clause -- otherwise the description
+        quotes itself recursively.
+        """
+        mock_is_multirun.return_value = False
+
+        mock_hydra_cfg = MagicMock()
+        mock_hydra_cfg.runtime.choices.items.return_value = []
+        mock_hydra_cfg.overrides.task = [
+            "description='Multirun sweep: lr_grid'",
+            "model_config.learning_rate=0.01",
+        ]
+        mock_hydra_config.get.return_value = mock_hydra_cfg
+
+        mock_ml_class = MagicMock()
+        mock_ml_instance = MagicMock()
+        mock_ml_class.instantiate.return_value = mock_ml_instance
+
+        mock_execution = MagicMock()
+        mock_execution.execute.return_value.__enter__ = Mock(return_value=mock_execution)
+        mock_execution.execute.return_value.__exit__ = Mock(return_value=False)
+        mock_execution.commit_output_assets.return_value = UploadReport(
+            execution_rids=[], total_uploaded=0, total_failed=0, per_table={}, errors=[]
+        )
+        mock_ml_instance.create_execution.return_value = mock_execution
+
+        run_model(
+            deriva_ml=MagicMock(),
+            datasets=[],
+            assets=[],
+            description="Multirun sweep: lr_grid",
+            workflow=MagicMock(),
+            model_config=Mock(),
+            dry_run=False,
+            ml_class=mock_ml_class,
+        )
+
+        exec_config = mock_ml_instance.create_execution.call_args.args[0]
+        # The synthetic description= override is filtered; the real parameter
+        # override survives.
+        assert exec_config.description == ("Multirun sweep: lr_grid [overrides: model_config.learning_rate=0.01]")
+        assert "description=" not in exec_config.description
 
 
 class TestRunModelUploadCallContract:


### PR DESCRIPTION
## Observation

`run_model` silently drops Hydra override context from
`Execution.description`. The sister entry point `run_notebook` does
not — it already appends an `[overrides: ...]` clause via the existing
`_format_description_with_overrides` helper, so an analyst sweeping
`find_executions(...)` can tell apart runs that differ only in a group
or parameter override. `run_model` produced rows that all read like the
registration-time default.

## Root cause

The fix for this was attempted downstream in
`deriva-ml-model-template` PR #46, which wrapped `run_model` with a
`@wraps(run_model)` function that composed the description from
overrides. But the wrapper is registered as a config `_target_` and
never actually executes — the canonical CLI dispatches via
`zen(run_model).hydra_main(config_name="deriva_model", ...)`, which
targets the unwrapped function. The wrapper has been dead code in the
real CLI path.

## Fix

Move composition into `run_model` itself. The helper
`_format_description_with_overrides` already exists, is documented,
and is exercised by `run_notebook`. The new call site sits next to the
existing `HydraConfig.get()` block that captures
`runtime.choices` — it now also captures `overrides.task` and passes
it through the same helper before the `ExecutionConfiguration` is
built.

The synthetic `description='...'` override the multirun CLI path
injects (see `DerivaMLRunCLI.main`) is filtered before formatting so
the description does not recursively quote itself.

## Symmetry win

Both entry points now:

- Resolve the override list from Hydra (env-var + arg for
  `run_notebook`; `HydraConfig.overrides.task` for `run_model`).
- Call the same `_format_description_with_overrides` helper.
- Produce the same `<base> [overrides: ...]` shape in the catalog
  `Execution.description`.

## Tests

Added `TestRunModelDescriptionFromOverrides` to
`tests/execution/test_runner.py`. Three cases:

- `test_description_includes_resolved_overrides` — overrides
  resolved by Hydra land in the description.
- `test_description_unchanged_when_no_overrides` — empty list
  produces no bracket clutter.
- `test_synthetic_description_override_is_filtered` — the
  multirun CLI's self-referential `description='...'` override is
  dropped before formatting.

## Follow-up

A separate PR in `deriva-ml-model-template` will delete the now-dead
`_run_model_with_auto_description` wrapper. Intentionally out of scope
here so the fix is contained to the canonical library path.

## Test plan

- [x] `uv run python -m pytest tests/execution/test_runner.py -v` (21
  passed, including 3 new)
- [x] `uv run python -m pytest tests/execution/test_base_config.py -v`
  (27 passed — no regressions in the `run_notebook` companion path)
- [x] `uv run ruff check src/deriva_ml/execution/runner.py tests/execution/test_runner.py`
- [x] `uv run ruff format src/deriva_ml/execution/runner.py tests/execution/test_runner.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)