### PR TITLE
feat(denormalize): add selector for multi-row feature reduction (Stage 1)

### DIFF
--- a/src/deriva_ml/dataset/dataset.py
+++ b/src/deriva_ml/dataset/dataset.py
@@ -1655,6 +1655,7 @@ class Dataset:
         row_per: str | None = None,
         via: list[str] | None = None,
         ignore_unrelated_anchors: bool = False,
+        selector: Callable[[list[FeatureRecord]], FeatureRecord | None] | None = None,
         version: DatasetVersion | str | None = None,
     ) -> pd.DataFrame:
         """Return the dataset as a denormalized wide table (DataFrame).
@@ -1670,6 +1671,14 @@ class Dataset:
             via: Optional path-only intermediates (Rule 6).
             ignore_unrelated_anchors: If True, silently drop anchors
                 with no FK path (Rule 8).
+            selector: Optional callable
+                ``(list[FeatureRecord]) -> FeatureRecord | None`` used to
+                reduce multi-row feature groups. See ``FeatureRecord`` for
+                built-ins (``select_newest``, ``select_first``, etc.).
+                Requires ``include_tables`` to contain exactly one
+                feature-association table; raises ``ValueError``
+                otherwise. Identical contract to
+                :meth:`feature_values`'s ``selector`` argument.
             version: Optional dataset version. When given, queries run
                 against the corresponding catalog snapshot for
                 reproducibility (same semantics as
@@ -1690,6 +1699,12 @@ class Dataset:
             df = dataset.get_denormalized_as_dataframe(
                 ["Image", "Subject"], version="1.0.0"
             )
+            # Reduce multi-annotator feature rows to one row per Image:
+            from deriva_ml.feature import FeatureRecord
+            df = dataset.get_denormalized_as_dataframe(
+                ["Image", "Execution_Image_Image_Classification"],
+                selector=FeatureRecord.select_newest,
+            )
         """
         from deriva_ml.local_db.denormalizer import Denormalizer
 
@@ -1698,6 +1713,7 @@ class Dataset:
             row_per=row_per,
             via=via,
             ignore_unrelated_anchors=ignore_unrelated_anchors,
+            selector=selector,
         )
 
     def get_denormalized_as_dict(
@@ -1707,6 +1723,7 @@ class Dataset:
         row_per: str | None = None,
         via: list[str] | None = None,
         ignore_unrelated_anchors: bool = False,
+        selector: Callable[[list[FeatureRecord]], FeatureRecord | None] | None = None,
         version: DatasetVersion | str | None = None,
     ) -> Generator[dict[str, Any], None, None]:
         """Stream the denormalized dataset rows as dicts.
@@ -1724,6 +1741,10 @@ class Dataset:
             via: Optional path-only intermediates (Rule 6).
             ignore_unrelated_anchors: If True, silently drop anchors
                 with no FK path (Rule 8).
+            selector: Optional callable
+                ``(list[FeatureRecord]) -> FeatureRecord | None`` used to
+                reduce multi-row feature groups. Same contract as
+                :meth:`get_denormalized_as_dataframe`.
             version: Optional dataset version (snapshot-bound queries).
                 Same semantics as
                 :meth:`get_denormalized_as_dataframe`'s ``version``.
@@ -1736,6 +1757,13 @@ class Dataset:
 
             for row in dataset.get_denormalized_as_dict(["Image", "Subject"]):
                 print(row["Image.RID"], row["Subject.Name"])
+
+            # With selector reduction:
+            from deriva_ml.feature import FeatureRecord
+            rows = dataset.get_denormalized_as_dict(
+                ["Image", "Execution_Image_Image_Classification"],
+                selector=FeatureRecord.select_newest,
+            )
         """
         from deriva_ml.local_db.denormalizer import Denormalizer
 
@@ -1744,6 +1772,7 @@ class Dataset:
             row_per=row_per,
             via=via,
             ignore_unrelated_anchors=ignore_unrelated_anchors,
+            selector=selector,
         )
 
     def list_denormalized_columns(
@@ -2019,8 +2048,7 @@ class Dataset:
             nonlocal _cycle_rids_cache
             if _cycle_rids_cache is None:
                 _cycle_rids_cache = {self.dataset_rid} | {
-                    child.dataset_rid
-                    for child in self.list_dataset_children(recurse=True)
+                    child.dataset_rid for child in self.list_dataset_children(recurse=True)
                 }
             return _cycle_rids_cache
 

--- a/src/deriva_ml/dataset/dataset_bag.py
+++ b/src/deriva_ml/dataset/dataset_bag.py
@@ -903,6 +903,7 @@ class DatasetBag:
         row_per: str | None = None,
         via: list[str] | None = None,
         ignore_unrelated_anchors: bool = False,
+        selector: Callable[[list[FeatureRecord]], FeatureRecord | None] | None = None,
     ) -> pd.DataFrame:
         """Return the dataset bag as a denormalized wide table (DataFrame).
 
@@ -918,6 +919,14 @@ class DatasetBag:
             via: Optional path-only intermediates (Rule 6).
             ignore_unrelated_anchors: If True, silently drop anchors
                 with no FK path (Rule 8).
+            selector: Optional callable
+                ``(list[FeatureRecord]) -> FeatureRecord | None`` used to
+                reduce multi-row feature groups. See ``FeatureRecord`` for
+                built-ins (``select_newest``, ``select_first``, etc.).
+                Requires ``include_tables`` to contain exactly one
+                feature-association table; raises ``ValueError``
+                otherwise. Identical contract to
+                :meth:`feature_values`'s ``selector`` argument.
 
         Returns:
             A :class:`pandas.DataFrame` with one row per ``row_per``
@@ -927,6 +936,13 @@ class DatasetBag:
 
             bag = dataset.download_dataset_bag(version)
             df = bag.get_denormalized_as_dataframe(["Image", "Subject"])
+
+            # Reduce multi-annotator feature rows to one row per Image:
+            from deriva_ml.feature import FeatureRecord
+            df = bag.get_denormalized_as_dataframe(
+                ["Image", "Execution_Image_Image_Classification"],
+                selector=FeatureRecord.select_newest,
+            )
         """
         from deriva_ml.local_db.denormalizer import Denormalizer
 
@@ -935,6 +951,7 @@ class DatasetBag:
             row_per=row_per,
             via=via,
             ignore_unrelated_anchors=ignore_unrelated_anchors,
+            selector=selector,
         )
 
     def get_denormalized_as_dict(
@@ -944,6 +961,7 @@ class DatasetBag:
         row_per: str | None = None,
         via: list[str] | None = None,
         ignore_unrelated_anchors: bool = False,
+        selector: Callable[[list[FeatureRecord]], FeatureRecord | None] | None = None,
     ) -> Generator[dict[str, Any], None, None]:
         """Stream the denormalized dataset bag rows as dicts.
 
@@ -960,6 +978,10 @@ class DatasetBag:
             via: Optional path-only intermediates (Rule 6).
             ignore_unrelated_anchors: If True, silently drop anchors
                 with no FK path (Rule 8).
+            selector: Optional callable
+                ``(list[FeatureRecord]) -> FeatureRecord | None`` used to
+                reduce multi-row feature groups. Same contract as
+                :meth:`get_denormalized_as_dataframe`.
 
         Yields:
             ``dict[str, Any]`` per row — keys are ``Table.column``
@@ -969,6 +991,13 @@ class DatasetBag:
 
             for row in bag.get_denormalized_as_dict(["Image", "Subject"]):
                 process(row["Image.RID"], row["Subject.Name"])
+
+            # With selector reduction:
+            from deriva_ml.feature import FeatureRecord
+            rows = bag.get_denormalized_as_dict(
+                ["Image", "Execution_Image_Image_Classification"],
+                selector=FeatureRecord.select_newest,
+            )
         """
         from deriva_ml.local_db.denormalizer import Denormalizer
 
@@ -977,6 +1006,7 @@ class DatasetBag:
             row_per=row_per,
             via=via,
             ignore_unrelated_anchors=ignore_unrelated_anchors,
+            selector=selector,
         )
 
     def list_denormalized_columns(

--- a/src/deriva_ml/interfaces.py
+++ b/src/deriva_ml/interfaces.py
@@ -300,6 +300,7 @@ class DatasetLike(Protocol):
         row_per: str | None = None,
         via: list[str] | None = None,
         ignore_unrelated_anchors: bool = False,
+        selector: Callable[[list[FeatureRecord]], FeatureRecord | None] | None = None,
     ) -> pd.DataFrame:
         """Return the dataset as a denormalized wide table (DataFrame).
 
@@ -325,6 +326,12 @@ class DatasetLike(Protocol):
                 columns (useful to disambiguate path ambiguity).
             ignore_unrelated_anchors: If True, silently drop anchors whose
                 table has no FK path to any requested table.
+            selector: Optional callable
+                ``(list[FeatureRecord]) -> FeatureRecord | None`` used to
+                reduce multi-row feature groups. Same contract as
+                :meth:`feature_values`'s ``selector`` argument. Requires
+                ``include_tables`` to contain exactly one
+                feature-association table.
 
         Returns:
             pd.DataFrame: Wide table with columns from all included tables.
@@ -343,6 +350,7 @@ class DatasetLike(Protocol):
         row_per: str | None = None,
         via: list[str] | None = None,
         ignore_unrelated_anchors: bool = False,
+        selector: Callable[[list[FeatureRecord]], FeatureRecord | None] | None = None,
     ) -> Generator[dict[str, Any], None, None]:
         """Stream the denormalized dataset rows as dicts.
 
@@ -355,6 +363,10 @@ class DatasetLike(Protocol):
             row_per: Explicit leaf table. Must be in ``include_tables``.
             via: Tables forced into the join chain without contributing columns.
             ignore_unrelated_anchors: See :meth:`get_denormalized_as_dataframe`.
+            selector: Optional callable
+                ``(list[FeatureRecord]) -> FeatureRecord | None`` used to
+                reduce multi-row feature groups. Same contract as
+                :meth:`get_denormalized_as_dataframe`.
 
         Yields:
             dict[str, Any]: Dictionary per row; keys are ``Table.Column``.

--- a/src/deriva_ml/local_db/denormalize.py
+++ b/src/deriva_ml/local_db/denormalize.py
@@ -205,6 +205,7 @@ def _denormalize_impl(
     *,
     row_per: str | None = None,
     via: list[str] | None = None,
+    selector: Callable[[list[Any]], Any] | None = None,
 ) -> DenormalizeResult:
     """Unified denormalization: plan joins via ``_prepare_wide_table``, execute locally.
 
@@ -234,12 +235,24 @@ def _denormalize_impl(
         via: Optional list of tables forced into the join chain without
             contributing columns. Used to disambiguate path ambiguity
             (Rule 6).
+        selector: Optional callable
+            ``(list[FeatureRecord]) -> FeatureRecord | None`` used to reduce
+            multi-row feature groups after materialization. When provided,
+            ``include_tables`` must contain exactly one feature-association
+            table; materialized rows are grouped by the feature's target RID
+            and the selector picks one row per group (or returns ``None``
+            to omit the group). Same contract as
+            :meth:`~deriva_ml.core.mixins.feature.FeatureMixin.feature_values`'s
+            ``selector`` argument. See ``FeatureRecord`` for built-in
+            selectors (``select_newest``, ``select_first``, etc.).
 
     Returns:
         :class:`DenormalizeResult` with rows and column metadata.
 
     Raises:
-        ValueError: If ``source="catalog"`` but ``paged_client`` is ``None``.
+        ValueError: If ``source="catalog"`` but ``paged_client`` is ``None``;
+            if ``selector`` is given and ``include_tables`` contains zero or
+            more than one feature-association table.
         RuntimeError: If the ``"Dataset"`` ORM class cannot be resolved
             (likely because ``build_local_schema`` was not called with the
             ``deriva-ml`` schema).
@@ -285,6 +298,28 @@ def _denormalize_impl(
         raise ValueError(
             "paged_client is required when source='catalog'. Pass an ErmrestPagedClient (or compatible) to fetch rows."
         )
+
+    # Validate selector / include_tables shape up front. The selector
+    # reduction in Step 6 needs exactly one feature-association table to
+    # group rows by — zero gives nothing to reduce, more than one would
+    # require a per-feature ``dict[name, selector]`` shape (future Stage 2
+    # extension; not in this stage's scope).
+    feature_assoc_table: str | None = None
+    if selector is not None:
+        feature_assoc_tables = [t for t in include_tables if model._planner._is_feature_association(t)]
+        if not feature_assoc_tables:
+            raise ValueError(
+                "selector requires a feature-association table in include_tables; "
+                f"none found in {include_tables!r}. Pass include_tables that contains "
+                "exactly one feature-association table (or the feature name that resolves "
+                "to one), or drop the selector."
+            )
+        if len(feature_assoc_tables) > 1:
+            raise ValueError(
+                "selector with multiple feature-association tables not yet supported "
+                f"({feature_assoc_tables!r}); pass include_tables with one feature at a time."
+            )
+        feature_assoc_table = feature_assoc_tables[0]
 
     # Step 1: Plan the join.
     if dataset is None:
@@ -425,12 +460,342 @@ def _denormalize_impl(
         result = session.execute(final_query)
         rows = [dict(row._mapping) for row in result]
 
+    # Step 6: Apply selector reduction (Stage 1 of the
+    # Denormalizer / feature_values consolidation). When a selector is
+    # provided, group materialized rows by their feature-assoc target RID
+    # and let the selector pick one row per group. Same "filter then
+    # reduce" ordering used by ``Dataset.feature_values`` — materialize
+    # first, then reduce.
+    if selector is not None and feature_assoc_table is not None and rows:
+        rows = _apply_selector(
+            rows=rows,
+            model=model,
+            engine=engine,
+            orm_resolver=orm_resolver,
+            feature_assoc_table=feature_assoc_table,
+            schema_for_table=table_to_schema,
+            multi_schema=multi_schema,
+            selector=selector,
+        )
+
     return DenormalizeResult(
         columns=output_columns,
         row_count=len(rows),
         _rows=rows,
         cache_age_seconds=cache_age_seconds,
     )
+
+
+def _apply_selector(
+    rows: list[dict[str, Any]],
+    *,
+    model: DerivaModel,
+    engine: Engine,
+    orm_resolver: Callable[[str], Any],
+    feature_assoc_table: str,
+    schema_for_table: dict[str, str],
+    multi_schema: bool,
+    selector: Callable[[list[Any]], Any],
+) -> list[dict[str, Any]]:
+    """Group materialized denormalize rows by feature target RID and reduce.
+
+    Shared selector application for the ``Denormalizer`` surface
+    (Stage 1 of the ``feature_values`` / ``Denormalizer`` consolidation).
+
+    For each materialized row, builds a ``FeatureRecord`` instance from
+    the feature-association columns and runs
+    :func:`~deriva_ml.feature.reduce_with_selector` over groups keyed by
+    the feature's target RID. The selected ``FeatureRecord`` is mapped
+    back to its source row so the output preserves the full wide-table
+    shape (all ``include_tables`` columns, not just the feature ones).
+
+    Args:
+        rows: Materialized denormalize rows (``Table.column`` /
+            ``schema.Table.column`` labelled dicts) from the SQL JOIN.
+        model: :class:`DerivaModel` used to look up the
+            :class:`~deriva_ml.feature.Feature` for
+            ``feature_assoc_table`` and the schema name for label
+            construction.
+        feature_assoc_table: Name of the feature-association table
+            in ``include_tables`` (already validated by the caller).
+        schema_for_table: ``{table_name: schema_name}`` map produced by
+            ``_denormalize_impl`` for use with
+            :func:`denormalize_column_name`.
+        multi_schema: Whether output labels carry the schema prefix.
+        selector: Callable
+            ``(list[FeatureRecord]) -> FeatureRecord | None`` — the
+            same shape as :meth:`Dataset.feature_values`'s ``selector``.
+
+    Returns:
+        Reduced rows — one per target RID for which the selector
+        returned a non-``None`` choice. Order follows the surviving
+        target RIDs in dict iteration order (insertion order of
+        first-seen target RID in the input rows). When the selector
+        drops every group, returns an empty list.
+
+    Raises:
+        DerivaMLException: If the feature-association table can't be
+            resolved to a :class:`~deriva_ml.feature.Feature` (e.g. the
+            model exposes no ``find_features`` or the table name doesn't
+            match any feature).
+
+    Example::
+
+        # Materialized rows from Execution_Image_Quality + Image.
+        reduced = _apply_selector(
+            rows=rows,
+            model=model,
+            feature_assoc_table="Execution_Image_Quality",
+            schema_for_table={"Image": "domain", "Execution_Image_Quality": "deriva-ml"},
+            multi_schema=False,
+            selector=FeatureRecord.select_newest,
+        )
+        # ``reduced`` has one row per Image RID — the newest Quality
+        # record per Image — with the rest of the wide-table columns
+        # preserved.
+    """
+    from collections import defaultdict
+
+    from deriva_ml.core.exceptions import DerivaMLException
+
+    # Locate the target table for the feature-association table. The
+    # preferred path is ``DerivaModel.find_features`` — that returns
+    # canonical :class:`Feature` objects with a real
+    # ``feature_record_class()``, keeping this code in lockstep with
+    # ``Dataset.feature_values``. Some model shapes (minimal offline
+    # fixtures whose ``Model.fromfile`` doesn't wire ``referenced_by``)
+    # don't surface features that way, so we fall back to a structural
+    # lookup on the feature-association table's own foreign keys.
+    find_feats = getattr(model, "find_features", None)
+    feature = None
+    if callable(find_feats):
+        try:
+            feature = next(
+                (f for f in find_feats() if f.feature_table.name == feature_assoc_table),
+                None,
+            )
+        except Exception:
+            feature = None
+
+    if feature is not None:
+        record_class = feature.feature_record_class()
+        target_table_name = feature.target_table.name
+        field_names = set(record_class.model_fields.keys())
+    else:
+        # Structural fallback. The planner's
+        # ``_is_feature_association`` predicate already guaranteed the
+        # table has the feature-association shape (Execution FK +
+        # target FK + value FK). Walk the FKs, identify the target
+        # (the one that is neither Execution nor a vocabulary/asset),
+        # and synthesize a minimal FeatureRecord subclass so the
+        # selector contract still resolves.
+        from typing import Optional
+
+        from pydantic import create_model
+
+        from deriva_ml.feature import FeatureRecord
+
+        try:
+            feat_tbl = model.name_to_table(feature_assoc_table)
+        except Exception as e:
+            raise DerivaMLException(
+                f"Cannot apply selector: {feature_assoc_table!r} is not a "
+                f"known table in the catalog model ({type(e).__name__}: {e})."
+            ) from e
+        ml_schema = getattr(model, "ml_schema", "deriva-ml")
+        domain_fks = [fk for fk in feat_tbl.foreign_keys if fk.pk_table.name not in ("ERMrest_Client", "ERMrest_Group")]
+        target_fk = None
+        for fk in domain_fks:
+            pk_table = fk.pk_table
+            if pk_table.name == "Execution" and pk_table.schema.name == ml_schema:
+                continue
+            is_vocab = getattr(model, "is_vocabulary", None)
+            if callable(is_vocab):
+                try:
+                    if is_vocab(pk_table):
+                        continue
+                except Exception:
+                    pass
+            is_asset = getattr(model, "is_asset", None)
+            if callable(is_asset):
+                try:
+                    if is_asset(pk_table):
+                        continue
+                except Exception:
+                    pass
+            target_fk = fk
+            break
+        if target_fk is None:
+            raise DerivaMLException(
+                f"Cannot apply selector: could not identify the target FK on "
+                f"{feature_assoc_table!r}. The table's domain FKs do not match "
+                f"the feature-association shape (Execution + target + value)."
+            )
+        target_table_name = target_fk.pk_table.name
+        # Build a minimal subclass keyed by the feature-assoc table's
+        # columns. Field types collapse to ``Optional[str]`` — the
+        # built-in selectors read string-shaped fields (``RCT``
+        # lexicographic compare, ``Execution`` equality), so this is
+        # type-safe for the contract. Customer selectors that need
+        # typed feature columns should use ``feature_values`` or
+        # ``lookup_feature``-built records instead.
+        record_fields: dict[str, Any] = {}
+        for col in feat_tbl.columns:
+            if col.name in {"RID", "RMB", "RCB", "RMT", "Execution", "Feature_Name", "RCT"}:
+                continue
+            record_fields[col.name] = (Optional[str], None)
+        # Target FK column is required so grouping always finds a key.
+        record_fields[target_table_name] = (str, ...)
+        feature_name_default = feat_tbl.columns["Feature_Name"].default or "default"
+        record_fields["Feature_Name"] = (str, feature_name_default)
+        record_class = create_model(  # type: ignore[call-overload]
+            f"_Denormalize_{feature_assoc_table}_Record",
+            __base__=FeatureRecord,
+            **record_fields,
+        )
+        field_names = set(record_class.model_fields.keys())
+
+    # Resolve the wide-table column prefix for the feature-assoc table.
+    schema_name = schema_for_table.get(feature_assoc_table, "")
+
+    def _label(col_name: str) -> str:
+        return denormalize_column_name(schema_name, feature_assoc_table, col_name, multi_schema)
+
+    target_label = _label(target_table_name)
+    rid_label = _label("RID")
+
+    # Supplementary fetch: the wide-table SELECT in
+    # ``_prepare_wide_table`` skips the system columns
+    # ``{RCT, RMT, RCB, RMB}`` on every contributing table — but the
+    # selector contract reads them (``select_newest`` keys on RCT,
+    # ``select_by_execution`` keys on Execution which IS preserved).
+    # Fetch RCT (and any other FeatureRecord field that's missing from
+    # the wide-table row) keyed by the feature-assoc RID before we
+    # build the FeatureRecord shadows. Without this step,
+    # ``select_newest`` falls back to the empty-string default on every
+    # record and picks an arbitrary group member.
+    feature_rids = [row.get(rid_label) for row in rows if row.get(rid_label) is not None]
+    supplements: dict[str, dict[str, Any]] = {}
+    if feature_rids:
+        from sqlalchemy import select as sa_select
+
+        feat_orm = orm_resolver(feature_assoc_table)
+        if feat_orm is not None:
+            # Pull the columns the FeatureRecord cares about that the
+            # wide table doesn't already carry. The wide table preserves
+            # the feature-association table's domain columns; we only
+            # need to fetch the system columns the planner skipped.
+            wanted_cols = [c for c in field_names if c not in {"feature", "Feature_Name"}]
+            try:
+                with engine.connect() as conn:
+                    rows_supp = (
+                        conn.execute(sa_select(feat_orm.__table__).where(feat_orm.__table__.c.RID.in_(feature_rids)))
+                        .mappings()
+                        .all()
+                    )
+                for r in rows_supp:
+                    rid = r.get("RID")
+                    if rid is None:
+                        continue
+                    # ``RCT`` may come back from SQLite as a Python
+                    # ``datetime`` (depending on the column type
+                    # affinity), but the FeatureRecord schema declares
+                    # ``RCT: Optional[str]`` to match the ISO-8601
+                    # shape ``Dataset.feature_values`` materializes.
+                    # Normalize timestamp-shaped values to ISO strings
+                    # so the selector built-ins (lexicographic
+                    # comparison on RCT) behave the same way they do
+                    # on the ``feature_values`` surface.
+                    coerced: dict[str, Any] = {}
+                    for col in wanted_cols:
+                        if col not in r:
+                            continue
+                        val = r.get(col)
+                        if hasattr(val, "isoformat"):
+                            val = val.isoformat()
+                        coerced[col] = val
+                    supplements[rid] = coerced
+            except Exception as e:
+                # Supplementary fetch is best-effort: if it fails, the
+                # selector falls back to whatever fields the wide-table
+                # row provides. Log so operators can see the path was
+                # exercised but degraded.
+                logger.warning(
+                    "Denormalizer selector path: supplementary fetch of %s system columns failed (%s); "
+                    "selector may see None for skipped fields.",
+                    feature_assoc_table,
+                    e,
+                )
+
+    # Group rows by target RID. We carry source rows alongside their
+    # built FeatureRecord shadow so the selector's choice can be mapped
+    # back to a full wide-table row. Rows whose target RID is missing
+    # (NULL on a LEFT JOIN, etc.) can't be grouped and are passed
+    # through unchanged — mirrors ``reduce_with_selector``, which
+    # silently drops records with no target.
+    groups: dict[str, list[tuple[Any, dict[str, Any]]]] = defaultdict(list)
+    untouched: list[dict[str, Any]] = []
+    for row in rows:
+        target_rid = row.get(target_label)
+        if target_rid is None:
+            untouched.append(row)
+            continue
+        # Build a FeatureRecord shadow from just the feature-assoc
+        # columns. The generated record class is constructed by
+        # ``Feature.feature_record_class`` with ``extra="forbid"``
+        # inherited from ``FeatureRecord.Config``, so we feed only the
+        # fields the class declares — other include_tables columns are
+        # excluded. Supplementary fetch values overlay onto the
+        # wide-table row contributions, so the FeatureRecord sees RCT
+        # etc. when the wide table dropped them.
+        record_kwargs: dict[str, Any] = {}
+        for field_name in field_names:
+            label = _label(field_name)
+            if label in row:
+                record_kwargs[field_name] = row[label]
+        supp = supplements.get(row.get(rid_label), {})
+        for field_name, value in supp.items():
+            if field_name in field_names and record_kwargs.get(field_name) is None:
+                record_kwargs[field_name] = value
+        try:
+            record = record_class(**record_kwargs)
+        except Exception:
+            # If a row can't be coerced into the FeatureRecord (e.g.,
+            # unexpected NULL where the schema declares non-null), keep
+            # the raw row in untouched so the selector path doesn't
+            # silently eat it.
+            untouched.append(row)
+            continue
+        groups[target_rid].append((record, row))
+
+    if not groups:
+        # No feature rows present (every materialized row was a
+        # passthrough). Return verbatim so this behaves identically to
+        # selector=None on a result with no feature side.
+        return untouched
+
+    # Apply the selector per-group and map the chosen FeatureRecord
+    # back to its source row by identity. Built-in selectors
+    # (``select_newest``, ``select_by_execution``, etc.) always return
+    # one of the inputs, so ``is`` comparison resolves the original
+    # row deterministically. ``reduce_with_selector`` follows the same
+    # contract; we inline the loop here instead of delegating so we can
+    # walk (record, row) pairs together rather than threading an index
+    # alongside a record-only iteration.
+    reduced: list[dict[str, Any]] = []
+    for pairs in groups.values():
+        chosen = selector([rec for rec, _ in pairs])
+        if chosen is None:
+            continue
+        match = next((row for rec, row in pairs if rec is chosen), None)
+        if match is not None:
+            reduced.append(match)
+
+    # Preserve passthrough rows (no target RID) — they never
+    # participated in reduction so it would be wrong to drop them
+    # silently. A caller that wants them gone can filter the result.
+    reduced.extend(untouched)
+    return reduced
 
 
 def _compute_cache_age_seconds(fetcher: PagedFetcher | None) -> float | None:

--- a/src/deriva_ml/local_db/denormalizer.py
+++ b/src/deriva_ml/local_db/denormalizer.py
@@ -14,7 +14,7 @@ the single source of record:
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Generator
+from typing import TYPE_CHECKING, Any, Callable, Generator
 
 import pandas as pd
 
@@ -22,6 +22,7 @@ from deriva_ml.core.logging_config import get_logger
 from deriva_ml.local_db.denormalize import DenormalizeResult, _denormalize_impl
 
 if TYPE_CHECKING:
+    from deriva_ml.feature import FeatureRecord
     from deriva_ml.interfaces import DatasetLike
 
 logger = get_logger(__name__)
@@ -431,12 +432,17 @@ class Denormalizer:
         row_per: str | None = None,
         via: list[str] | None = None,
         ignore_unrelated_anchors: bool = False,
+        selector: Callable[[list["FeatureRecord"]], "FeatureRecord | None"] | None = None,
     ) -> pd.DataFrame:
         """Materialize the denormalized table as a :class:`pandas.DataFrame`.
 
         Runs the full 4-phase pipeline: planner decisions (Rules 2/5/6) →
         anchor classification (Rules 7/8) → main SQL join → orphan-row
-        combine.
+        combine. When ``selector`` is provided, a final reduction pass
+        groups rows by the feature-association table's target RID and
+        applies the selector per group — same contract as
+        :meth:`~deriva_ml.core.mixins.feature.FeatureMixin.feature_values`'s
+        ``selector`` argument.
 
         Args:
             include_tables: Tables whose columns appear in the output.
@@ -453,13 +459,25 @@ class Denormalizer:
                 table has no FK path to any requested table. Default
                 False raises :class:`DerivaMLDenormalizeUnrelatedAnchor`
                 (Rule 8).
+            selector: Optional callable
+                ``(list[FeatureRecord]) -> FeatureRecord | None`` used to
+                reduce multi-row feature groups. See ``FeatureRecord`` for
+                built-ins (``select_newest``, ``select_first``,
+                ``select_by_execution``, ``select_by_workflow``,
+                ``select_majority_vote``). Return ``None`` from a selector
+                to omit that target RID. Requires ``include_tables`` to
+                contain exactly one feature-association table; raises
+                ``ValueError`` when zero or more than one are present
+                (multi-feature reduction is a future extension).
 
         Returns:
             A :class:`pandas.DataFrame` with one row per ``row_per``
             instance in scope, plus any orphan rows from upstream anchors
             that don't reach a ``row_per`` row (Rule 7 case 3). Upstream
             table columns are hoisted onto each row; orphan rows have
-            ``row_per``-side columns set to ``NaN``.
+            ``row_per``-side columns set to ``NaN``. When ``selector`` is
+            provided, multi-row feature groups collapse to one row per
+            target RID per the selector's choice.
 
         Raises:
             DerivaMLDenormalizeMultiLeaf: auto-inference finds multiple
@@ -472,6 +490,8 @@ class Denormalizer:
             DerivaMLDenormalizeUnrelatedAnchor: anchor has no FK path to
                 any table in ``include_tables`` (Rule 8) — unless the
                 ``ignore_unrelated_anchors`` flag is set.
+            ValueError: ``selector`` was provided but ``include_tables``
+                does not contain exactly one feature-association table.
 
         Example::
 
@@ -493,12 +513,21 @@ class Denormalizer:
             df = d.as_dataframe(
                 ["Image", "Subject"], ignore_unrelated_anchors=True
             )
+
+            # Reduce multi-row feature groups (e.g., multiple annotators
+            # per Image) to one row per Image — the newest by RCT:
+            from deriva_ml.feature import FeatureRecord
+            df = d.as_dataframe(
+                ["Image", "Execution_Image_Image_Classification"],
+                selector=FeatureRecord.select_newest,
+            )
         """
         result = self._run(
             include_tables,
             row_per=row_per,
             via=via,
             ignore_unrelated_anchors=ignore_unrelated_anchors,
+            selector=selector,
         )
         return result.to_dataframe()
 
@@ -509,6 +538,7 @@ class Denormalizer:
         row_per: str | None = None,
         via: list[str] | None = None,
         ignore_unrelated_anchors: bool = False,
+        selector: Callable[[list["FeatureRecord"]], "FeatureRecord | None"] | None = None,
     ) -> Generator[dict[str, Any], None, None]:
         """Convert the denormalized table to dicts and yield row-by-row.
 
@@ -538,6 +568,11 @@ class Denormalizer:
             via: Path-only intermediates (Rule 6 disambiguation).
             ignore_unrelated_anchors: If True, silently drop unrelated
                 anchors (Rule 8).
+            selector: Optional callable
+                ``(list[FeatureRecord]) -> FeatureRecord | None`` used to
+                reduce multi-row feature groups after materialization.
+                Same contract as :meth:`as_dataframe`. See
+                ``FeatureRecord`` for built-in selectors.
 
         Yields:
             ``dict[str, Any]`` — one per output row. Keys are
@@ -556,12 +591,21 @@ class Denormalizer:
             d = Denormalizer(dataset)
             for row in d.as_dict(["Image", "Subject"]):
                 print(row["Image.RID"], row["Subject.Name"])
+
+            # With selector reduction:
+            from deriva_ml.feature import FeatureRecord
+            for row in d.as_dict(
+                ["Image", "Execution_Image_Image_Classification"],
+                selector=FeatureRecord.select_newest,
+            ):
+                ...
         """
         result = self._run(
             include_tables,
             row_per=row_per,
             via=via,
             ignore_unrelated_anchors=ignore_unrelated_anchors,
+            selector=selector,
         )
         yield from result.iter_rows()
 
@@ -754,8 +798,7 @@ class Denormalizer:
             include = original_include
             via_list = original_via
             warnings.append(
-                f"_resolve_table_names: {type(e).__name__} ({str(e)[:120]}); "
-                "reverted to original include/via"
+                f"_resolve_table_names: {type(e).__name__} ({str(e)[:120]}); reverted to original include/via"
             )
 
         # ── row_per resolution ─────────────────────────────────────────────
@@ -769,10 +812,7 @@ class Denormalizer:
             row_per_candidates = self._model._planner._find_sinks(include, via_list)
         except Exception as e:
             row_per_candidates = []
-            warnings.append(
-                f"_find_sinks: {type(e).__name__} ({str(e)[:120]}); "
-                "row_per_candidates is empty"
-            )
+            warnings.append(f"_find_sinks: {type(e).__name__} ({str(e)[:120]}); row_per_candidates is empty")
         try:
             resolved_row_per: str | None = self._model._planner._determine_row_per(
                 include_tables=include,
@@ -799,8 +839,7 @@ class Denormalizer:
             element_tables = {}
             cols = []
             warnings.append(
-                f"_prepare_wide_table: {type(e).__name__} ({str(e)[:120]}); "
-                "element_tables and columns are empty"
+                f"_prepare_wide_table: {type(e).__name__} ({str(e)[:120]}); element_tables and columns are empty"
             )
 
         # ── ambiguities (reported, not raised) ─────────────────────────────
@@ -817,8 +856,7 @@ class Denormalizer:
                 # treat as "no ambiguities detected" rather than raising.
                 ambiguities_raw = []
                 warnings.append(
-                    f"_find_path_ambiguities: {type(e).__name__} ({str(e)[:120]}); "
-                    "ambiguities not detected"
+                    f"_find_path_ambiguities: {type(e).__name__} ({str(e)[:120]}); ambiguities not detected"
                 )
         ambiguities = [
             {
@@ -861,10 +899,7 @@ class Denormalizer:
             anchors = self._anchors_as_dict()
         except Exception as e:
             anchors = {}
-            warnings.append(
-                f"_anchors_as_dict: {type(e).__name__} ({str(e)[:120]}); "
-                "anchors summary is empty"
-            )
+            warnings.append(f"_anchors_as_dict: {type(e).__name__} ({str(e)[:120]}); anchors summary is empty")
         # RB-03: skip empty anchor sets, matching the ``if not rids: continue``
         # guard in :meth:`_classify_anchors`. ``list_dataset_members`` returns
         # ``{"File": []}`` for empty association tables; describe and run must
@@ -942,8 +977,7 @@ class Denormalizer:
                     }
             except Exception as e:
                 warnings.append(
-                    f"estimated_row_count: {type(e).__name__} ({str(e)[:120]}); "
-                    "row-count estimate left as None"
+                    f"estimated_row_count: {type(e).__name__} ({str(e)[:120]}); row-count estimate left as None"
                 )
 
         return {
@@ -1251,6 +1285,7 @@ class Denormalizer:
         row_per: str | None,
         via: list[str] | None,
         ignore_unrelated_anchors: bool,
+        selector: Callable[[list["FeatureRecord"]], "FeatureRecord | None"] | None = None,
     ) -> DenormalizeResult:
         """Execute the full 4-phase denormalization pipeline.
 
@@ -1268,18 +1303,21 @@ class Denormalizer:
            ``ignored`` (Rule 7 case 5 silent drop / Rule 8 with flag).
            Raises if Rule 8 fires and the flag is off.
         3. **Main SQL**: delegate to :func:`_denormalize_impl` with
-           ``row_per`` / ``via`` threaded through. For live Datasets
-           ``source="catalog"`` and a :class:`PagedClient` fetches rows
-           before the join; for DatasetBag / fixtures ``source="local"``
-           and the engine is assumed pre-populated.
+           ``row_per`` / ``via`` / ``selector`` threaded through. For
+           live Datasets ``source="catalog"`` and a :class:`PagedClient`
+           fetches rows before the join; for DatasetBag / fixtures
+           ``source="local"`` and the engine is assumed pre-populated.
+           Selector reduction (when supplied) runs inside
+           ``_denormalize_impl`` after materialization, before this
+           method's orphan-row combine.
         4. **Orphan-row combine**: both table-level orphans (case 3)
            AND per-RID orphans (scoping anchors whose specific RIDs
            didn't appear in the main result) are emitted as LEFT-JOIN-
            shaped rows and appended via :meth:`DenormalizeResult.extend`.
 
         Args:
-            include_tables, row_per, via, ignore_unrelated_anchors:
-                forwarded from the public method.
+            include_tables, row_per, via, ignore_unrelated_anchors,
+            selector: forwarded from the public method.
 
         Returns:
             The final :class:`DenormalizeResult` — main SQL rows plus
@@ -1393,6 +1431,7 @@ class Denormalizer:
             paged_client=self._paged_client,
             row_per=resolved_row_per,
             via=list(via or []) or None,
+            selector=selector,
         )
 
         # Step 4a: Augment orphans with scoping-upstream anchors whose specific

--- a/tests/local_db/test_denormalize_selector.py
+++ b/tests/local_db/test_denormalize_selector.py
@@ -1,0 +1,383 @@
+"""Tests for the ``selector`` parameter on ``_denormalize_impl``.
+
+Stage 1 of the ``feature_values`` / ``Denormalizer`` consolidation —
+closes the gap identified by finding 01 §7 of the e2e denormalizer
+audit. The contract matches ``Dataset.feature_values``'s ``selector``
+argument: a callable ``(list[FeatureRecord]) -> FeatureRecord | None``
+that picks one record per target-RID group (or returns ``None`` to drop
+the group).
+
+The fixture ``denorm_local_schema_feature`` provides a feature-
+association table ``Execution_Image_Image_Classification`` with FKs to
+``Image``, ``Execution``, and ``Image_Classification``. These unit
+tests pre-populate the engine with multiple feature rows per Image
+(distinct RCT, distinct Execution) so the selector reduction has
+something to do.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from sqlalchemy.orm import Session
+
+from deriva_ml.feature import FeatureRecord
+from deriva_ml.local_db.denormalize import _denormalize_impl
+
+# ----------------------------------------------------------------------
+# Shared fixture: populate the feature-fixture engine with multi-row data
+# ----------------------------------------------------------------------
+
+
+@pytest.fixture
+def populated_feature_denorm(
+    denorm_feature_deriva_model: Any,
+    denorm_local_schema_feature: Any,
+) -> dict[str, Any]:
+    """LocalSchema pre-populated with a dataset, images, and multiple
+    feature rows per image.
+
+    Each image carries ``N_ANNOTATORS`` feature rows in
+    ``Execution_Image_Image_Classification``, written under distinct
+    Executions, with monotonically increasing RCT timestamps so
+    ``select_newest`` has a deterministic pick. Returns a dict with
+    enough handles for the selector tests to exercise reduction.
+    """
+    ls = denorm_local_schema_feature
+    model = denorm_feature_deriva_model
+
+    ds_rid = "DS-001"
+    image_rids = ["IMG-1", "IMG-2", "IMG-3"]
+    exec_rids = ["EXE-1", "EXE-2", "EXE-3"]
+    cls_rid = "CLS-cat"
+
+    # Per-image, per-execution RCT timestamps. The third execution's
+    # timestamps are uniformly newest, so select_newest must pick it
+    # for every image.
+    rct_table = {
+        "EXE-1": "2026-01-01T00:00:00.000000+00:00",
+        "EXE-2": "2026-02-01T00:00:00.000000+00:00",
+        "EXE-3": "2026-03-01T00:00:00.000000+00:00",
+    }
+
+    with Session(ls.engine) as session:
+        # Dataset row (Dataset table comes from the feature fixture's
+        # deriva-ml schema; the planner needs Dataset_Image to wire
+        # Dataset → Image for the join, so populate that too).
+        ds_cls = ls.get_orm_class("Dataset")
+        session.add(ds_cls(RID=ds_rid, Description="selector unit fixture"))
+
+        img_cls = ls.get_orm_class("Image")
+        for rid in image_rids:
+            session.add(img_cls(RID=rid, Filename=f"{rid}.png", Subject=None))
+
+        di_cls = ls.get_orm_class("Dataset_Image")
+        for rid in image_rids:
+            session.add(di_cls(RID=f"DI-{rid}", Dataset=ds_rid, Image=rid))
+
+        exe_cls = ls.get_orm_class("Execution")
+        for erid in exec_rids:
+            session.add(exe_cls(RID=erid, Description=f"run {erid}"))
+
+        cls_cls = ls.get_orm_class("Image_Classification")
+        session.add(cls_cls(RID=cls_rid, Name="cat"))
+
+        feat_cls = ls.get_orm_class("Execution_Image_Image_Classification")
+        for img_rid in image_rids:
+            for erid in exec_rids:
+                session.add(
+                    feat_cls(
+                        RID=f"EIIC-{img_rid}-{erid}",
+                        RCT=rct_table[erid],
+                        Feature_Name="default",
+                        Image=img_rid,
+                        Execution=erid,
+                        Image_Classification=cls_rid,
+                    )
+                )
+
+        session.commit()
+
+    return {
+        "model": model,
+        "local_schema": ls,
+        "dataset_rid": ds_rid,
+        "image_rids": image_rids,
+        "exec_rids": exec_rids,
+        "rct_table": rct_table,
+        "feature_assoc_table": "Execution_Image_Image_Classification",
+        "newest_execution": "EXE-3",
+    }
+
+
+# ----------------------------------------------------------------------
+# Core reduction behavior
+# ----------------------------------------------------------------------
+
+
+class TestSelectorReducesGroups:
+    """Selector reduces multi-row feature groups to one row per target RID."""
+
+    def test_selector_reduces_multi_row_feature_to_one_per_target(
+        self, populated_feature_denorm: dict[str, Any]
+    ) -> None:
+        """``selector=FeatureRecord.select_newest`` ⇒ one row per Image."""
+        model = populated_feature_denorm["model"]
+        ls = populated_feature_denorm["local_schema"]
+        ds_rid = populated_feature_denorm["dataset_rid"]
+        image_rids = populated_feature_denorm["image_rids"]
+        feature_assoc = populated_feature_denorm["feature_assoc_table"]
+        newest_exec = populated_feature_denorm["newest_execution"]
+
+        # Baseline: without selector, three Images × three Executions
+        # = nine rows.
+        baseline = _denormalize_impl(
+            model=model,
+            engine=ls.engine,
+            orm_resolver=ls.get_orm_class,
+            dataset_rid=ds_rid,
+            include_tables=["Image", feature_assoc],
+            row_per=feature_assoc,
+        )
+        assert baseline.row_count == len(image_rids) * 3, (
+            f"Baseline expected {len(image_rids) * 3} rows; got {baseline.row_count}."
+        )
+
+        # With selector: one row per Image — the newest by RCT.
+        reduced = _denormalize_impl(
+            model=model,
+            engine=ls.engine,
+            orm_resolver=ls.get_orm_class,
+            dataset_rid=ds_rid,
+            include_tables=["Image", feature_assoc],
+            row_per=feature_assoc,
+            selector=FeatureRecord.select_newest,
+        )
+        assert reduced.row_count == len(image_rids), (
+            f"Selector should reduce to one row per Image ({len(image_rids)}); got {reduced.row_count}."
+        )
+        # The kept row per Image must come from the newest execution.
+        target_label = f"{feature_assoc}.Image"
+        exec_label = f"{feature_assoc}.Execution"
+        per_image: dict[str, str] = {}
+        for row in reduced.iter_rows():
+            per_image[row[target_label]] = row[exec_label]
+        assert set(per_image.keys()) == set(image_rids), (
+            f"Reduced output should cover every Image; got keys {sorted(per_image.keys())}."
+        )
+        for img, exec_chosen in per_image.items():
+            assert exec_chosen == newest_exec, (
+                f"select_newest should pick {newest_exec} for Image {img}; got {exec_chosen}."
+            )
+
+    def test_selector_none_is_passthrough(self, populated_feature_denorm: dict[str, Any]) -> None:
+        """``selector=None`` ⇒ unchanged behavior."""
+        model = populated_feature_denorm["model"]
+        ls = populated_feature_denorm["local_schema"]
+        ds_rid = populated_feature_denorm["dataset_rid"]
+        image_rids = populated_feature_denorm["image_rids"]
+        feature_assoc = populated_feature_denorm["feature_assoc_table"]
+
+        result = _denormalize_impl(
+            model=model,
+            engine=ls.engine,
+            orm_resolver=ls.get_orm_class,
+            dataset_rid=ds_rid,
+            include_tables=["Image", feature_assoc],
+            row_per=feature_assoc,
+            selector=None,
+        )
+        assert result.row_count == len(image_rids) * 3, (
+            f"selector=None should preserve all rows; got {result.row_count}."
+        )
+
+    def test_selector_returning_none_omits_target(self, populated_feature_denorm: dict[str, Any]) -> None:
+        """Selector returning ``None`` for a target ⇒ that target drops."""
+        model = populated_feature_denorm["model"]
+        ls = populated_feature_denorm["local_schema"]
+        ds_rid = populated_feature_denorm["dataset_rid"]
+        image_rids = populated_feature_denorm["image_rids"]
+        feature_assoc = populated_feature_denorm["feature_assoc_table"]
+
+        dropped_image = image_rids[0]
+
+        def drop_first_image(records: list[FeatureRecord]) -> FeatureRecord | None:
+            # All records in a group share a target RID, so probe the
+            # first one to decide.
+            if getattr(records[0], "Image", None) == dropped_image:
+                return None
+            return FeatureRecord.select_newest(records)
+
+        result = _denormalize_impl(
+            model=model,
+            engine=ls.engine,
+            orm_resolver=ls.get_orm_class,
+            dataset_rid=ds_rid,
+            include_tables=["Image", feature_assoc],
+            row_per=feature_assoc,
+            selector=drop_first_image,
+        )
+        target_label = f"{feature_assoc}.Image"
+        surviving = {row[target_label] for row in result.iter_rows()}
+        assert surviving == set(image_rids) - {dropped_image}, (
+            f"Selector returning None should drop {dropped_image} only; surviving={surviving}."
+        )
+
+
+# ----------------------------------------------------------------------
+# Validation
+# ----------------------------------------------------------------------
+
+
+class TestSelectorValidation:
+    """include_tables shape requirements for the selector parameter."""
+
+    def test_selector_without_feature_assoc_table_raises(self, populated_denorm: dict[str, Any]) -> None:
+        """No feature-association table in include_tables + selector ⇒ ValueError.
+
+        Uses the basic ``populated_denorm`` fixture, which has no
+        feature-association tables in its schema.
+        """
+        model = populated_denorm["model"]
+        ls = populated_denorm["local_schema"]
+        ds_rid = populated_denorm["dataset_rid"]
+
+        with pytest.raises(ValueError, match=r"selector requires a feature-association table"):
+            _denormalize_impl(
+                model=model,
+                engine=ls.engine,
+                orm_resolver=ls.get_orm_class,
+                dataset_rid=ds_rid,
+                include_tables=["Image", "Subject"],
+                selector=FeatureRecord.select_newest,
+            )
+
+    def test_selector_with_multiple_feature_assoc_tables_raises(
+        self,
+        denorm_feature_deriva_model: Any,
+        denorm_local_schema_feature: Any,
+    ) -> None:
+        """More than one feature-association table + selector ⇒ ValueError.
+
+        The unit feature fixture only declares one real feature-association
+        table (``Execution_Image_Image_Classification``); to exercise the
+        multi-feature branch synthesize the predicate result via
+        monkeypatching ``_is_feature_association`` so the planner sees two
+        feature-association tables. Verifies the guard fires before any
+        materialization work happens.
+        """
+        ls = denorm_local_schema_feature
+        model = denorm_feature_deriva_model
+
+        # Force two table names to pass the feature-association predicate.
+        fake_feature_tables = {
+            "Execution_Image_Image_Classification",
+            "Image_Subject_UnrelatedThing",  # a 3-FK non-feature in the fixture
+        }
+        original = model._planner._is_feature_association
+
+        def fake_is_feature(name_or_table: Any) -> bool:
+            name = name_or_table if isinstance(name_or_table, str) else getattr(name_or_table, "name", "")
+            return name in fake_feature_tables or original(name_or_table)
+
+        model._planner._is_feature_association = fake_is_feature  # type: ignore[assignment]
+        try:
+            with pytest.raises(
+                ValueError, match=r"selector with multiple feature-association tables not yet supported"
+            ):
+                _denormalize_impl(
+                    model=model,
+                    engine=ls.engine,
+                    orm_resolver=ls.get_orm_class,
+                    dataset_rid="DS-001",
+                    include_tables=[
+                        "Image",
+                        "Execution_Image_Image_Classification",
+                        "Image_Subject_UnrelatedThing",
+                    ],
+                    selector=FeatureRecord.select_newest,
+                )
+        finally:
+            model._planner._is_feature_association = original  # type: ignore[assignment]
+
+
+# ----------------------------------------------------------------------
+# Surface-level forwarding (Denormalizer + Dataset/DatasetBag wrappers)
+# ----------------------------------------------------------------------
+
+
+class TestSelectorPlumbing:
+    """The selector parameter flows through Denormalizer and the public wrappers."""
+
+    def test_selector_via_denormalizer_as_dict(self, populated_feature_denorm: dict[str, Any]) -> None:
+        """``Denormalizer.as_dict(selector=...)`` reduces just like as_dataframe."""
+        from deriva_ml.local_db.denormalizer import Denormalizer
+
+        model = populated_feature_denorm["model"]
+        ls = populated_feature_denorm["local_schema"]
+        ds_rid = populated_feature_denorm["dataset_rid"]
+        image_rids = populated_feature_denorm["image_rids"]
+        feature_assoc = populated_feature_denorm["feature_assoc_table"]
+
+        # Build a Denormalizer over a minimal DatasetLike shim that
+        # mirrors the populated engine.
+        class _Shim:
+            dataset_rid = ds_rid
+            model = denormalizer_model = None
+            engine = ls.engine
+            _orm_resolver = ls.get_orm_class
+
+            def __init__(self, m):  # noqa: D401
+                self.model = m
+
+            def list_dataset_members(self, **_kwargs: Any) -> dict[str, list[dict]]:
+                return {"Image": [{"RID": r} for r in image_rids]}
+
+            def list_dataset_children(self, **_kwargs: Any) -> list:
+                return []
+
+        d = Denormalizer(_Shim(model))
+        rows = list(
+            d.as_dict(
+                ["Image", feature_assoc],
+                row_per=feature_assoc,
+                selector=FeatureRecord.select_newest,
+            )
+        )
+        target_label = f"{feature_assoc}.Image"
+        assert len(rows) == len(image_rids), (
+            f"Denormalizer.as_dict + selector should yield one row per Image; got {len(rows)}."
+        )
+        assert {r[target_label] for r in rows} == set(image_rids)
+
+    def test_selector_via_denormalizer_as_dataframe(self, populated_feature_denorm: dict[str, Any]) -> None:
+        """``Denormalizer.as_dataframe(selector=...)`` reduces correctly."""
+        from deriva_ml.local_db.denormalizer import Denormalizer
+
+        model = populated_feature_denorm["model"]
+        ls = populated_feature_denorm["local_schema"]
+        ds_rid = populated_feature_denorm["dataset_rid"]
+        image_rids = populated_feature_denorm["image_rids"]
+        feature_assoc = populated_feature_denorm["feature_assoc_table"]
+
+        class _Shim:
+            def __init__(self, m: Any) -> None:
+                self.dataset_rid = ds_rid
+                self.model = m
+                self.engine = ls.engine
+                self._orm_resolver = ls.get_orm_class
+
+            def list_dataset_members(self, **_kwargs: Any) -> dict[str, list[dict]]:
+                return {"Image": [{"RID": r} for r in image_rids]}
+
+            def list_dataset_children(self, **_kwargs: Any) -> list:
+                return []
+
+        d = Denormalizer(_Shim(model))
+        df = d.as_dataframe(
+            ["Image", feature_assoc],
+            row_per=feature_assoc,
+            selector=FeatureRecord.select_newest,
+        )
+        assert len(df) == len(image_rids)


### PR DESCRIPTION
## Summary

Closes the aggregation-knob contract gap identified by finding 01 §7 of
the e2e denormalizer audit: ``Denormalizer.as_dataframe`` /
``as_dict`` (and the public wrappers on ``Dataset`` / ``DatasetBag``)
now accept a ``selector`` parameter matching
``Dataset.feature_values``'s shape.

- ``selector: Callable[[list[FeatureRecord]], FeatureRecord | None] | None = None``
- When provided, materialized denormalize rows are grouped by the
  feature-association table's target RID; the selector picks one row
  per group (or returns ``None`` to drop the group). Same contract,
  same built-in selectors (``FeatureRecord.select_newest``,
  ``select_first``, ``select_by_execution``, ``select_by_workflow``,
  ``select_majority_vote``).
- ``include_tables`` must contain exactly one feature-association
  table when the selector is set. Zero ⇒
  ``ValueError("selector requires a feature-association table ...")``;
  more than one ⇒ ``ValueError("selector with multiple
  feature-association tables not yet supported ...")``.

This is Stage 1 of a planned three-stage architectural consolidation:

1. **Stage 1 (this PR):** wire ``selector`` into the Denormalizer +
   public wrappers + ``DatasetLike`` protocol.
2. **Stage 2:** audit whether ``feature_values`` can be expressed via
   ``Denormalizer`` (cardinality / materialize_limit semantics, etc.).
3. **Stage 3:** refactor ``feature_values`` to delegate to
   ``Denormalizer``.

The single-selector shape (matching ``feature_values`` exactly) makes
Stage 3 a clean delegation rather than a shape mismatch.

### User-facing problem fix

The e2e Analyst persona had to write an external
``df.groupby("Image.RID").apply(select_latest)`` reduction (losing
provenance) or run two materializations — denormalize for columns
plus a separate ``feature_values`` call for reduction — exactly the
routes-around-the-denormalizer pattern catalogued in finding 01 §H.
That gap is what this PR closes for Stage 1.

Audit chain referenced (absolute paths so future readers can find
them):

- ``/Users/carl/GitHub/DerivaML/deriva-ml-model-template-e2e/findings/investigation/01-denormalizer-spec-vs-implementation.md`` §7
  — names the aggregation-knob contract gap this PR closes.
- ``/Users/carl/GitHub/DerivaML/deriva-ml-model-template-e2e/findings/investigation/01-denormalizer-spec-vs-implementation.md`` §H
  — the routes-around-the-denormalizer pattern the Analyst hit.

### Implementation notes

- The planner's ``_prepare_wide_table`` skips system columns
  ``{RCT, RMT, RCB, RMB}`` on every contributing table, so the
  selector pass does a small supplementary fetch of those columns
  keyed by the feature-association RID before constructing the
  FeatureRecord shadow. ``datetime`` values coming back from SQLite
  are coerced to ISO-8601 strings so ``select_newest``'s lexicographic
  RCT compare behaves identically to ``feature_values``.
- ``find_features()`` is preferred for Feature lookup so the
  ``feature_record_class`` is the canonical one. A structural
  fallback (FK-shape inspection) handles offline fixtures where
  ``Model.fromfile`` doesn't wire ``referenced_by`` and
  ``find_features`` returns empty.
- ``split_dataset`` is **not** touched in this PR. The
  ``partition_by="element"`` interaction the spec mentions only
  matters once ``split_dataset`` forwards a selector through, which
  is Stage 2/3 territory.

## Test plan

- [x] ``uv run ruff check src tests`` — clean on changed files.
- [x] ``uv run ruff format src tests`` — clean on changed files.
- [x] ``uv run python -m pytest tests/local_db/`` — 308 passed,
      3 skipped. Includes the new
      ``tests/local_db/test_denormalize_selector.py`` (7 cases):
      multi-row reduction, ``selector=None`` passthrough, selector
      returning ``None`` drops a target, both ValueError branches
      (zero + multiple feature-assoc tables), ``as_dict`` and
      ``as_dataframe`` plumbing via ``Denormalizer``.
- [x] ``DERIVA_ML_ALLOW_DIRTY=true uv run python -m pytest
      tests/dataset/test_split*.py`` — 120 passed (baseline unchanged;
      ``split_dataset`` not touched).
- [ ] Live verification on dev-localhost catalog 27 — **not run**
      from this worktree (host unreachable from this environment).
      The selector pass is exercised end-to-end against the
      in-memory SQLite engine the unit tests use; the catalog-fetch
      path differs only in row source, not in the
      materialize-then-reduce step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)