### PR TITLE
refactor(dataset): delegate Dataset.feature_values to Denormalizer (Stage 3a)

### DIFF
--- a/src/deriva_ml/dataset/dataset.py
+++ b/src/deriva_ml/dataset/dataset.py
@@ -42,7 +42,6 @@ from deriva.core.asyncio.async_catalog import AsyncErmrestSnapshot
 
 if TYPE_CHECKING:
     from deriva_ml.execution.execution import Execution
-    from deriva_ml.feature import FeatureRecord
 
 # Third-party imports
 import pandas as pd
@@ -67,7 +66,7 @@ from deriva_ml.dataset.aux_classes import (
 )
 from deriva_ml.dataset.bag_builder import DatasetBagBuilder
 from deriva_ml.dataset.dataset_bag import DatasetBag
-from deriva_ml.feature import Feature
+from deriva_ml.feature import Feature, FeatureRecord
 from deriva_ml.interfaces import DerivaMLCatalog
 from deriva_ml.model.database import DatabaseModel
 
@@ -594,6 +593,7 @@ class Dataset:
         members = self.list_dataset_members()
         return [r["RID"] for r in members.get(table_name, [])]
 
+    @validate_call(config=VALIDATION_CONFIG)
     def feature_values(
         self,
         table: str | Table,
@@ -605,9 +605,19 @@ class Dataset:
         """Dataset-scoped feature values — identical signature to DerivaML.feature_values.
 
         Yields only records whose target RID is a member of this dataset.
-        Filtering is applied to the raw feature table query before selector
-        reduction — a target RID outside the dataset's member set is never
-        presented to the selector.
+        Dataset scoping is enforced by the denormalize SQL join (the
+        feature rows are reached *through* the dataset's membership
+        tables), so a target RID outside the dataset is never materialized.
+
+        **Implementation (Stage 3a of the ``feature_values`` /
+        ``Denormalizer`` consolidation):** this method delegates to
+        :meth:`~deriva_ml.local_db.denormalizer.Denormalizer.feature_records`
+        rather than running its own PathBuilder query. The catalog-wide
+        ``DerivaML.feature_values`` keeps its PathBuilder path (it has no
+        dataset anchor for the denormalize join); ``Dataset.feature_values``
+        is intrinsically dataset-scoped, so the denormalize join is the
+        natural fit and the two surfaces now share one SQL-join
+        implementation instead of two.
 
         See :meth:`deriva_ml.core.mixins.feature.FeatureMixin.feature_values`
         for the full contract (return type, selector semantics, exceptions).
@@ -618,36 +628,45 @@ class Dataset:
             selector: Optional callable ``(list[FeatureRecord]) -> FeatureRecord | None``
                 used to reduce multi-value groups. See ``FeatureRecord`` for built-ins.
                 Return ``None`` from a selector to omit that target RID.
-            materialize_limit: Optional cap on the upstream catalog
-                query's row materialization. Forwarded to
-                ``DerivaML.feature_values``; raises
-                ``DerivaMLMaterializeLimitExceeded`` if exceeded.
-                Default ``None`` preserves unbounded behavior.
+            materialize_limit: Optional cap on the number of feature rows
+                materialized. Raises ``DerivaMLMaterializeLimitExceeded``
+                when exceeded. Default ``None`` preserves unbounded
+                behavior.
 
-                **The cap applies to the catalog query, not to the
-                dataset-filtered result.** ``Dataset.feature_values``
-                fetches every feature row from the catalog first, then
-                drops rows whose target RID isn't a dataset member.
-                A feature with ``10*N`` catalog rows where only ``N/2``
-                belong to this dataset will trip the limit at ``N``
-                even though the post-filter yield would be small.
-                To bound the dataset-scope output instead, leave
-                ``materialize_limit`` unset and consume the iterator
-                with ``itertools.islice``.
-            execution_rids: Optional filter forwarded to the upstream
-                catalog query. When set, only feature rows whose
-                ``Execution`` value is in this list are materialized.
-                Empty list short-circuits to an empty result.
+                **Post-count guard (Stage 3a behavior note).** The
+                denormalize join materializes the dataset-scoped feature
+                rows into memory, then this wrapper counts them and raises
+                if the count exceeds the cap. This is a *weaker* guard than
+                the legacy PathBuilder server-side cap — the rows are
+                already in memory when the check fires — but it is no worse
+                than the full materialization the PathBuilder fetch also
+                performed. To bound the output by yield count instead, leave
+                ``materialize_limit`` unset and consume the iterator with
+                ``itertools.islice``.
+            execution_rids: Optional filter on the ``Execution`` column.
+                When set, only feature rows whose ``Execution`` value is in
+                this list survive. Empty list short-circuits to an empty
+                result.
+
+                **Post-filter (Stage 3a behavior note).** The denormalize
+                join has no server-side ``Execution`` predicate, so this
+                filter is applied in Python after the dataset-scoped rows
+                are materialized. The legacy PathBuilder path filtered
+                server-side, saving a round-trip's worth of rows; the
+                delegation trades that round-trip-savings for one
+                consolidated SQL-join implementation. The filter runs
+                *before* selector reduction, matching the legacy ordering.
 
         Returns:
-            Iterator of ``FeatureRecord`` — filtered to dataset members, then
-            reduced by selector if provided.
+            Iterator of ``FeatureRecord`` — dataset-scoped, optionally
+            filtered by ``execution_rids``, then reduced by selector if
+            provided. ``RCT`` is populated on every record.
 
         Raises:
             DerivaMLTableNotFound: ``table`` does not exist.
             DerivaMLException: ``feature_name`` is not a feature on ``table``.
-            DerivaMLMaterializeLimitExceeded: If the upstream
-                materialization exceeds ``materialize_limit``.
+            DerivaMLMaterializeLimitExceeded: If the materialized row count
+                exceeds ``materialize_limit``.
 
         Example:
             >>> from deriva_ml.feature import FeatureRecord  # doctest: +SKIP
@@ -655,36 +674,46 @@ class Dataset:
             ...     "Image", "Glaucoma", selector=FeatureRecord.select_newest,
             ... ))
         """
-        members = set(self.list_members(table))
-        target_col = table if isinstance(table, str) else table.name
+        from deriva_ml.core.exceptions import DerivaMLMaterializeLimitExceeded
+        from deriva_ml.feature import reduce_with_selector
+        from deriva_ml.local_db.denormalizer import Denormalizer
 
-        # Filter upstream raw records to dataset members. Forward
-        # materialize_limit and execution_rids to the catalog query so
-        # the upstream materialization is bounded too. The dataset-scope
-        # filter is applied AFTER the catalog query, so the limit check
-        # in the upstream guards us against memory blow-up before we
-        # filter further.
-        raw_in_scope = [
-            rec
-            for rec in self._ml_instance.feature_values(
-                table,
-                feature_name,
-                selector=None,
-                materialize_limit=materialize_limit,
-                execution_rids=execution_rids,
+        # execution_rids=[] short-circuits to empty — preserve the legacy
+        # PathBuilder behavior explicitly (audit §10).
+        if execution_rids is not None and not execution_rids:
+            return
+
+        feat = self.lookup_feature(table, feature_name)
+        target_col = feat.target_table.name
+
+        # Delegate the dataset-scoped SQL join + RCT recovery + FeatureRecord
+        # materialization to the Denormalizer. Selector reduction is applied
+        # in this wrapper (not pushed into feature_records) so the
+        # execution_rids filter runs first — matching the legacy ordering
+        # "filter by execution, then reduce".
+        records = Denormalizer(self).feature_records(feat, selector=None)
+
+        # materialize_limit: post-count guard. Weaker than the legacy
+        # server-side cap (rows are already materialized), documented above.
+        if materialize_limit is not None and len(records) > materialize_limit:
+            raise DerivaMLMaterializeLimitExceeded(
+                actual_count=len(records),
+                limit=materialize_limit,
             )
-            if getattr(rec, target_col, None) in members
-        ]
+
+        # execution_rids: post-filter in the wrapper. The denormalize join
+        # has no server-side Execution predicate (audit §6).
+        if execution_rids is not None:
+            exec_set = set(execution_rids)
+            records = [rec for rec in records if rec.Execution in exec_set]
 
         if selector is None:
-            yield from raw_in_scope
+            yield from records
             return
 
         # Group by target RID + apply selector — shared helper
         # so the three feature_values surfaces stay in lockstep.
-        from deriva_ml.feature import reduce_with_selector
-
-        yield from reduce_with_selector(raw_in_scope, target_col, selector)
+        yield from reduce_with_selector(records, target_col, selector)
 
     def lookup_feature(self, table: str | Table, feature_name: str) -> Feature:
         """Look up a Feature definition — delegates to the owning DerivaML.

--- a/src/deriva_ml/local_db/denormalize.py
+++ b/src/deriva_ml/local_db/denormalize.py
@@ -37,6 +37,7 @@ from __future__ import annotations
 import time
 from contextlib import contextmanager
 from dataclasses import dataclass, field
+from datetime import timezone
 from typing import Any, Callable, Generator
 
 import pandas as pd
@@ -664,68 +665,17 @@ def _apply_selector(
     target_label = _label(target_table_name)
     rid_label = _label("RID")
 
-    # Supplementary fetch: the wide-table SELECT in
-    # ``_prepare_wide_table`` skips the system columns
-    # ``{RCT, RMT, RCB, RMB}`` on every contributing table — but the
-    # selector contract reads them (``select_newest`` keys on RCT,
-    # ``select_by_execution`` keys on Execution which IS preserved).
-    # Fetch RCT (and any other FeatureRecord field that's missing from
-    # the wide-table row) keyed by the feature-assoc RID before we
-    # build the FeatureRecord shadows. Without this step,
-    # ``select_newest`` falls back to the empty-string default on every
-    # record and picks an arbitrary group member.
-    feature_rids = [row.get(rid_label) for row in rows if row.get(rid_label) is not None]
-    supplements: dict[str, dict[str, Any]] = {}
-    if feature_rids:
-        from sqlalchemy import select as sa_select
-
-        feat_orm = orm_resolver(feature_assoc_table)
-        if feat_orm is not None:
-            # Pull the columns the FeatureRecord cares about that the
-            # wide table doesn't already carry. The wide table preserves
-            # the feature-association table's domain columns; we only
-            # need to fetch the system columns the planner skipped.
-            wanted_cols = [c for c in field_names if c not in {"feature", "Feature_Name"}]
-            try:
-                with engine.connect() as conn:
-                    rows_supp = (
-                        conn.execute(sa_select(feat_orm.__table__).where(feat_orm.__table__.c.RID.in_(feature_rids)))
-                        .mappings()
-                        .all()
-                    )
-                for r in rows_supp:
-                    rid = r.get("RID")
-                    if rid is None:
-                        continue
-                    # ``RCT`` may come back from SQLite as a Python
-                    # ``datetime`` (depending on the column type
-                    # affinity), but the FeatureRecord schema declares
-                    # ``RCT: Optional[str]`` to match the ISO-8601
-                    # shape ``Dataset.feature_values`` materializes.
-                    # Normalize timestamp-shaped values to ISO strings
-                    # so the selector built-ins (lexicographic
-                    # comparison on RCT) behave the same way they do
-                    # on the ``feature_values`` surface.
-                    coerced: dict[str, Any] = {}
-                    for col in wanted_cols:
-                        if col not in r:
-                            continue
-                        val = r.get(col)
-                        if hasattr(val, "isoformat"):
-                            val = val.isoformat()
-                        coerced[col] = val
-                    supplements[rid] = coerced
-            except Exception as e:
-                # Supplementary fetch is best-effort: if it fails, the
-                # selector falls back to whatever fields the wide-table
-                # row provides. Log so operators can see the path was
-                # exercised but degraded.
-                logger.warning(
-                    "Denormalizer selector path: supplementary fetch of %s system columns failed (%s); "
-                    "selector may see None for skipped fields.",
-                    feature_assoc_table,
-                    e,
-                )
+    # Recover the system columns the planner skipped (RCT, etc.) keyed by
+    # the feature-assoc RID. Shared with ``Dataset.feature_values``'s
+    # delegation via :func:`_recover_system_columns`.
+    supplements = _recover_system_columns(
+        rows=rows,
+        engine=engine,
+        orm_resolver=orm_resolver,
+        feature_assoc_table=feature_assoc_table,
+        rid_label=rid_label,
+        field_names=field_names,
+    )
 
     # Group rows by target RID. We carry source rows alongside their
     # built FeatureRecord shadow so the selector's choice can be mapped
@@ -796,6 +746,231 @@ def _apply_selector(
     # silently. A caller that wants them gone can filter the result.
     reduced.extend(untouched)
     return reduced
+
+
+def _recover_system_columns(
+    *,
+    rows: list[dict[str, Any]],
+    engine: Engine,
+    orm_resolver: Callable[[str], Any],
+    feature_assoc_table: str,
+    rid_label: str,
+    field_names: set[str],
+) -> dict[str, dict[str, Any]]:
+    """Fetch the system columns the wide-table SELECT dropped, keyed by RID.
+
+    The denormalize planner (``_prepare_wide_table``) skips the system
+    columns ``{RCT, RMT, RCB, RMB}`` on every contributing table, so a
+    materialized wide-table row carries the feature-association table's
+    domain columns but not its ``RCT``. The selector built-ins read
+    ``RCT`` (``select_newest`` / ``select_first`` compare it
+    lexicographically) and ``Dataset.feature_values`` exposes ``RCT`` on
+    every yielded ``FeatureRecord`` — both need it back.
+
+    This is a single ``SELECT * FROM <feat_assoc> WHERE RID IN (:rids)``
+    against the local engine, returning ``{feature_assoc_RID:
+    {field: value}}`` for the ``FeatureRecord`` fields the wide table did
+    not already carry. Timestamp-shaped values (``RCT`` may come back from
+    SQLite as a Python ``datetime`` depending on column affinity) are
+    normalized to ISO-8601 strings so the selector built-ins and the
+    ``FeatureRecord.RCT: Optional[str]`` schema see the same shape the
+    PathBuilder path materializes.
+
+    Shared by :func:`_apply_selector` (the ``Denormalizer`` selector path)
+    and :func:`materialize_feature_records` (the ``Dataset.feature_values``
+    delegation) so RCT recovery lives in exactly one place.
+
+    Args:
+        rows: Materialized wide-table rows from the SQL JOIN.
+        engine: SQLAlchemy engine to read the feature-association table.
+        orm_resolver: Maps ``feature_assoc_table`` -> ORM class.
+        feature_assoc_table: Name of the feature-association table.
+        rid_label: The dotted output label for the feature-assoc table's
+            ``RID`` column (e.g. ``"Execution_Image_Quality.RID"``).
+        field_names: ``FeatureRecord`` field names — the wanted columns
+            (minus ``feature`` / ``Feature_Name``) are pulled.
+
+    Returns:
+        ``{feature_assoc_RID: {field_name: coerced_value}}``. Empty when
+        no feature RIDs are present in ``rows`` or the supplementary
+        fetch fails (best-effort — a failure is logged, not raised).
+
+    Example::
+
+        supplements = _recover_system_columns(
+            rows=rows, engine=engine, orm_resolver=resolver,
+            feature_assoc_table="Execution_Image_Quality",
+            rid_label="Execution_Image_Quality.RID",
+            field_names={"Image", "Quality", "RCT", "Execution"},
+        )
+        # supplements["3-ABC"] == {"RCT": "2026-05-28T16:54:02+00:00", ...}
+    """
+    feature_rids = [row.get(rid_label) for row in rows if row.get(rid_label) is not None]
+    supplements: dict[str, dict[str, Any]] = {}
+    if not feature_rids:
+        return supplements
+
+    from sqlalchemy import select as sa_select
+
+    feat_orm = orm_resolver(feature_assoc_table)
+    if feat_orm is None:
+        return supplements
+
+    # Pull the FeatureRecord fields the wide table doesn't already carry.
+    # The wide table preserves the feature-association table's domain
+    # columns; we only need the system columns the planner skipped.
+    wanted_cols = [c for c in field_names if c not in {"feature", "Feature_Name"}]
+    try:
+        with engine.connect() as conn:
+            rows_supp = (
+                conn.execute(sa_select(feat_orm.__table__).where(feat_orm.__table__.c.RID.in_(feature_rids)))
+                .mappings()
+                .all()
+            )
+        for r in rows_supp:
+            rid = r.get("RID")
+            if rid is None:
+                continue
+            coerced: dict[str, Any] = {}
+            for col in wanted_cols:
+                if col not in r:
+                    continue
+                val = r.get(col)
+                if hasattr(val, "isoformat"):
+                    # Deriva ``timestamptz`` columns (RCT, etc.) are stored
+                    # as UTC, and the PathBuilder ``feature_values`` path
+                    # surfaces them as ISO-8601 strings WITH a ``+00:00``
+                    # offset. The local SQLite round-trip drops the tzinfo
+                    # (the value comes back tz-naive), so a bare
+                    # ``.isoformat()`` would emit ``...232194`` instead of
+                    # ``...232194+00:00`` and diverge from the legacy shape.
+                    # Re-attach UTC on naive datetimes so the recovered RCT
+                    # is bit-identical to the PathBuilder output (selectors
+                    # compare RCT lexicographically — a missing offset also
+                    # breaks ordering against catalog-shaped timestamps).
+                    if getattr(val, "tzinfo", None) is None:
+                        val = val.replace(tzinfo=timezone.utc)
+                    val = val.isoformat()
+                coerced[col] = val
+            supplements[rid] = coerced
+    except Exception as e:
+        # Best-effort: if the fetch fails, callers fall back to whatever
+        # fields the wide-table row provides. Log so operators can see
+        # the path was exercised but degraded.
+        logger.warning(
+            "Denormalizer: supplementary fetch of %s system columns failed (%s); "
+            "RCT and other skipped fields may be None.",
+            feature_assoc_table,
+            e,
+        )
+    return supplements
+
+
+def materialize_feature_records(
+    rows: list[dict[str, Any]],
+    *,
+    record_class: type,
+    engine: Engine,
+    orm_resolver: Callable[[str], Any],
+    feature_assoc_table: str,
+    target_table_name: str,
+    schema_for_table: dict[str, str],
+    multi_schema: bool,
+) -> list[Any]:
+    """Materialize wide-table denormalize rows into typed ``FeatureRecord`` instances.
+
+    The strip-prefix-and-project adapter from audit finding 08 §4: the
+    wide-table rows carry dotted column labels
+    (``Execution_Image_Quality.Quality``) plus the target table's own
+    columns (``Image.URL``, etc.). This function:
+
+    1. Strips the feature-association table's dotted prefix.
+    2. Projects down to only the keys in ``record_class.model_fields``
+       (so ``Image.URL`` and other non-FeatureRecord columns are dropped —
+       ``FeatureRecord`` is ``extra="forbid"``).
+    3. Overlays the recovered system columns (RCT) from
+       :func:`_recover_system_columns`.
+    4. Constructs ``record_class(**projected)``.
+
+    Rows whose target FK is ``None`` are dropped — matching the
+    ``reduce_with_selector`` / PathBuilder semantics where a feature row
+    with a NULL target is never surfaced (audit §10). This guards against
+    the Denormalizer's LEFT-JOIN emit producing an orphan row with
+    ``target=None`` that the PathBuilder path could never return.
+
+    Args:
+        rows: Materialized wide-table rows (no selector reduction applied
+            — that happens upstream of this call if requested).
+        record_class: The ``FeatureRecord`` subclass from
+            ``Feature.feature_record_class()``.
+        engine: SQLAlchemy engine for the RCT supplementary fetch.
+        orm_resolver: Maps table name -> ORM class.
+        feature_assoc_table: Name of the feature-association table (the
+            column-label prefix to strip).
+        target_table_name: Name of the feature's target table (its FK
+            column on the feature-assoc table — used for the null-target
+            drop).
+        schema_for_table: ``{table_name: schema_name}`` for label building.
+        multi_schema: Whether output labels carry the schema prefix.
+
+    Returns:
+        List of ``record_class`` instances — one per input row whose
+        target FK is non-null. Each has ``RCT`` populated from the
+        supplementary fetch (the wide table drops it).
+
+    Example::
+
+        recs = materialize_feature_records(
+            rows,
+            record_class=feat.feature_record_class(),
+            engine=engine, orm_resolver=resolver,
+            feature_assoc_table="Execution_Image_Quality",
+            target_table_name="Image",
+            schema_for_table={"Image": "domain", "Execution_Image_Quality": "deriva-ml"},
+            multi_schema=False,
+        )
+        # recs[0].Image == "1-ABC"; recs[0].RCT == "2026-05-28T..."
+    """
+    field_names = set(record_class.model_fields.keys())
+    schema_name = schema_for_table.get(feature_assoc_table, "")
+
+    def _label(col_name: str) -> str:
+        return denormalize_column_name(schema_name, feature_assoc_table, col_name, multi_schema)
+
+    target_label = _label(target_table_name)
+    rid_label = _label("RID")
+
+    supplements = _recover_system_columns(
+        rows=rows,
+        engine=engine,
+        orm_resolver=orm_resolver,
+        feature_assoc_table=feature_assoc_table,
+        rid_label=rid_label,
+        field_names=field_names,
+    )
+
+    records: list[Any] = []
+    for row in rows:
+        # Null target FK → drop, matching reduce_with_selector / PathBuilder
+        # (audit §10). The Denormalizer's LEFT-JOIN emit could otherwise
+        # surface a feature row with target=None that the PathBuilder path
+        # never returns.
+        if row.get(target_label) is None:
+            continue
+        # Strip prefix + project down to FeatureRecord fields only.
+        record_kwargs: dict[str, Any] = {}
+        for field_name in field_names:
+            label = _label(field_name)
+            if label in row:
+                record_kwargs[field_name] = row[label]
+        # Overlay recovered system columns (RCT) where the wide table
+        # left a gap.
+        supp = supplements.get(row.get(rid_label), {})
+        for field_name, value in supp.items():
+            if field_name in field_names and record_kwargs.get(field_name) is None:
+                record_kwargs[field_name] = value
+        records.append(record_class(**record_kwargs))
+    return records
 
 
 def _compute_cache_age_seconds(fetcher: PagedFetcher | None) -> float | None:

--- a/src/deriva_ml/local_db/denormalize.py
+++ b/src/deriva_ml/local_db/denormalize.py
@@ -555,9 +555,8 @@ def _apply_selector(
         # record per Image — with the rest of the wide-table columns
         # preserved.
     """
-    from collections import defaultdict
-
     from deriva_ml.core.exceptions import DerivaMLException
+    from deriva_ml.feature import reduce_with_selector
 
     # Locate the target table for the feature-association table. The
     # preferred path is ``DerivaModel.find_features`` — that returns
@@ -677,27 +676,45 @@ def _apply_selector(
         field_names=field_names,
     )
 
-    # Group rows by target RID. We carry source rows alongside their
-    # built FeatureRecord shadow so the selector's choice can be mapped
-    # back to a full wide-table row. Rows whose target RID is missing
-    # (NULL on a LEFT JOIN, etc.) can't be grouped and are passed
-    # through unchanged — mirrors ``reduce_with_selector``, which
-    # silently drops records with no target.
-    groups: dict[str, list[tuple[Any, dict[str, Any]]]] = defaultdict(list)
+    # Build a FeatureRecord shadow for every row that carries a target
+    # RID, recording the source row keyed by ``id(shadow)``. The id map
+    # is the only ``_apply_selector``-specific piece: it lets us recover
+    # the full wide-table dict row after the selector picks a shadow,
+    # since ``reduce_with_selector`` (the shared grouping + selector
+    # algorithm) yields ``FeatureRecord`` instances, not rows.
+    #
+    # ``id(shadow)`` — never the shadow itself — keys the map: two
+    # distinct rows can build value-equal FeatureRecords (``FeatureRecord``
+    # is a pydantic model with value-based equality), so a record-keyed
+    # dict would collide and mis-map rows under duplicate feature values.
+    # Identity (``id``) is stable for the lifetime of each shadow object
+    # and unique per live instance — and the shadows stay referenced in
+    # ``shadows`` for the whole call, so no id is reused mid-flight.
+    #
+    # Two sets of rows stay out of the reduction and pass through
+    # untouched, exactly as before:
+    #   - rows whose target RID is missing (NULL on a LEFT JOIN, etc.) —
+    #     ``reduce_with_selector`` drops None-target *records* before
+    #     grouping, but ``_apply_selector`` must *keep* the source row,
+    #     so we partition them out here rather than feed them in;
+    #   - rows whose FeatureRecord construction raises (e.g. an
+    #     unexpected NULL where the schema declares non-null) — kept so
+    #     the selector path doesn't silently eat them.
+    #
+    # The generated record class is constructed by
+    # ``Feature.feature_record_class`` with ``extra="forbid"`` inherited
+    # from ``FeatureRecord.Config``, so we feed only the fields the class
+    # declares — other include_tables columns are excluded. Supplementary
+    # fetch values overlay onto the wide-table row contributions so the
+    # FeatureRecord sees RCT etc. when the wide table dropped them.
+    shadows: list[Any] = []
+    id_to_row: dict[int, dict[str, Any]] = {}
     untouched: list[dict[str, Any]] = []
     for row in rows:
         target_rid = row.get(target_label)
         if target_rid is None:
             untouched.append(row)
             continue
-        # Build a FeatureRecord shadow from just the feature-assoc
-        # columns. The generated record class is constructed by
-        # ``Feature.feature_record_class`` with ``extra="forbid"``
-        # inherited from ``FeatureRecord.Config``, so we feed only the
-        # fields the class declares — other include_tables columns are
-        # excluded. Supplementary fetch values overlay onto the
-        # wide-table row contributions, so the FeatureRecord sees RCT
-        # etc. when the wide table dropped them.
         record_kwargs: dict[str, Any] = {}
         for field_name in field_names:
             label = _label(field_name)
@@ -710,34 +727,27 @@ def _apply_selector(
         try:
             record = record_class(**record_kwargs)
         except Exception:
-            # If a row can't be coerced into the FeatureRecord (e.g.,
-            # unexpected NULL where the schema declares non-null), keep
-            # the raw row in untouched so the selector path doesn't
-            # silently eat it.
             untouched.append(row)
             continue
-        groups[target_rid].append((record, row))
+        shadows.append(record)
+        id_to_row[id(record)] = row
 
-    if not groups:
+    if not shadows:
         # No feature rows present (every materialized row was a
         # passthrough). Return verbatim so this behaves identically to
         # selector=None on a result with no feature side.
         return untouched
 
-    # Apply the selector per-group and map the chosen FeatureRecord
-    # back to its source row by identity. Built-in selectors
-    # (``select_newest``, ``select_by_execution``, etc.) always return
-    # one of the inputs, so ``is`` comparison resolves the original
-    # row deterministically. ``reduce_with_selector`` follows the same
-    # contract; we inline the loop here instead of delegating so we can
-    # walk (record, row) pairs together rather than threading an index
-    # alongside a record-only iteration.
+    # Delegate grouping + per-group selector application to the one
+    # canonical helper. ``reduce_with_selector`` groups the shadows by
+    # ``target_table_name`` (defaultdict), applies the selector per group,
+    # drops ``None`` survivors, and yields the chosen shadow *instances*
+    # (the built-in selectors return a group member, so identity holds —
+    # the helper never copies records). We map each chosen shadow back to
+    # its source dict row via ``id()``.
     reduced: list[dict[str, Any]] = []
-    for pairs in groups.values():
-        chosen = selector([rec for rec, _ in pairs])
-        if chosen is None:
-            continue
-        match = next((row for rec, row in pairs if rec is chosen), None)
+    for chosen in reduce_with_selector(shadows, target_table_name, selector):
+        match = id_to_row.get(id(chosen))
         if match is not None:
             reduced.append(match)
 

--- a/src/deriva_ml/local_db/denormalizer.py
+++ b/src/deriva_ml/local_db/denormalizer.py
@@ -609,6 +609,91 @@ class Denormalizer:
         )
         yield from result.iter_rows()
 
+    def feature_records(
+        self,
+        feature: Any,
+        *,
+        selector: Callable[[list["FeatureRecord"]], "FeatureRecord | None"] | None = None,
+    ) -> list["FeatureRecord"]:
+        """Materialize one feature's values as typed ``FeatureRecord`` instances.
+
+        Dataset-scoped feature read built on the denormalize SQL join — the
+        delegation target for :meth:`Dataset.feature_values` (Stage 3a of
+        the ``feature_values`` / ``Denormalizer`` consolidation). Runs the
+        wide-table join over ``[target_table, feature_assoc_table]``,
+        optionally reduces multi-row groups with ``selector``, then strips
+        the dotted column prefix, projects down to the ``FeatureRecord``
+        fields, recovers the ``RCT`` system column the planner skips, and
+        constructs typed records.
+
+        Unlike :meth:`as_dict` (which yields the raw wide-table dict with
+        dotted labels and no ``RCT``), this returns ``FeatureRecord``
+        objects with ``RCT`` populated — the same shape the legacy
+        PathBuilder ``feature_values`` produced.
+
+        Args:
+            feature: A :class:`~deriva_ml.feature.Feature` (from
+                ``lookup_feature``). Supplies the feature-association
+                table, the target table, and ``feature_record_class()``.
+            selector: Optional callable
+                ``(list[FeatureRecord]) -> FeatureRecord | None`` used to
+                reduce multi-row feature groups. ``None`` yields every
+                record (no reduction). See ``FeatureRecord`` for built-ins.
+
+        Returns:
+            List of ``FeatureRecord`` instances — one per surviving feature
+            row (after selector reduction, if any), with ``RCT`` populated
+            and rows whose target FK is ``None`` dropped.
+
+        Example::
+
+            feat = ml.lookup_feature("Image", "Quality")
+            d = Denormalizer(dataset)
+            records = d.feature_records(feat, selector=FeatureRecord.select_newest)
+            # records[0].Image, records[0].Quality, records[0].RCT all set
+        """
+        from deriva_ml.local_db.denormalize import materialize_feature_records
+
+        feat_table = feature.feature_table.name
+        target_table_name = feature.target_table.name
+        record_class = feature.feature_record_class()
+
+        # Run the wide-table join over the target + feature-assoc tables.
+        # row_per is the feature-assoc table so each output row is one
+        # feature value (matching the PathBuilder "one row per feature-assoc
+        # row" shape). The selector, when given, reduces multi-row groups
+        # inside _denormalize_impl before we materialize records.
+        result = self._run(
+            [target_table_name, feat_table],
+            row_per=feat_table,
+            via=None,
+            ignore_unrelated_anchors=False,
+            selector=selector,
+        )
+
+        # Recompute the (schema_for_table, multi_schema) metadata the
+        # materialization adapter needs to build/strip dotted labels.
+        # This is the same planner call _denormalize_impl makes; it is
+        # model-only (no data fetch) so the cost is negligible.
+        _, column_specs, multi_schema = self._model._planner._prepare_wide_table(
+            self._dataset,
+            self._dataset_rid,
+            [target_table_name, feat_table],
+            row_per=feat_table,
+        )
+        schema_for_table = {t: s for s, t, _c, _tp in column_specs}
+
+        return materialize_feature_records(
+            list(result.iter_rows()),
+            record_class=record_class,
+            engine=self._engine,
+            orm_resolver=self._orm_resolver,
+            feature_assoc_table=feat_table,
+            target_table_name=target_table_name,
+            schema_for_table=schema_for_table,
+            multi_schema=multi_schema,
+        )
+
     def columns(
         self,
         include_tables: list[str],

--- a/tests/local_db/test_denormalize_feature_records.py
+++ b/tests/local_db/test_denormalize_feature_records.py
@@ -1,0 +1,247 @@
+"""Tests for the ``materialize_feature_records`` adapter (Stage 3a).
+
+Stage 3a of the ``feature_values`` / ``Denormalizer`` consolidation:
+``Dataset.feature_values`` delegates to
+``Denormalizer.feature_records``, which runs the dataset-scoped
+denormalize join and then calls :func:`materialize_feature_records` to
+turn the wide-table rows into typed ``FeatureRecord`` instances with
+``RCT`` recovered from the system-column supplementary fetch.
+
+These offline unit tests exercise the pure adapter directly with
+synthetic wide-table rows over a small in-memory SQLite engine — the
+end-to-end ``Denormalizer.feature_records`` path against a live catalog
+is covered by the bit-identical live verification in the PR description.
+The adapter is where the strip-prefix-and-project, the null-target drop,
+and the RCT/UTC coercion live, so it is the unit worth pinning.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Optional
+
+import pytest
+from pydantic import create_model
+from sqlalchemy import Column, DateTime, MetaData, String, create_engine, insert
+from sqlalchemy.orm import declarative_base
+
+from deriva_ml.feature import FeatureRecord
+from deriva_ml.local_db.denormalize import materialize_feature_records
+
+FEAT_TABLE = "Execution_Image_Quality"
+TARGET = "Image"
+
+
+def _record_class() -> type[FeatureRecord]:
+    """A FeatureRecord subclass shaped like an Image/Quality feature."""
+    return create_model(
+        "ImageFeatureQuality",
+        __base__=FeatureRecord,
+        Image=(str, ...),
+        Quality=(Optional[str], None),
+    )
+
+
+@pytest.fixture
+def engine_with_feature_rows():
+    """In-memory engine holding feature-assoc rows with tz-naive RCT datetimes.
+
+    The RCT column is declared as a plain string column but populated with
+    Python ``datetime`` objects so the read-back returns tz-naive datetimes
+    — the exact shape a live-catalog SQLite round-trip produces, which the
+    UTC-coercion branch of ``_recover_system_columns`` must normalize.
+    """
+    engine = create_engine("sqlite://")
+    Base = declarative_base(metadata=MetaData())
+
+    class _Feat(Base):
+        __tablename__ = FEAT_TABLE
+        RID = Column(String, primary_key=True)
+        Image = Column(String)
+        Quality = Column(String)
+        Execution = Column(String)
+        Feature_Name = Column(String)
+        RCT = Column(DateTime)  # SQLite stores the datetime, returns it tz-naive
+
+    Base.metadata.create_all(engine)
+
+    rows = [
+        {
+            "RID": "F1",
+            "Image": "IMG-A",
+            "Quality": "good",
+            "Execution": "EXE-old",
+            "Feature_Name": "Quality",
+            "RCT": datetime(2026, 1, 1, 0, 0, 0),
+        },
+        {
+            "RID": "F2",
+            "Image": "IMG-A",
+            "Quality": "bad",
+            "Execution": "EXE-new",
+            "Feature_Name": "Quality",
+            "RCT": datetime(2026, 6, 1, 0, 0, 0),
+        },
+        {
+            "RID": "F3",
+            "Image": "IMG-B",
+            "Quality": "good",
+            "Execution": "EXE-old",
+            "Feature_Name": "Quality",
+            "RCT": datetime(2026, 1, 1, 0, 0, 0),
+        },
+    ]
+    with engine.begin() as conn:
+        conn.execute(insert(_Feat.__table__), rows)
+
+    def resolver(name: str):
+        return _Feat if name == FEAT_TABLE else None
+
+    return engine, resolver
+
+
+def _wide_rows():
+    """Wide-table rows as ``Denormalizer`` would emit them (dotted labels, no RCT).
+
+    Includes a target-table column (``Image.URL``) the FeatureRecord must
+    project away, and the feature-assoc columns the planner keeps.
+    """
+    return [
+        {
+            f"{TARGET}.RID": "IMG-A",
+            f"{TARGET}.URL": "a.png",
+            f"{FEAT_TABLE}.RID": "F1",
+            f"{FEAT_TABLE}.Image": "IMG-A",
+            f"{FEAT_TABLE}.Quality": "good",
+            f"{FEAT_TABLE}.Execution": "EXE-old",
+            f"{FEAT_TABLE}.Feature_Name": "Quality",
+        },
+        {
+            f"{TARGET}.RID": "IMG-A",
+            f"{TARGET}.URL": "a.png",
+            f"{FEAT_TABLE}.RID": "F2",
+            f"{FEAT_TABLE}.Image": "IMG-A",
+            f"{FEAT_TABLE}.Quality": "bad",
+            f"{FEAT_TABLE}.Execution": "EXE-new",
+            f"{FEAT_TABLE}.Feature_Name": "Quality",
+        },
+    ]
+
+
+def test_strip_prefix_and_project_to_feature_record(engine_with_feature_rows):
+    """Dotted labels stripped, target-table columns dropped, FeatureRecord built."""
+    engine, resolver = engine_with_feature_rows
+    records = materialize_feature_records(
+        _wide_rows(),
+        record_class=_record_class(),
+        engine=engine,
+        orm_resolver=resolver,
+        feature_assoc_table=FEAT_TABLE,
+        target_table_name=TARGET,
+        schema_for_table={TARGET: "domain", FEAT_TABLE: "deriva-ml"},
+        multi_schema=False,
+    )
+    assert len(records) == 2
+    assert all(isinstance(r, FeatureRecord) for r in records)
+    # Bare-name projection: Image / Quality / Execution populated; URL dropped.
+    assert {r.Image for r in records} == {"IMG-A"}
+    assert {r.Quality for r in records} == {"good", "bad"}
+    assert not hasattr(records[0], "URL")
+
+
+def test_rct_recovered_with_utc_offset(engine_with_feature_rows):
+    """RCT is recovered from the supplementary fetch and carries a +00:00 offset.
+
+    Pins the live-verification divergence fix: the tz-naive SQLite datetime
+    must serialize to the PathBuilder ``...+00:00`` shape, not a bare
+    offset-less ISO string.
+    """
+    engine, resolver = engine_with_feature_rows
+    records = materialize_feature_records(
+        _wide_rows(),
+        record_class=_record_class(),
+        engine=engine,
+        orm_resolver=resolver,
+        feature_assoc_table=FEAT_TABLE,
+        target_table_name=TARGET,
+        schema_for_table={TARGET: "domain", FEAT_TABLE: "deriva-ml"},
+        multi_schema=False,
+    )
+    assert all(r.RCT for r in records), [r.RCT for r in records]
+    assert all(r.RCT.endswith("+00:00") for r in records), [r.RCT for r in records]
+    # F2 (EXE-new) is the June timestamp; confirm it round-tripped correctly.
+    by_exec = {r.Execution: r.RCT for r in records}
+    assert by_exec["EXE-new"] == "2026-06-01T00:00:00+00:00"
+
+
+def test_null_target_fk_row_dropped(engine_with_feature_rows):
+    """A wide-table row whose target FK is None is dropped (audit §10)."""
+    engine, resolver = engine_with_feature_rows
+    rows = _wide_rows()
+    # Simulate the Denormalizer LEFT-JOIN orphan: target FK is None.
+    rows.append(
+        {
+            f"{TARGET}.RID": None,
+            f"{TARGET}.URL": None,
+            f"{FEAT_TABLE}.RID": "F-orphan",
+            f"{FEAT_TABLE}.Image": None,
+            f"{FEAT_TABLE}.Quality": "ghost",
+            f"{FEAT_TABLE}.Execution": "EXE-x",
+            f"{FEAT_TABLE}.Feature_Name": "Quality",
+        }
+    )
+    records = materialize_feature_records(
+        rows,
+        record_class=_record_class(),
+        engine=engine,
+        orm_resolver=resolver,
+        feature_assoc_table=FEAT_TABLE,
+        target_table_name=TARGET,
+        schema_for_table={TARGET: "domain", FEAT_TABLE: "deriva-ml"},
+        multi_schema=False,
+    )
+    # Orphan dropped — only the two real rows survive.
+    assert len(records) == 2
+    assert "ghost" not in {r.Quality for r in records}
+
+
+def test_multi_schema_label_prefix(engine_with_feature_rows):
+    """Multi-schema labels (``schema.Table.col``) are stripped correctly."""
+    engine, resolver = engine_with_feature_rows
+    rows = [
+        {
+            f"domain.{TARGET}.RID": "IMG-A",
+            f"domain.{TARGET}.URL": "a.png",
+            f"deriva-ml.{FEAT_TABLE}.RID": "F1",
+            f"deriva-ml.{FEAT_TABLE}.Image": "IMG-A",
+            f"deriva-ml.{FEAT_TABLE}.Quality": "good",
+            f"deriva-ml.{FEAT_TABLE}.Execution": "EXE-old",
+            f"deriva-ml.{FEAT_TABLE}.Feature_Name": "Quality",
+        },
+    ]
+    records = materialize_feature_records(
+        rows,
+        record_class=_record_class(),
+        engine=engine,
+        orm_resolver=resolver,
+        feature_assoc_table=FEAT_TABLE,
+        target_table_name=TARGET,
+        schema_for_table={TARGET: "domain", FEAT_TABLE: "deriva-ml"},
+        multi_schema=True,
+    )
+    assert len(records) == 1
+    assert records[0].Image == "IMG-A"
+    assert records[0].Quality == "good"
+    assert records[0].RCT.endswith("+00:00")
+
+
+def test_naive_datetime_iso_matches_pathbuilder_shape() -> None:
+    """A tz-naive datetime and the same instant tz-aware serialize identically.
+
+    Pins the specific fix for the live-verification divergence at the
+    serialization level.
+    """
+    naive = datetime(2026, 6, 1, 12, 30, 0)
+    aware = naive.replace(tzinfo=timezone.utc)
+    assert naive.replace(tzinfo=timezone.utc).isoformat() == aware.isoformat()
+    assert aware.isoformat().endswith("+00:00")


### PR DESCRIPTION
## Summary

Stage 3a of the `feature_values` / `Denormalizer` consolidation. The
architectural goal is to **minimize the number of different ways the same
functionality is implemented so as to improve robustness** — the
dataset-scoped feature read now leans on the denormalize SQL join instead
of a second hand-rolled "PathBuilder fetch the whole catalog, then filter
in Python" path.

`Dataset.feature_values` now delegates to a new
`Denormalizer.feature_records()`, which runs the dataset-scoped denormalize
join over `[target, feature-assoc]` tables, optionally reduces with a
`selector`, recovers the `RCT` system column the planner skips, strips the
dotted column prefix, projects down to the `FeatureRecord` fields, and
constructs typed `FeatureRecord` instances with `RCT` populated.

**This is Stage 3a — ONLY `Dataset.feature_values`:**

- ✅ `Dataset.feature_values` delegates to `Denormalizer.feature_records`.
- ❌ `DerivaML.feature_values` is **unchanged** — it stays on PathBuilder.
  It is a catalog-wide read with no `Dataset` anchor, so it has no
  `Denormalizer` analogue (finding 08 §7, the blocker). This is deliberate.
- ❌ `DatasetBag.feature_values` is **unchanged** — that is Stage 3b, gated
  on live bag verification of the array/datetime divergence (finding 08 §8).
  `BagFeatureCache` is not touched.

The consolidation eliminates one of two dataset-scoped feature-read
implementations: `Dataset.feature_values` no longer does its own
Python-side member filtering after a catalog-wide fetch — it shares the
`Denormalizer` SQL-join path.

A `_recover_system_columns` helper is extracted from PR #257's
`_apply_selector` (the supplementary RCT fetch) so the selector path and
the new no-selector delegation both recover RCT through one place.
`Denormalizer.as_dict`'s contract is **not** widened.

Source: `/Users/carl/GitHub/DerivaML/deriva-ml-model-template-e2e/findings/investigation/08-feature-values-delegation-audit.md`

## Test plan

- `uv run ruff check src tests && uv run ruff format src tests` — clean.
- Offline unit tests:
  - `tests/local_db/test_denormalize_feature_records.py` (new) — 5 passed:
    strip-prefix-and-project, RCT-recovered-with-UTC-offset, null-target
    drop, multi-schema label prefix, datetime→ISO shape.
  - `tests/local_db/test_denormalize_selector.py` — 7 passed (the
    `_apply_selector` refactor preserves the selector path, incl. the
    `select_newest` supplementary-RCT-fetch dependency).
- `tests/feature/test_feature_values.py::test_dataset_feature_values_filters_to_members`
  — PASS (dataset-scoping regression gate: non-member RIDs excluded).
- **Live verification — bit-identical old-vs-new** on dev-localhost catalog
  27, dataset M16 (cifar10_training, 550 images), feature
  `Image_Classification` (target `Image`, feature-assoc
  `Execution_Image_Image_Classification`). The catalog carries
  multi-row-per-image values from two executions (`HSR`: 550 GT rows,
  `854`: 250 prediction rows = 800 total). Baseline captured on pristine
  `origin/main` before the refactor; compared after:

  ```
  [Case 1] selector=None (every raw record, dataset-scoped)
    PASS same row count — old=800 new=800
    PASS same (Image, Image_Class, Execution) set
    PASS RCT populated on every NEW record — missing=0
    PASS same (Image, Execution) keys
    PASS all comparable fields equal — mismatches=[]
  [Case 2] selector=FeatureRecord.select_newest (one record per Image)
    PASS same row count — old=550 new=550
    PASS same Image set
    PASS same selection (Image_Class, Execution, RCT) per Image — mismatches=[]
    PASS RCT populated on every NEW selected record
  [Case 3] execution_rids=[<HSR>] filter
    PASS same top_exec chosen — old=HSR new=HSR
    PASS same row count — old=550 new=550
    PASS same (Image, Image_Class, Execution) set
    PASS all rows match the requested execution
  [Case 4] execution_rids=[] (short-circuit to empty)
    PASS OLD returns empty — old=0
    PASS NEW returns empty — new=0
  [Inventory]
    execs present old=['854', 'HSR'] new=['854', 'HSR']
    exec_counts old={'854': 250, 'HSR': 550} new={'854': 250, 'HSR': 550}
  RESULT: BIT-IDENTICAL — all checks pass
  ```

  Sample record (old vs new, byte-identical):
  ```
  old: {"Confidence": null, "Execution": "854", "Feature_Name": "Image_Classification",
        "Image": "47Y", "Image_Class": "truck",
        "RCT": "2026-05-28T16:52:50.189559+00:00", "_type": "ImageFeatureImage_Classification"}
  new: {"Confidence": null, "Execution": "854", "Feature_Name": "Image_Classification",
        "Image": "47Y", "Image_Class": "truck",
        "RCT": "2026-05-28T16:52:50.189559+00:00", "_type": "ImageFeatureImage_Classification"}
  ```

  The verification **caught one divergence on the first pass** — the `RCT`
  recovered from the local SQLite engine came back tz-naive
  (`...232194`, no offset) where the PathBuilder path returns
  `...232194+00:00`. Fixed by re-attaching UTC in `_recover_system_columns`
  (Deriva `timestamptz` is UTC; the SQLite round-trip drops the tzinfo).
  Re-verified bit-identical. Pinned by `test_rct_recovered_with_utc_offset`.

Pre-existing failures unaffected by this change (reproduced on pristine
`origin/main` with the refactor stashed): `test_features.py::test_list_workflow_executions_returns_matching_rids`
(`assert '4B4' in []`) and the `TestFeatureValuesSymmetry` setup errors
(`'Workflow' object has no attribute 'rid'` — a stale fixture). Both are in
`list_workflow_executions` / the symmetry fixture, not in any code this PR
touches.

## Behavior notes

These three behaviors change shape (documented in the
`Dataset.feature_values` docstring):

1. **`execution_rids` is now post-filtered in Python** (finding 08 §6). The
   denormalize join has no server-side `Execution` predicate, so the
   round-trip-savings the PathBuilder filter provided are traded for one
   consolidated SQL-join implementation. The filter runs *before* selector
   reduction, matching the legacy ordering. The `execution_rids=[]`
   short-circuit-to-empty is preserved explicitly (finding 08 §10).
2. **`materialize_limit` is now a post-count guard** (finding 08 §5): rows
   are materialized, counted, then `DerivaMLMaterializeLimitExceeded` is
   raised past the cap. Weaker than the legacy server-side cap, but no worse
   than the full PathBuilder materialization the wrapper did before.
3. **Null target-FK rows are explicitly dropped** (finding 08 §10) so the
   Denormalizer's LEFT-JOIN emit can't surface a `target=None` record the
   PathBuilder path never returned.

## Follow-up — selector-reduction duplication resolved (commit 37b3fa21)

The review flagged that two grouping loops still applied a selector by
target RID after Stage 3a: the canonical `reduce_with_selector`
(`feature.py`) and `_apply_selector`'s own `defaultdict` loop over
`(record, row)` pairs (`local_db/denormalize.py`). `_apply_selector`'s
inline comment even admitted it: *"reduce_with_selector follows the same
contract; we inline the loop here instead of delegating."*

`_apply_selector` now **delegates** grouping + per-group selector
application to `reduce_with_selector`. The only piece that stays is the
`_apply_selector`-specific identity remap that recovers the wide-table
dict row after the selector picks a `FeatureRecord` shadow. That remap is
keyed by **`id(shadow)`**, not the shadow object — `FeatureRecord` is a
pydantic model with value-based equality, so two distinct source rows
that build value-equal shadows would collide in a record-keyed dict and
mis-map rows under duplicate feature values. `reduce_with_selector`
yields the exact instances it was given (built-in selectors return a
group member; the helper never copies), so `id(chosen)` resolves the
right row deterministically.

The untouched / null-target partition is preserved exactly:
`reduce_with_selector` *drops* None-target records, whereas
`_apply_selector` must *pass through* the source row — so rows with a
null target (and rows whose `FeatureRecord` construction raises) are
partitioned out into `untouched` before the delegation, never fed in.

Live re-verified against dev-localhost catalog 27 (M16, 550 Images, 800
`Image_Classification` rows — 250 Images carry duplicate feature rows,
the case that exposes identity-map bugs). `_apply_selector` with
`select_newest`, before vs after: identical 800->550 reduction, identical
target->selected-feature-RID mapping (zero divergence), identical per-row
`Image_Class` / `Confidence` / `Execution`, all 550 selected RIDs
distinct (no mis-mapping). All 12 direct-gate tests
(`test_denormalize_selector.py` + `test_denormalize_feature_records.py`)
and the full `local_db` suite (313 passed, 3 skipped) stay green.

`reduce_with_selector`, `materialize_feature_records`, `feature_records`,
and `Dataset.feature_values` are unchanged. This completes the
selector-reduction consolidation this PR started: one grouping algorithm
now backs every selector path.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

