### PR TITLE
fix(workflow): find_workflows/lookup_workflow populate workflow_rid; fix stale .rid test refs

### DIFF
--- a/src/deriva_ml/core/mixins/workflow.py
+++ b/src/deriva_ml/core/mixins/workflow.py
@@ -106,7 +106,7 @@ class WorkflowMixin:
                 - workflow_type: Type(s) of workflow
                 - version: Version identifier
                 - description: Workflow description
-                - rid: Resource identifier
+                - workflow_rid: Resource identifier
                 - checksum: Source code checksum
 
         Examples:
@@ -145,7 +145,7 @@ class WorkflowMixin:
                 workflow_type=types_index.get(w["RID"], []),
                 version=w["Version"],
                 description=w["Description"],
-                rid=w["RID"],
+                workflow_rid=w["RID"],
                 checksum=w["Checksum"],
             )
             # Bind the workflow to this catalog instance
@@ -274,7 +274,7 @@ class WorkflowMixin:
             workflow_type=workflow_types,
             version=w["Version"],
             description=w["Description"],
-            rid=w["RID"],
+            workflow_rid=w["RID"],
             checksum=w["Checksum"],
         )
         # Bind the workflow to this catalog instance for write-back support

--- a/src/deriva_ml/execution/workflow.py
+++ b/src/deriva_ml/execution/workflow.py
@@ -109,7 +109,15 @@ class Workflow(BaseModel):
             >>> workflow.description = "New description"  # Raises DerivaMLException
     """
 
-    model_config = VALIDATION_CONFIG
+    # extra="forbid" guards against the silent kwarg-drop that masked the
+    # rid -> workflow_rid rename regression (#226): the renamed field was
+    # passed under its old name, Pydantic dropped the unknown kwarg without
+    # error, and every find_workflows()/lookup_workflow() result silently
+    # carried workflow_rid=None. Forbidding extra fields turns that class of
+    # mistake into a loud ValidationError at construction time. Scoped to
+    # Workflow only (mirrors the existing STRICT_VALIDATION_CONFIG idiom in
+    # core/validation.py) rather than widening the shared VALIDATION_CONFIG.
+    model_config = {**VALIDATION_CONFIG, "extra": "forbid"}
 
     name: str
     workflow_type: str | list[str]

--- a/tests/dataset/test_validate_execution_configuration_unit.py
+++ b/tests/dataset/test_validate_execution_configuration_unit.py
@@ -151,7 +151,7 @@ def _make_workflow(rid: str = "2-WFAA") -> Workflow:
         name="test wf",
         url="https://example.org/wf.py",
         workflow_type="python_script",
-        rid=rid,
+        workflow_rid=rid,
         checksum="abc123",
     )
 

--- a/tests/dataset/test_validate_specs_live.py
+++ b/tests/dataset/test_validate_specs_live.py
@@ -93,7 +93,7 @@ def test_validate_execution_configuration_live_full(test_ml):
         workflow_type="Validate Test",
         description="composite smoke",
     )
-    wf = wf.model_copy(update={"rid": test_ml._add_workflow(wf)})
+    wf = wf.model_copy(update={"workflow_rid": test_ml._add_workflow(wf)})
     config = ExecutionConfiguration(
         workflow=wf,
         datasets=[DatasetSpec(rid=rid, version=version)],
@@ -157,10 +157,10 @@ def test_validate_execution_configuration_live_assets(test_ml):
         workflow_type="Validate Test",
         description="asset smoke",
     )
-    wf = wf.model_copy(update={"rid": test_ml._add_workflow(wf)})
+    wf = wf.model_copy(update={"workflow_rid": test_ml._add_workflow(wf)})
     config = ExecutionConfiguration(
         workflow=wf,
-        assets=[AssetSpec(rid=wf.rid)],
+        assets=[AssetSpec(rid=wf.workflow_rid)],
     )
     report = test_ml.validate_execution_configuration(config)
     assert report.all_valid is False

--- a/tests/execution/test_execution.py
+++ b/tests/execution/test_execution.py
@@ -238,7 +238,7 @@ class TestWorkflow:
         workflows = list(ml.find_workflows())
         assert len(workflows) >= 1
         # Verify our workflow RID is in the catalog
-        assert workflow_rid in [w.rid for w in workflows]
+        assert workflow_rid in [w.workflow_rid for w in workflows]
 
     def test_workflow_multiple_types(self, test_ml):
         """Test creating a workflow with multiple types."""

--- a/tests/execution/test_find_workflows_sort.py
+++ b/tests/execution/test_find_workflows_sort.py
@@ -61,7 +61,7 @@ def test_find_workflows_sort_true_returns_newest_first(catalog_with_workflows):
     """
     ml = catalog_with_workflows
     workflows = list(ml.find_workflows(sort=True))
-    rids = [w.rid for w in workflows]
+    rids = [w.workflow_rid for w in workflows]
     assert rids == sorted(rids, reverse=True), f"workflows should be newest-first (RID-desc proxy); got rids={rids}"
 
 
@@ -74,7 +74,7 @@ def test_find_workflows_sort_callable_applies_user_keys(catalog_with_workflows):
         return path.RID
 
     workflows = list(ml.find_workflows(sort=by_rid_asc))
-    rids = [w.rid for w in workflows]
+    rids = [w.workflow_rid for w in workflows]
     assert rids == sorted(rids), f"workflows should be RID-ascending; got {rids}"
 
 

--- a/tests/execution/test_lookup_lineage_unit.py
+++ b/tests/execution/test_lookup_lineage_unit.py
@@ -51,7 +51,7 @@ class _StubResolved:
 
 @dataclass
 class _StubWorkflow:
-    rid: str
+    workflow_rid: str
     name: str
 
 
@@ -246,7 +246,7 @@ def test_lineage_dataset_one_level_chain():
     ml.add_execution(
         "2-EXAA",
         description="train",
-        workflow=_StubWorkflow(rid="3-WFAB", name="trainer"),
+        workflow=_StubWorkflow(workflow_rid="3-WFAB", name="trainer"),
         input_datasets=[_StubDataset("1-DSAA", "root data", "0.1.0")],
     )
     ml.add_dataset("1-DSAB", description="trained set", producer="2-EXAA")

--- a/tests/feature/conftest.py
+++ b/tests/feature/conftest.py
@@ -193,7 +193,7 @@ def feature_symmetry_fixture(catalog_manager, tmp_path_factory):
         f"Expected exactly one workflow after test catalog setup (workflow dedup by "
         f"checksum), but found {len(all_workflows)}: {[w.name for w in all_workflows]}"
     )
-    feature_workflow_rid = all_workflows[0].rid
+    feature_workflow_rid = all_workflows[0].workflow_rid
     assert feature_workflow_rid, "Workflow must have a RID"
 
     # Create a new dataset that contains ALL image RIDs so that the dataset-scoped


### PR DESCRIPTION
## Summary

This PR fixes a **production regression** in `find_workflows` / `lookup_workflow` that returned `Workflow` objects with `workflow_rid = None`, plus the stale test references that surfaced it.

The `rid` → `workflow_rid` field rename in #226 left two `Workflow(...)` construction sites in `WorkflowMixin` (`src/deriva_ml/core/mixins/workflow.py`) still passing `rid=w["RID"]`. Because `Workflow.model_config = VALIDATION_CONFIG` does **not** set `extra="forbid"`, Pydantic **silently dropped** the unknown `rid=` kwarg instead of raising — so every `Workflow` returned by `find_workflows()` and `lookup_workflow()` carried `workflow_rid = None`. Downstream this broke:

- sorting on `workflow_rid` → `TypeError: '<' not supported between NoneType and NoneType`
- the `workflow_types` property → its association-table query filtered on `Workflow == None`, returning `[]`
- the feature-symmetry fixture → `assert feature_workflow_rid` failed on `None`

The earlier commit on this branch (`84b4e11d`) fixed 3 stale `.rid` test references but explicitly deferred the `src/` fix and could not make the tests green. This branch now contains the full fix.

## Changes

**src — the real defect:**
- `core/mixins/workflow.py` — both Workflow construction sites (`find_workflows`, `lookup_workflow`) now pass `workflow_rid=w["RID"]` instead of the dropped `rid=`. Restores RID population. (docstring `rid:` → `workflow_rid:` too)
- `execution/workflow.py` — `Workflow` model now uses `{**VALIDATION_CONFIG, "extra": "forbid"}`. This is the hardening that would have caught the original bug loudly: a stale/misspelled kwarg now raises `ValidationError` at construction instead of being silently discarded. Scoped to `Workflow` only (mirrors the existing `STRICT_VALIDATION_CONFIG` idiom in `core/validation.py`); the shared `VALIDATION_CONFIG` is unchanged.

**tests — stale `.rid` refs from the #226 rename (8 total, 6 files):**
- `conftest.py:196`, `test_find_workflows_sort.py:64,77` — fixed in `84b4e11d` (3 refs)
- `test_execution.py:241` — `[w.rid for w in workflows]` → `[w.workflow_rid ...]`
- `test_validate_execution_configuration_unit.py` — `_make_workflow` constructed `Workflow(rid=...)` in test setup
- `test_validate_specs_live.py` (x2) — `model_copy(update={"rid": ...})` + `AssetSpec(rid=wf.rid)` now target `workflow_rid`
- `test_lookup_lineage_unit.py` — `_StubWorkflow.rid` field renamed to `workflow_rid` to match production `record.workflow.workflow_rid` (was raising `AttributeError`)

Legitimate `.rid` uses on other classes (`VocabularyTerm`, `DatasetSpec`/`DatasetSpecConfig`, `AssetSpec`, `WorkflowSummary`/lineage summary objects, config-entry RIDs) were left untouched. No repo-wide ruff reformats included.

## Test plan

Verified against the live localhost catalog (`DERIVA_ML_ALLOW_DIRTY=true`). Ruff `check` + `format --check` clean on every touched file (pre-existing repo-wide lint drift in `test_execution.py` / `execution/workflow.py` was confirmed present at the PR base and left alone).

| Suite | Before (at `84b4e11d`) | After (this PR) |
|-------|------------------------|-----------------|
| `test_find_workflows_sort.py` + `test_execution.py` | **7 failed**, 57 passed, 1 skipped | **0 failed, 64 passed**, 1 skipped |
| `TestFeatureValuesSymmetry` (the 15 errors) | 15 errors (fixture `assert feature_workflow_rid` → `None`) | **15 passed** |
| `test_feature_values.py` (full) | 11 passed / 15 errors | **26 passed**, 0 errors |
| `tests/execution/` (full regression) | 1 failed (pre-existing `_StubWorkflow.rid`), 479 passed | **480 passed**, 8 skipped |

The 7 execution-suite failures and the 15 `TestFeatureValuesSymmetry` errors all traced to the single `workflow_rid=None` root cause and are now cleared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
