### PR TITLE
chore(deps): sync deriva-py to 9501c2b (bag array decode)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -838,7 +838,7 @@ wheels = [
 [[package]]
 name = "deriva"
 version = "2.0.0.dev0"
-source = { git = "https://github.com/informatics-isi-edu/deriva-py?branch=deriva-ml#27f26e2713fefd79b95168e8404042994c7c2e7a" }
+source = { git = "https://github.com/informatics-isi-edu/deriva-py?branch=deriva-ml#9501c2b1854e0d14c1404c69aa323e2fe367b747" }
 dependencies = [
     { name = "bdbag" },
     { name = "fair-identifiers-client" },


### PR DESCRIPTION
## Summary

- Bumps the `deriva` (deriva-py) git pin in `uv.lock` from `27f26e27` to `9501c2b`, picking up deriva-py PR #266 which fixes the bag CSV - SQLite array-column round-trip bug at bind time and retires the now-dead `BagCatalogLoader._coerce_pg_array` safety net.
- **User-visible behavior change in deriva-ml:** callers of `DatasetBag.get_denormalized_as_dataframe(include_tables=[..., vocab_table])` will now receive Python `list` values in vocab `Synonyms` columns instead of PG-literal strings (`"{plane,aeroplane}"`). Previously this was silently broken — no error, just wrong data; now it's correct.
- The catalog write-back path (`BagCatalogLoader._load_table` ingesting bags into a target ERMrest catalog) was not observably broken before because `_coerce_pg_array` masked it; that path also continues to work after the bump because `ArrayAsJson.process_bind_param` now produces the right shape at SQLite bind time.

## Audit chain

- `/Users/carl/GitHub/DerivaML/deriva-ml-model-template-e2e/findings/investigation/04-sqlite-array-binding-bug.md` §5 — flagged the bag-side path as latent.
- `/Users/carl/GitHub/DerivaML/deriva-ml-model-template-e2e/findings/investigation/06-bag-csv-array-ingest-verification.md` — verified the bug; recommended the `ArrayAsJson.process_bind_param` override that deriva-py PR #266 implements.
- deriva-py PR #266 — implemented the fix + retired `_coerce_pg_array`. This PR picks it up.

## Test plan

- [x] `uv sync --upgrade-package deriva` resolves `deriva` to `9501c2b1854e0d14c1404c69aa323e2fe367b747` in `uv.lock`.
- [x] Targeted reproducer (the same one used by deriva-py PR #266) returns Python `list` for all three input shapes — Python list, PG-literal `{x,y}`, and empty PG-literal `{}`:
  ```
  $ uv run python -c "<reproducer>"
  A list ['x', 'y']
  B list ['x', 'y']
  C list []
  ```
- [x] `uv run python -m pytest tests/dataset/test_split*.py -v` — 120 passed, 0 failed (173s).
- [ ] (Not run in this PR — gated on live catalog / catalog 27 access.) Full `DatasetBag.get_denormalized_as_dataframe(include_tables=[..., "Image_Class"], row_per="Image")` smoke test confirming the resulting dataframe's `Image_Class.Synonyms` column carries `list` values. The bind-time reproducer above exercises the same `ArrayAsJson` code path as the denormalize query, so the behavior is identical for that consumer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)