### PR TITLE
fix(cite): return placeholder for dry-run sentinel RID "0000"

### DIFF
--- a/src/deriva_ml/core/base.py
+++ b/src/deriva_ml/core/base.py
@@ -42,7 +42,7 @@ DEFAULT_LOGGER_OVERRIDES = _core_utils.DEFAULT_LOGGER_OVERRIDES
 from deriva_ml.core.catalog_stub import CatalogStub
 from deriva_ml.core.config import DerivaMLConfig
 from deriva_ml.core.connection_mode import ConnectionMode
-from deriva_ml.core.definitions import ML_SCHEMA, RID, TableDefinition, VocabularyTableDef
+from deriva_ml.core.definitions import DRY_RUN_RID, ML_SCHEMA, RID, TableDefinition, VocabularyTableDef
 from deriva_ml.core.exceptions import (
     DerivaMLConfigurationError,
     DerivaMLException,
@@ -1051,7 +1051,22 @@ class DerivaML(
 
             Using a dictionary:
                 >>> url = ml.cite({"RID": "1-abc123"})
+
+            Dry-run sentinel — no catalog round-trip, no clickable link:
+                >>> url = ml.cite("0000")
+                >>> print(url)
+                'dry-run (rid=0000)'
         """
+        # Dry-run sentinel: ``run_notebook(dry_run=True)`` and friends
+        # hand back ``DRY_RUN_RID`` as the execution RID because no row
+        # was created on the catalog. Resolving it would 404. Return a
+        # bare, non-link string so notebook templates that embed the
+        # output in ``[label]({url})`` markdown render it as plain text
+        # rather than a clickable link to a 404.
+        rid_value = entity if isinstance(entity, str) else entity.get("RID")
+        if rid_value == DRY_RUN_RID:
+            return f"dry-run (rid={DRY_RUN_RID})"
+
         # Return if already a citation URL
         if isinstance(entity, str) and entity.startswith(f"https://{self.host_name}/id/{self.catalog_id}/"):
             return entity

--- a/tests/core/test_base.py
+++ b/tests/core/test_base.py
@@ -231,6 +231,45 @@ def test_cite_accepts_dict_with_rid_key():
     assert url.startswith("https://deriva.example.org/id/42/1-XYZ@")
 
 
+def test_cite_dry_run_sentinel_returns_placeholder_string():
+    """Dry-run sentinel RID ``"0000"`` short-circuits to a non-link string.
+
+    ``run_notebook(dry_run=True)`` (and related dry-run paths) hand back
+    ``DRY_RUN_RID`` ("0000") as the execution RID because no execution
+    row was created on the catalog. Notebook templates commonly embed
+    the cite output in ``[label]({url})`` markdown. Resolving "0000"
+    against the catalog 404s and crashes the informational header cell,
+    so ``cite`` must guard the sentinel before reaching the catalog.
+
+    The placeholder is a bare string (no scheme) so a markdown link
+    renderer leaves it as plain text rather than rendering a clickable
+    link that would resolve to a 404.
+    """
+    from deriva_ml.core.base import DerivaML
+    from deriva_ml.core.constants import DRY_RUN_RID
+
+    harness = _CiteHarness()
+
+    def _explode(_rid):  # pragma: no cover - sentinel must not call this
+        raise AssertionError("resolve_rid must not be invoked for the dry-run sentinel")
+
+    harness.resolve_rid = _explode  # type: ignore[assignment]
+
+    out = DerivaML.cite(harness, DRY_RUN_RID)  # type: ignore[arg-type]
+    assert out == f"dry-run (rid={DRY_RUN_RID})"
+    assert "http" not in out  # not a clickable link
+
+
+def test_cite_dry_run_sentinel_via_dict():
+    """Same short-circuit when the sentinel arrives wrapped in ``{"RID": ...}``."""
+    from deriva_ml.core.base import DerivaML
+    from deriva_ml.core.constants import DRY_RUN_RID
+
+    harness = _CiteHarness()
+    out = DerivaML.cite(harness, {"RID": DRY_RUN_RID})  # type: ignore[arg-type]
+    assert out == f"dry-run (rid={DRY_RUN_RID})"
+
+
 # ---------------------------------------------------------------------------
 # catalog_snapshot — kwarg forwarding
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`run_notebook(dry_run=True)` (and related dry-run paths) hand back the
literal RID `"0000"` (`DRY_RUN_RID`) as the execution RID because no
execution row is created on the catalog. Notebook templates commonly
embed the cite output in a markdown link, e.g.:

```python
display(Markdown(f"**Execution:** [{execution.execution_rid}]({ml.cite(execution.execution_rid)})"))
```

Under `dry_run=true` this hit `cite("0000")`, which forwarded to
`resolve_rid`, 404'd on `/ermrest/catalog/<cid>/entity_rid/0000`, and
crashed the informational header cell before any of the analysis cells
ran -- strictly less useful than a real run.

## Fix

Three-line guard at the top of `cite()`: when the incoming RID is
`DRY_RUN_RID`, return the bare string `"dry-run (rid=0000)"`. A bare
string (no scheme) means markdown link renderers leave it as plain
text instead of generating a clickable link that would resolve to a
404 -- honest about the dry-run state. All other RIDs route through
the existing resolution path unchanged.

## Test plan

- [x] `uv run python -m pytest tests/core/test_base.py -v` — 13 passed
  (including 2 new tests for the sentinel via bare string and dict).
- [x] `uv run ruff check src/deriva_ml/core/base.py tests/core/test_base.py`
  — no new lint findings.
- [x] `uv run ruff format src/deriva_ml/core/base.py tests/core/test_base.py`
  — unchanged.
- [ ] CI: full suite.

## Reference

Reported in the 2026-05-28 e2e run:
`/Users/carl/GitHub/DerivaML/deriva-ml-model-template-e2e/findings/analyst/01-roc-notebook-dry-run-cites-fake-rid.md`