### PR TITLE
fix(planner): recognize 4-FK feature tables in _is_feature_association

### DIFF
--- a/src/deriva_ml/model/denormalize_planner.py
+++ b/src/deriva_ml/model/denormalize_planner.py
@@ -25,17 +25,20 @@ planner treats two kinds of tables as transparent:
    them in both directions so ``A → assoc → B`` discovers B from A.
 
 2. **Feature association tables** (DerivaML feature value tables):
-   :meth:`DenormalizePlanner._is_feature_association`. Three domain
-   FKs, exactly one of which targets the ML schema's ``Execution``
-   table; the other two are the feature's target domain table and a
-   vocabulary / value table. Examples:
+   :meth:`DenormalizePlanner._is_feature_association`. The association
+   ``create_feature`` builds — at least four domain FKs: the feature's
+   target domain table, one or more value FKs (vocabulary term / asset
+   / metadata), an FK to the ML schema's ``Feature_Name`` vocab, and an
+   FK to the ML schema's ``Execution`` table. The ``Feature_Name`` and
+   ``Execution`` FKs are the two reliable structural markers (the
+   predicate keys off them, not the FK count). Examples:
    ``Execution_Image_Image_Classification``,
    ``Execution_Subject_Diagnosis``. These exist to record one
    feature value per (target, execution) — the Execution FK is an
-   audit / provenance edge, *not* a domain edge that callers ever
-   want to filter on. From the planner's denormalization perspective
-   they behave like a pure 2-FK bridge between the target and the
-   value table.
+   audit / provenance edge and the Feature_Name FK identifies the
+   feature, *not* domain edges that callers ever want to filter on.
+   From the planner's denormalization perspective they behave like a
+   pure 2-FK bridge between the target and the value table.
 
 In both cases, transparency means:
 
@@ -52,11 +55,12 @@ In both cases, transparency means:
 
 What is intentionally **not** transparent:
 
-- 4+ FK tables (multi-way associations the caller has to disambiguate
-  by hand).
-- 3-FK domain-only tables that don't reference ``Execution`` (these
-  are genuine 3-way associations whose third FK is a domain
-  semantic, not provenance, and the caller should signal intent).
+- Multi-way domain associations that lack the feature marker FKs
+  (no FK to ``Feature_Name`` and/or ``Execution``) — even when they
+  carry an ``Execution`` provenance edge, an association without a
+  ``Feature_Name`` FK is a genuine multi-way join whose extra edges
+  are domain semantics, not feature plumbing, and the caller should
+  signal intent.
 - Tables that satisfy neither predicate. The planner treats anything
   not in ``include_tables`` / ``via`` and not transparent as a dead
   end during reachability — that's how it stops itself from sliding
@@ -125,9 +129,9 @@ The methods compose in three layers, lowest first:
   with cycle detection and vocab termination.
 - :meth:`DenormalizePlanner._is_topological_association` — 2-FK
   predicate (pure M:N bridges).
-- :meth:`DenormalizePlanner._is_feature_association` — 3-FK predicate
-  (one FK targets the ML schema's ``Execution`` table; the other two
-  are domain/value edges).
+- :meth:`DenormalizePlanner._is_feature_association` — feature predicate
+  (one FK targets the ML schema's ``Feature_Name`` vocab and one targets
+  the ML schema's ``Execution`` table; the rest are domain/value edges).
 - :meth:`DenormalizePlanner._is_transparent_intermediate` — union of
   the two predicates; this is what the reachability primitives consult.
 - :meth:`DenormalizePlanner._table_relationship` — column-pair
@@ -388,34 +392,51 @@ class DenormalizePlanner:
     def _is_feature_association(self, name_or_table: str | Table) -> bool:
         """Predicate for DerivaML feature-association transparency.
 
-        A feature-association table is a 3-FK association whose third
-        FK is the DerivaML ``Execution`` provenance edge — the other
-        two FKs are the feature's *target* domain table (the entity
-        the feature is attached to) and a *value* table (a vocabulary
-        term, an asset, or a metadata table). Concrete example::
+        A feature-association table is the association
+        :meth:`~deriva_ml.core.mixins.feature.FeatureMixin.create_feature`
+        builds for every feature. Its canonical FK set is::
 
             Execution_Image_Image_Classification
                 -> Image                    (feature target)
-                -> Image_Classification     (value: vocab term)
-                -> Execution                (provenance / audit)
+                -> Image_Class              (value: vocab term, asset, or metadata)
+                -> Feature_Name             (-> ML Feature_Name vocab)
+                -> Execution                (-> ML Execution, provenance / audit)
 
-        The Execution FK is structurally an audit edge, not a domain
-        edge — it records *which run* asserted the value, not a
-        semantic relationship a caller would ever join through. The
-        denormalization planner therefore treats feature-association
-        tables as transparent in the same sense as topological 2-FK
-        associations: the planner hops through them in both directions
-        during reachability, and they don't count as interior tables
-        when checking for diamond ambiguity.
+        That is **four or more domain FKs**: the target domain table,
+        one or more value FKs (a vocabulary term, an asset, or a
+        metadata table), the ``Feature_Name`` vocabulary FK, and the
+        ``Execution`` provenance FK. ``create_feature`` always emits
+        the ``Feature_Name`` and ``Execution`` FKs, so they are the two
+        reliable structural markers of a feature; the target and value
+        FKs vary per feature, so their *count* is not a usable
+        discriminator.
+
+        The ``Execution`` FK is an audit edge (it records *which run*
+        asserted the value), and the ``Feature_Name`` FK identifies the
+        feature — neither is a semantic relationship a caller would
+        ever join through. The denormalization planner therefore treats
+        feature-association tables as transparent in the same sense as
+        topological 2-FK associations: the planner hops through them in
+        both directions during reachability, and they don't count as
+        interior tables when checking for diamond ambiguity.
+
+        **Keyed off the marker FKs, not the FK count.** This predicate
+        deliberately mirrors ``DerivaModel.find_features``'s
+        ``is_feature`` column-presence test (``model/catalog.py``) —
+        the DerivaML-native definition of a feature — by requiring an
+        FK to the ML schema's ``Feature_Name`` vocab AND an FK to the
+        ML schema's ``Execution`` table. An FK-count equality check is
+        wrong: the value FKs make every real feature ≥4 domain FKs, and
+        ``create_feature`` cannot produce a 3-FK feature.
 
         **Why we don't widen** :meth:`_is_topological_association` **instead**:
         the 2-FK predicate is intentionally strict because the diamond
         rule (Rule 6) uses it. Conflating "transparent bridge" with
-        "feature with audit edge" inside a single predicate makes the
-        rule docs harder to read and risks accidentally treating other
-        3-FK shapes as transparent in the future. The two predicates
-        compose at the call sites (mostly
-        :meth:`_outbound_reachable`) where transparency is consulted.
+        "feature" inside a single predicate makes the rule docs harder
+        to read and risks accidentally treating other multi-FK shapes
+        as transparent in the future. The two predicates compose at the
+        call sites (mostly :meth:`_outbound_reachable`) where
+        transparency is consulted.
 
         **Structural, not naming.** The predicate ignores the table
         name (``Execution_*`` is a convention, not a contract) and
@@ -428,17 +449,21 @@ class DenormalizePlanner:
                 instance.
 
         Returns:
-            ``True`` if the table has exactly 3 domain FKs and exactly
-            one of them targets the ML schema's ``Execution`` table.
+            ``True`` if the table has exactly one FK to the ML schema's
+            ``Feature_Name`` vocab AND exactly one FK to the ML schema's
+            ``Execution`` table.
 
         Example::
 
+            # Real 4-FK feature: target + value + Feature_Name + Execution.
             planner._is_feature_association(
                 "Execution_Image_Image_Classification"
             )                                                          # True
-            planner._is_feature_association("Dataset_Image")           # False (2 FKs)
-            planner._is_feature_association("Image")                   # False (no Execution FK)
-            planner._is_feature_association("Three_Way_Domain_Assoc")  # False (no FK to Execution)
+            planner._is_feature_association("Dataset_Image")           # False (2-FK assoc)
+            planner._is_feature_association("Image")                   # False (no marker FKs)
+            # 4-FK domain association WITHOUT a Feature_Name FK
+            # (e.g. an Execution-stamped multi-way join) is not a feature.
+            planner._is_feature_association("FourWayAssoc")            # False (no Feature_Name FK)
         """
         # Same narrowing as ``_is_topological_association``: only
         # ``DerivaMLException`` from ``name_to_table`` is the
@@ -452,13 +477,23 @@ class DenormalizePlanner:
         # Domain FKs exclude the system FKs to ERMrest_Client /
         # ERMrest_Group that every table carries (for RCB/RMB).
         domain_fks = [fk for fk in fks if fk.pk_table.name not in ("ERMrest_Client", "ERMrest_Group")]
-        if len(domain_fks) != 3:
-            return False
+        # Key off the two defining markers of a DerivaML feature, NOT
+        # the FK count: an FK to the ML schema's ``Feature_Name`` vocab
+        # AND an FK to the ML schema's ``Execution`` table. This mirrors
+        # ``DerivaModel.find_features``'s ``is_feature`` column-presence
+        # test (see model/catalog.py) so the planner and the rest of
+        # deriva-ml agree on what a feature is. A real feature carries
+        # ``target + value(s) + Feature_Name + Execution`` — at least 4
+        # domain FKs — so an FK-count equality check (the original
+        # ``!= 3`` guard) rejected every real feature table.
         ml_schema = self.model.ml_schema
         execution_fks = [
             fk for fk in domain_fks if fk.pk_table.name == "Execution" and fk.pk_table.schema.name == ml_schema
         ]
-        return len(execution_fks) == 1
+        feature_name_fks = [
+            fk for fk in domain_fks if fk.pk_table.name == "Feature_Name" and fk.pk_table.schema.name == ml_schema
+        ]
+        return len(execution_fks) == 1 and len(feature_name_fks) == 1
 
     def _is_transparent_intermediate(self, name_or_table: str | Table) -> bool:
         """Return ``True`` if the table is transparent (assoc or feature-assoc).
@@ -482,7 +517,7 @@ class DenormalizePlanner:
             planner._is_transparent_intermediate(
                 "Execution_Image_Image_Classification"
             )
-            # True — 3-FK feature association.
+            # True — feature association (Feature_Name + Execution FKs).
 
             planner._is_transparent_intermediate("Image")
             # False — domain table, not a bridge.
@@ -616,9 +651,10 @@ class DenormalizePlanner:
         table) wouldn't be traversable.
 
         Both topological 2-FK associations (e.g. ``Dataset_Image``)
-        and 3-FK feature associations (e.g.
-        ``Execution_Image_Image_Classification``, where the third FK
-        is the audit edge to ``Execution``) count as transparent —
+        and feature associations (e.g.
+        ``Execution_Image_Image_Classification``, marked by FKs to the
+        ML schema's ``Feature_Name`` vocab and ``Execution`` table)
+        count as transparent —
         see the module docstring's "Transparency model" section.
 
         **Direction matters**: with ``Image.Subject → Subject.RID``:
@@ -835,13 +871,9 @@ class DenormalizePlanner:
 
         # Resolve defaults.
         exclude_names = exclude_tables or set()
-        skip_names = (
-            skip_tables if skip_tables is not None else _DEFAULT_SKIP_TABLES
-        )
+        skip_names = skip_tables if skip_tables is not None else _DEFAULT_SKIP_TABLES
         if root is None:
-            root = self.model.model.schemas[self.model.ml_schema].tables[
-                "Dataset"
-            ]
+            root = self.model.model.schemas[self.model.ml_schema].tables["Dataset"]
 
         # Scope to the domain schemas plus the ML schema — the same
         # filter the legacy ``_fk_neighbors`` enforced.
@@ -851,9 +883,7 @@ class DenormalizePlanner:
         # rules: skip-table exclusion (Dataset_Dataset / Execution by
         # default), caller-supplied exclude_tables, and nested-dataset
         # loopback prevention.
-        dataset_table = (
-            self.model.model.schemas[self.model.ml_schema].tables["Dataset"]
-        )
+        dataset_table = self.model.model.schemas[self.model.ml_schema].tables["Dataset"]
 
         def edge_filter(src: Table, tgt: Table) -> bool:
             # Schema scope is handled by the walker (via policy.schemas),
@@ -868,10 +898,7 @@ class DenormalizePlanner:
             # ``Dataset → Dataset_X → ...`` (the intended outbound
             # direction) but prevents the inverse walk back to the
             # root through an element association.
-            if (
-                src is not dataset_table
-                and self._is_topological_association(tgt)
-            ):
+            if src is not dataset_table and self._is_topological_association(tgt):
                 for fk in tgt.foreign_keys:
                     if fk.pk_table is dataset_table:
                         return False
@@ -884,9 +911,7 @@ class DenormalizePlanner:
             edge_filter=edge_filter,
         )
 
-        prefixes = walker.walk_all_prefixes(
-            root=root, max_depth=max_depth, stop_at=stop_at
-        )
+        prefixes = walker.walk_all_prefixes(root=root, max_depth=max_depth, stop_at=stop_at)
 
         # Convert tuples to lists for compatibility with existing
         # callers (they iterate and slice freely).
@@ -1473,7 +1498,7 @@ class DenormalizePlanner:
             #
             # We detect transparent intermediates via
             # ``self._is_transparent_intermediate`` (the union of the
-            # 2-FK topological-association predicate and the 3-FK
+            # 2-FK topological-association predicate and the
             # feature-association predicate; both ignore ERMrest system FKs).
 
             def _intermediates_covered(sp: list[Table], ints: tuple[str, ...]) -> bool:

--- a/tests/local_db/conftest.py
+++ b/tests/local_db/conftest.py
@@ -438,18 +438,23 @@ def denorm_schema_feature(tmp_path: Path) -> Path:
     Extends :func:`denorm_schema` by adding:
 
     - ``Execution`` table in the ``deriva-ml`` schema (provenance).
+    - ``Feature_Name`` vocabulary table in the ``deriva-ml`` schema
+      (one of the two feature marker FK targets).
     - ``Image_Classification`` vocabulary table in the ``isa`` schema
       (the value table — i.e. the term).
     - ``Execution_Image_Image_Classification`` association table with
-      three FKs (Image, Execution, Image_Classification) and a
-      ``Feature_Name`` column. This is the canonical shape of a
-      DerivaML feature value table — see ``DerivaModel.find_features``
-      for the runtime predicate.
+      **four** domain FKs (Image, Image_Classification, Feature_Name,
+      Execution). This is the canonical real shape of a DerivaML
+      feature value table — exactly what ``create_feature`` produces.
+      The Feature_Name FK + Execution FK are the structural markers
+      ``_is_feature_association`` keys off; see
+      ``DerivaModel.find_features`` for the equivalent runtime
+      predicate.
 
     Plus a *non-feature* 3-FK association,
     ``Image_Subject_UnrelatedThing``, with three domain FKs but no
-    FK to ``Execution`` — used to verify
-    :meth:`_is_feature_association` correctly rejects 3-FK associations
+    FK to ``Execution`` or ``Feature_Name`` — used to verify
+    :meth:`_is_feature_association` correctly rejects associations
     that aren't features.
 
     Used by the planner-rules tests in
@@ -504,6 +509,28 @@ def denorm_schema_feature(tmp_path: Path) -> Path:
         "foreign_keys": [],
     }
 
+    # Add Feature_Name vocabulary table (deriva-ml schema). Every
+    # DerivaML feature-association table carries an FK to this vocab —
+    # it's one of the two structural markers
+    # ``_is_feature_association`` keys off (the other is the Execution
+    # FK). See ``DerivaModel.find_features``'s is_feature predicate and
+    # ``FeatureMixin.create_feature`` (which always adds this FK).
+    doc["schemas"]["deriva-ml"]["tables"]["Feature_Name"] = {
+        "table_name": "Feature_Name",
+        "schema_name": "deriva-ml",
+        "column_definitions": [
+            {"name": "RID", "type": {"typename": "text"}, "nullok": False},
+            {"name": "RCT", "type": {"typename": "timestamptz"}},
+            {"name": "RMT", "type": {"typename": "timestamptz"}},
+            {"name": "RCB", "type": {"typename": "text"}},
+            {"name": "RMB", "type": {"typename": "text"}},
+            {"name": "Name", "type": {"typename": "text"}, "nullok": False},
+            {"name": "Description", "type": {"typename": "text"}, "nullok": True},
+        ],
+        "keys": [{"unique_columns": ["RID"]}, {"unique_columns": ["Name"]}],
+        "foreign_keys": [],
+    }
+
     # Add Image_Classification vocabulary term table (isa schema)
     doc["schemas"]["isa"]["tables"]["Image_Classification"] = {
         "table_name": "Image_Classification",
@@ -522,9 +549,18 @@ def denorm_schema_feature(tmp_path: Path) -> Path:
     }
 
     # Add Execution_Image_Image_Classification feature-assoc table.
-    # Three domain FKs: Image, Execution, Image_Classification.
-    # Includes a Feature_Name column to match the DerivaML runtime
-    # predicate (DerivaModel.find_features's is_feature check).
+    # Four domain FKs — the canonical real DerivaML feature shape:
+    #   Image                (feature target)
+    #   Image_Classification (value: vocab term)
+    #   Feature_Name         (-> deriva-ml.Feature_Name vocab)
+    #   Execution            (-> deriva-ml.Execution, provenance)
+    # The Feature_Name FK + Execution FK are the two structural markers
+    # ``_is_feature_association`` keys off (mirroring
+    # ``DerivaModel.find_features``'s is_feature check). This matches
+    # what ``FeatureMixin.create_feature`` actually produces; an earlier
+    # version of this fixture modeled Feature_Name as a plain text
+    # column and gave the table only 3 FKs, which is why the 4-FK
+    # predicate bug shipped green (see finding 09).
     doc["schemas"]["deriva-ml"]["tables"]["Execution_Image_Image_Classification"] = {
         "table_name": "Execution_Image_Image_Classification",
         "schema_name": "deriva-ml",
@@ -560,6 +596,18 @@ def denorm_schema_feature(tmp_path: Path) -> Path:
                     }
                 ],
                 "referenced_columns": [{"schema_name": "deriva-ml", "table_name": "Execution", "column_name": "RID"}],
+            },
+            {
+                "foreign_key_columns": [
+                    {
+                        "schema_name": "deriva-ml",
+                        "table_name": "Execution_Image_Image_Classification",
+                        "column_name": "Feature_Name",
+                    }
+                ],
+                "referenced_columns": [
+                    {"schema_name": "deriva-ml", "table_name": "Feature_Name", "column_name": "Name"}
+                ],
             },
             {
                 "foreign_key_columns": [
@@ -683,6 +731,55 @@ def denorm_feature_deriva_model(denorm_feature_model: Model) -> DerivaModel:
     """DerivaModel for the feature-association fixture."""
     return DerivaModel(
         model=denorm_feature_model,
+        ml_schema="deriva-ml",
+        domain_schemas={"isa"},
+    )
+
+
+@pytest.fixture
+def denorm_schema_feature_diamond(denorm_schema_feature: Path, tmp_path: Path) -> Path:
+    """Feature fixture + a *second* independent FK path target↔value.
+
+    Builds the "diamond-with-feature-bridge" shape (finding 09 §7.1,
+    §10 limitation #2): ``Image`` reaches ``Image_Classification`` via
+    **two** routes —
+
+    1. the transparent feature bridge
+       ``Execution_Image_Image_Classification`` (4-FK feature), and
+    2. a direct ``Image.Image_Classification`` FK.
+
+    Under the old (broken) predicate the feature bridge was opaque, so
+    Rule 6 saw only the direct path and planned silently. Under the
+    Option E2 predicate the bridge is transparent and hops in
+    ``_is_downstream_chain``, so Rule 6 now sees two competing
+    downstream chains from ``Image`` to ``Image_Classification`` and
+    must raise ``DerivaMLDenormalizeAmbiguousPath``. This fixture pins
+    that intentional new behavior.
+    """
+    # Start from the JSON the feature fixture already wrote, then add a
+    # direct Image → Image_Classification FK to create the second path.
+    doc = json.loads(denorm_schema_feature.read_text())
+    image = doc["schemas"]["isa"]["tables"]["Image"]
+    image["column_definitions"].append({"name": "Image_Classification", "type": {"typename": "text"}, "nullok": True})
+    image["foreign_keys"].append(
+        {
+            "foreign_key_columns": [
+                {"schema_name": "isa", "table_name": "Image", "column_name": "Image_Classification"}
+            ],
+            "referenced_columns": [{"schema_name": "isa", "table_name": "Image_Classification", "column_name": "RID"}],
+        }
+    )
+
+    out = tmp_path / "schema_feature_diamond.json"
+    out.write_text(json.dumps(doc))
+    return out
+
+
+@pytest.fixture
+def denorm_feature_diamond_deriva_model(denorm_schema_feature_diamond: Path) -> DerivaModel:
+    """DerivaModel for the diamond-with-feature-bridge fixture."""
+    return DerivaModel(
+        model=Model.fromfile("file-system", denorm_schema_feature_diamond),
         ml_schema="deriva-ml",
         domain_schemas={"isa"},
     )

--- a/tests/local_db/test_denormalize_impl.py
+++ b/tests/local_db/test_denormalize_impl.py
@@ -407,6 +407,12 @@ class TestRowCompletenessInvariant:
             cls_cls = ls.get_orm_class("Image_Classification")
             session.add(cls_cls(RID=cls_rid, Name="cat"))
 
+            # Feature_Name is now an FK to deriva-ml.Feature_Name.Name
+            # (the real 4-FK feature shape), so the term must exist
+            # before the feature rows reference it.
+            fn_cls = ls.get_orm_class("Feature_Name")
+            session.add(fn_cls(RID="FN-default", Name="default"))
+
             feat_cls = ls.get_orm_class("Execution_Image_Image_Classification")
             for img in path_b_image_rids:
                 session.add(

--- a/tests/local_db/test_denormalize_selector.py
+++ b/tests/local_db/test_denormalize_selector.py
@@ -83,6 +83,13 @@ def populated_feature_denorm(
         cls_cls = ls.get_orm_class("Image_Classification")
         session.add(cls_cls(RID=cls_rid, Name="cat"))
 
+        # Feature_Name vocab term the feature-assoc rows reference. The
+        # feature-assoc table's Feature_Name column is now an FK to
+        # deriva-ml.Feature_Name.Name (the real 4-FK feature shape), so
+        # the term has to exist before the feature rows are inserted.
+        fn_cls = ls.get_orm_class("Feature_Name")
+        session.add(fn_cls(RID="FN-default", Name="default"))
+
         feat_cls = ls.get_orm_class("Execution_Image_Image_Classification")
         for img_rid in image_rids:
             for erid in exec_rids:
@@ -381,3 +388,89 @@ class TestSelectorPlumbing:
             selector=FeatureRecord.select_newest,
         )
         assert len(df) == len(image_rids)
+
+
+# ----------------------------------------------------------------------
+# Regression guard: the selector path must ENGAGE on a real 4-FK feature
+# (finding 09 — the predicate originally rejected every real feature, so
+# the Stage 1 selector raised "no feature-association table" on real
+# catalogs and was dead on arrival).
+# ----------------------------------------------------------------------
+
+
+class TestSelectorEngagesOnRealFourFkFeature:
+    """The selector gate recognizes a real 4-FK feature-association table.
+
+    The fixture's ``Execution_Image_Image_Classification`` now carries
+    the real four domain FKs (Image, Image_Classification, Feature_Name,
+    Execution). This class proves the selector path engages on that
+    shape — the regression guard so the predicate bug (a 3-FK count
+    check that rejected every real feature) can't silently kill the
+    selector again.
+    """
+
+    def test_fixture_feature_table_is_four_fk(self, populated_feature_denorm: dict[str, Any]) -> None:
+        """Sanity: the fixture models the real 4-FK shape, not the old 3-FK one."""
+        model = populated_feature_denorm["model"]
+        feature_assoc = populated_feature_denorm["feature_assoc_table"]
+        tbl = model.name_to_table(feature_assoc)
+        domain_fks = [fk for fk in tbl.foreign_keys if fk.pk_table.name not in ("ERMrest_Client", "ERMrest_Group")]
+        targets = sorted(fk.pk_table.name for fk in domain_fks)
+        assert targets == ["Execution", "Feature_Name", "Image", "Image_Classification"], (
+            f"fixture must model the real 4-FK feature shape; got domain FK targets {targets}"
+        )
+        # The predicate must recognize it (it would have returned False
+        # under the old !=3 count guard).
+        assert model._planner._is_feature_association(feature_assoc)
+
+    def test_selector_engages_and_reduces_on_real_shape(self, populated_feature_denorm: dict[str, Any]) -> None:
+        """as_dict(selector=...) engages (no ValueError) and reduces to one row per target.
+
+        Before the fix, the selector gate at ``denormalize.py`` would
+        raise ``ValueError: selector requires a feature-association
+        table ...`` because ``_is_feature_association`` returned False
+        for the real 4-FK table. This test fails closed if that gate
+        ever stops recognizing the real shape.
+        """
+        from deriva_ml.local_db.denormalizer import Denormalizer
+
+        model = populated_feature_denorm["model"]
+        ls = populated_feature_denorm["local_schema"]
+        ds_rid = populated_feature_denorm["dataset_rid"]
+        image_rids = populated_feature_denorm["image_rids"]
+        feature_assoc = populated_feature_denorm["feature_assoc_table"]
+        newest_exec = populated_feature_denorm["newest_execution"]
+
+        class _Shim:
+            def __init__(self, m: Any) -> None:
+                self.dataset_rid = ds_rid
+                self.model = m
+                self.engine = ls.engine
+                self._orm_resolver = ls.get_orm_class
+
+            def list_dataset_members(self, **_kwargs: Any) -> dict[str, list[dict]]:
+                return {"Image": [{"RID": r} for r in image_rids]}
+
+            def list_dataset_children(self, **_kwargs: Any) -> list:
+                return []
+
+        d = Denormalizer(_Shim(model))
+        # Must NOT raise the "no feature-association table" ValueError.
+        rows = list(
+            d.as_dict(
+                ["Image", feature_assoc],
+                row_per=feature_assoc,
+                selector=FeatureRecord.select_newest,
+            )
+        )
+        target_label = f"{feature_assoc}.Image"
+        exec_label = f"{feature_assoc}.Execution"
+        assert len(rows) == len(image_rids), (
+            f"selector should reduce the multi-row feature to one row per Image ({len(image_rids)}); got {len(rows)}."
+        )
+        assert {r[target_label] for r in rows} == set(image_rids)
+        # The kept row per Image comes from the newest execution.
+        for r in rows:
+            assert r[exec_label] == newest_exec, (
+                f"select_newest should pick {newest_exec}; got {r[exec_label]} for Image {r[target_label]}."
+            )

--- a/tests/local_db/test_planner_rules.py
+++ b/tests/local_db/test_planner_rules.py
@@ -194,6 +194,92 @@ class TestPrepareWideTableIntegration:
         assert "Image" in element_tables
 
 
+class TestFeatureBridgeDiamond:
+    """Rule 6 over the diamond-with-feature-bridge shape (finding 09 §7.1).
+
+    This pins the one *intentional behavior change* of the Option E2
+    predicate fix. When a target and a value table are connected by
+    BOTH a transparent feature bridge AND a second independent FK path,
+    the now-transparent bridge hops in ``_is_downstream_chain`` and
+    registers as a competing downstream chain. Rule 6 must therefore
+    raise ``DerivaMLDenormalizeAmbiguousPath`` — behavior that did NOT
+    fire under the old predicate (the bridge was opaque, so Rule 6 saw
+    only the direct path and planned silently). Raising here is the
+    *correct* outcome: there really are two ways to relate the tables,
+    so the planner asks the caller to pick.
+    """
+
+    def test_feature_bridge_is_transparent(self, denorm_feature_diamond_deriva_model) -> None:
+        """Precondition: the 4-FK feature bridge is transparent under E2.
+
+        This is the property that turns the second path into a genuine
+        competing downstream chain. If this regresses, the ambiguity
+        below would silently disappear (the bug we're guarding against).
+        """
+        model = denorm_feature_diamond_deriva_model
+        assert model._planner._is_feature_association("Execution_Image_Image_Classification")
+        # Image reaches Image_Classification through the bridge hop.
+        assert model._planner._outbound_reachable(
+            "Image",
+            {"Image", "Image_Classification"},
+        ) == {"Image_Classification"}
+
+    def test_diamond_with_feature_bridge_raises_ambiguity(self, denorm_feature_diamond_deriva_model) -> None:
+        """Two downstream chains (direct FK + feature bridge) → ambiguity."""
+        model = denorm_feature_diamond_deriva_model
+        result = model._planner._find_path_ambiguities(
+            row_per="Image",
+            include_tables=["Image", "Image_Classification"],
+            via=[],
+        )
+        assert len(result) == 1, f"expected exactly one ambiguity, got {result}"
+        amb = result[0]
+        assert amb["from_table"] == "Image"
+        assert amb["to_table"] == "Image_Classification"
+        # Both competing paths must be present: the direct FK and the
+        # one that hops the feature bridge.
+        path_sigs = {tuple(p) for p in amb["paths"]}
+        assert ("Image", "Image_Classification") in path_sigs, (
+            f"direct FK path missing from ambiguity, got {amb['paths']}"
+        )
+        assert (
+            "Image",
+            "Execution_Image_Image_Classification",
+            "Image_Classification",
+        ) in path_sigs, f"feature-bridge path missing from ambiguity, got {amb['paths']}"
+
+    def test_prepare_wide_table_raises_on_feature_bridge_diamond(self, denorm_feature_diamond_deriva_model) -> None:
+        """The public planner entry point raises AmbiguousPath on the diamond."""
+        model = denorm_feature_diamond_deriva_model
+        with pytest.raises(DerivaMLDenormalizeAmbiguousPath):
+            model._planner._prepare_wide_table(
+                dataset=None,
+                dataset_rid="DS-001",
+                include_tables=["Image", "Image_Classification"],
+            )
+
+    def test_via_bridge_does_not_disambiguate(self, denorm_feature_diamond_deriva_model) -> None:
+        """Naming the *transparent* bridge in via= does NOT resolve the diamond.
+
+        ``_is_signaled`` deliberately excludes transparent intermediates
+        (feature-assoc and pure-association tables) from counting as a
+        user path-signal — the user shouldn't have to name plumbing.
+        Consequently the feature bridge cannot be used to pick the
+        bridged path: the ambiguity stands, and the caller must instead
+        narrow ``include_tables`` (drop one endpoint). This pins the
+        interaction between transparency and Rule 6's signaling rule.
+        """
+        model = denorm_feature_diamond_deriva_model
+        result = model._planner._find_path_ambiguities(
+            row_per="Image",
+            include_tables=["Image", "Image_Classification"],
+            via=["Execution_Image_Image_Classification"],
+        )
+        assert len(result) == 1, (
+            f"transparent bridge in via= must not signal a path, so the diamond stays ambiguous, got {result}"
+        )
+
+
 # ---------------------------------------------------------------------------
 # Transparency predicates (issue #174)
 # ---------------------------------------------------------------------------
@@ -207,8 +293,11 @@ class TestTransparencyPredicates:
     or ``via``. The original predicate (:meth:`_is_topological_association`)
     only recognized pure 2-FK association tables. Issue #174 widens
     the rule to also include DerivaML feature-association tables —
-    3-FK tables whose third FK is the audit edge to the ML schema's
-    ``Execution`` table.
+    the (≥4)-FK tables ``create_feature`` builds, marked by an FK to
+    the ML schema's ``Feature_Name`` vocab AND an FK to the ML schema's
+    ``Execution`` table (finding 09: the predicate originally keyed off
+    a 3-FK count and so rejected every real feature, which has at least
+    target + value + Feature_Name + Execution = 4 domain FKs).
 
     See the module-level "Transparency model" section in
     ``denormalize_planner.py`` for the conceptual contract.
@@ -224,10 +313,12 @@ class TestTransparencyPredicates:
         assert not model._planner._is_feature_association("Dataset_Image")
 
     def test_feature_assoc_recognized(self, denorm_feature_deriva_model) -> None:
-        """3-FK feature-assoc with FK to Execution is a feature-assoc."""
+        """Real 4-FK feature-assoc (Feature_Name FK + Execution FK) is recognized."""
         model = denorm_feature_deriva_model
-        # Execution_Image_Image_Classification: 3 FKs (Image, Execution,
-        # Image_Classification). Has an FK to Execution → feature-assoc.
+        # Execution_Image_Image_Classification: 4 domain FKs (Image,
+        # Image_Classification, Feature_Name, Execution) — the canonical
+        # shape create_feature produces. The Feature_Name FK + Execution
+        # FK are the two markers _is_feature_association keys off.
         assert model._planner._is_feature_association("Execution_Image_Image_Classification")
         # Strictly NOT a 2-FK topological association.
         assert not model._planner._is_topological_association("Execution_Image_Image_Classification")
@@ -236,12 +327,12 @@ class TestTransparencyPredicates:
         assert model._planner._is_transparent_intermediate("Execution_Image_Image_Classification")
 
     def test_three_fk_without_execution_is_not_feature(self, denorm_feature_deriva_model) -> None:
-        """3-FK table without FK to Execution is NOT a feature-assoc.
+        """3-FK table without the feature marker FKs is NOT a feature-assoc.
 
         ``Image_Subject_UnrelatedThing`` has three domain FKs but none
-        points at ``Execution`` — it's a genuine 3-way domain
-        association, which the caller must name explicitly to route
-        through.
+        points at ``Execution`` or ``Feature_Name`` — it's a genuine
+        3-way domain association, which the caller must name explicitly
+        to route through.
         """
         model = denorm_feature_deriva_model
         assert not model._planner._is_feature_association("Image_Subject_UnrelatedThing")
@@ -249,11 +340,18 @@ class TestTransparencyPredicates:
         assert not model._planner._is_transparent_intermediate("Image_Subject_UnrelatedThing")
 
     def test_four_fk_assoc_is_not_transparent(self, denorm_feature_deriva_model) -> None:
-        """4+ FK tables are not transparent even with an FK to Execution.
+        """A 4-FK association WITHOUT a Feature_Name FK is not a feature.
 
-        Multi-way associations have an arbitrary number of domain
-        edges, so the caller has to disambiguate which edge they
-        want — they can't be silently hopped.
+        ``FourWayAssoc`` has four domain FKs (Image, Subject,
+        UnrelatedThing, Execution) — including an ``Execution``
+        provenance edge — but **no** FK to ``Feature_Name``. Since the
+        predicate keys off the Feature_Name FK + Execution FK pair (not
+        the FK count), this multi-way domain association is correctly
+        rejected: it has an arbitrary number of domain edges the caller
+        must disambiguate, so it can't be silently hopped. This is the
+        negative guard that distinguishes Option E2 (key off marker
+        FKs) from the rejected Option E1 (``>=3`` count, which would
+        wrongly accept this).
         """
         model = denorm_feature_deriva_model
         assert not model._planner._is_feature_association("FourWayAssoc")


### PR DESCRIPTION
## Summary

`DenormalizePlanner._is_feature_association` required **exactly 3
domain FKs**, but every real DerivaML feature table has **4**: target
+ value(s) + `Feature_Name` + `Execution`. `create_feature` always
emits the `Feature_Name` and `Execution` FKs (via
`_define_association`), so a 3-FK feature cannot exist — the predicate
returned `False` on every real feature table.

The predicate was **born wrong** in PR #174 (2026-05-20), ~11 months
after `Feature_Name` became an FK on the feature-association table
(commit `484f3b41`, 2025-06-04). The author modeled "3 FKs"
(target/value/Execution) and forgot the `Feature_Name` FK.

**Blast radius** (all confirmed live on dev-localhost catalog 27):

- **Stage 1 selector (PR #257) was DOA on real catalogs.**
  `Denormalizer.as_dict/as_dataframe(..., selector=...)` raised
  `ValueError: selector requires a feature-association table` (gate at
  `local_db/denormalize.py:308-323`), because the predicate rejected
  the only feature-assoc table in the request.
- **Reachability primitives returned empty for the feature bridge**
  (`_outbound_reachable`, `_enumerate_paths`).
- **The materialization path was unaffected.** `_prepare_wide_table`
  routes via raw `_schema_to_paths` endpoint filtering with no
  transparency predicate, so `as_dataframe(["Image","Image_Class"])`
  kept working. This PR does **not** touch that path.

**The fix — Option E2** (finding 09 §7.2): key off the `Feature_Name`
FK + `Execution` FK pair instead of the FK count, mirroring
`find_features.is_feature` (`model/catalog.py`) — the DerivaML-native,
correct-since-2025 definition of a feature. Option E1 (`>=3` count)
was rejected: it would wrongly accept any Execution-stamped multi-way
domain association (the `FourWayAssoc` fixture has 4 FKs incl.
`Execution` but no `Feature_Name` FK).

**The test gap fixed** (finding 09 §8): the `denorm_schema_feature`
fixture declared `Feature_Name` as a plain **text column** and gave
the table only **3 FKs** — matching the predicate's wrong mental
model, which is why the bug shipped green. Corrected to the real 4-FK
shape (promote `Feature_Name` to an FK to a new `Feature_Name` vocab
table).

Findings (absolute paths):
- `deriva-ml-model-template-e2e/findings/investigation/09-feature-association-predicate-audit.md`
- `deriva-ml-model-template-e2e/findings/investigation/01-denormalizer-spec-vs-implementation.md` (§B/§H context)

## Test plan

- `uv run python -m pytest tests/local_db/` → **319 passed, 3 skipped**
  (was 313/3; +6 new tests).
- New tests:
  - `TestSelectorEngagesOnRealFourFkFeature` — regression guard that
    the selector path engages and reduces against a real 4-FK feature
    (so it can't silently die again).
  - `TestFeatureBridgeDiamond` — pins the Rule 6 behavior change (see
    below) and that a transparent bridge named in `via=` can't act as
    a disambiguating signal.
  - Updated predicate tests: `test_feature_assoc_recognized` (now True
    on the corrected 4-FK fixture), `test_four_fk_assoc_is_not_transparent`
    (still False on FourWayAssoc; rationale reworded to "4-FK without a
    Feature_Name FK").
- `uv run ruff check` / `ruff format --check` clean on all touched files.

**Live verification on dev-localhost catalog 27** (schema
`e2e-test-20260528`, table `Execution_Image_Image_Classification`,
dataset `M16`):

```
=== PREDICATE (after fix) ===
domain FK targets = ['Execution', 'Feature_Name', 'Image', 'Image_Class']
_is_feature_association(Execution_Image_Image_Classification) = True
_is_transparent_intermediate(Execution_Image_Image_Classification) = True

=== SELECTOR BEFORE (reverted !=3 predicate) ===
BEFORE raised ValueError: selector requires a feature-association table in
include_tables; none found in ['Image', 'Execution_Image_Image_Classification'].
Pass include_tables that contains exactly one feature-association table (or the
feature name that resolves to one), or drop the selector.

=== SELECTOR AFTER (fixed predicate) ===
AFTER: row_count = 550
distinct Image RIDs in reduced output = 550

=== MATERIALIZATION REGRESSION (as_dataframe(['Image','Image_Class'], row_per='Image')) ===
shape = (800, 12)
Image_Class.* columns present = ['Image_Class.RID', 'Image_Class.ID', 'Image_Class.URI',
                                 'Image_Class.Name', 'Image_Class.Description', 'Image_Class.Synonyms']

=== RULE 6 ON REAL SINGLE-PATH SHAPE ===
_find_path_ambiguities(row_per=Image, [Image, Image_Class]) = []
```

Live outbound FKs on the real table (6 total; 4 domain after dropping
the RCB/RMB → ERMrest_Client system edges): `Execution` (→
deriva-ml.Execution), `Image` (→ Image), `Feature_Name` (→
deriva-ml.Feature_Name.Name), `Image_Class` (→ Image_Class.Name).

## Behavior change

Feature bridges now hop in reachability (`_is_downstream_chain`). On a
**diamond-with-feature-bridge** schema — where a target and a value
table are connected by BOTH a feature-association bridge AND a second
independent FK path — the now-transparent bridge registers as a
competing downstream chain, and the planner now raises
`DerivaMLDenormalizeAmbiguousPath` where it previously planned
silently. This is the **correct** outcome (two real ways to relate the
tables → ask the user). Reproduced live before pinning, and pinned by
`TestFeatureBridgeDiamond::test_diamond_with_feature_bridge_raises_ambiguity`
and `::test_prepare_wide_table_raises_on_feature_bridge_diamond`.

This is the only behavior change; single-path real-catalog feature
shapes are unaffected (Rule 6 returns `[]` on catalog 27, verified
above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)