### PR TITLE
fix(feature): discover and correctly reduce key-qualified multi-value features

### DIFF
--- a/src/deriva_ml/core/mixins/feature.py
+++ b/src/deriva_ml/core/mixins/feature.py
@@ -520,13 +520,15 @@ class FeatureMixin:
             yield from records
             return
 
-        # Group by target RID, apply selector, skip None results.
+        # Group by feature identity, apply selector, skip None results.
         # Three sites (this one, Dataset.feature_values,
         # DatasetBag.feature_values) share the same reduction
-        # shape; the helper pins it in one place.
+        # shape; the helper pins it in one place. ``qualifier_columns``
+        # carries the per-eye-style identity FKs (empty for ordinary
+        # features → group-by-target, unchanged).
         from deriva_ml.feature import reduce_with_selector
 
-        yield from reduce_with_selector(records, target_col, selector)
+        yield from reduce_with_selector(records, target_col, selector, feat.qualifier_columns)
 
     @validate_call(config=VALIDATION_CONFIG)
     def list_workflow_executions(self, workflow: str) -> list[str]:
@@ -589,4 +591,3 @@ class FeatureMixin:
                 f"No workflow resolved for '{workflow}' — tried as Workflow RID and Workflow_Type name."
             )
         return rids
-

--- a/src/deriva_ml/dataset/dataset.py
+++ b/src/deriva_ml/dataset/dataset.py
@@ -711,9 +711,12 @@ class Dataset:
             yield from records
             return
 
-        # Group by target RID + apply selector — shared helper
+        # Group by feature identity + apply selector — shared helper
         # so the three feature_values surfaces stay in lockstep.
-        yield from reduce_with_selector(records, target_col, selector)
+        # ``qualifier_columns`` is empty for ordinary features
+        # (group-by-target, unchanged) and carries the identity FKs for
+        # key-qualified features so distinct observations aren't collapsed.
+        yield from reduce_with_selector(records, target_col, selector, feat.qualifier_columns)
 
     def lookup_feature(self, table: str | Table, feature_name: str) -> Feature:
         """Look up a Feature definition — delegates to the owning DerivaML.

--- a/src/deriva_ml/dataset/dataset_bag.py
+++ b/src/deriva_ml/dataset/dataset_bag.py
@@ -648,11 +648,13 @@ class DatasetBag:
             yield from records
             return
 
-        # Group by target RID, then apply selector to every group
+        # Group by feature identity, then apply selector to every group
         # — always call selector, never short-circuit for
         # single-element groups. Shared helper so the three
-        # feature_values surfaces stay in lockstep.
-        yield from reduce_with_selector(records, target_col, selector)
+        # feature_values surfaces stay in lockstep. ``qualifier_columns``
+        # is empty for ordinary features (group-by-target, unchanged) and
+        # carries the identity FKs for key-qualified features.
+        yield from reduce_with_selector(records, target_col, selector, feat.qualifier_columns)
 
     def lookup_feature(self, table: str | Table, feature_name: str) -> Feature:
         """Look up a feature definition from bag metadata — works fully offline.

--- a/src/deriva_ml/feature.py
+++ b/src/deriva_ml/feature.py
@@ -50,8 +50,9 @@ def reduce_with_selector(
     records: Iterable["FeatureRecord"],
     target_col: str,
     selector: Callable[[list["FeatureRecord"]], "FeatureRecord | None"],
+    qualifier_cols: Iterable[str] = (),
 ) -> Iterator["FeatureRecord"]:
-    """Group records by target RID, apply ``selector`` per group, drop ``None`` results.
+    """Group records by feature identity, apply ``selector`` per group, drop ``None`` results.
 
     Centralises the three-step pattern that previously lived inline
     in three places — ``feature_values`` on
@@ -59,15 +60,33 @@ def reduce_with_selector(
     :class:`~deriva_ml.dataset.dataset.Dataset`, and
     :class:`~deriva_ml.dataset.dataset_bag.DatasetBag`:
 
-    1. Group raw records by their target-RID column (the FK to the
-       target table, e.g. ``Image`` for an Image feature).
+    1. Group raw records by their *feature identity*: the target-RID
+       column (the FK to the target table, e.g. ``Image`` for an
+       Image feature) plus any ``qualifier_cols`` (value FKs that
+       participate in the association table's compound uniqueness
+       key, e.g. ``Image_Side`` for a per-eye feature).
     2. Apply the selector to each group; the selector picks one
        record from the group (or returns ``None`` to drop).
     3. Yield surviving selections.
 
+    A selector exists to reduce *redundant* records describing the
+    same logical observation (the same Image labelled by three
+    annotators, say) down to one. The grouping unit must therefore
+    be the feature's identity, not the target RID alone. For an
+    ordinary (unqualified) feature, identity *is* the target RID, so
+    with the default empty ``qualifier_cols`` the composite key
+    degenerates to ``(target_rid,)`` and the behavior is byte-identical
+    to grouping on the target RID alone. For a *key-qualified* feature
+    (a value FK in the uniqueness key), the schema author declared
+    ``(target, *qualifiers)`` to be the identity — e.g. a left-eye and
+    a right-eye ``Chart_Label`` for the same Subject are two distinct
+    observations, not redundant copies — so the selector must reduce
+    *within* each qualifier bucket and preserve both.
+
     Records whose ``target_col`` is missing or ``None`` are
     silently dropped before grouping — they have no target to
-    group under.
+    group under. ``None`` qualifier values are tolerated and form
+    their own bucket.
 
     Args:
         records: Raw feature records to group + reduce. Iterated
@@ -75,28 +94,35 @@ def reduce_with_selector(
         target_col: Name of the FK column on each record that
             identifies its target row (e.g. ``"Image"``).
         selector: Callable that takes a non-empty list of records
-            sharing one target RID and returns the chosen record
-            (or ``None`` to skip). Examples:
+            sharing one feature identity and returns the chosen
+            record (or ``None`` to skip). Examples:
             :meth:`FeatureRecord.select_newest`,
             :meth:`FeatureRecord.select_by_workflow` (returned by
             the closure factory of the same name).
+        qualifier_cols: Names of additional record fields that, with
+            ``target_col``, form the feature's composite identity key
+            (a :class:`~deriva_ml.feature.Feature`'s
+            ``qualifier_columns``). Defaults to empty — group by target
+            RID alone, the historical behavior for unqualified features.
 
     Yields:
-        One :class:`FeatureRecord` per target RID for which the
-        selector returned a non-``None`` choice. Order is
-        unspecified (dict iteration order, i.e. insertion order
-        of first-seen target RIDs in ``records``).
+        One :class:`FeatureRecord` per ``(target_rid, *qualifiers)``
+        identity for which the selector returned a non-``None`` choice.
+        Order is unspecified (dict iteration order, i.e. insertion
+        order of first-seen identities in ``records``).
 
     Example:
         >>> from deriva_ml.feature import FeatureRecord, reduce_with_selector
         >>> callable(reduce_with_selector)
         True
     """
-    grouped: dict[str, list[FeatureRecord]] = defaultdict(list)
+    qualifier_cols = tuple(qualifier_cols)
+    grouped: dict[tuple, list[FeatureRecord]] = defaultdict(list)
     for rec in records:
         target_rid = getattr(rec, target_col, None)
         if target_rid is not None:
-            grouped[target_rid].append(rec)
+            key = (target_rid, *(getattr(rec, q, None) for q in qualifier_cols))
+            grouped[key].append(rec)
     for group in grouped.values():
         chosen = selector(group)
         if chosen is not None:
@@ -561,6 +587,12 @@ class Feature:
         asset_columns (set[Column]): Columns referencing asset tables.
         term_columns (set[Column]): Columns referencing vocabulary tables.
         value_columns (set[Column]): Columns containing direct values (not FK references).
+        qualifier_columns (list[str]): Names of value-FK columns that participate
+            in the association table's compound uniqueness key (e.g. ``Image_Side``
+            on a per-eye feature). Empty for ordinary features, where the target
+            RID alone is the identity. Used by ``reduce_with_selector`` to group on
+            ``(target, *qualifiers)`` so a selector preserves distinct qualified
+            observations instead of collapsing them.
 
     Example:
         >>> feature = ml.lookup_feature("Image", "Diagnosis")  # doctest: +SKIP
@@ -613,6 +645,29 @@ class Feature:
         # this subtraction, those structural FKs would be misclassified as feature
         # columns and create spurious fields in the generated FeatureRecord class.
         assoc_fkeys = {atable.self_fkey} | atable.other_fkeys
+
+        # Qualifier columns are the value FKs that participate in the
+        # association table's compound uniqueness key — i.e. ``other_fkeys``
+        # minus the structural ``Feature_Name`` / ``Execution`` FKs (the
+        # self-FK to the target is never in ``other_fkeys``). Their presence
+        # means the schema author declared ``(target, *qualifiers)`` — not the
+        # target alone — to be the feature's identity (e.g. ``Image_Side`` on
+        # ``Execution_Subject_Chart_Label``: one Chart_Label row per eye per
+        # Subject). ``reduce_with_selector`` must group on this composite
+        # identity so a selector reduces redundant records *within* each
+        # qualifier bucket instead of collapsing distinct observations.
+        #
+        # For an unqualified feature ``other_fkeys`` is exactly
+        # ``{Feature_Name FK, Execution FK}``, so this set is empty and
+        # grouping degenerates to group-by-target — the historical behavior.
+        # Exposed as the FeatureRecord *field names* (the association table's
+        # own column names) so ``reduce_with_selector`` can ``getattr`` them.
+        structural_fk_names = {"Feature_Name", "Execution"}
+        self.qualifier_columns: list[str] = [
+            fk.foreign_key_columns[0].name
+            for fk in atable.other_fkeys
+            if fk.foreign_key_columns[0].name not in structural_fk_names
+        ]
 
         # Determine the role of each column in the feature outside the FK columns.
         self.asset_columns = {

--- a/src/deriva_ml/local_db/denormalize.py
+++ b/src/deriva_ml/local_db/denormalize.py
@@ -581,6 +581,12 @@ def _apply_selector(
         record_class = feature.feature_record_class()
         target_table_name = feature.target_table.name
         field_names = set(record_class.model_fields.keys())
+        # Identity qualifiers (value FKs in the compound key, e.g.
+        # ``Image_Side``). Empty for ordinary features. Threaded into
+        # ``reduce_with_selector`` so key-qualified features group on
+        # ``(target, *qualifiers)`` — same identity semantics as the
+        # ``feature_values`` wrappers.
+        qualifier_cols: list[str] = list(feature.qualifier_columns)
     else:
         # Structural fallback. The planner's
         # ``_is_feature_association`` predicate already guaranteed the
@@ -654,6 +660,11 @@ def _apply_selector(
             **record_fields,
         )
         field_names = set(record_class.model_fields.keys())
+        # The structural fallback can't reconstruct compound-key
+        # membership without a ``FindAssociationResult``, so it groups by
+        # target alone. This path only fires for minimal offline fixtures
+        # that don't model key-qualified features.
+        qualifier_cols = []
 
     # Resolve the wide-table column prefix for the feature-assoc table.
     schema_name = schema_for_table.get(feature_assoc_table, "")
@@ -740,13 +751,14 @@ def _apply_selector(
 
     # Delegate grouping + per-group selector application to the one
     # canonical helper. ``reduce_with_selector`` groups the shadows by
-    # ``target_table_name`` (defaultdict), applies the selector per group,
+    # the feature identity ``(target_table_name, *qualifier_cols)``
+    # (defaultdict), applies the selector per group,
     # drops ``None`` survivors, and yields the chosen shadow *instances*
     # (the built-in selectors return a group member, so identity holds —
     # the helper never copies records). We map each chosen shadow back to
     # its source dict row via ``id()``.
     reduced: list[dict[str, Any]] = []
-    for chosen in reduce_with_selector(shadows, target_table_name, selector):
+    for chosen in reduce_with_selector(shadows, target_table_name, selector, qualifier_cols):
         match = id_to_row.get(id(chosen))
         if match is not None:
             reduced.append(match)

--- a/src/deriva_ml/model/catalog.py
+++ b/src/deriva_ml/model/catalog.py
@@ -657,9 +657,28 @@ class DerivaModel:
             }.issubset({c.name for c in a.table.columns})
 
         def find_table_features(t: Table) -> list[Feature]:
-            """Find all features for a single table."""
+            """Find all features for a single table.
+
+            ``max_arity`` is left unbounded (``None``) so that
+            *key-qualified* multi-value features are discovered. A
+            qualifier is a value FK that participates in the
+            association table's compound uniqueness key — e.g.
+            ``Image_Side`` on eye-ai's ``Execution_Subject_Chart_Label``,
+            where the same Subject legitimately has a left-eye and a
+            right-eye row. Such a key includes
+            ``{Execution, Subject, Feature_Name, Image_Side}``, giving a
+            key-FK arity of 4. The former ``max_arity=3`` cap silently
+            excluded these features from discovery (and therefore from
+            ``lookup_feature`` / ``feature_values``).
+
+            ``is_feature`` remains the sole filter: it still requires the
+            ``Feature_Name`` and ``Execution`` FKs plus the target FK, so
+            removing the ceiling cannot admit a non-feature association
+            (a plain N-way domain join lacks ``Feature_Name``).
+            ``min_arity=3`` is retained as the lower bound.
+            """
             return [
-                Feature(a, self) for a in t.find_associations(min_arity=3, max_arity=3, pure=False) if is_feature(a)
+                Feature(a, self) for a in t.find_associations(min_arity=3, max_arity=None, pure=False) if is_feature(a)
             ]
 
         if table is not None:

--- a/tests/feature/test_reduce_with_selector.py
+++ b/tests/feature/test_reduce_with_selector.py
@@ -31,11 +31,7 @@ class TestReduceWithSelector:
             SimpleNamespace(Image="img-2", val=10, RCT="t1"),
         ]
         # Selector picks the highest `val` in each group.
-        result = list(
-            reduce_with_selector(
-                records, "Image", selector=lambda group: max(group, key=lambda r: r.val)
-            )
-        )
+        result = list(reduce_with_selector(records, "Image", selector=lambda group: max(group, key=lambda r: r.val)))
 
         # Two groups → two survivors. ``Image == "img-1"`` keeps val=2
         # (max), ``"img-2"`` keeps val=10.
@@ -49,9 +45,7 @@ class TestReduceWithSelector:
             SimpleNamespace(Image=None, val=2),  # explicit None
             SimpleNamespace(val=3),  # attribute missing entirely
         ]
-        result = list(
-            reduce_with_selector(records, "Image", selector=lambda group: group[0])
-        )
+        result = list(reduce_with_selector(records, "Image", selector=lambda group: group[0]))
         assert len(result) == 1
         assert result[0].Image == "img-1"
 
@@ -101,9 +95,7 @@ class TestReduceWithSelector:
             called.append(group)
             return group[0]
 
-        result = list(
-            reduce_with_selector([rec], "Image", selector=tracking_selector)
-        )
+        result = list(reduce_with_selector([rec], "Image", selector=tracking_selector))
         assert result == [rec]
         assert len(called) == 1
         assert called[0] == [rec]
@@ -121,8 +113,142 @@ class TestReduceWithSelector:
             SimpleNamespace(Image="img-A", val=2),
             SimpleNamespace(Image="img-B", val=3),
         ]
-        result = list(
-            reduce_with_selector(records, "Image", selector=lambda group: group[0])
-        )
+        result = list(reduce_with_selector(records, "Image", selector=lambda group: group[0]))
         # img-B first seen at index 0, img-A first seen at index 1.
         assert [r.Image for r in result] == ["img-B", "img-A"]
+
+
+class TestReduceWithSelectorQualifierColumns:
+    """Composite-key grouping for key-qualified features (findings 10 + 12).
+
+    A *key-qualified* feature puts a value FK (e.g. ``Image_Side``) in the
+    association table's compound uniqueness key, declaring
+    ``(target, *qualifiers)`` — not the target alone — to be the feature's
+    identity. The same Subject legitimately has a left-eye row and a
+    right-eye row; a selector must reduce *within* each qualifier bucket and
+    keep both, not collapse the two into one.
+
+    These tests pin the new ``qualifier_cols`` parameter directly. The empty
+    default must be byte-identical to grouping on the target alone — the
+    backward-compat invariant for every unqualified feature and every
+    existing caller.
+    """
+
+    def test_empty_qualifier_cols_is_group_by_target(self):
+        """Default ``qualifier_cols=()`` ⇒ identical to group-by-target.
+
+        Two rows for the same Subject with no qualifier collapse to one,
+        exactly as before this parameter existed.
+        """
+        records = [
+            SimpleNamespace(Subject="subj-1", RCT="t1"),
+            SimpleNamespace(Subject="subj-1", RCT="t2"),
+            SimpleNamespace(Subject="subj-2", RCT="t1"),
+        ]
+        result = list(reduce_with_selector(records, "Subject", selector=lambda group: group[0]))
+        assert {r.Subject for r in result} == {"subj-1", "subj-2"}
+        assert len(result) == 2
+
+    def test_qualifier_splits_one_target_into_per_qualifier_groups(self):
+        """A qualifier in the key keeps both eyes for the same Subject.
+
+        Without ``qualifier_cols`` these two rows (same Subject, different
+        ``Image_Side``) would collapse to one — the Chart_Label bug. With
+        ``qualifier_cols=["Image_Side"]`` they remain two distinct
+        observations.
+        """
+        records = [
+            SimpleNamespace(Subject="subj-1", Image_Side="Left", RCT="t1"),
+            SimpleNamespace(Subject="subj-1", Image_Side="Right", RCT="t2"),
+        ]
+        # selector picks the single member of each (Subject, Image_Side) group.
+        result = list(
+            reduce_with_selector(
+                records,
+                "Subject",
+                selector=lambda group: group[0],
+                qualifier_cols=["Image_Side"],
+            )
+        )
+        sides = {r.Image_Side for r in result}
+        assert sides == {"Left", "Right"}
+        assert len(result) == 2
+
+    def test_qualifier_reduces_within_each_bucket(self):
+        """Selector still reduces redundant records *within* a qualifier bucket.
+
+        Two annotators labelled the Left eye and two the Right eye. The
+        selector (newest by RCT) must reduce each eye to one record — two
+        survivors total, one per eye — not four and not one.
+        """
+        records = [
+            SimpleNamespace(Subject="s1", Image_Side="Left", RCT="t1"),
+            SimpleNamespace(Subject="s1", Image_Side="Left", RCT="t2"),  # newer Left
+            SimpleNamespace(Subject="s1", Image_Side="Right", RCT="t1"),
+            SimpleNamespace(Subject="s1", Image_Side="Right", RCT="t3"),  # newer Right
+        ]
+        result = list(
+            reduce_with_selector(
+                records,
+                "Subject",
+                selector=lambda group: max(group, key=lambda r: r.RCT),
+                qualifier_cols=["Image_Side"],
+            )
+        )
+        by_side = {r.Image_Side: r.RCT for r in result}
+        assert by_side == {"Left": "t2", "Right": "t3"}
+
+    def test_multiple_qualifier_columns_form_composite_key(self):
+        """The composite key spans all qualifier columns, not just the first."""
+        records = [
+            SimpleNamespace(Subject="s1", Q1="a", Q2="x"),
+            SimpleNamespace(Subject="s1", Q1="a", Q2="y"),
+            SimpleNamespace(Subject="s1", Q1="b", Q2="x"),
+        ]
+        result = list(
+            reduce_with_selector(
+                records,
+                "Subject",
+                selector=lambda group: group[0],
+                qualifier_cols=["Q1", "Q2"],
+            )
+        )
+        # Three distinct (Subject, Q1, Q2) identities → three survivors.
+        assert len(result) == 3
+
+    def test_none_qualifier_value_forms_its_own_bucket(self):
+        """A ``None`` qualifier value is a distinct bucket, not dropped.
+
+        Only a missing/``None`` *target* drops a record; a ``None``
+        qualifier just groups separately.
+        """
+        records = [
+            SimpleNamespace(Subject="s1", Image_Side="Left"),
+            SimpleNamespace(Subject="s1", Image_Side=None),
+        ]
+        result = list(
+            reduce_with_selector(
+                records,
+                "Subject",
+                selector=lambda group: group[0],
+                qualifier_cols=["Image_Side"],
+            )
+        )
+        assert len(result) == 2
+        assert {r.Image_Side for r in result} == {"Left", None}
+
+    def test_qualifier_cols_accepts_any_iterable(self):
+        """``qualifier_cols`` is normalised from any iterable (e.g. a generator)."""
+        records = [
+            SimpleNamespace(Subject="s1", Image_Side="Left"),
+            SimpleNamespace(Subject="s1", Image_Side="Right"),
+        ]
+        result = list(
+            reduce_with_selector(
+                records,
+                "Subject",
+                selector=lambda group: group[0],
+                qualifier_cols=(c for c in ["Image_Side"]),
+            )
+        )
+        assert len(result) == 2

--- a/tests/local_db/conftest.py
+++ b/tests/local_db/conftest.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-from deriva.core.ermrest_model import Model
+from deriva.core.ermrest_model import Model, tag
 from sqlalchemy.orm import Session
 
 from deriva_ml.local_db.schema import LocalSchema
@@ -1073,6 +1073,361 @@ def denorm_qualified_feature_deriva_model(denorm_qualified_feature_model: Model)
         ml_schema="deriva-ml",
         domain_schemas={"isa"},
     )
+
+
+# ---------------------------------------------------------------------------
+# Arbitrary-shape qualified-feature fixtures (PR #261 generalization proof)
+# ---------------------------------------------------------------------------
+#
+# The single-qualifier ``denorm_schema_qualified_feature`` above proved the
+# #261 fix on ONE vocab-FK qualifier (the eye-ai Chart_Label / Image_Side
+# shape). The fix generalizes *by construction* — ``Feature.qualifier_columns``
+# is a comprehension over ``atable.other_fkeys`` (the compound-key-covered
+# FKs), so it is agnostic to the number of qualifiers and to the referent
+# type of each qualifier FK. These fixtures make that generalization
+# *empirical*: arbitrary qualifier counts, an asset-table qualifier referent,
+# and the inverse — a many-column unqualified feature that must NOT be
+# mistaken for a qualified one (the over-split guard).
+#
+# The structural distinction the whole fix hinges on: a qualifier FK's column
+# is part of a multi-column uniqueness KEY (→ it appears in deriva-py's
+# ``covered_fkeys`` / ``other_fkeys``); a decoration FK is NOT in any compound
+# key (→ it never appears there). Each fixture below is verified in its test
+# to actually produce the intended ``qualifier_columns`` via the real
+# ``find_features`` / ``Feature`` path — never asserted by construction alone.
+
+
+def _qf_sys_cols() -> list[dict[str, Any]]:
+    """The five ERMrest system columns every table carries."""
+    return [
+        {"name": "RID", "type": {"typename": "text"}, "nullok": False},
+        {"name": "RCT", "type": {"typename": "timestamptz"}},
+        {"name": "RMT", "type": {"typename": "timestamptz"}},
+        {"name": "RCB", "type": {"typename": "text"}},
+        {"name": "RMB", "type": {"typename": "text"}},
+    ]
+
+
+def _qf_simple_vocab(name: str, schema: str = "isa") -> dict[str, Any]:
+    """A name-keyed reference table (Name/Description only).
+
+    NOT a deriva-py *vocabulary* (which requires ID/URI/Synonyms of specific
+    types) — so an FK to it that is NOT key-covered classifies as a
+    ``value_column``, mirroring the existing fixtures' Condition_Label shape.
+    Used where the referent's vocab-vs-value classification is irrelevant and
+    only the FK's key-coverage matters.
+    """
+    return {
+        "table_name": name,
+        "schema_name": schema,
+        "column_definitions": _qf_sys_cols()
+        + [
+            {"name": "Name", "type": {"typename": "text"}, "nullok": False},
+            {"name": "Description", "type": {"typename": "text"}, "nullok": True},
+        ],
+        "keys": [{"unique_columns": ["RID"]}, {"unique_columns": ["Name"]}],
+        "foreign_keys": [],
+    }
+
+
+def _qf_real_vocab(name: str, schema: str = "isa") -> dict[str, Any]:
+    """A proper deriva-py vocabulary table (ID/URI/Name/Description/Synonyms).
+
+    Recognized by ``DerivaModel.is_vocabulary``, so a non-key-covered FK to it
+    classifies as a ``term_column`` on the feature. Used for the decoration
+    vocab FK so the over-split guard can assert the FeatureRecord carries it
+    as a real term field (feature data, just not identity).
+    """
+    return {
+        "table_name": name,
+        "schema_name": schema,
+        "column_definitions": _qf_sys_cols()
+        + [
+            {"name": "ID", "type": {"typename": "ermrest_curie"}, "nullok": False},
+            {"name": "URI", "type": {"typename": "ermrest_uri"}, "nullok": False},
+            {"name": "Name", "type": {"typename": "text"}, "nullok": False},
+            {"name": "Description", "type": {"typename": "markdown"}, "nullok": False},
+            {"name": "Synonyms", "type": {"typename": "text[]"}, "nullok": True},
+        ],
+        "keys": [
+            {"unique_columns": ["RID"]},
+            {"unique_columns": ["Name"]},
+            {"unique_columns": ["ID"]},
+        ],
+        "foreign_keys": [],
+    }
+
+
+def _qf_asset(name: str, schema: str = "isa") -> dict[str, Any]:
+    """A proper deriva-py asset table (URL/Filename/Length/MD5 + asset tag).
+
+    Recognized by ``DerivaModel.is_asset``. Used both as a *qualifier* referent
+    (fixture 2 — proving the qualifier derivation is referent-type-agnostic)
+    and as a *decoration* referent (fixtures 3 + 4 — a non-key asset FK that
+    becomes a record asset field but not part of identity).
+    """
+    return {
+        "table_name": name,
+        "schema_name": schema,
+        "column_definitions": _qf_sys_cols()
+        + [
+            {
+                "name": "URL",
+                "type": {"typename": "text"},
+                "nullok": False,
+                "annotations": {tag.asset: {}},
+            },
+            {"name": "Filename", "type": {"typename": "text"}, "nullok": True},
+            {"name": "Length", "type": {"typename": "int8"}, "nullok": False},
+            {"name": "MD5", "type": {"typename": "text"}, "nullok": False},
+        ],
+        "keys": [{"unique_columns": ["RID"]}],
+        "foreign_keys": [],
+    }
+
+
+def _qf_fk(table: str, col: str, ref_schema: str, ref_table: str, ref_col: str = "RID") -> dict[str, Any]:
+    """An outbound single-column FK from ``deriva-ml.<table>.<col>`` to a referent."""
+    return {
+        "foreign_key_columns": [{"schema_name": "deriva-ml", "table_name": table, "column_name": col}],
+        "referenced_columns": [{"schema_name": ref_schema, "table_name": ref_table, "column_name": ref_col}],
+    }
+
+
+def _qf_base_doc() -> dict[str, Any]:
+    """Base schema for the arbitrary-shape fixtures: Subject, Image, Execution, Feature_Name.
+
+    ``_base_schema_doc`` carries Dataset + UnrelatedThing that these fixtures
+    don't need; this trimmed base keeps each fixture's intent legible.
+    """
+    return {
+        "schemas": {
+            "isa": {
+                "tables": {
+                    "Subject": {
+                        "table_name": "Subject",
+                        "schema_name": "isa",
+                        "column_definitions": _qf_sys_cols()
+                        + [{"name": "Name", "type": {"typename": "text"}, "nullok": True}],
+                        "keys": [{"unique_columns": ["RID"]}],
+                        "foreign_keys": [],
+                    },
+                    "Image": {
+                        "table_name": "Image",
+                        "schema_name": "isa",
+                        "column_definitions": _qf_sys_cols()
+                        + [{"name": "Filename", "type": {"typename": "text"}, "nullok": True}],
+                        "keys": [{"unique_columns": ["RID"]}],
+                        "foreign_keys": [],
+                    },
+                }
+            },
+            "deriva-ml": {
+                "tables": {
+                    "Execution": {
+                        "table_name": "Execution",
+                        "schema_name": "deriva-ml",
+                        "column_definitions": _qf_sys_cols()
+                        + [{"name": "Description", "type": {"typename": "text"}, "nullok": True}],
+                        "keys": [{"unique_columns": ["RID"]}],
+                        "foreign_keys": [],
+                    },
+                    "Feature_Name": _qf_simple_vocab("Feature_Name", "deriva-ml"),
+                }
+            },
+        }
+    }
+
+
+def _qf_model(doc: dict[str, Any], tmp_path: Path, name: str) -> DerivaModel:
+    """Write ``doc`` to ``tmp_path/<name>.json`` and build a DerivaModel."""
+    out = tmp_path / f"{name}.json"
+    out.write_text(json.dumps(doc))
+    model = Model.fromfile("file-system", out)
+    return DerivaModel(model=model, ml_schema="deriva-ml", domain_schemas={"isa"})
+
+
+@pytest.fixture
+def denorm_multi_qualifier_deriva_model(tmp_path: Path) -> DerivaModel:
+    """A feature with TWO key-covered qualifier FKs (``Image_Side`` + ``Visit_Number``).
+
+    The compound uniqueness key is
+    ``[Execution, Subject, Feature_Name, Image_Side, Visit_Number]`` (key-FK
+    arity 5). The same Subject therefore has rows distinguished by a
+    *combination* of two qualifiers — (Left, V1), (Left, V2), (Right, V1), …
+    ``Condition_Label`` and ``Score`` are non-key value columns. Proves the
+    qualifier derivation handles an arbitrary qualifier count, not just one.
+    """
+    doc = _qf_base_doc()
+    doc["schemas"]["isa"]["tables"]["Image_Side"] = _qf_simple_vocab("Image_Side")
+    doc["schemas"]["isa"]["tables"]["Visit_Number"] = _qf_simple_vocab("Visit_Number")
+    doc["schemas"]["isa"]["tables"]["Condition_Label"] = _qf_simple_vocab("Condition_Label")
+    t = "Execution_Subject_Visit_Chart"
+    doc["schemas"]["deriva-ml"]["tables"][t] = {
+        "table_name": t,
+        "schema_name": "deriva-ml",
+        "column_definitions": _qf_sys_cols()
+        + [
+            {"name": "Feature_Name", "type": {"typename": "text"}, "nullok": False, "default": "Visit_Chart"},
+            {"name": "Subject", "type": {"typename": "text"}, "nullok": False},
+            {"name": "Execution", "type": {"typename": "text"}, "nullok": False},
+            {"name": "Image_Side", "type": {"typename": "text"}, "nullok": False},
+            {"name": "Visit_Number", "type": {"typename": "text"}, "nullok": False},
+            {"name": "Condition_Label", "type": {"typename": "text"}, "nullok": True},
+            {"name": "Score", "type": {"typename": "float8"}, "nullok": True},
+        ],
+        "keys": [
+            {"unique_columns": ["RID"]},
+            # BOTH qualifiers are in the key — the composite identity is
+            # (Subject, Image_Side, Visit_Number) per execution.
+            {"unique_columns": ["Execution", "Subject", "Feature_Name", "Image_Side", "Visit_Number"]},
+        ],
+        "foreign_keys": [
+            _qf_fk(t, "Subject", "isa", "Subject"),
+            _qf_fk(t, "Execution", "deriva-ml", "Execution"),
+            _qf_fk(t, "Feature_Name", "deriva-ml", "Feature_Name", "Name"),
+            _qf_fk(t, "Image_Side", "isa", "Image_Side"),
+            _qf_fk(t, "Visit_Number", "isa", "Visit_Number"),
+            _qf_fk(t, "Condition_Label", "isa", "Condition_Label"),
+        ],
+    }
+    return _qf_model(doc, tmp_path, "multi_qualifier")
+
+
+@pytest.fixture
+def denorm_asset_qualifier_deriva_model(tmp_path: Path) -> DerivaModel:
+    """A feature whose key-covered qualifier FK points to an ASSET table.
+
+    ``Image_Region`` is a proper asset table and is *in* the compound key
+    ``[Execution, Subject, Feature_Name, Image_Region]``. Proves
+    ``qualifier_columns`` keys off FK-in-``other_fkeys`` membership, NOT off
+    the referent being a vocabulary — the derivation is referent-type-agnostic.
+    ``Condition_Label`` is a non-key value column.
+    """
+    doc = _qf_base_doc()
+    doc["schemas"]["isa"]["tables"]["Image_Region"] = _qf_asset("Image_Region")
+    doc["schemas"]["isa"]["tables"]["Condition_Label"] = _qf_simple_vocab("Condition_Label")
+    t = "Execution_Subject_Region_Label"
+    doc["schemas"]["deriva-ml"]["tables"][t] = {
+        "table_name": t,
+        "schema_name": "deriva-ml",
+        "column_definitions": _qf_sys_cols()
+        + [
+            {"name": "Feature_Name", "type": {"typename": "text"}, "nullok": False, "default": "Region_Label"},
+            {"name": "Subject", "type": {"typename": "text"}, "nullok": False},
+            {"name": "Execution", "type": {"typename": "text"}, "nullok": False},
+            {"name": "Image_Region", "type": {"typename": "text"}, "nullok": False},
+            {"name": "Condition_Label", "type": {"typename": "text"}, "nullok": True},
+        ],
+        "keys": [
+            {"unique_columns": ["RID"]},
+            # The qualifier FK referent is an ASSET table, not a vocabulary.
+            {"unique_columns": ["Execution", "Subject", "Feature_Name", "Image_Region"]},
+        ],
+        "foreign_keys": [
+            _qf_fk(t, "Subject", "isa", "Subject"),
+            _qf_fk(t, "Execution", "deriva-ml", "Execution"),
+            _qf_fk(t, "Feature_Name", "deriva-ml", "Feature_Name", "Name"),
+            _qf_fk(t, "Image_Region", "isa", "Image_Region"),
+            _qf_fk(t, "Condition_Label", "isa", "Condition_Label"),
+        ],
+    }
+    return _qf_model(doc, tmp_path, "asset_qualifier")
+
+
+@pytest.fixture
+def denorm_decoration_feature_deriva_model(tmp_path: Path) -> DerivaModel:
+    """A decoration-heavy UNQUALIFIED feature — the over-split guard.
+
+    ``Execution_Image_RichQuality`` has many non-key columns: three scalar
+    metadata columns (``Confidence`` float, ``Vote_Count`` int, ``Notes``
+    text), an asset FK (``Thumbnail``), and a vocab FK (``Quality_Grade``) —
+    NONE in the compound key ``[Execution, Image, Feature_Name]`` (impure
+    decoration; ``pure=False`` keeps it discoverable). Its identity is the
+    target ``Image`` alone, so ``qualifier_columns`` must be EMPTY and a
+    selector must reduce to one-row-per-Image. Proves a many-column feature is
+    NOT mistaken for a qualified one (the inverse of the qualifier bug).
+    """
+    doc = _qf_base_doc()
+    doc["schemas"]["isa"]["tables"]["Thumbnail"] = _qf_asset("Thumbnail")
+    doc["schemas"]["isa"]["tables"]["Quality_Grade"] = _qf_real_vocab("Quality_Grade")
+    t = "Execution_Image_RichQuality"
+    doc["schemas"]["deriva-ml"]["tables"][t] = {
+        "table_name": t,
+        "schema_name": "deriva-ml",
+        "column_definitions": _qf_sys_cols()
+        + [
+            {"name": "Feature_Name", "type": {"typename": "text"}, "nullok": False, "default": "RichQuality"},
+            {"name": "Image", "type": {"typename": "text"}, "nullok": False},
+            {"name": "Execution", "type": {"typename": "text"}, "nullok": False},
+            # Scalar metadata — real feature data, NOT identity, NOT in key.
+            {"name": "Confidence", "type": {"typename": "float8"}, "nullok": True},
+            {"name": "Vote_Count", "type": {"typename": "int4"}, "nullok": True},
+            {"name": "Notes", "type": {"typename": "text"}, "nullok": True},
+            # Asset FK + vocab FK — decoration, NOT in key.
+            {"name": "Thumbnail", "type": {"typename": "text"}, "nullok": True},
+            {"name": "Quality_Grade", "type": {"typename": "text"}, "nullok": True},
+        ],
+        "keys": [
+            {"unique_columns": ["RID"]},
+            # No decoration FK in the key — the target (Image) alone is identity.
+            {"unique_columns": ["Execution", "Image", "Feature_Name"]},
+        ],
+        "foreign_keys": [
+            _qf_fk(t, "Image", "isa", "Image"),
+            _qf_fk(t, "Execution", "deriva-ml", "Execution"),
+            _qf_fk(t, "Feature_Name", "deriva-ml", "Feature_Name", "Name"),
+            _qf_fk(t, "Thumbnail", "isa", "Thumbnail"),
+            _qf_fk(t, "Quality_Grade", "isa", "Quality_Grade"),
+        ],
+    }
+    return _qf_model(doc, tmp_path, "decoration_feature")
+
+
+@pytest.fixture
+def denorm_mixed_feature_deriva_model(tmp_path: Path) -> DerivaModel:
+    """A feature with a key qualifier AND non-key decoration columns together.
+
+    ``Execution_Subject_MixedLabel`` puts ``Image_Side`` *in* the compound key
+    ``[Execution, Subject, Feature_Name, Image_Side]`` (a qualifier) while
+    carrying ``Severity_Label`` (vocab), ``Heatmap`` (asset), and
+    ``Confidence`` (scalar) as non-key decoration. Proves the two are
+    correctly separated: the qualifier joins the group key; the decoration
+    becomes record fields but does NOT split the group.
+    """
+    doc = _qf_base_doc()
+    doc["schemas"]["isa"]["tables"]["Image_Side"] = _qf_simple_vocab("Image_Side")
+    doc["schemas"]["isa"]["tables"]["Severity_Label"] = _qf_real_vocab("Severity_Label")
+    doc["schemas"]["isa"]["tables"]["Heatmap"] = _qf_asset("Heatmap")
+    t = "Execution_Subject_MixedLabel"
+    doc["schemas"]["deriva-ml"]["tables"][t] = {
+        "table_name": t,
+        "schema_name": "deriva-ml",
+        "column_definitions": _qf_sys_cols()
+        + [
+            {"name": "Feature_Name", "type": {"typename": "text"}, "nullok": False, "default": "MixedLabel"},
+            {"name": "Subject", "type": {"typename": "text"}, "nullok": False},
+            {"name": "Execution", "type": {"typename": "text"}, "nullok": False},
+            {"name": "Image_Side", "type": {"typename": "text"}, "nullok": False},  # qualifier (IN key)
+            {"name": "Severity_Label", "type": {"typename": "text"}, "nullok": True},  # decoration vocab
+            {"name": "Heatmap", "type": {"typename": "text"}, "nullok": True},  # decoration asset
+            {"name": "Confidence", "type": {"typename": "float8"}, "nullok": True},  # decoration scalar
+        ],
+        "keys": [
+            {"unique_columns": ["RID"]},
+            # Only Image_Side is in the key; Severity_Label/Heatmap/Confidence are not.
+            {"unique_columns": ["Execution", "Subject", "Feature_Name", "Image_Side"]},
+        ],
+        "foreign_keys": [
+            _qf_fk(t, "Subject", "isa", "Subject"),
+            _qf_fk(t, "Execution", "deriva-ml", "Execution"),
+            _qf_fk(t, "Feature_Name", "deriva-ml", "Feature_Name", "Name"),
+            _qf_fk(t, "Image_Side", "isa", "Image_Side"),
+            _qf_fk(t, "Severity_Label", "isa", "Severity_Label"),
+            _qf_fk(t, "Heatmap", "isa", "Heatmap"),
+        ],
+    }
+    return _qf_model(doc, tmp_path, "mixed_feature")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/local_db/conftest.py
+++ b/tests/local_db/conftest.py
@@ -805,6 +805,277 @@ def denorm_local_schema_feature(denorm_feature_model: Model, tmp_path: Path) -> 
 
 
 # ---------------------------------------------------------------------------
+# Key-qualified feature fixture (findings 10 + 12)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def denorm_schema_qualified_feature(tmp_path: Path) -> Path:
+    """Canned schema with a *key-qualified* multi-value feature.
+
+    This is the structural shape that no prior fixture modeled — and the
+    gap that hid two coupled bugs (findings 10 + 12). It mirrors eye-ai's
+    real ``Execution_Subject_Chart_Label`` feature: a feature-association
+    table whose **compound uniqueness key includes a qualifier FK** beyond
+    ``{target, Feature_Name, Execution}``. The same target (Subject) can
+    therefore have two rows distinguished only by the qualifier.
+
+    Tables added on top of :func:`_base_schema_doc`:
+
+    - ``Execution`` and ``Feature_Name`` (``deriva-ml`` schema) — the two
+      structural feature markers.
+    - ``Image_Side`` vocabulary (``isa`` schema) — the qualifier's target
+      (terms: ``Left`` / ``Right``).
+    - ``Condition_Label`` vocabulary (``isa`` schema) — an ordinary value
+      term (NOT in the key).
+    - ``Execution_Subject_Chart_Label`` feature-association table with FKs
+      to ``Subject`` (target), ``Execution``, ``Feature_Name``,
+      ``Image_Side`` (qualifier), and ``Condition_Label`` (value). Its
+      compound key is
+      ``[Execution, Subject, Feature_Name, Image_Side]`` — exactly the
+      eye-ai shape. The ``Image_Side`` FK is *in the key* (a qualifier);
+      ``Condition_Label`` is *not* (a value).
+
+    Because the key-FK arity is 4, ``find_associations(max_arity=3)`` —
+    the former ``find_features`` cap — silently excludes this table.
+    ``find_associations(max_arity=None)`` discovers it. The fixture thus
+    fails the old code and passes the new code, which is the whole point.
+    """
+    doc = _base_schema_doc()
+
+    # Execution (deriva-ml).
+    doc["schemas"]["deriva-ml"]["tables"]["Execution"] = {
+        "table_name": "Execution",
+        "schema_name": "deriva-ml",
+        "column_definitions": [
+            {"name": "RID", "type": {"typename": "text"}, "nullok": False},
+            {"name": "RCT", "type": {"typename": "timestamptz"}},
+            {"name": "RMT", "type": {"typename": "timestamptz"}},
+            {"name": "RCB", "type": {"typename": "text"}},
+            {"name": "RMB", "type": {"typename": "text"}},
+            {"name": "Description", "type": {"typename": "text"}, "nullok": True},
+        ],
+        "keys": [{"unique_columns": ["RID"]}],
+        "foreign_keys": [],
+    }
+
+    # Feature_Name vocabulary (deriva-ml).
+    doc["schemas"]["deriva-ml"]["tables"]["Feature_Name"] = {
+        "table_name": "Feature_Name",
+        "schema_name": "deriva-ml",
+        "column_definitions": [
+            {"name": "RID", "type": {"typename": "text"}, "nullok": False},
+            {"name": "RCT", "type": {"typename": "timestamptz"}},
+            {"name": "RMT", "type": {"typename": "timestamptz"}},
+            {"name": "RCB", "type": {"typename": "text"}},
+            {"name": "RMB", "type": {"typename": "text"}},
+            {"name": "Name", "type": {"typename": "text"}, "nullok": False},
+            {"name": "Description", "type": {"typename": "text"}, "nullok": True},
+        ],
+        "keys": [{"unique_columns": ["RID"]}, {"unique_columns": ["Name"]}],
+        "foreign_keys": [],
+    }
+
+    # Image_Side vocabulary (isa) — the QUALIFIER's target (Left/Right).
+    doc["schemas"]["isa"]["tables"]["Image_Side"] = {
+        "table_name": "Image_Side",
+        "schema_name": "isa",
+        "column_definitions": [
+            {"name": "RID", "type": {"typename": "text"}, "nullok": False},
+            {"name": "RCT", "type": {"typename": "timestamptz"}},
+            {"name": "RMT", "type": {"typename": "timestamptz"}},
+            {"name": "RCB", "type": {"typename": "text"}},
+            {"name": "RMB", "type": {"typename": "text"}},
+            {"name": "Name", "type": {"typename": "text"}, "nullok": False},
+            {"name": "Description", "type": {"typename": "text"}, "nullok": True},
+        ],
+        "keys": [{"unique_columns": ["RID"]}, {"unique_columns": ["Name"]}],
+        "foreign_keys": [],
+    }
+
+    # Condition_Label vocabulary (isa) — an ordinary VALUE term (NOT in key).
+    doc["schemas"]["isa"]["tables"]["Condition_Label"] = {
+        "table_name": "Condition_Label",
+        "schema_name": "isa",
+        "column_definitions": [
+            {"name": "RID", "type": {"typename": "text"}, "nullok": False},
+            {"name": "RCT", "type": {"typename": "timestamptz"}},
+            {"name": "RMT", "type": {"typename": "timestamptz"}},
+            {"name": "RCB", "type": {"typename": "text"}},
+            {"name": "RMB", "type": {"typename": "text"}},
+            {"name": "Name", "type": {"typename": "text"}, "nullok": False},
+            {"name": "Description", "type": {"typename": "text"}, "nullok": True},
+        ],
+        "keys": [{"unique_columns": ["RID"]}, {"unique_columns": ["Name"]}],
+        "foreign_keys": [],
+    }
+
+    # The key-qualified feature-association table. Its compound key
+    # includes Image_Side (the qualifier), giving key-FK arity 4.
+    doc["schemas"]["deriva-ml"]["tables"]["Execution_Subject_Chart_Label"] = {
+        "table_name": "Execution_Subject_Chart_Label",
+        "schema_name": "deriva-ml",
+        "column_definitions": [
+            {"name": "RID", "type": {"typename": "text"}, "nullok": False},
+            {"name": "RCT", "type": {"typename": "timestamptz"}},
+            {"name": "RMT", "type": {"typename": "timestamptz"}},
+            {"name": "RCB", "type": {"typename": "text"}},
+            {"name": "RMB", "type": {"typename": "text"}},
+            # Default on Feature_Name is what Feature.feature_name reads.
+            {
+                "name": "Feature_Name",
+                "type": {"typename": "text"},
+                "nullok": False,
+                "default": "Chart_Label",
+            },
+            {"name": "Subject", "type": {"typename": "text"}, "nullok": False},
+            {"name": "Execution", "type": {"typename": "text"}, "nullok": False},
+            {"name": "Image_Side", "type": {"typename": "text"}, "nullok": False},
+            {"name": "Condition_Label", "type": {"typename": "text"}, "nullok": True},
+        ],
+        "keys": [
+            {"unique_columns": ["RID"]},
+            # The compound IDENTITY key — Image_Side IN the key makes it a
+            # qualifier (key-FK arity 4, the eye-ai Chart_Label shape).
+            {"unique_columns": ["Execution", "Subject", "Feature_Name", "Image_Side"]},
+        ],
+        "foreign_keys": [
+            {
+                "foreign_key_columns": [
+                    {
+                        "schema_name": "deriva-ml",
+                        "table_name": "Execution_Subject_Chart_Label",
+                        "column_name": "Subject",
+                    }
+                ],
+                "referenced_columns": [{"schema_name": "isa", "table_name": "Subject", "column_name": "RID"}],
+            },
+            {
+                "foreign_key_columns": [
+                    {
+                        "schema_name": "deriva-ml",
+                        "table_name": "Execution_Subject_Chart_Label",
+                        "column_name": "Execution",
+                    }
+                ],
+                "referenced_columns": [{"schema_name": "deriva-ml", "table_name": "Execution", "column_name": "RID"}],
+            },
+            {
+                "foreign_key_columns": [
+                    {
+                        "schema_name": "deriva-ml",
+                        "table_name": "Execution_Subject_Chart_Label",
+                        "column_name": "Feature_Name",
+                    }
+                ],
+                "referenced_columns": [
+                    {"schema_name": "deriva-ml", "table_name": "Feature_Name", "column_name": "Name"}
+                ],
+            },
+            {
+                "foreign_key_columns": [
+                    {
+                        "schema_name": "deriva-ml",
+                        "table_name": "Execution_Subject_Chart_Label",
+                        "column_name": "Image_Side",
+                    }
+                ],
+                "referenced_columns": [{"schema_name": "isa", "table_name": "Image_Side", "column_name": "RID"}],
+            },
+            {
+                "foreign_key_columns": [
+                    {
+                        "schema_name": "deriva-ml",
+                        "table_name": "Execution_Subject_Chart_Label",
+                        "column_name": "Condition_Label",
+                    }
+                ],
+                "referenced_columns": [{"schema_name": "isa", "table_name": "Condition_Label", "column_name": "RID"}],
+            },
+        ],
+    }
+
+    # An ORDINARY (unqualified) feature alongside the qualified one, so a
+    # single fixture proves both the fix AND the backward-compat invariant
+    # via the same ``find_features`` path. Compound key is
+    # ``[Execution, Image, Feature_Name]`` (key-FK arity 3, no qualifier),
+    # so ``Feature.qualifier_columns`` must be empty and a selector must
+    # reduce to one-per-Image — unchanged from before the fix.
+    doc["schemas"]["deriva-ml"]["tables"]["Execution_Image_Quality"] = {
+        "table_name": "Execution_Image_Quality",
+        "schema_name": "deriva-ml",
+        "column_definitions": [
+            {"name": "RID", "type": {"typename": "text"}, "nullok": False},
+            {"name": "RCT", "type": {"typename": "timestamptz"}},
+            {"name": "RMT", "type": {"typename": "timestamptz"}},
+            {"name": "RCB", "type": {"typename": "text"}},
+            {"name": "RMB", "type": {"typename": "text"}},
+            {"name": "Feature_Name", "type": {"typename": "text"}, "nullok": False, "default": "Quality"},
+            {"name": "Image", "type": {"typename": "text"}, "nullok": False},
+            {"name": "Execution", "type": {"typename": "text"}, "nullok": False},
+            {"name": "Condition_Label", "type": {"typename": "text"}, "nullok": True},
+        ],
+        "keys": [
+            {"unique_columns": ["RID"]},
+            # No qualifier in the key — the target (Image) alone is identity.
+            {"unique_columns": ["Execution", "Image", "Feature_Name"]},
+        ],
+        "foreign_keys": [
+            {
+                "foreign_key_columns": [
+                    {"schema_name": "deriva-ml", "table_name": "Execution_Image_Quality", "column_name": "Image"}
+                ],
+                "referenced_columns": [{"schema_name": "isa", "table_name": "Image", "column_name": "RID"}],
+            },
+            {
+                "foreign_key_columns": [
+                    {"schema_name": "deriva-ml", "table_name": "Execution_Image_Quality", "column_name": "Execution"}
+                ],
+                "referenced_columns": [{"schema_name": "deriva-ml", "table_name": "Execution", "column_name": "RID"}],
+            },
+            {
+                "foreign_key_columns": [
+                    {"schema_name": "deriva-ml", "table_name": "Execution_Image_Quality", "column_name": "Feature_Name"}
+                ],
+                "referenced_columns": [
+                    {"schema_name": "deriva-ml", "table_name": "Feature_Name", "column_name": "Name"}
+                ],
+            },
+            {
+                "foreign_key_columns": [
+                    {
+                        "schema_name": "deriva-ml",
+                        "table_name": "Execution_Image_Quality",
+                        "column_name": "Condition_Label",
+                    }
+                ],
+                "referenced_columns": [{"schema_name": "isa", "table_name": "Condition_Label", "column_name": "RID"}],
+            },
+        ],
+    }
+
+    out = tmp_path / "schema_qualified_feature.json"
+    out.write_text(json.dumps(doc))
+    return out
+
+
+@pytest.fixture
+def denorm_qualified_feature_model(denorm_schema_qualified_feature: Path) -> Model:
+    """ERMrest Model with a key-qualified feature-association table."""
+    return Model.fromfile("file-system", denorm_schema_qualified_feature)
+
+
+@pytest.fixture
+def denorm_qualified_feature_deriva_model(denorm_qualified_feature_model: Model) -> DerivaModel:
+    """DerivaModel for the key-qualified feature fixture."""
+    return DerivaModel(
+        model=denorm_qualified_feature_model,
+        ml_schema="deriva-ml",
+        domain_schemas={"isa"},
+    )
+
+
+# ---------------------------------------------------------------------------
 # Shared helpers
 # ---------------------------------------------------------------------------
 

--- a/tests/local_db/test_qualified_feature_arbitrary_shapes.py
+++ b/tests/local_db/test_qualified_feature_arbitrary_shapes.py
@@ -1,0 +1,365 @@
+"""Empirical generalization of the #261 key-qualified-feature fix.
+
+The single-qualifier ``test_qualified_feature_discovery.py`` proved the fix on
+ONE vocab-FK qualifier (eye-ai's ``Chart_Label`` / ``Image_Side``). The fix
+generalizes *by construction* — ``Feature.qualifier_columns`` is a
+comprehension over ``atable.other_fkeys`` (deriva-py's compound-key-covered
+FKs), so it is agnostic to the number of qualifiers and to each qualifier FK's
+referent type. "By construction" is not "tested," and the live eye-ai catalog
+has no multi-qualifier or asset-qualifier feature to exercise. These tests make
+the generalization empirical, on offline fixtures whose ``qualifier_columns``
+are verified through the real ``find_features`` / ``Feature`` path (never
+asserted by construction alone — the "fixture lies" guard).
+
+Four shapes (one fixture each in ``conftest.py``):
+
+1. ``denorm_multi_qualifier_deriva_model`` — TWO key-covered qualifier FKs
+   (``Image_Side`` + ``Visit_Number``). Arbitrary qualifier *count*.
+2. ``denorm_asset_qualifier_deriva_model`` — a key-covered qualifier FK whose
+   referent is an ASSET table (``Image_Region``). Referent-type-agnostic.
+3. ``denorm_decoration_feature_deriva_model`` — a many-column UNQUALIFIED
+   feature (scalars + a non-key asset FK + a non-key vocab FK). The over-split
+   guard: a richly-decorated feature must NOT be mistaken for a qualified one.
+4. ``denorm_mixed_feature_deriva_model`` — a key qualifier AND non-key
+   decoration together; the two must be separated (qualifier → group key,
+   decoration → record field but not group key).
+
+Findings (absolute paths):
+  /Users/carl/GitHub/DerivaML/deriva-ml-model-template-e2e/findings/investigation/10-find-features-multivalue-arity-cap.md
+  /Users/carl/GitHub/DerivaML/deriva-ml-model-template-e2e/findings/investigation/12-selector-grouping-qualified-features.md
+"""
+
+from __future__ import annotations
+
+from deriva_ml.feature import FeatureRecord, reduce_with_selector
+from deriva_ml.model.catalog import DerivaModel
+
+
+class TestMultiQualifierFeature:
+    """Two key-covered qualifier FKs — arbitrary qualifier count (task §1)."""
+
+    FEATURE = "Visit_Chart"
+    TABLE = "Execution_Subject_Visit_Chart"
+
+    def test_find_features_discovers_it(self, denorm_multi_qualifier_deriva_model: DerivaModel):
+        """A key-FK-arity-5 feature is discovered (the cap is gone)."""
+        names = {f.feature_table.name for f in denorm_multi_qualifier_deriva_model.find_features("Subject")}
+        assert self.TABLE in names
+
+    def test_qualifier_columns_are_both_fks(self, denorm_multi_qualifier_deriva_model: DerivaModel):
+        """``qualifier_columns`` is exactly the two in-key value FKs.
+
+        Compared as a set — order is the comprehension's iteration order over
+        ``other_fkeys`` and is not part of the contract. ``Condition_Label``
+        and ``Score`` are non-key values and must be excluded; ``Feature_Name``
+        / ``Execution`` are structural and excluded.
+        """
+        feat = denorm_multi_qualifier_deriva_model.lookup_feature("Subject", self.FEATURE)
+        assert set(feat.qualifier_columns) == {"Image_Side", "Visit_Number"}
+
+    def test_record_class_carries_all_columns(self, denorm_multi_qualifier_deriva_model: DerivaModel):
+        """The FeatureRecord exposes both qualifiers and both value columns."""
+        feat = denorm_multi_qualifier_deriva_model.lookup_feature("Subject", self.FEATURE)
+        fields = set(feat.feature_record_class().model_fields.keys())
+        assert {"Subject", "Image_Side", "Visit_Number", "Condition_Label", "Score"}.issubset(fields)
+
+    def _combo_records(self, model: DerivaModel) -> tuple:
+        """One record per (Image_Side, Visit_Number) combination for SUBJ-A.
+
+        Four distinct identities: (Left,V1), (Left,V2), (Right,V1), (Right,V2).
+        """
+        feat = model.lookup_feature("Subject", self.FEATURE)
+        rc = feat.feature_record_class()
+        recs = [
+            rc(Subject="SUBJ-A", Image_Side="Left", Visit_Number="V1", Execution="E1", RCT="2026-01-01T00:00:00+00:00"),
+            rc(Subject="SUBJ-A", Image_Side="Left", Visit_Number="V2", Execution="E1", RCT="2026-01-02T00:00:00+00:00"),
+            rc(
+                Subject="SUBJ-A", Image_Side="Right", Visit_Number="V1", Execution="E1", RCT="2026-01-03T00:00:00+00:00"
+            ),
+            rc(
+                Subject="SUBJ-A", Image_Side="Right", Visit_Number="V2", Execution="E1", RCT="2026-01-04T00:00:00+00:00"
+            ),
+        ]
+        return feat, recs
+
+    def test_selector_none_returns_all_combinations(self, denorm_multi_qualifier_deriva_model: DerivaModel):
+        """No selector ⇒ every (target, q1, q2) row survives, no grouping at all.
+
+        ``reduce_with_selector`` is never called on the no-selector path
+        (``feature_values`` yields raw records), so the analogue here is the
+        full record list — all four combinations.
+        """
+        _feat, recs = self._combo_records(denorm_multi_qualifier_deriva_model)
+        assert len(recs) == 4
+        assert {(r.Image_Side, r.Visit_Number) for r in recs} == {
+            ("Left", "V1"),
+            ("Left", "V2"),
+            ("Right", "V1"),
+            ("Right", "V2"),
+        }
+
+    def test_select_newest_keeps_one_per_combination(self, denorm_multi_qualifier_deriva_model: DerivaModel):
+        """``select_newest`` yields one row per (Subject, Image_Side, Visit_Number).
+
+        NOT one-per-Subject and NOT one-per-(Subject, Image_Side): all four
+        identities are distinct, each its own singleton bucket, so all four
+        survive.
+        """
+        feat, recs = self._combo_records(denorm_multi_qualifier_deriva_model)
+        result = list(reduce_with_selector(recs, "Subject", FeatureRecord.select_newest, feat.qualifier_columns))
+        assert len(result) == 4
+        assert {(r.Image_Side, r.Visit_Number) for r in result} == {
+            ("Left", "V1"),
+            ("Left", "V2"),
+            ("Right", "V1"),
+            ("Right", "V2"),
+        }
+
+    def test_composite_key_uses_all_qualifiers_not_just_first(self, denorm_multi_qualifier_deriva_model: DerivaModel):
+        """Two rows sharing (Subject, Image_Side) but differing in Visit_Number
+        are kept by ``select_newest`` — proving Q2 participates in the key.
+
+        If the composite key used only the first qualifier, these two would
+        collapse to one (the newest). They must NOT. This is the multi-column
+        analogue of the original one-eye-dropped bug.
+        """
+        feat = denorm_multi_qualifier_deriva_model.lookup_feature("Subject", self.FEATURE)
+        rc = feat.feature_record_class()
+        recs = [
+            rc(Subject="SUBJ-A", Image_Side="Left", Visit_Number="V1", Execution="E1", RCT="2026-01-01T00:00:00+00:00"),
+            rc(Subject="SUBJ-A", Image_Side="Left", Visit_Number="V2", Execution="E1", RCT="2026-01-09T00:00:00+00:00"),
+        ]
+        result = list(reduce_with_selector(recs, "Subject", FeatureRecord.select_newest, feat.qualifier_columns))
+        assert len(result) == 2, "two rows differing only in Q2 must NOT collapse"
+        assert {r.Visit_Number for r in result} == {"V1", "V2"}
+
+    def test_reduces_within_full_composite_bucket(self, denorm_multi_qualifier_deriva_model: DerivaModel):
+        """Redundant records sharing the FULL composite identity still reduce to one.
+
+        Two rows with identical (Subject, Image_Side, Visit_Number) but
+        different executions reduce to the newest; the other three distinct
+        combinations are untouched. Four distinct identities → four survivors,
+        one of which is the within-bucket newest.
+        """
+        feat = denorm_multi_qualifier_deriva_model.lookup_feature("Subject", self.FEATURE)
+        rc = feat.feature_record_class()
+        recs = [
+            # (Left, V1) twice — must reduce to the E2 (newer) row.
+            rc(Subject="SUBJ-A", Image_Side="Left", Visit_Number="V1", Execution="E1", RCT="2026-01-01T00:00:00+00:00"),
+            rc(Subject="SUBJ-A", Image_Side="Left", Visit_Number="V1", Execution="E2", RCT="2026-01-05T00:00:00+00:00"),
+            rc(Subject="SUBJ-A", Image_Side="Left", Visit_Number="V2", Execution="E1", RCT="2026-01-02T00:00:00+00:00"),
+            rc(
+                Subject="SUBJ-A", Image_Side="Right", Visit_Number="V1", Execution="E1", RCT="2026-01-03T00:00:00+00:00"
+            ),
+        ]
+        result = list(reduce_with_selector(recs, "Subject", FeatureRecord.select_newest, feat.qualifier_columns))
+        by_combo = {(r.Image_Side, r.Visit_Number): r.Execution for r in result}
+        assert by_combo == {("Left", "V1"): "E2", ("Left", "V2"): "E1", ("Right", "V1"): "E1"}
+
+
+class TestAssetQualifierFeature:
+    """A key-covered qualifier FK pointing at an ASSET table (task §2)."""
+
+    FEATURE = "Region_Label"
+    TABLE = "Execution_Subject_Region_Label"
+
+    def test_find_features_discovers_it(self, denorm_asset_qualifier_deriva_model: DerivaModel):
+        names = {f.feature_table.name for f in denorm_asset_qualifier_deriva_model.find_features("Subject")}
+        assert self.TABLE in names
+
+    def test_qualifier_referent_is_genuinely_an_asset(self, denorm_asset_qualifier_deriva_model: DerivaModel):
+        """Precondition: ``Image_Region`` really is an asset table, not a vocab.
+
+        Without this the test below would be vacuous (the point is that an
+        ASSET-referent qualifier is still discovered as a qualifier).
+        """
+        assert denorm_asset_qualifier_deriva_model.is_asset("Image_Region")
+        assert not denorm_asset_qualifier_deriva_model.is_vocabulary("Image_Region")
+
+    def test_asset_fk_is_a_qualifier(self, denorm_asset_qualifier_deriva_model: DerivaModel):
+        """The asset-referent FK is in ``qualifier_columns`` — referent type is irrelevant.
+
+        ``qualifier_columns`` keys off FK-in-``other_fkeys`` (key coverage),
+        NOT off the referent being a vocabulary. ``Condition_Label`` (non-key
+        value) is excluded.
+        """
+        feat = denorm_asset_qualifier_deriva_model.lookup_feature("Subject", self.FEATURE)
+        assert feat.qualifier_columns == ["Image_Region"]
+
+    def test_asset_qualifier_participates_in_group_key(self, denorm_asset_qualifier_deriva_model: DerivaModel):
+        """Two rows for one Subject differing only by the asset qualifier both survive.
+
+        The asset FK is the identity discriminator, so ``select_newest`` keeps
+        both regions rather than collapsing to one-per-Subject.
+        """
+        feat = denorm_asset_qualifier_deriva_model.lookup_feature("Subject", self.FEATURE)
+        rc = feat.feature_record_class()
+        recs = [
+            rc(Subject="SUBJ-A", Image_Region="REGION-1", Execution="E1", RCT="2026-01-01T00:00:00+00:00"),
+            rc(Subject="SUBJ-A", Image_Region="REGION-2", Execution="E1", RCT="2026-01-02T00:00:00+00:00"),
+        ]
+        result = list(reduce_with_selector(recs, "Subject", FeatureRecord.select_newest, feat.qualifier_columns))
+        assert len(result) == 2
+        assert {r.Image_Region for r in result} == {"REGION-1", "REGION-2"}
+
+
+class TestDecorationFeatureOverSplitGuard:
+    """A many-column UNQUALIFIED feature must NOT be mistaken for qualified (task §3)."""
+
+    FEATURE = "RichQuality"
+    TABLE = "Execution_Image_RichQuality"
+
+    def test_find_features_discovers_it(self, denorm_decoration_feature_deriva_model: DerivaModel):
+        """``pure=False`` keeps an impure-decoration feature discoverable."""
+        names = {f.feature_table.name for f in denorm_decoration_feature_deriva_model.find_features("Image")}
+        assert self.TABLE in names
+
+    def test_qualifier_columns_is_empty(self, denorm_decoration_feature_deriva_model: DerivaModel):
+        """No decoration FK is key-covered ⇒ ``qualifier_columns`` is EMPTY.
+
+        Five non-structural columns (3 scalar, 1 asset FK, 1 vocab FK), none in
+        the compound key ``[Execution, Image, Feature_Name]`` — so none is a
+        qualifier.
+        """
+        feat = denorm_decoration_feature_deriva_model.lookup_feature("Image", self.FEATURE)
+        assert feat.qualifier_columns == []
+
+    def test_record_class_carries_all_decoration(self, denorm_decoration_feature_deriva_model: DerivaModel):
+        """The decoration columns ARE real feature data on the record.
+
+        They are classified by referent: ``Thumbnail`` → asset, ``Quality_Grade``
+        → term (it's a real vocab table), the scalars → value. All present as
+        fields; just none of them is identity.
+        """
+        feat = denorm_decoration_feature_deriva_model.lookup_feature("Image", self.FEATURE)
+        fields = set(feat.feature_record_class().model_fields.keys())
+        assert {"Image", "Confidence", "Vote_Count", "Notes", "Thumbnail", "Quality_Grade"}.issubset(fields)
+        # The asset / term classification is exercised end-to-end here.
+        assert {c.name for c in feat.asset_columns} == {"Thumbnail"}
+        assert {c.name for c in feat.term_columns} == {"Quality_Grade"}
+        assert {"Confidence", "Vote_Count", "Notes"}.issubset({c.name for c in feat.value_columns})
+
+    def test_select_newest_groups_by_target_alone(self, denorm_decoration_feature_deriva_model: DerivaModel):
+        """Decoration does NOT cause over-splitting — group by Image alone.
+
+        Two records for IMG-1 that differ in their decoration columns still
+        collapse to one (the newest), because identity is the target RID alone.
+        IMG-2 is a separate target. Two targets → two survivors. This is the
+        inverse-bug guard: a richly-decorated feature is NOT over-split.
+        """
+        feat = denorm_decoration_feature_deriva_model.lookup_feature("Image", self.FEATURE)
+        rc = feat.feature_record_class()
+        recs = [
+            rc(
+                Image="IMG-1",
+                Execution="E1",
+                Confidence=0.5,
+                Vote_Count=2,
+                Notes="a",
+                Thumbnail="T1",
+                Quality_Grade="High",
+                RCT="2026-01-01T00:00:00+00:00",
+            ),
+            rc(
+                Image="IMG-1",
+                Execution="E2",
+                Confidence=0.9,
+                Vote_Count=5,
+                Notes="b",
+                Thumbnail="T2",
+                Quality_Grade="Low",
+                RCT="2026-01-02T00:00:00+00:00",
+            ),
+            rc(
+                Image="IMG-2",
+                Execution="E1",
+                Confidence=0.3,
+                Vote_Count=1,
+                Notes="c",
+                Thumbnail="T3",
+                Quality_Grade="High",
+                RCT="2026-01-01T00:00:00+00:00",
+            ),
+        ]
+        result = list(reduce_with_selector(recs, "Image", FeatureRecord.select_newest, feat.qualifier_columns))
+        assert {r.Image for r in result} == {"IMG-1", "IMG-2"}
+        assert len(result) == 2
+        # IMG-1 reduced to the newer (E2) row despite differing decoration.
+        img1 = next(r for r in result if r.Image == "IMG-1")
+        assert img1.Execution == "E2"
+
+
+class TestMixedQualifierAndDecoration:
+    """A key qualifier AND non-key decoration together; the two are separated (task §4)."""
+
+    FEATURE = "MixedLabel"
+    TABLE = "Execution_Subject_MixedLabel"
+
+    def test_find_features_discovers_it(self, denorm_mixed_feature_deriva_model: DerivaModel):
+        names = {f.feature_table.name for f in denorm_mixed_feature_deriva_model.find_features("Subject")}
+        assert self.TABLE in names
+
+    def test_only_the_key_qualifier_is_a_qualifier(self, denorm_mixed_feature_deriva_model: DerivaModel):
+        """``Image_Side`` (in key) is the sole qualifier; decoration is excluded.
+
+        ``Severity_Label`` (vocab) and ``Heatmap`` (asset) and ``Confidence``
+        (scalar) are non-key decoration — none is a qualifier even though two of
+        them are FKs.
+        """
+        feat = denorm_mixed_feature_deriva_model.lookup_feature("Subject", self.FEATURE)
+        assert feat.qualifier_columns == ["Image_Side"]
+
+    def test_decoration_classified_but_not_identity(self, denorm_mixed_feature_deriva_model: DerivaModel):
+        """Decoration FKs become record fields (asset/term) but are not the group key."""
+        feat = denorm_mixed_feature_deriva_model.lookup_feature("Subject", self.FEATURE)
+        assert {c.name for c in feat.asset_columns} == {"Heatmap"}
+        assert {c.name for c in feat.term_columns} == {"Severity_Label"}
+        fields = set(feat.feature_record_class().model_fields.keys())
+        assert {"Image_Side", "Severity_Label", "Heatmap", "Confidence"}.issubset(fields)
+
+    def test_qualifier_splits_but_decoration_does_not(self, denorm_mixed_feature_deriva_model: DerivaModel):
+        """Same Subject + same Image_Side but differing decoration → reduces to one.
+
+        Different Image_Side → two distinct identities. So three records — two
+        Left (differing only in decoration) + one Right — reduce to exactly two
+        survivors (one per eye), proving the qualifier joins the group key while
+        the decoration does not split it.
+        """
+        feat = denorm_mixed_feature_deriva_model.lookup_feature("Subject", self.FEATURE)
+        rc = feat.feature_record_class()
+        recs = [
+            rc(
+                Subject="SUBJ-A",
+                Image_Side="Left",
+                Execution="E1",
+                Severity_Label="Mild",
+                Heatmap="H1",
+                Confidence=0.4,
+                RCT="2026-01-01T00:00:00+00:00",
+            ),
+            rc(
+                Subject="SUBJ-A",
+                Image_Side="Left",
+                Execution="E2",
+                Severity_Label="Severe",
+                Heatmap="H2",
+                Confidence=0.95,
+                RCT="2026-01-05T00:00:00+00:00",
+            ),  # newer Left
+            rc(
+                Subject="SUBJ-A",
+                Image_Side="Right",
+                Execution="E1",
+                Severity_Label="Mild",
+                Heatmap="H3",
+                Confidence=0.6,
+                RCT="2026-01-02T00:00:00+00:00",
+            ),
+        ]
+        result = list(reduce_with_selector(recs, "Subject", FeatureRecord.select_newest, feat.qualifier_columns))
+        assert len(result) == 2, "decoration must not split; qualifier must"
+        by_side = {r.Image_Side: r.Execution for r in result}
+        assert by_side == {"Left": "E2", "Right": "E1"}
+        # The surviving Left row kept its (decoration) Severity_Label intact.
+        left = next(r for r in result if r.Image_Side == "Left")
+        assert left.Severity_Label == "Severe"

--- a/tests/local_db/test_qualified_feature_discovery.py
+++ b/tests/local_db/test_qualified_feature_discovery.py
@@ -1,0 +1,231 @@
+"""Regression tests for key-qualified multi-value features (findings 10 + 12).
+
+Two coupled bugs hid behind the same fixture gap — no prior fixture
+modeled a feature-association table whose **compound uniqueness key
+includes a qualifier FK** beyond ``{target, Feature_Name, Execution}``.
+That is the structural shape of eye-ai's real
+``Execution_Subject_Chart_Label`` feature (an ``Image_Side`` qualifier:
+the same Subject has a left-eye row and a right-eye row).
+
+Bug 1 (finding 10): ``find_features`` capped ``find_associations`` at
+``max_arity=3``, so a key-FK-arity-4 qualified feature was silently
+undiscoverable (and therefore unreadable via ``lookup_feature`` /
+``feature_values``).
+
+Bug 2 (finding 12): ``reduce_with_selector`` grouped by the target RID
+alone, so a selector collapsed the two eyes of one Subject into one row —
+silently dropping a distinct, valid observation.
+
+The fixture here (``denorm_schema_qualified_feature``) reproduces both:
+under the old ``max_arity=3`` cap ``find_features`` returns nothing for it;
+under the fix it is discovered, exposes its ``Image_Side`` qualifier
+column, and a selector keyed on ``(Subject, Image_Side)`` preserves both
+eyes.
+
+Findings (absolute paths):
+  /Users/carl/GitHub/DerivaML/deriva-ml-model-template-e2e/findings/investigation/10-find-features-multivalue-arity-cap.md
+  /Users/carl/GitHub/DerivaML/deriva-ml-model-template-e2e/findings/investigation/12-selector-grouping-qualified-features.md
+
+Pure offline tests — ``Model.fromfile`` wires ``referenced_by`` so
+``find_features`` works without a live catalog.
+"""
+
+from __future__ import annotations
+
+from deriva_ml.feature import reduce_with_selector
+from deriva_ml.model.catalog import DerivaModel
+
+
+class TestQualifiedFeatureDiscovery:
+    """Bug 1: the arity cap. ``find_features`` must discover the qualified feature."""
+
+    def test_find_features_discovers_key_qualified_feature(self, denorm_qualified_feature_deriva_model: DerivaModel):
+        """``find_features("Subject")`` includes the key-qualified feature.
+
+        Under the former ``max_arity=3`` cap this returned ``[]`` (the
+        compound key's FK arity is 4). The fix drops the ceiling so the
+        feature is discovered.
+        """
+        feats = list(denorm_qualified_feature_deriva_model.find_features("Subject"))
+        names = {f.feature_table.name for f in feats}
+        assert "Execution_Subject_Chart_Label" in names
+
+    def test_old_arity_cap_would_miss_it(self, denorm_qualified_feature_deriva_model: DerivaModel):
+        """Pin the gap: the OLD ``max_arity=3`` cap excludes this feature.
+
+        This is what made the bug invisible. We call ``find_associations``
+        directly with both ceilings and assert they disagree — guaranteeing
+        the fixture genuinely exercises the cap (and isn't accidentally
+        arity-3).
+        """
+        subject = denorm_qualified_feature_deriva_model.name_to_table("Subject")
+        old = [a.table.name for a in subject.find_associations(min_arity=3, max_arity=3, pure=False)]
+        new = [a.table.name for a in subject.find_associations(min_arity=3, max_arity=None, pure=False)]
+        assert "Execution_Subject_Chart_Label" not in old
+        assert "Execution_Subject_Chart_Label" in new
+
+    def test_lookup_feature_succeeds(self, denorm_qualified_feature_deriva_model: DerivaModel):
+        """``lookup_feature`` resolves the qualified feature (was ``DerivaMLFeatureNotFound``)."""
+        feat = denorm_qualified_feature_deriva_model.lookup_feature("Subject", "Chart_Label")
+        assert feat.feature_name == "Chart_Label"
+        assert feat.target_table.name == "Subject"
+
+
+class TestQualifierColumns:
+    """``Feature.qualifier_columns`` exposes the in-key value FKs."""
+
+    def test_qualifier_columns_is_image_side(self, denorm_qualified_feature_deriva_model: DerivaModel):
+        """The qualifier is exactly ``Image_Side`` — the in-key value FK.
+
+        ``Condition_Label`` is a value FK too, but NOT in the compound key,
+        so it must NOT appear as a qualifier. ``Feature_Name`` / ``Execution``
+        are structural and excluded.
+        """
+        feat = denorm_qualified_feature_deriva_model.lookup_feature("Subject", "Chart_Label")
+        assert feat.qualifier_columns == ["Image_Side"]
+
+    def test_record_class_carries_qualifier_field(self, denorm_qualified_feature_deriva_model: DerivaModel):
+        """The generated FeatureRecord carries the ``Image_Side`` field.
+
+        The qualifier must be present and distinguishable on every record so
+        ``reduce_with_selector`` can group on it.
+        """
+        feat = denorm_qualified_feature_deriva_model.lookup_feature("Subject", "Chart_Label")
+        record_class = feat.feature_record_class()
+        fields = set(record_class.model_fields.keys())
+        assert {"Subject", "Image_Side", "Condition_Label"}.issubset(fields)
+
+
+class TestQualifiedFeatureSelectorReduction:
+    """Bug 2: selector grouping. Both eyes must survive a selector."""
+
+    def _records(self, denorm_qualified_feature_deriva_model: DerivaModel):
+        """Build two records for one Subject — a Left eye and a Right eye.
+
+        Uses the feature's own ``feature_record_class`` so the records carry
+        exactly the fields the production read path produces.
+        """
+        feat = denorm_qualified_feature_deriva_model.lookup_feature("Subject", "Chart_Label")
+        record_class = feat.feature_record_class()
+        # RIDs are obtained as opaque strings here only because no catalog is
+        # involved (offline FeatureRecord construction). They are never parsed.
+        left = record_class(
+            Subject="SUBJ-A",
+            Image_Side="Left",
+            Condition_Label="POAG",
+            Execution="EXEC-1",
+            RCT="2026-01-01T00:00:00+00:00",
+        )
+        right = record_class(
+            Subject="SUBJ-A",
+            Image_Side="Right",
+            Condition_Label="POAG",
+            Execution="EXEC-1",
+            RCT="2026-01-02T00:00:00+00:00",
+        )
+        return feat, [left, right]
+
+    def test_select_newest_preserves_both_eyes(self, denorm_qualified_feature_deriva_model: DerivaModel):
+        """``select_newest`` keeps the Left AND the Right eye — not one.
+
+        This is the core fix proof: grouping on ``(Subject, Image_Side)``
+        means each eye is its own identity bucket. The selector reduces
+        *within* each bucket (here each bucket has one record), so both
+        survive. Pre-fix (group-by-Subject) the two collapsed to one.
+        """
+        from deriva_ml.feature import FeatureRecord
+
+        feat, records = self._records(denorm_qualified_feature_deriva_model)
+        result = list(
+            reduce_with_selector(
+                records,
+                feat.target_table.name,
+                FeatureRecord.select_newest,
+                feat.qualifier_columns,
+            )
+        )
+        assert len(result) == 2
+        assert {r.Image_Side for r in result} == {"Left", "Right"}
+        # Same Subject on both — they are two observations of one Subject.
+        assert {r.Subject for r in result} == {"SUBJ-A"}
+
+    def test_without_qualifier_would_collapse_to_one(self, denorm_qualified_feature_deriva_model: DerivaModel):
+        """Pin the bug: group-by-target alone collapses the two eyes to one.
+
+        Calling the helper WITHOUT the qualifier reproduces the pre-fix
+        behavior — proof that threading ``qualifier_columns`` is what fixes
+        it, not some incidental change.
+        """
+        from deriva_ml.feature import FeatureRecord
+
+        feat, records = self._records(denorm_qualified_feature_deriva_model)
+        collapsed = list(
+            reduce_with_selector(
+                records,
+                feat.target_table.name,
+                FeatureRecord.select_newest,
+            )
+        )
+        assert len(collapsed) == 1  # one eye dropped — the old, wrong answer
+
+    def test_selector_reduces_redundant_within_eye(self, denorm_qualified_feature_deriva_model: DerivaModel):
+        """Two annotations of the SAME eye still reduce to one; both eyes kept.
+
+        Identity is ``(Subject, Image_Side)``: redundant records within one
+        eye collapse, but the two eyes stay distinct. Result: exactly two
+        survivors (newest Left, newest Right).
+        """
+        from deriva_ml.feature import FeatureRecord
+
+        feat = denorm_qualified_feature_deriva_model.lookup_feature("Subject", "Chart_Label")
+        record_class = feat.feature_record_class()
+        records = [
+            record_class(Subject="SUBJ-A", Image_Side="Left", Execution="E1", RCT="2026-01-01T00:00:00+00:00"),
+            record_class(Subject="SUBJ-A", Image_Side="Left", Execution="E2", RCT="2026-01-03T00:00:00+00:00"),
+            record_class(Subject="SUBJ-A", Image_Side="Right", Execution="E1", RCT="2026-01-02T00:00:00+00:00"),
+        ]
+        result = list(reduce_with_selector(records, "Subject", FeatureRecord.select_newest, feat.qualifier_columns))
+        by_side = {r.Image_Side: r.Execution for r in result}
+        assert by_side == {"Left": "E2", "Right": "E1"}
+
+
+class TestUnqualifiedFeatureBackwardCompat:
+    """Backward-compat: an unqualified feature is unchanged by the fix.
+
+    Uses the ``Execution_Image_Quality`` feature carried in the same
+    fixture — a key-FK-arity-3 feature whose compound key is
+    ``[Execution, Image, Feature_Name]`` (no qualifier). It is discovered
+    by the same ``find_features`` path, so it exercises the new code while
+    asserting the historical group-by-target behavior is preserved.
+    """
+
+    def test_unqualified_feature_has_no_qualifiers(self, denorm_qualified_feature_deriva_model: DerivaModel):
+        """The ordinary ``Quality`` feature has empty qualifier_columns.
+
+        Its compound identity is the target RID alone, so grouping is
+        unchanged — exactly the historical behavior. ``Condition_Label`` is
+        a value FK but NOT in the key, so it must NOT be treated as a
+        qualifier.
+        """
+        feat = denorm_qualified_feature_deriva_model.lookup_feature("Image", "Quality")
+        assert feat.qualifier_columns == []
+
+    def test_unqualified_feature_reduces_to_one_per_target(self, denorm_qualified_feature_deriva_model: DerivaModel):
+        """With empty qualifiers, two records for one Image collapse to one.
+
+        Byte-identical to grouping on the target RID alone — the invariant
+        the fix must preserve for every existing (unqualified) caller.
+        """
+        from deriva_ml.feature import FeatureRecord
+
+        feat = denorm_qualified_feature_deriva_model.lookup_feature("Image", "Quality")
+        record_class = feat.feature_record_class()
+        records = [
+            record_class(Image="IMG-1", Execution="E1", RCT="2026-01-01T00:00:00+00:00"),
+            record_class(Image="IMG-1", Execution="E2", RCT="2026-01-02T00:00:00+00:00"),
+            record_class(Image="IMG-2", Execution="E1", RCT="2026-01-01T00:00:00+00:00"),
+        ]
+        result = list(reduce_with_selector(records, "Image", FeatureRecord.select_newest, feat.qualifier_columns))
+        # Two target Images → two survivors; IMG-1's two records collapse.
+        assert {r.Image for r in result} == {"IMG-1", "IMG-2"}
+        assert len(result) == 2


### PR DESCRIPTION
## Summary

Two coupled bugs in the feature surface, shipped together because fixing
the first alone exposes the second as a silent correctness regression.

**Bug 1 — discovery (finding 10).** `find_features` capped
`find_associations` at `max_arity=3`, silently excluding any feature
whose value FK participates in the association table's compound
uniqueness key (a *qualifier*). eye-ai's `Execution_Subject_Chart_Label`
has key `{Execution, Subject, Feature_Name, Image_Side}` (key-FK arity 4),
so `find_features("Subject")` returned `[]` and the feature's 1832 rows
were unreadable via `lookup_feature` / `feature_values`.
Fix: `max_arity=3` → `max_arity=None` (keep `min_arity=3`). `is_feature`
remains the sole filter, so the ceiling removal admits no non-feature.

**Bug 2 — selector grouping (finding 12).** `reduce_with_selector`
grouped by the target RID alone, so a selector collapsed all rows for one
target into one. On Chart_Label, `select_newest` dropped 915 of 1832 rows:
each Subject has a left-eye and a right-eye row, and grouping on Subject
kept one eye and discarded the other.
Fix: retain `Feature.qualifier_columns` (the in-key value FKs minus the
structural `{Feature_Name, Execution}` — already computed as `assoc_fkeys`
and previously discarded) and group on the composite identity
`(target_rid, *qualifiers)`. Empty qualifiers degenerate to
`(target_rid,)` — **byte-identical** to today for every unqualified
feature and every existing caller. The four `reduce_with_selector` call
sites (FeatureMixin / Dataset / DatasetBag `feature_values` + the
Denormalizer's `_apply_selector`) thread `feat.qualifier_columns`.

**Why coupled:** shipping Bug-1's fix alone would make a feature
discoverable + readable but silently halve its data the moment any
selector is applied — a correctness regression introduced by the very PR
meant to fix a correctness bug. (1)+(2) together: visible *and* correct
on every path.

**The fixture gap fixed:** no prior fixture modeled a value FK *in the
compound key* — the shape that hid both bugs. The new fixture
(`denorm_schema_qualified_feature`) does, and fails the old code (missed
under `max_arity=3`) while passing the new.

Findings:
- `/Users/carl/GitHub/DerivaML/deriva-ml-model-template-e2e/findings/investigation/10-find-features-multivalue-arity-cap.md`
- `/Users/carl/GitHub/DerivaML/deriva-ml-model-template-e2e/findings/investigation/12-selector-grouping-qualified-features.md`

## Test plan

- New `tests/local_db/test_qualified_feature_discovery.py`: discovery
  (incl. direct old-vs-new ceiling contrast), `qualifier_columns ==
  ["Image_Side"]` (Condition_Label excluded), both-eyes-survive +
  collapse-when-withheld, within-bucket reduction, and the
  unqualified-unchanged backward-compat invariant.
- New unit coverage in `tests/feature/test_reduce_with_selector.py` for
  the `qualifier_cols` composite key (empty default == group-by-target,
  per-qualifier split, within-bucket reduce, multi-column keys,
  None-bucket, iterable normalization).
- `uv run python -m pytest tests/local_db/ tests/feature/`: 411 passed,
  3 skipped. The 15 `TestFeatureValuesSymmetry` errors + 2
  `test_features.py` failures (`test_download_feature`,
  `test_list_workflow_executions_returns_matching_rids`) reproduce on
  clean `main` — pre-existing (`Workflow.rid`→`.RID` fixture rot and a
  workflow-execution issue), not introduced here.
- `tests/model/` 108 passed; offline denormalize-selector tests pass.
- ruff check + format clean on touched files.

## Live validation (dev.eye-ai.org, read-only)

```
find_features("Subject")
  BEFORE (clean main): []
  AFTER:               ['Chart_Label']   (Feature.qualifier_columns = ['Image_Side'])

feature_values("Subject","Chart_Label", selector=None)
  AFTER: 1832 rows  (917 distinct Subjects, 1832 distinct (Subject,Image_Side))

feature_values("Subject","Chart_Label", select_newest)
  BEFORE (clean main): DerivaMLFeatureNotFound  (undiscoverable)
  cap-fix-only (per finding 12): 917 rows  (one eye per Subject — WRONG)
  AFTER (both fixes):  1832 rows  (one per (Subject,Image_Side) — both eyes preserved)

  Subject 2-7P00 after select_newest:
    Subject=2-7P00 Image_Side=Right Condition=POAG Exec=6-9SMR
    Subject=2-7P00 Image_Side=Left  Condition=POAG Exec=6-9SMR
    -> both eyes survive
```

Unqualified features unchanged (backward-compat proof):
```
Image / Fundus_Angle    selector=None=1972   select_newest=1972   (unchanged)
Image / Image_Diagnosis selector=None=190377 select_newest=171108 (unchanged — multi-annotator reduction)
```

eye-ai was read-only throughout; no writes.

---

## Test coverage (follow-up commit `5b2c77d1`)

The fix generalizes the qualifier handling **by construction** —
`Feature.qualifier_columns` is a comprehension over `atable.other_fkeys`
(deriva-py's compound-key-covered FKs), agnostic to the *number* of
qualifiers and to each qualifier FK's *referent type*. The original
commits validated this empirically only on eye-ai's `Chart_Label` (ONE
vocab-FK qualifier). This follow-up makes the generalization **empirical
for arbitrary feature shapes** — the live catalog has no multi-qualifier
or asset-qualifier feature to exercise.

New offline fixtures (`tests/local_db/conftest.py`), each verifying its
`qualifier_columns` through the real `find_features` / `Feature` path
(never by construction — the "fixture lies" guard), modeling each
qualifier as a real FK in a real compound key (the exact distinction the
fix hinges on):

- **multi-qualifier** — TWO key-covered qualifier FKs (`Image_Side` +
  `Visit_Number`), key-FK arity 5.
- **asset-FK qualifier** — a key-covered qualifier FK whose referent is an
  **asset** table (proves the derivation is referent-type-agnostic).
- **decoration-heavy unqualified** — a many-column feature (3 scalars +
  non-key asset FK + non-key vocab FK), none in the key (over-split guard).
- **mixed** — a key qualifier AND non-key decoration together.

New tests (`tests/local_db/test_qualified_feature_arbitrary_shapes.py`, 19):

- **Multi-qualifier (7):** discovery; `qualifier_columns ==`
  `{Image_Side, Visit_Number}`; `selector=None` returns all `(target,q1,q2)`
  combinations; `select_newest` keeps one row **per `(target,q1,q2)`
  identity** — not one-per-target, not one-per-`(target,q1)`; the critical
  case where two rows share `(target,q1)` but differ in `q2` keeps **both**;
  within-bucket reduction over the full composite key.
- **Asset-FK qualifier (4):** the asset FK is in `qualifier_columns` and
  participates in the group key; a precondition asserts the referent really
  is an asset (not a vocab), so the test isn't vacuous.
- **Decoration over-split guard (4):** discovery; `qualifier_columns`
  **empty**; `select_newest` groups by target **alone** (decoration does not
  over-split); the FeatureRecord carries all decoration columns
  (asset/term/value-classified) as real feature data.
- **Mixed (4):** only the in-key qualifier is a qualifier; decoration is
  classified into record fields but is NOT the group key; the qualifier
  splits the group while decoration does not.

**The generalization is now empirically proven for arbitrary
value/asset/qualifier counts, not just reasoned. All 19 new tests pass; no
new test exposed a logic gap; no production logic changed.**

### Session-finding regression sweep (verified, not assumed)

| Finding | Regression test | Status |
|---|---|---|
| #257 selector param on Denormalizer | `test_denormalize_selector.py` — selector reduction + no-feature-assoc `ValueError` + multi-assoc `ValueError` + real-4-FK engagement | already present |
| #258 Stage 3a delegation + Option B grouping unify | `test_denormalize_feature_records.py` — RCT recovery + tz-naive→UTC coercion + null-target drop | already present |
| #259 4-FK predicate | `test_planner_rules.py` — predicate tests + diamond Rule 6 + FourWayAssoc negative | already present |
| #260 Stage 3b bag delegation | `test_bag_feature_values.py` — bag-mode read (typed records, UTC RCT, selector) | already present |
| #260-fix multi-element UnrelatedAnchor | `test_feature_records_unrelated_anchors.py` — multi-element drop AND default-path-still-raises scoped-relaxation guard | already present |
| #261 arity cap + qualified grouping | new `test_qualified_feature_arbitrary_shapes.py` + existing `test_qualified_feature_discovery.py` + `test_reduce_with_selector.py` | **present + extended** |
| RCT timezone shape (tz-naive vs +00:00) | `test_denormalize_feature_records.py` — UTC-aware ISO RCT round-trip | already present |

Every finding already carried a regression test; nothing was missing, so
no gap-fill was needed beyond the #261 arbitrary-shape extension.

### Counts

`tests/local_db/` (deterministic, offline): 333 → **352 passed** (+19,
exact), 3 skipped. The `tests/feature/` live-localhost-catalog tests
(`TestFeatures`, `test_feature_values_limits`, `TestFeatureValuesSymmetry`)
pass slowly when catalog 27 is reachable and error at fixture setup when it
isn't — identical behavior on clean HEAD, unaffected by this change (no
`src/` or `tests/feature/` edits). The pre-existing
`test_download_feature` / `test_list_workflow_executions_returns_matching_rids`
failures and 15 `TestFeatureValuesSymmetry` errors reproduce on clean HEAD.
