### PR TITLE
feat(split_dataset): add partition_by parameter; enforce element-RID disjointness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,46 @@
 
 All notable changes to this project are documented here.
 
+## Unreleased — `split_dataset` partition_by parameter + element-RID disjointness invariant
+
+### Added
+
+- **`split_dataset(..., partition_by="element" | "row")`.** Makes
+  the partition unit an explicit caller decision whenever the
+  `(row_per, element_table)` pair is ambiguous (`row_per !=
+  element_table`). `partition_by="element"` deduplicates the
+  denormalized dataframe to one row per `element_table` RID before
+  the selector runs and enforces within-element agreement on
+  `stratify_by_column`; `partition_by="row"` keeps the
+  one-row-per-denormalized-row behavior callers used pre-#174 with
+  `row_per=<feature_table>`. Auto-defaults to `"element"` when
+  `row_per` is `None` or equals `element_table` (the unambiguous
+  case). Required — no default — when `row_per` is set and differs
+  from `element_table`.
+
+### Changed
+
+- **`split_dataset` now refuses the ambiguous `(row_per !=
+  element_table)` shape at the call site with a `ValueError` that
+  names both modes.** This is intentionally breaking for callers
+  that previously relied on the implicit-row-partition behavior of
+  `row_per=<feature_table>`; that shape silently sent the same
+  element RID's multiple denormalized rows to opposite partitions
+  (train/test leakage). Adding `partition_by="row"` restores the
+  prior behavior; `partition_by="element"` switches to safer
+  per-element semantics. Callers passing `row_per=None` (or
+  `row_per == element_table`) get the auto-default and remain
+  unchanged.
+
+- **Internal: element-RID disjointness invariant.** When
+  `partition_by="element"` is in effect, `_compute_partitions`
+  asserts that no element_table RID appears in more than one
+  partition after the selector returns. The assertion is
+  defensive — a correct dedupe + a contract-obeying selector can
+  never trip it — but it catches future regressions in either
+  piece. Cites `findings/curator/02` and `findings/evaluator/02`
+  from the 2026-05-28 e2e run.
+
 ## Unreleased — Issue #251: dirty-tree check scoping + clearer error
 
 ### Changed

--- a/docs/user-guide/denormalization.md
+++ b/docs/user-guide/denormalization.md
@@ -277,6 +277,43 @@ to the underlying feature-association table
 backs `find_features` / `feature_values`. The full table name
 works too.
 
+**Setting `row_per=<target_table>` with a feature shorthand in
+`include_tables` is rejected (Rule 5).** The feature-association
+table is downstream of the target table, and the denormalizer does
+not aggregate. The two intents the caller might have in mind are
+spelled differently:
+
+```python
+# Intent A: "one row per Image with the feature value projected
+# as a column." Pass the value table (vocabulary) directly, not
+# the feature-name shorthand. The feature-association table
+# becomes a transparent bridge in the join.
+ds.get_denormalized_as_dataframe(
+    ["Image", "Image_Class"],
+    row_per="Image",
+)
+# OK: one row per Image, Image_Class.Name projected.
+
+# Intent B: "one row per feature observation." Let auto-inference
+# pick the feature-association table as row_per (the default
+# behavior shown at the top of this section), or name it
+# explicitly. Image RIDs repeat across multi-execution annotations.
+ds.get_denormalized_as_dataframe(
+    ["Image", "Image_Classification"],
+    row_per="Execution_Image_Image_Classification",
+)
+# OK: one row per feature observation.
+
+# Forbidden combination: feature shorthand with row_per=<target>.
+ds.get_denormalized_as_dataframe(
+    ["Image", "Image_Classification"],
+    row_per="Image",
+)
+# RAISES DerivaMLDenormalizeDownstreamLeaf: the shorthand resolves
+# to Execution_Image_Image_Classification, which is downstream of
+# Image. To project the feature value, use Intent A's shape.
+```
+
 ### Heterogeneous dataset with orphan members
 
 ```python

--- a/src/deriva_ml/dataset/split.py
+++ b/src/deriva_ml/dataset/split.py
@@ -1341,29 +1341,26 @@ def split_dataset(
                 testing_types=["Labeled"],
             )
 
-        Stratified split preserving class distribution::
+        Stratified split preserving class distribution (one row per
+        Image, projecting the Image_Class vocab term as a column)::
 
+            # Image and Image_Class are linked by the feature-
+            # association table Execution_Image_Image_Classification,
+            # which is a transparent bridge for the denormalizer.
+            # Pass the **vocab/value table** (``Image_Class``) in
+            # ``include_tables``, not the feature-name shorthand
+            # (``Image_Classification``): the shorthand resolves to
+            # the feature-association table, which is downstream of
+            # Image and would trip Rule 5 against the auto-defaulted
+            # ``row_per="Image"``. Stratify on the dotted column
+            # against the vocab table.
             result = split_dataset(
                 ml, "28D0",
                 test_size=0.2,
-                stratify_by_column="Image_Classification.Image_Class",
-                include_tables=["Image", "Image_Classification"],
-            )
-
-        Stratified split on a feature-target column (one row per
-        Image, projecting the Image_Classification vocab term)::
-
-            # Image and Image_Classification are linked by the feature-
-            # association table Execution_Image_Image_Classification.
-            # ``split_dataset`` auto-defaults ``row_per=element_table``
-            # when stratifying, so the join produces one row per Image
-            # with the classification label projected as a column.
-            result = split_dataset(
-                ml, "28D0",
-                test_size=0.2,
-                stratify_by_column="Image_Classification.Image_Class",
-                include_tables=["Image", "Image_Classification"],
+                stratify_by_column="Image_Class.Name",
+                include_tables=["Image", "Image_Class"],
                 element_table="Image",
+                partition_by="element",
             )
 
         Override ``row_per`` to project one row per feature value
@@ -1377,24 +1374,46 @@ def split_dataset(
 
             # Per-annotation statistics — element RIDs may legitimately
             # appear in multiple partitions because each annotator-image
-            # pair is its own observation.
+            # pair is its own observation. The feature-name shorthand
+            # ``Image_Classification`` resolves to the feature-
+            # association table; setting ``row_per`` to that table
+            # explicitly makes the per-observation intent visible.
+            # Stratify on the FK column on the feature-association
+            # table (the resolver does not pull the vocab table into
+            # the join when the shorthand is used with an explicit
+            # feature-assoc ``row_per``).
             result = split_dataset(
                 ml, "28D0",
                 test_size=0.2,
-                stratify_by_column="Image_Classification.Image_Class",
-                include_tables=["Image", "Execution_Image_Image_Classification"],
+                stratify_by_column="Execution_Image_Image_Classification.Image_Class",
+                include_tables=["Image", "Image_Classification"],
                 row_per="Execution_Image_Image_Classification",
                 partition_by="row",
             )
+
+        Note: to get "one row per element with a feature value
+        projected as a column," pass the vocab/value table in
+        ``include_tables`` (as in the first stratified example
+        above), not the feature-name shorthand. Rule 5 of the
+        denormalizer rejects the shorthand combined with
+        ``row_per=<element>`` because the feature-association table
+        the shorthand resolves to is strictly downstream of the
+        element — aggregation is not supported. To partition by
+        feature *observation* instead (per-annotation statistics),
+        use the shorthand together with an explicit
+        ``row_per=<feature-assoc-table>`` and ``partition_by="row"``
+        as in the second example above.
 
         Stratified split dropping rows with missing labels::
 
             result = split_dataset(
                 ml, "28D0",
                 test_size=0.2,
-                stratify_by_column="Image_Classification.Image_Class",
+                stratify_by_column="Image_Class.Name",
                 stratify_missing="drop",
-                include_tables=["Image", "Image_Classification"],
+                include_tables=["Image", "Image_Class"],
+                element_table="Image",
+                partition_by="element",
             )
 
         Custom selection function for balanced sampling::
@@ -1403,7 +1422,7 @@ def split_dataset(
 
             def balanced_selector(df, partition_sizes, seed):
                 rng = np.random.default_rng(seed)
-                label_col = "Image_Classification_Image_Class"
+                label_col = "Image_Class_Name"
                 classes = df[label_col].unique()
                 result = {name: [] for name in partition_sizes}
                 for cls in classes:
@@ -1420,7 +1439,9 @@ def split_dataset(
                 ml, "28D0",
                 test_size=100,
                 selection_fn=balanced_selector,
-                include_tables=["Image", "Image_Classification"],
+                include_tables=["Image", "Image_Class"],
+                element_table="Image",
+                partition_by="element",
             )
 
         Dry run to preview the split plan without modifying the catalog::

--- a/src/deriva_ml/dataset/split.py
+++ b/src/deriva_ml/dataset/split.py
@@ -91,7 +91,7 @@ from __future__ import annotations
 import json
 import logging
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Literal, Protocol, runtime_checkable
 
 import numpy as np
 import pandas as pd
@@ -485,10 +485,13 @@ def _validate_split_inputs(
     stratify_by_column: str | None,
     selection_fn: SelectionFunction | None,
     include_tables: list[str] | None,
-) -> None:
+    row_per: str | None = None,
+    element_table: str | None = None,
+    partition_by: Literal["element", "row"] | None = None,
+) -> Literal["element", "row"]:
     """Validate the mutually-exclusive + required-companion arg constraints.
 
-    Three rules:
+    Four rules:
 
     1. ``stratify_by_column`` and ``selection_fn`` are mutually
        exclusive — both produce per-element partitioning decisions
@@ -498,11 +501,46 @@ def _validate_split_inputs(
        drives a denormalization that needs explicit table scope).
     3. ``selection_fn`` requires ``include_tables`` for the same
        reason.
+    4. ``partition_by`` is required whenever ``row_per`` is set and
+       differs from ``element_table`` — the (row_per !=
+       element_table) shape is exactly the silent-leakage case
+       (one element_table RID can have multiple denormalized rows
+       that the selector may scatter across partitions), so the
+       caller must declare intent explicitly. When ``row_per`` is
+       ``None`` or equals ``element_table`` the partition unit is
+       unambiguous and ``partition_by`` auto-defaults to
+       ``"element"``.
 
-    Raises ``ValueError`` rather than a ``DerivaMLException`` to
-    match the existing surface: these are argument-shape errors
-    the caller should fix at the call site, not catalog-side
-    failures.
+    Args:
+        stratify_by_column: As passed to :func:`split_dataset`.
+        selection_fn: As passed to :func:`split_dataset`.
+        include_tables: As passed to :func:`split_dataset`.
+        row_per: As passed to :func:`split_dataset`. Used only to
+            decide whether ``partition_by`` is required.
+        element_table: As passed to :func:`split_dataset`. Compared
+            against ``row_per`` to decide ambiguity.
+        partition_by: As passed to :func:`split_dataset`.
+
+    Returns:
+        The effective ``partition_by`` value after defaulting. When
+        the caller passed ``"element"`` or ``"row"`` it is returned
+        as-is. When the caller passed ``None`` and ambiguity is
+        absent (``row_per`` is ``None`` or equals ``element_table``),
+        returns ``"element"``. When ``partition_by`` is required and
+        the caller passed ``None``, raises ``ValueError`` instead of
+        returning.
+
+    Raises:
+        ValueError: When the mutual-exclusion / requires rules are
+            violated, or when ``partition_by`` is required and not
+            supplied, or when ``partition_by`` is not one of the
+            allowed string values.
+
+    Note:
+        ``ValueError`` rather than a ``DerivaMLException`` to match
+        the existing surface: these are argument-shape errors the
+        caller should fix at the call site, not catalog-side
+        failures.
     """
     if stratify_by_column and selection_fn:
         raise ValueError("stratify_by_column and selection_fn are mutually exclusive. Use one or the other.")
@@ -519,6 +557,156 @@ def _validate_split_inputs(
             "include_tables is required when using a custom selection_fn. "
             "Specify the tables needed for denormalization."
         )
+
+    if partition_by is not None and partition_by not in ("element", "row"):
+        raise ValueError(f"partition_by must be 'element', 'row', or None, got {partition_by!r}.")
+
+    # Decide whether the (row_per, element_table) pair is ambiguous.
+    # Ambiguity exists only when row_per is set AND differs from the
+    # element_table — that's the shape where one element_table RID
+    # can have multiple denormalized rows that the selector may
+    # scatter across partitions (the silent-leakage case).
+    row_per_differs = row_per is not None and row_per != element_table
+
+    if partition_by is None:
+        if row_per_differs:
+            raise ValueError(
+                "partition_by is required when row_per != element_table "
+                f"(got row_per={row_per!r}, element_table={element_table!r}). "
+                "This (row_per, element_table) shape is ambiguous: the "
+                "denormalized dataframe has multiple rows per "
+                f"{element_table or 'element'} RID, and the selector "
+                "may scatter them across partitions — silently putting "
+                "the same RID in train and test.\n\n"
+                "Pick the intent explicitly:\n"
+                "  partition_by='element' — dedupe rows per "
+                f"{element_table or 'element'} RID before partitioning; "
+                "partitions are disjoint at the element-RID level. "
+                "Requires within-element agreement on selector-read "
+                "columns (stratify_by_column).\n"
+                "  partition_by='row'     — partition rows directly; "
+                f"{element_table or 'element'} RIDs may appear in "
+                "multiple partitions (per-annotation statistics, "
+                "intentional row-level granularity)."
+            )
+        # Unambiguous case: auto-default to "element".
+        return "element"
+
+    return partition_by
+
+
+def _dedupe_for_element_partition(
+    df: pd.DataFrame,
+    *,
+    rid_column: str,
+    element_table: str | None,
+    stratify_by_column: str | None,
+    stratify_missing: str,
+    using_selection_fn: bool,
+) -> pd.DataFrame:
+    """Reduce the denormalized df to one row per element_table RID.
+
+    Two steps:
+
+    1. Verify within-element agreement on selector-read columns.
+       For stratified splits that means ``stratify_by_column``;
+       for custom ``selection_fn`` we skip (the read set is opaque)
+       and the docstring warns the caller they own this check.
+       NaN-handling follows ``stratify_missing`` — ``"error"`` raises
+       on any NaN in a group, ``"drop"`` excludes whole groups whose
+       members are NaN, ``"include"`` treats NaN as a sentinel that
+       must match.
+    2. Dedupe with stable, seed-deterministic ordering — sort by
+       ``rid_column`` to make iteration order reproducible, then
+       ``drop_duplicates(keep="first")`` on ``rid_column``. When
+       within-element values agree (guaranteed by step 1), the
+       first row encountered is representative.
+
+    Args:
+        df: Denormalized DataFrame from
+            :meth:`Dataset.get_denormalized_as_dataframe`.
+        rid_column: Name of the column carrying element_table RIDs
+            (e.g., ``"Image.RID"``).
+        element_table: Element table name (used in error messages).
+        stratify_by_column: Column the stratified selector will
+            read, or ``None`` when using ``selection_fn``.
+        stratify_missing: NaN policy as passed to
+            :func:`split_dataset` (``"error"`` / ``"drop"`` /
+            ``"include"``). Only applied during the within-element
+            check; doesn't override the selector's own NaN policy.
+        using_selection_fn: ``True`` when the caller passed a custom
+            ``selection_fn``. Skips the within-element check —
+            the selector's read set is opaque so we can't enforce
+            uniformity, and the docstring documents this is the
+            caller's responsibility.
+
+    Returns:
+        DataFrame with one row per ``rid_column`` value.
+
+    Raises:
+        ValueError: When ``stratify_by_column`` is set and some
+            element_table RID has disagreeing values across its
+            rows. The error message names the consensus-feature
+            pattern as the deriva-ml-shape fix.
+    """
+    if stratify_by_column and not using_selection_fn:
+        if stratify_by_column not in df.columns:
+            # Defer this error to the selector, which prints
+            # the available columns helpfully.
+            pass
+        else:
+            check_df = df[[rid_column, stratify_by_column]].copy()
+
+            # NaN handling: match stratify_missing policy at the
+            # group level.
+            null_mask = check_df[stratify_by_column].isna()
+            if null_mask.any():
+                if stratify_missing == "error":
+                    null_count = int(null_mask.sum())
+                    raise ValueError(
+                        f"Column '{stratify_by_column}' has {null_count} missing values. "
+                        "Use stratify_missing='drop' to exclude these rows, "
+                        "or 'include' to treat nulls as a separate class."
+                    )
+                elif stratify_missing == "drop":
+                    # Drop any group that has ANY NaN — even partial
+                    # NaN agreement within a group is uninformative
+                    # for stratification.
+                    bad_rids = set(check_df.loc[null_mask, rid_column])
+                    check_df = check_df[~check_df[rid_column].isin(bad_rids)].copy()
+                    df = df[~df[rid_column].isin(bad_rids)].copy()
+                elif stratify_missing == "include":
+                    check_df[stratify_by_column] = check_df[stratify_by_column].fillna("__missing__")
+
+            # Within-element uniformity check.
+            disagreement = check_df.groupby(rid_column)[stratify_by_column].nunique(dropna=False).loc[lambda s: s > 1]
+            if len(disagreement) > 0:
+                offenders = list(disagreement.index)[:5]
+                raise ValueError(
+                    f"split_dataset cannot partition by element when stratify column "
+                    f"{stratify_by_column!r} has disagreeing values for the same "
+                    f"{element_table or 'element'} RID. This usually means you're "
+                    "stratifying on a multi-annotator feature without consensus "
+                    "resolution.\n\n"
+                    "The deriva-ml pattern for this is a separate consensus feature "
+                    "that records the resolved label per element (e.g., "
+                    f"'{element_table or 'Element'}_Classification_Consensus' written "
+                    "by your adjudication workflow). Stratify on the consensus "
+                    "feature, not the raw annotator feature.\n\n"
+                    "Alternatively, pass partition_by='row' if you intend per-row "
+                    "partitioning and accept that the same "
+                    f"{element_table or 'element'} RID may appear in multiple "
+                    "partitions.\n\n"
+                    f"Offending RIDs (first {len(offenders)} of "
+                    f"{len(disagreement)}): {offenders}"
+                )
+
+    # Stable, seed-deterministic dedupe. mergesort preserves the
+    # original row order within equal sort keys, and keep="first"
+    # then picks the first encountered occurrence. The result is
+    # deterministic for a given input df.
+    deduped = df.sort_values(by=rid_column, kind="mergesort").drop_duplicates(subset=[rid_column], keep="first")
+    return deduped.reset_index(drop=True)
 
 
 def _compute_partitions(
@@ -538,6 +726,7 @@ def _compute_partitions(
     row_per: str | None,
     via: list[str] | None,
     ignore_unrelated_anchors: bool,
+    partition_by: Literal["element", "row"] = "element",
 ) -> tuple[
     dict[str, list[str]],
     dict[str, int],
@@ -574,6 +763,15 @@ def _compute_partitions(
             selection_fn, row_per, via,
             ignore_unrelated_anchors: As passed to
             :func:`split_dataset`.
+        partition_by: Effective partition unit after defaulting in
+            :func:`_validate_split_inputs`. ``"element"`` (default)
+            dedupes the denormalized dataframe to one row per
+            ``element_table`` RID before partitioning, enforces
+            within-element agreement on selector-read columns, and
+            asserts element-RID disjointness at the end.
+            ``"row"`` partitions denormalized rows directly with no
+            dedupe — element RIDs may legitimately appear in
+            multiple partitions.
 
     Returns:
         Four-tuple ``(partition_rids, partition_sizes,
@@ -638,7 +836,9 @@ def _compute_partitions(
         # explicitly. See issue #174 for the motivating case.
         effective_row_per = row_per if row_per is not None else element_table
         logger.info(
-            f"Denormalizing dataset with tables: {include_tables} (row_per={effective_row_per}, via={via or []})"
+            f"Denormalizing dataset with tables: {include_tables} "
+            f"(row_per={effective_row_per}, via={via or []}, "
+            f"partition_by={partition_by!r})"
         )
         df = source_ds.get_denormalized_as_dataframe(
             include_tables,
@@ -647,6 +847,43 @@ def _compute_partitions(
             ignore_unrelated_anchors=ignore_unrelated_anchors,
         )
         logger.info(f"Denormalized DataFrame: {len(df)} rows, {len(df.columns)} columns")
+
+        # Resolve the element_table RID column once — both the
+        # element-level dedupe and the partition-RID extraction need it.
+        rid_column = f"{element_table}.RID"
+        if rid_column not in df.columns:
+            rid_column = "RID"
+            if rid_column not in df.columns:
+                raise ValueError(
+                    f"Cannot find RID column. Tried '{element_table}.RID' and 'RID'. "
+                    f"Available columns: {list(df.columns)}"
+                )
+
+        if partition_by == "element":
+            # Element-mode contract: the selector sees one row per
+            # element_table RID. Two steps:
+            #
+            # 1. Verify within-element agreement on every column the
+            #    selector will read. For stratified splits that's
+            #    just stratify_by_column; for selection_fn the read
+            #    set is opaque, so we skip and document that the
+            #    caller is responsible.
+            # 2. Dedupe to one row per element_table RID with stable
+            #    seed-deterministic ordering — sort by element_RID
+            #    then drop_duplicates(keep="first").
+            df = _dedupe_for_element_partition(
+                df,
+                rid_column=rid_column,
+                element_table=element_table,
+                stratify_by_column=stratify_by_column,
+                stratify_missing=stratify_missing,
+                using_selection_fn=selection_fn is not None,
+            )
+            logger.info(f"After element-level dedupe: {len(df)} rows")
+            # Re-resolve partition sizes against the deduped row count.
+            partition_sizes = _resolve_sizes(len(df), test_size, train_size, val_size)
+            size_summary = ", ".join(f"{k}={v}" for k, v in partition_sizes.items())
+            logger.info(f"Adjusted split sizes after dedupe: {size_summary} (total={len(df)})")
 
         if stratify_by_column:
             logger.info(f"Using stratified split on column: {stratify_by_column}")
@@ -657,17 +894,26 @@ def _compute_partitions(
 
         partition_indices = selector(df, partition_sizes, seed)
 
-        # Map indices back to RIDs (dot notation: Table.RID).
-        rid_column = f"{element_table}.RID"
-        if rid_column not in df.columns:
-            rid_column = "RID"
-            if rid_column not in df.columns:
-                raise ValueError(
-                    f"Cannot find RID column. Tried '{element_table}.RID' and 'RID'. "
-                    f"Available columns: {list(df.columns)}"
-                )
-
         partition_rids = {name: df.iloc[indices][rid_column].tolist() for name, indices in partition_indices.items()}
+
+        if partition_by == "element":
+            # Defensive invariant — after a correct dedupe the
+            # selector sees disjoint rows (one per element_RID), so
+            # mapping indices → RIDs preserves disjointness. If this
+            # ever fires, the dedupe logic regressed or a selector
+            # ignored its input contract; either case is a bug, not
+            # bad user input — hence ``assert``, not ``ValueError``.
+            seen: dict[str, str] = {}
+            for name, rids in partition_rids.items():
+                for r in rids:
+                    assert r not in seen, (
+                        "partition_by='element' disjointness invariant violated: "
+                        f"RID {r!r} appears in both {seen.get(r)!r} and {name!r}. "
+                        "Internal correctness bug — the element-level dedupe "
+                        "failed to produce one row per element_table RID, or "
+                        "the selector returned overlapping indices."
+                    )
+                    seen[r] = name
     else:
         all_rids = [record["RID"] for record in member_records]
 
@@ -889,6 +1135,8 @@ def split_dataset(
     row_per: str | None = None,
     via: list[str] | None = None,
     ignore_unrelated_anchors: bool = False,
+    # Partition-unit selector
+    partition_by: Literal["element", "row"] | None = None,
 ) -> SplitResult:
     """Split a DerivaML dataset into training, testing, and optionally validation subsets.
 
@@ -969,7 +1217,9 @@ def split_dataset(
             natural anchor when partitioning element rows. Set
             explicitly to override (e.g., when projecting a feature
             value table's columns through a feature-association
-            bridge and you want one row per feature value).
+            bridge and you want one row per feature value). When
+            ``row_per != element_table`` the partition unit becomes
+            ambiguous; ``partition_by`` must then be set explicitly.
         via: Tables forced into the join chain without contributing
             columns (denormalizer ``via=`` parameter). Useful to
             disambiguate path ambiguity (Rule 6) without polluting
@@ -979,6 +1229,77 @@ def split_dataset(
             table. Pass-through to the denormalizer (Rule 8) — useful
             when the source dataset has heterogeneous member tables
             and only a subset participates in the split.
+        partition_by: Explicit declaration of the partition unit
+            when ``row_per`` is set and differs from ``element_table``.
+            Either ``"element"`` (one element_table RID per
+            partition; dedupe rows before partitioning; enforces
+            within-element agreement on the stratify column) or
+            ``"row"`` (one denormalized row per partition; element
+            RIDs may legitimately appear in multiple partitions).
+            Auto-defaults to ``"element"`` when ``row_per`` is
+            ``None`` or equals ``element_table`` (the unambiguous
+            case). Required — no default — when ``row_per`` is set
+            and differs from ``element_table``. See the
+            "When to use ``partition_by='element'`` vs
+            ``partition_by='row'``" section below.
+
+    When to use ``partition_by='element'`` vs ``partition_by='row'``:
+        The (``row_per``, ``element_table``) pair encodes two
+        independent choices that the old API conflated:
+
+        - ``element_table`` — what catalog entity does each partition
+          collect (Image, Subject, Trial, ...).
+        - ``row_per`` — how does the denormalized dataframe shape
+          its rows (one per element_table RID, one per
+          feature-value, one per visit, ...).
+
+        When ``row_per`` equals ``element_table`` (or is unset) the
+        two intents collapse: one element RID = one row, the
+        selector partitions rows, and the resulting partitions are
+        naturally disjoint at the element level. This is the
+        unambiguous case and ``partition_by`` auto-defaults to
+        ``"element"``.
+
+        When ``row_per`` differs from ``element_table`` the same
+        element RID can have multiple denormalized rows (the 1:N
+        feature case). The selector now faces a real architectural
+        choice the caller must make explicitly:
+
+        ``partition_by="element"`` — partition the *elements*. The
+        dataframe is deduplicated to one row per element_table RID
+        before the selector runs. Partitions are guaranteed
+        disjoint at the element-RID level. Use this when downstream
+        consumers (training loaders, ROC analysis, accuracy
+        metrics) operate at the element level — every reasonable ML
+        evaluation does. Requires within-element agreement on any
+        selector-read column: stratifying on
+        ``Image_Classification.Image_Class`` only makes sense if
+        every Image_RID has one class. When multiple annotators
+        disagree per image, resolve them upstream (the deriva-ml
+        pattern is a separate consensus feature that records the
+        resolved label per element, written by your adjudication
+        workflow) and stratify on the consensus feature, not on
+        the raw annotator rows. ``split_dataset`` enforces this
+        with a within-element uniformity check that names the
+        offending RIDs.
+
+        ``partition_by="row"`` — partition the *rows*. No dedupe,
+        no uniformity check. Element RIDs may appear in multiple
+        partitions; this is the expected shape for legitimate
+        per-row use cases such as per-annotation statistics (each
+        annotator-image pair scored independently) or time-series
+        splits within a subject. The caller is responsible for
+        ensuring partition disjointness at whatever granularity
+        downstream consumers actually need.
+
+        Migration note: callers that previously relied on the
+        implicit-row-partition behavior of
+        ``row_per=<feature_table>`` get a ``ValueError`` at the
+        call site directing them to choose. Adding
+        ``partition_by="row"`` restores the prior behavior;
+        ``partition_by="element"`` switches to the safer
+        per-element semantics (and almost always what the caller
+        meant).
 
     Returns:
         SplitResult with partition info for split, training, testing,
@@ -1046,14 +1367,24 @@ def split_dataset(
             )
 
         Override ``row_per`` to project one row per feature value
-        instead (e.g., when computing per-annotation statistics)::
+        instead — *per-annotation* statistics. Because ``row_per``
+        differs from ``element_table``, ``partition_by`` must be set
+        explicitly. ``"row"`` accepts that the same Image RID may
+        appear in multiple partitions (its multiple annotation
+        rows can land independently); ``"element"`` would dedupe
+        to one row per Image before partitioning and would raise
+        if annotators disagreed::
 
+            # Per-annotation statistics — element RIDs may legitimately
+            # appear in multiple partitions because each annotator-image
+            # pair is its own observation.
             result = split_dataset(
                 ml, "28D0",
                 test_size=0.2,
                 stratify_by_column="Image_Classification.Image_Class",
                 include_tables=["Image", "Execution_Image_Image_Classification"],
                 row_per="Execution_Image_Image_Classification",
+                partition_by="row",
             )
 
         Stratified split dropping rows with missing labels::
@@ -1146,10 +1477,13 @@ def split_dataset(
     # 3. ``_create_split_hierarchy`` — catalog-writing path
     #    (parent/child datasets, member assignment).
 
-    _validate_split_inputs(
+    effective_partition_by = _validate_split_inputs(
         stratify_by_column=stratify_by_column,
         selection_fn=selection_fn,
         include_tables=include_tables,
+        row_per=row_per,
+        element_table=element_table,
+        partition_by=partition_by,
     )
 
     logger.info(f"Looking up source dataset: {source_dataset_rid}")
@@ -1171,6 +1505,7 @@ def split_dataset(
         row_per=row_per,
         via=via,
         ignore_unrelated_anchors=ignore_unrelated_anchors,
+        partition_by=effective_partition_by,
     )
 
     # Dry-run early return — no catalog writes.
@@ -1228,6 +1563,7 @@ def split_dataset(
         "row_per": row_per,
         "via": via,
         "ignore_unrelated_anchors": ignore_unrelated_anchors,
+        "partition_by": effective_partition_by,
         "training_types": train_types,
         "testing_types": test_types,
         "validation_types": val_types if val_types else None,
@@ -1396,6 +1732,16 @@ def main() -> int:
         help="Silently drop dataset anchors with no FK path to any requested table (denormalizer Rule 8 escape hatch).",
     )
     parser.add_argument(
+        "--partition-by",
+        choices=["element", "row"],
+        default=None,
+        help="Partition unit: 'element' dedupes per element_table RID before "
+        "partitioning (disjoint at the element level); 'row' partitions "
+        "denormalized rows directly (element RIDs may overlap). Required when "
+        "--row-per is set and differs from --element-table; auto-defaults to "
+        "'element' otherwise.",
+    )
+    parser.add_argument(
         "--training-types",
         default="Labeled",
         help="Comma-separated additional dataset types for training set (default: Labeled)",
@@ -1490,6 +1836,7 @@ def main() -> int:
                 row_per=args.row_per,
                 via=via,
                 ignore_unrelated_anchors=args.ignore_unrelated_anchors,
+                partition_by=args.partition_by,
                 dry_run=True,
             )
         else:

--- a/tests/dataset/test_split.py
+++ b/tests/dataset/test_split.py
@@ -1385,7 +1385,13 @@ class TestDenormalizationPlumbing:
 
     @requires_sklearn
     def test_row_per_explicit_passed_through(self):
-        """Explicit ``row_per`` overrides the element_table default."""
+        """Explicit ``row_per`` overrides the element_table default.
+
+        Note: when ``row_per != element_table``, ``partition_by`` is
+        required — the (row_per, element_table) shape is exactly the
+        silent-leakage case. The stub returns one row per Item.RID so
+        the within-element check is trivially satisfied.
+        """
         captured: dict = {}
         ml, _ = self._stub_ml_and_dataset(captured)
 
@@ -1400,6 +1406,7 @@ class TestDenormalizationPlumbing:
             include_tables=["Item", "Vocab"],
             element_table="Item",
             row_per="Vocab",
+            partition_by="element",
             dry_run=True,
         )
         assert captured["row_per"] == "Vocab"

--- a/tests/dataset/test_split_partition_by.py
+++ b/tests/dataset/test_split_partition_by.py
@@ -1,0 +1,466 @@
+"""Unit tests for the ``partition_by`` parameter on ``split_dataset``.
+
+These tests pin the design decision that ``split_dataset`` must
+make the partition unit (element vs row) an explicit caller
+intent whenever the (``row_per``, ``element_table``) pair is
+ambiguous. The motivating finding is the e2e-run train/test
+leakage where ``row_per=<feature_table>`` silently sent the same
+Image RID's annotation rows to opposite partitions (see
+``findings/curator/02-train-test-leakage-in-labeled-split-datasets.md``
+in the model template's e2e archive).
+
+The unit tests use a stubbed :class:`Dataset` whose
+``get_denormalized_as_dataframe`` returns a synthetic DataFrame
+modelling the relevant 1:N-feature shape, so they run without a
+live catalog.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from deriva_ml.dataset.split import (
+    _compute_partitions,
+    _dedupe_for_element_partition,
+    _validate_split_inputs,
+    split_dataset,
+)
+
+
+def _fake_dataset_with_denorm(members: dict[str, list[dict]], denorm_df: pd.DataFrame) -> MagicMock:
+    """Build a :class:`Dataset` stand-in for the denormalization path.
+
+    Args:
+        members: ``list_dataset_members`` return value.
+        denorm_df: DataFrame that ``get_denormalized_as_dataframe``
+            returns regardless of arguments.
+    """
+    ds = MagicMock()
+    ds.list_dataset_members.return_value = members
+    ds.get_denormalized_as_dataframe.return_value = denorm_df
+    return ds
+
+
+def _multi_row_feature_df(
+    *,
+    n_images: int,
+    rows_per_image: int = 2,
+    agreeing_labels: bool = True,
+    disagreement_rids: list[str] | None = None,
+) -> pd.DataFrame:
+    """Build a synthetic denormalized DataFrame modelling a 1:N feature.
+
+    Args:
+        n_images: Number of distinct Image RIDs to synthesise.
+        rows_per_image: How many annotation rows each image carries.
+            Mimics two annotators per image when 2.
+        agreeing_labels: When True, every image's annotation rows
+            carry the same label (so the within-element check
+            passes). When False, ``disagreement_rids`` are flipped.
+        disagreement_rids: Image RIDs to give disagreeing labels.
+            Only used when ``agreeing_labels`` is False.
+
+    Returns:
+        DataFrame with columns ``Image.RID`` (str),
+        ``Image_Classification.Image_Class`` (str), and a dummy
+        ``Image_Classification.RID`` column.
+    """
+    rng = np.random.default_rng(123)
+    classes = np.array(["cat", "dog", "bird", "fish"])
+    image_rids = [f"img-{i:04d}" for i in range(n_images)]
+    image_labels = {rid: classes[rng.integers(len(classes))] for rid in image_rids}
+    disagree = set(disagreement_rids or [])
+
+    rows = []
+    for rid in image_rids:
+        for k in range(rows_per_image):
+            if not agreeing_labels and rid in disagree and k == 1:
+                # Pick a class different from the chosen label.
+                other = next(c for c in classes if c != image_labels[rid])
+                label = other
+            else:
+                label = image_labels[rid]
+            rows.append(
+                {
+                    "Image.RID": rid,
+                    "Image_Classification.Image_Class": label,
+                    "Image_Classification.RID": f"feat-{rid}-{k}",
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+# =============================================================================
+# _validate_split_inputs — partition_by rules
+# =============================================================================
+
+
+class TestValidatePartitionBy:
+    """Pin the (row_per, element_table, partition_by) validation matrix."""
+
+    def test_partition_by_defaults_to_element_when_row_per_omitted(self):
+        result = _validate_split_inputs(
+            stratify_by_column=None,
+            selection_fn=None,
+            include_tables=None,
+            row_per=None,
+            element_table="Image",
+            partition_by=None,
+        )
+        assert result == "element"
+
+    def test_partition_by_defaults_to_element_when_row_per_equals_element_table(self):
+        result = _validate_split_inputs(
+            stratify_by_column="Image_Classification.Image_Class",
+            selection_fn=None,
+            include_tables=["Image", "Image_Classification"],
+            row_per="Image",
+            element_table="Image",
+            partition_by=None,
+        )
+        assert result == "element"
+
+    def test_partition_by_required_when_row_per_differs_from_element_table(self):
+        with pytest.raises(ValueError) as exc:
+            _validate_split_inputs(
+                stratify_by_column="Image_Classification.Image_Class",
+                selection_fn=None,
+                include_tables=["Image", "Execution_Image_Image_Classification"],
+                row_per="Execution_Image_Image_Classification",
+                element_table="Image",
+                partition_by=None,
+            )
+        msg = str(exc.value)
+        # Message must name both modes so the caller can fix the call site.
+        assert "partition_by" in msg
+        assert "'element'" in msg
+        assert "'row'" in msg
+        assert "row_per" in msg
+
+    def test_explicit_partition_by_element_returns_element(self):
+        result = _validate_split_inputs(
+            stratify_by_column="Image_Classification.Image_Class",
+            selection_fn=None,
+            include_tables=["Image", "Execution_Image_Image_Classification"],
+            row_per="Execution_Image_Image_Classification",
+            element_table="Image",
+            partition_by="element",
+        )
+        assert result == "element"
+
+    def test_explicit_partition_by_row_returns_row(self):
+        result = _validate_split_inputs(
+            stratify_by_column="Image_Classification.Image_Class",
+            selection_fn=None,
+            include_tables=["Image", "Execution_Image_Image_Classification"],
+            row_per="Execution_Image_Image_Classification",
+            element_table="Image",
+            partition_by="row",
+        )
+        assert result == "row"
+
+    def test_invalid_partition_by_raises(self):
+        with pytest.raises(ValueError, match="partition_by must be"):
+            _validate_split_inputs(
+                stratify_by_column=None,
+                selection_fn=None,
+                include_tables=None,
+                row_per=None,
+                element_table="Image",
+                partition_by="oops",  # type: ignore[arg-type]
+            )
+
+
+# =============================================================================
+# _dedupe_for_element_partition — uniformity check
+# =============================================================================
+
+
+class TestDedupeForElementPartition:
+    """Within-element uniformity + stable dedupe."""
+
+    def test_agreeing_labels_dedupe_to_one_row_per_rid(self):
+        df = _multi_row_feature_df(n_images=10, rows_per_image=2)
+        deduped = _dedupe_for_element_partition(
+            df,
+            rid_column="Image.RID",
+            element_table="Image",
+            stratify_by_column="Image_Classification.Image_Class",
+            stratify_missing="error",
+            using_selection_fn=False,
+        )
+        # 10 distinct Image RIDs in the synthetic source.
+        assert len(deduped) == 10
+        assert set(deduped["Image.RID"]) == set(df["Image.RID"])
+
+    def test_dedupe_is_seed_deterministic(self):
+        df = _multi_row_feature_df(n_images=10, rows_per_image=3)
+        a = _dedupe_for_element_partition(
+            df,
+            rid_column="Image.RID",
+            element_table="Image",
+            stratify_by_column="Image_Classification.Image_Class",
+            stratify_missing="error",
+            using_selection_fn=False,
+        )
+        b = _dedupe_for_element_partition(
+            df,
+            rid_column="Image.RID",
+            element_table="Image",
+            stratify_by_column="Image_Classification.Image_Class",
+            stratify_missing="error",
+            using_selection_fn=False,
+        )
+        pd.testing.assert_frame_equal(a, b)
+
+    def test_disagreement_raises_with_consensus_pattern_message(self):
+        df = _multi_row_feature_df(
+            n_images=10,
+            rows_per_image=2,
+            agreeing_labels=False,
+            disagreement_rids=["img-0003", "img-0007"],
+        )
+        with pytest.raises(ValueError) as exc:
+            _dedupe_for_element_partition(
+                df,
+                rid_column="Image.RID",
+                element_table="Image",
+                stratify_by_column="Image_Classification.Image_Class",
+                stratify_missing="error",
+                using_selection_fn=False,
+            )
+        msg = str(exc.value)
+        # Names the consensus-feature pattern explicitly.
+        assert "consensus" in msg.lower()
+        # Suggests partition_by='row' as the alternative.
+        assert "partition_by='row'" in msg
+        # Surfaces at least one offending RID.
+        assert "img-0003" in msg or "img-0007" in msg
+
+    def test_selection_fn_path_skips_uniformity_check(self):
+        df = _multi_row_feature_df(
+            n_images=10,
+            rows_per_image=2,
+            agreeing_labels=False,
+            disagreement_rids=["img-0003"],
+        )
+        # Even with disagreeing labels, using_selection_fn=True
+        # bypasses the check because the read set is opaque.
+        deduped = _dedupe_for_element_partition(
+            df,
+            rid_column="Image.RID",
+            element_table="Image",
+            stratify_by_column=None,
+            stratify_missing="error",
+            using_selection_fn=True,
+        )
+        assert len(deduped) == 10
+
+
+# =============================================================================
+# _compute_partitions — end-to-end through the denormalize path
+# =============================================================================
+
+
+class TestComputePartitionsElementMode:
+    """``_compute_partitions`` with ``partition_by="element"``."""
+
+    def test_element_mode_dedupes_multi_row_feature(self):
+        """Two-row-per-image dataframe partitions disjointly at element level."""
+        n_images = 100
+        df = _multi_row_feature_df(n_images=n_images, rows_per_image=2)
+        members = {"Image": [{"RID": f"img-{i:04d}"} for i in range(n_images)]}
+        ds = _fake_dataset_with_denorm(members, df)
+
+        partition_rids, partition_sizes, _, _ = _compute_partitions(
+            source_ds=ds,
+            source_dataset_rid="DS-1",
+            element_table="Image",
+            test_size=0.2,
+            train_size=None,
+            val_size=None,
+            shuffle=True,
+            seed=42,
+            stratify_by_column="Image_Classification.Image_Class",
+            stratify_missing="error",
+            include_tables=["Image", "Execution_Image_Image_Classification"],
+            selection_fn=None,
+            row_per="Execution_Image_Image_Classification",
+            via=None,
+            ignore_unrelated_anchors=False,
+            partition_by="element",
+        )
+
+        # Element-level disjointness — the property the e2e leak violated.
+        train_set = set(partition_rids["Training"])
+        test_set = set(partition_rids["Testing"])
+        assert train_set.isdisjoint(test_set)
+        # Sizes line up with the requested fractions of the deduped count.
+        assert partition_sizes == {"Training": 80, "Testing": 20}
+        assert len(partition_rids["Training"]) == 80
+        assert len(partition_rids["Testing"]) == 20
+
+    def test_element_mode_errors_on_within_element_disagreement(self):
+        """Stratifying on a disagreeing feature raises with consensus guidance."""
+        n_images = 20
+        df = _multi_row_feature_df(
+            n_images=n_images,
+            rows_per_image=2,
+            agreeing_labels=False,
+            disagreement_rids=["img-0005", "img-0012"],
+        )
+        members = {"Image": [{"RID": f"img-{i:04d}"} for i in range(n_images)]}
+        ds = _fake_dataset_with_denorm(members, df)
+
+        with pytest.raises(ValueError) as exc:
+            _compute_partitions(
+                source_ds=ds,
+                source_dataset_rid="DS-1",
+                element_table="Image",
+                test_size=0.2,
+                train_size=None,
+                val_size=None,
+                shuffle=True,
+                seed=42,
+                stratify_by_column="Image_Classification.Image_Class",
+                stratify_missing="error",
+                include_tables=["Image", "Execution_Image_Image_Classification"],
+                selection_fn=None,
+                row_per="Execution_Image_Image_Classification",
+                via=None,
+                ignore_unrelated_anchors=False,
+                partition_by="element",
+            )
+        msg = str(exc.value)
+        assert "consensus" in msg.lower()
+        # At least one offending RID surfaces.
+        assert "img-0005" in msg or "img-0012" in msg
+
+
+class TestComputePartitionsRowMode:
+    """``_compute_partitions`` with ``partition_by="row"``."""
+
+    def test_row_mode_allows_element_overlap(self):
+        """``partition_by='row'`` produces row-level partitions without dedupe.
+
+        The defining property of row-mode is that the same element_table
+        RID may appear in multiple partitions — each denormalized row
+        is its own observation. With 2 rows per image and a stratified
+        50/50 split, we expect overlap with very high probability.
+        """
+        n_images = 50
+        # Force disagreement to confirm uniformity is NOT enforced in
+        # row mode. We use a label that already exists in the synthesised
+        # source so stratified sampling stays well-conditioned.
+        df = _multi_row_feature_df(
+            n_images=n_images,
+            rows_per_image=2,
+            agreeing_labels=False,
+            disagreement_rids=[f"img-{i:04d}" for i in range(0, n_images, 3)],
+        )
+        members = {"Image": [{"RID": f"img-{i:04d}"} for i in range(n_images)]}
+        ds = _fake_dataset_with_denorm(members, df)
+
+        partition_rids, _, _, _ = _compute_partitions(
+            source_ds=ds,
+            source_dataset_rid="DS-1",
+            element_table="Image",
+            test_size=0.5,
+            train_size=None,
+            val_size=None,
+            shuffle=True,
+            seed=42,
+            stratify_by_column="Image_Classification.Image_Class",
+            stratify_missing="error",
+            include_tables=["Image", "Execution_Image_Image_Classification"],
+            selection_fn=None,
+            row_per="Execution_Image_Image_Classification",
+            via=None,
+            ignore_unrelated_anchors=False,
+            partition_by="row",
+        )
+
+        # Row-level partitioning -> the same Image RID may appear in both.
+        train_set = set(partition_rids["Training"])
+        test_set = set(partition_rids["Testing"])
+        overlap = train_set & test_set
+        # With 2 rows per image and a 50/50 stratified split, overlap is
+        # essentially certain. The test asserts the property the API now
+        # exposes: row mode does not enforce element-level disjointness.
+        assert len(overlap) > 0, (
+            "partition_by='row' must allow element-level overlap "
+            "(per-annotation partitioning is the legitimate use case)"
+        )
+
+
+# =============================================================================
+# Defensive disjointness assertion
+# =============================================================================
+
+
+class TestDisjointnessInvariant:
+    """The final ``assert`` in ``_compute_partitions``'s element path."""
+
+    def test_disjointness_invariant_fires_when_dedupe_regresses(self, monkeypatch: pytest.MonkeyPatch):
+        """A broken dedupe (duplicates leak through) must trip the assertion.
+
+        The assertion exists as a defensive invariant — it cannot fire
+        on a correct dedupe. To exercise it we monkeypatch the dedupe
+        helper to a no-op, simulating a future regression in the
+        dedupe logic. The subsequent random selector then scatters the
+        duplicate rows across partitions, and the disjointness check
+        catches it.
+        """
+        from deriva_ml.dataset import split as split_module
+
+        def _broken_dedupe(df, **_kwargs):
+            # Return the input unchanged — fail to dedupe.
+            return df.reset_index(drop=True)
+
+        monkeypatch.setattr(split_module, "_dedupe_for_element_partition", _broken_dedupe)
+
+        n_images = 40
+        df = _multi_row_feature_df(n_images=n_images, rows_per_image=2)
+        members = {"Image": [{"RID": f"img-{i:04d}"} for i in range(n_images)]}
+        ds = _fake_dataset_with_denorm(members, df)
+
+        with pytest.raises(AssertionError, match="disjointness invariant"):
+            _compute_partitions(
+                source_ds=ds,
+                source_dataset_rid="DS-1",
+                element_table="Image",
+                test_size=0.5,
+                train_size=None,
+                val_size=None,
+                shuffle=True,
+                seed=42,
+                stratify_by_column="Image_Classification.Image_Class",
+                stratify_missing="error",
+                include_tables=["Image", "Execution_Image_Image_Classification"],
+                selection_fn=None,
+                row_per="Execution_Image_Image_Classification",
+                via=None,
+                ignore_unrelated_anchors=False,
+                partition_by="element",
+            )
+
+
+# =============================================================================
+# Public surface — split_dataset signature carries partition_by
+# =============================================================================
+
+
+class TestSplitDatasetSurface:
+    """Confirm the public function exposes ``partition_by`` correctly."""
+
+    def test_partition_by_in_signature(self):
+        import inspect
+
+        sig = inspect.signature(split_dataset)
+        assert "partition_by" in sig.parameters
+        # Default is None (caller-must-decide-when-ambiguous semantics).
+        assert sig.parameters["partition_by"].default is None

--- a/uv.lock
+++ b/uv.lock
@@ -838,7 +838,7 @@ wheels = [
 [[package]]
 name = "deriva"
 version = "2.0.0.dev0"
-source = { git = "https://github.com/informatics-isi-edu/deriva-py?branch=deriva-ml#ce2124c44905147f8a707c280e833b763a622a1d" }
+source = { git = "https://github.com/informatics-isi-edu/deriva-py?branch=deriva-ml#27f26e2713fefd79b95168e8404042994c7c2e7a" }
 dependencies = [
     { name = "bdbag" },
     { name = "fair-identifiers-client" },


### PR DESCRIPTION
## Summary

- Adds `partition_by: Literal["element", "row"] | None = None` to `split_dataset`, making the partition unit an explicit caller decision whenever `(row_per, element_table)` is ambiguous (`row_per != element_table`). Auto-defaults to `"element"` in the unambiguous case (`row_per` is `None` or equals `element_table`), so existing callers using `row_per=None` are unaffected.
- `partition_by="element"` dedupes the denormalized dataframe to one row per `element_table` RID before the selector runs, enforces within-element agreement on `stratify_by_column`, and asserts element-RID disjointness at the end as a defensive invariant (catches future regressions in the dedupe helper or any selector that ignores its input contract).
- `partition_by="row"` keeps the pre-#174 one-row-per-denormalized-row behavior — no dedupe, no uniformity check; element RIDs may legitimately appear in multiple partitions (per-annotation statistics).
- **Bundles the docstring + user-guide corrections** (commits `0b43399b`, `79d7533e`) so the `partition_by` feature ships with teaching material that is consistent with the partition modes the feature exposes. See "Bundled documentation fixes" below.

## Why

The pre-fix API encoded the partition unit implicitly: `row_per` controlled denormalized row cardinality while `element_table` controlled what catalog entity each partition collected. When the two disagreed (typically `row_per=<feature_table>` with `element_table="Image"`), the selector partitioned feature rows, and the same Image RID's multiple denormalized rows could land in opposite partitions — silent train/test leakage.

The 2026-05-28 e2e run surfaced this on the model template's labeled split datasets (TCM ∩ TCY = 33 images; VAY ∩ VB8 = 24). References:

- `findings/curator/02-train-test-leakage-in-labeled-split-datasets.md`
- `findings/evaluator/02-split-dataset-row-per-feature-table-is-wrong-default.md`
- `findings/evaluator/03` (partition counts not matching descriptions — self-resolves once `partition_by="element"` re-resolves sizes against the deduplicated row count rather than the inflated feature-row count)

## Bundled documentation fixes

The 2026-05-28 denormalizer audit
(`/Users/carl/GitHub/DerivaML/deriva-ml-model-template-e2e/findings/investigation/01-denormalizer-spec-vs-implementation.md`, `03-recommendations.md`)
verified live against catalog 27 that the canonical `split_dataset` docstring stratification examples were broken in the same way as the `_cifar10_datasets.py` call site that the model-template's revised C.1 PR will use. The two examples asserted "one row per Image with the classification label projected as a column" but actually trip Rule 5 of the denormalizer at runtime: the feature-name shorthand `Image_Classification` in `include_tables` silently resolves to the feature-association table `Execution_Image_Image_Classification`, which is strictly downstream of `Image`, and the planner refuses to combine that with the auto-defaulted `row_per="Image"` because aggregation is not supported.

To prevent the partition_by feature from shipping with docs that contradict it, this PR now bundles:

- **Commit `0b43399b` — `split_dataset` docstring rewrite.** Replaces both broken stratification examples with the two valid shapes:
  - *Per-element projection:* `include_tables=["Image", "Image_Class"]` (vocab/value table; the feature-association table becomes a transparent bridge), `partition_by="element"`.
  - *Per-observation statistics:* `include_tables=["Image", "Image_Classification"]` with explicit `row_per="Execution_Image_Image_Classification"` and `partition_by="row"`. Element RIDs may legitimately appear in multiple partitions.
  Adds a between-example note that names both options so the reader does not need to reverse-engineer them, and propagates the corrected `include_tables` to the `stratify_missing="drop"` and custom-selector examples.
  Verified live against catalog 27: Example B end-to-end split_dataset(dry_run=True) returns train=880 / test=220; Example A passes the planner's `describe()` validation (the join path lists `Execution_Image_Image_Classification` as a transparent intermediate and `Image_Class.Name` is in the projected schema; end-to-end materialization is blocked by an unrelated pre-existing SQLite-cache bug on list-valued vocab `Synonyms`, which is not in scope for this PR).
- **Commit `79d7533e` — user-guide section in `docs/user-guide/denormalization.md`.** Adds a closing paragraph to "Feature values on images" that documents the forbidden combination (`row_per=<target_table>` + feature shorthand) by name (`DerivaMLDenormalizeDownstreamLeaf`), and shows side-by-side what to do instead for "one row per element with a feature column" (Intent A) and "one row per feature observation" (Intent B). Closes the user-guide gap §4 of the audit recommendations identified.

Audit references (absolute paths):
- `/Users/carl/GitHub/DerivaML/deriva-ml-model-template-e2e/findings/investigation/01-denormalizer-spec-vs-implementation.md`
- `/Users/carl/GitHub/DerivaML/deriva-ml-model-template-e2e/findings/investigation/03-recommendations.md` (§3 and §4)

## Breaking change

Callers passing `row_per != element_table` get a `ValueError` at the call site directing them to choose `partition_by="element"` (dedupe; safer per-element semantics) or `partition_by="row"` (preserve the prior one-row-per-row behavior). The model template's C.1 PR (in parallel) drops its `row_per` override on the labeled splits so the auto-default kicks in; no other in-tree caller hits this. The error message names both modes so the fix is obvious.

## Test plan

- [x] `uv run python -m pytest tests/dataset/test_split.py tests/dataset/test_split_helpers.py tests/dataset/test_split_partition_by.py -v` — 120 passed (15 new tests in `test_split_partition_by.py` + the existing 105).
- [x] `uv run python -m pytest tests/local_db/ tests/asset/ tests/model/ -q` — 493 passed, 8 skipped (unit-level regression check; matches `main`).
- [x] `uv run ruff check src/deriva_ml/dataset/split.py docs/user-guide/denormalization.md tests/dataset/test_split_partition_by.py` — no warnings on touched files.
- [x] `uv run ruff format src/deriva_ml/dataset/split.py tests/dataset/test_split_partition_by.py` — clean.
- [x] Live verification against `dev-localhost` catalog 27 of both new docstring examples (see "Bundled documentation fixes" above).

New tests in `tests/dataset/test_split_partition_by.py`:

- `test_partition_by_defaults_to_element_when_row_per_omitted`
- `test_partition_by_defaults_to_element_when_row_per_equals_element_table`
- `test_partition_by_required_when_row_per_differs_from_element_table` (names both modes in the error message)
- `test_element_mode_dedupes_multi_row_feature` (1:N feature with agreeing labels → disjoint element-level partitions at the requested test_size)
- `test_element_mode_errors_on_within_element_disagreement` (consensus-feature pattern message + surfaces offending RIDs)
- `test_row_mode_allows_element_overlap` (per-annotation statistics — legitimate use case)
- `test_disjointness_invariant_fires_when_dedupe_regresses` (defensive regression catch: monkeypatch dedupe to no-op, assertion fires)
- Plus surface-level pins (`test_partition_by_in_signature`), dedupe-helper pins, and explicit-value handling.

One pre-existing test (`TestDenormalizationPlumbing::test_row_per_explicit_passed_through`) updated to pass `partition_by="element"` so it still exercises the `row_per` plumbing path under the new required-argument rule.

## Live verification (2026-05-28, post-lockfile-bump)

After bumping `uv.lock` to `deriva-py @ 27f26e2` (PR
[deriva-py#265](https://github.com/informatics-isi-edu/deriva-py/pull/265) —
`fix(bag): map ermrest array types to SQLite JSON, not silent TEXT`),
the docs agent's planner-only verification was upgraded to end-to-end
materialization against `dev-localhost` catalog 27. Both new docstring
examples now run all the way through `_populate_from_catalog` without
the `sqlite3.ProgrammingError: type 'list' is not supported` that
previously blocked Example A (every vocab table on this catalog ships
with `Synonyms text[]`, which the live-catalog populate walk hits as
soon as `Image_Class` is on the join path).

**Source dataset:** M16 (`cifar10_training`, 550 Toronto-source labeled
images, version `0.1.0.post1.dev2`). `dry_run=True` throughout — no
new Split hierarchy written to catalog 27.

### Example A — `partition_by="element"` with vocab table

```python
result = split_dataset(
    ml, "M16", exe,
    test_size=0.2,
    stratify_by_column="Image_Class.Name",
    include_tables=["Image", "Image_Class"],
    element_table="Image",
    partition_by="element",
    dry_run=True,
)
```

**PASS.** Training=440 / Testing=110 / Total=550 (matches M16's image
count). Strategy: `stratified by Image_Class.Name`,
`element_table="Image"`. No `sqlite3.ProgrammingError`.

### Example B — `partition_by="row"` with feature shorthand

```python
result_b = split_dataset(
    ml, "M16", exe2,
    test_size=0.2,
    stratify_by_column="Execution_Image_Image_Classification.Image_Class",
    include_tables=["Image", "Image_Classification"],
    row_per="Execution_Image_Image_Classification",
    partition_by="row",
    dry_run=True,
)
```

**PASS.** Training=440 / Testing=110 / Total=550 rows. Strategy:
`stratified by Execution_Image_Image_Classification.Image_Class`. (M16
has one feature observation per image on this catalog, so the row count
equals the element count; on multi-execution images the row count would
be higher.)

### Direct denormalizer round-trip (the original blocker)

```python
d = Denormalizer(Dataset(ml, "M16"), version="0.1.0.post1.dev2")
df = d.as_dataframe(include_tables=["Image", "Image_Class"], row_per="Image")
```

**PASS.** `df.shape == (800, 12)`, `Image_Class.Synonyms` round-trips
as Python `list` end-to-end (e.g. `['lorry']`, `['plane', 'aeroplane']`,
`[]`). This is the exact shape that raised
`sqlite3.ProgrammingError` on every prior verification attempt; with
deriva-py 27f26e2 it now returns clean lists.

### Test-suite delta

- `uv run python -m pytest tests/dataset/test_split.py tests/dataset/test_split_helpers.py tests/dataset/test_split_partition_by.py` — **120 passed** (no change from prior baseline; `DERIVA_ML_ALLOW_DIRTY=true` required because `uv.lock` was modified at the time the test was kicked off).
- Lint on PR-touched files (`split.py`, `denormalization.md`,
  `test_split_partition_by.py`) — clean.

The broader `tests/dataset/ tests/local_db/` sweep was started but
exceeded the available verification window without reaching its summary
line; it was killed and not used for the regression delta. The
targeted split tests above are the relevant scope for this PR's
surface area and remain green.

### Audit chain referenced (absolute paths)

- [`/Users/carl/GitHub/DerivaML/deriva-ml-model-template-e2e/findings/investigation/01-denormalizer-spec-vs-implementation.md`](https://github.com/informatics-isi-edu/deriva-ml-model-template/blob/main/) — denormalizer spec / contract / planner audit.
- [`/Users/carl/GitHub/DerivaML/deriva-ml-model-template-e2e/findings/investigation/03-recommendations.md`](https://github.com/informatics-isi-edu/deriva-ml-model-template/blob/main/) — recommended fix shapes (§3, §4 closed by this PR).
- [`/Users/carl/GitHub/DerivaML/deriva-ml-model-template-e2e/findings/investigation/04-sqlite-array-binding-bug.md`](https://github.com/informatics-isi-edu/deriva-ml-model-template/blob/main/) — the array-binding audit that motivated deriva-py PR #265.

