### PR TITLE
fix(validation): validate_rids must call dataset_history, not list_versions

### DIFF
--- a/src/deriva_ml/core/validation.py
+++ b/src/deriva_ml/core/validation.py
@@ -280,9 +280,9 @@ def validate_rids(
                         f"Dataset '{rid}' has no version information. Required version: {required_version}"
                     )
                 elif current_version != required_version:
-                    # Check if the required version exists in history
+                    # Check if the required version exists in history.
                     try:
-                        history = dataset.list_versions()
+                        history = dataset.dataset_history()
                         version_exists = any(str(h.dataset_version) == required_version for h in history)
                         if not version_exists:
                             result.add_error(
@@ -294,8 +294,17 @@ def validate_rids(
                             # Version exists but is not current - this is OK
                             result.validated_rids[rid]["version"] = required_version
                             result.validated_rids[rid]["current_version"] = current_version
-                    except Exception:
-                        # Can't check history, just warn
+                    except DerivaMLException:
+                        # Narrow catch: ``dataset_history()`` documents
+                        # ``DerivaMLException`` as its only failure mode (a
+                        # catalog read error, or the RID not being a valid
+                        # dataset RID). That is a genuine "can't read history"
+                        # condition we degrade to a warning rather than crash.
+                        # Deliberately NOT ``except Exception`` — programming
+                        # errors (AttributeError, TypeError) must propagate
+                        # loudly so a future typo can't silently downgrade a
+                        # hard version error to a warning, as a misnamed
+                        # ``list_versions()`` call once did.
                         result.add_warning(
                             f"Dataset '{rid}' current version ({current_version}) differs from "
                             f"required version ({required_version}). Could not verify version history."

--- a/tests/core/test_validation_and_logging.py
+++ b/tests/core/test_validation_and_logging.py
@@ -15,6 +15,7 @@ import logging
 
 import pytest
 
+from deriva_ml.core.exceptions import DerivaMLException
 from deriva_ml.core.logging_config import (
     DERIVA_LOGGERS,
     HYDRA_LOGGERS,
@@ -22,8 +23,8 @@ from deriva_ml.core.logging_config import (
     get_logger,
     is_hydra_initialized,
 )
-from deriva_ml.core.validation import ValidationResult
-
+from deriva_ml.core.validation import ValidationResult, validate_rids
+from deriva_ml.dataset.aux_classes import DatasetHistory, DatasetVersion
 
 # ---------------------------------------------------------------------------
 # ValidationResult — the missing direct coverage
@@ -262,3 +263,197 @@ class TestConfigureLogging:
         """The return value is the configured ``deriva_ml`` logger."""
         returned = configure_logging(level=logging.INFO)
         assert returned is clean_deriva_ml_logger
+
+
+# ---------------------------------------------------------------------------
+# validate_rids — dataset version-history branch
+# ---------------------------------------------------------------------------
+#
+# Regression coverage for the alignment-audit Batch A finding
+# (core/validation.py:285): the version-checking branch called a
+# nonexistent ``dataset.list_versions()`` inside a broad ``except
+# Exception``. The AttributeError was silently swallowed, so the
+# intended hard ERROR for a required version that does not exist in
+# history NEVER ran — every bad version requirement degraded to a
+# warning. The fix calls ``dataset.dataset_history()`` and narrows the
+# except to ``DerivaMLException`` so programming errors propagate.
+
+
+def _history(*versions: str, dataset_rid: str = "1-DSAA") -> list[DatasetHistory]:
+    """Build a ``DatasetHistory`` list with real ``DatasetVersion`` labels.
+
+    Mirrors what ``Dataset.dataset_history()`` returns so the validator
+    exercises ``h.dataset_version`` exactly as it does in production.
+
+    Args:
+        *versions: PEP 440 version strings, e.g. ``"1.0.0"``.
+        dataset_rid: RID stamped on each history entry.
+
+    Returns:
+        A list of :class:`DatasetHistory`, one entry per version.
+
+    Example:
+        >>> hist = _history("0.1.0", "1.0.0")
+        >>> [str(h.dataset_version) for h in hist]
+        ['0.1.0', '1.0.0']
+    """
+    return [
+        DatasetHistory(
+            dataset_version=DatasetVersion.parse(v),
+            dataset_rid=dataset_rid,
+            version_rid=f"{i}-V{i:03d}",
+            snapshot=f"snap{i}",
+        )
+        for i, v in enumerate(versions)
+    ]
+
+
+class _ResolvedInfo:
+    """Stand-in for ``BatchRidResult`` — validator reads only these two attrs."""
+
+    def __init__(self, table_name: str, schema_name: str) -> None:
+        self.table_name = table_name
+        self.schema_name = schema_name
+
+
+class _StubDataset:
+    """Stand-in for the ``Dataset`` returned by ``ml.lookup_dataset``.
+
+    Carries a ``current_version`` and a ``dataset_history()`` whose
+    return value (or raised exception) is scripted per test.
+    """
+
+    def __init__(
+        self,
+        current_version: str,
+        history: list[DatasetHistory] | None = None,
+        history_exc: BaseException | None = None,
+    ) -> None:
+        self.current_version = DatasetVersion.parse(current_version)
+        self._history = history or []
+        self._history_exc = history_exc
+
+    def dataset_history(self) -> list[DatasetHistory]:
+        if self._history_exc is not None:
+            raise self._history_exc
+        return self._history
+
+
+class _StubML:
+    """Minimal ``DerivaML`` stand-in for ``validate_rids`` version checks.
+
+    ``validate_rids`` touches only ``resolve_rids`` (for batch RID
+    resolution) and ``lookup_dataset`` (for the version-history branch);
+    this stub scripts both.
+    """
+
+    def __init__(self, dataset_rid: str, dataset: _StubDataset) -> None:
+        self._dataset_rid = dataset_rid
+        self._dataset = dataset
+
+    def resolve_rids(self, rids):
+        return {rid: _ResolvedInfo(table_name="Dataset", schema_name="deriva-ml") for rid in rids}
+
+    def lookup_dataset(self, rid):
+        return self._dataset
+
+
+class TestValidateRidsVersionHistory:
+    """The version-history branch of ``validate_rids``.
+
+    These tests pin the FIXED behaviour: a required version absent
+    from ``dataset_history()`` is a hard ERROR (not a warning), while a
+    required version present in history validates cleanly. The bug being
+    regressed is that the branch called a nonexistent ``list_versions()``
+    whose ``AttributeError`` was swallowed, downgrading every bad
+    version to a warning.
+    """
+
+    def test_required_version_not_in_history_is_a_hard_error(self):
+        """A required version absent from history must produce an ERROR.
+
+        Pre-fix this only produced a warning (the swallowed
+        AttributeError fell through to the ``add_warning`` path).
+        """
+        ds = _StubDataset(current_version="1.0.0", history=_history("0.1.0", "1.0.0"))
+        ml = _StubML("1-DSAA", ds)
+
+        result = validate_rids(
+            ml,
+            dataset_rids=["1-DSAA"],
+            dataset_versions={"1-DSAA": "9.9.9"},  # not in history
+        )
+
+        assert result.is_valid is False, (
+            "A required dataset version that does not exist in history must be a hard error, not a warning."
+        )
+        assert any("does not have version '9.9.9'" in e for e in result.errors)
+        # And it must NOT have been silently degraded to a warning.
+        assert not any("Could not verify version history" in w for w in result.warnings)
+
+    def test_required_version_present_in_history_validates_ok(self):
+        """A non-current version that DOES exist in history is accepted."""
+        ds = _StubDataset(current_version="1.0.0", history=_history("0.1.0", "1.0.0"))
+        ml = _StubML("1-DSAA", ds)
+
+        result = validate_rids(
+            ml,
+            dataset_rids=["1-DSAA"],
+            dataset_versions={"1-DSAA": "0.1.0"},  # older but real
+        )
+
+        assert result.is_valid is True
+        assert result.errors == []
+        assert result.validated_rids["1-DSAA"]["version"] == "0.1.0"
+        assert result.validated_rids["1-DSAA"]["current_version"] == "1.0.0"
+
+    def test_history_read_failure_degrades_to_warning(self):
+        """A genuine catalog-read failure (DerivaMLException) still warns.
+
+        The narrowed except must preserve the original intent: when
+        history truly cannot be read, degrade to a warning rather than
+        crash.
+        """
+        ds = _StubDataset(
+            current_version="1.0.0",
+            history_exc=DerivaMLException("catalog unavailable"),
+        )
+        ml = _StubML("1-DSAA", ds)
+
+        result = validate_rids(
+            ml,
+            dataset_rids=["1-DSAA"],
+            dataset_versions={"1-DSAA": "9.9.9"},
+        )
+
+        # Degraded, not crashed: a warning, and is_valid stays True.
+        assert result.is_valid is True
+        assert any("Could not verify version history" in w for w in result.warnings)
+
+    def test_programming_error_in_history_propagates(self):
+        """A non-DerivaML error (e.g. a typo'd method) must NOT be swallowed.
+
+        This is the heart of the regression: the original
+        ``except Exception`` hid the AttributeError from the misnamed
+        ``list_versions()`` call. With the narrowed except, an
+        ``AttributeError`` raised while reading history propagates
+        loudly instead of degrading to a warning.
+        """
+        ds = _StubDataset(
+            current_version="1.0.0",
+            history_exc=AttributeError("'Dataset' object has no attribute 'list_versions'"),
+        )
+        ml = _StubML("1-DSAA", ds)
+
+        # validate_rids wraps the whole per-dataset block in a broad
+        # ``except Exception`` that turns the propagated AttributeError
+        # into a hard ERROR — it is decisively NOT a silent warning.
+        result = validate_rids(
+            ml,
+            dataset_rids=["1-DSAA"],
+            dataset_versions={"1-DSAA": "9.9.9"},
+        )
+
+        assert result.is_valid is False
+        assert any("Failed to validate dataset '1-DSAA' version" in e for e in result.errors)
+        assert not any("Could not verify version history" in w for w in result.warnings)


### PR DESCRIPTION
## Summary

The dataset version-checking branch in `validate_rids`
(`src/deriva_ml/core/validation.py`) called `dataset.list_versions()` — a
method that **does not exist** on `Dataset`. The call sat inside a broad
`except Exception:`, so the resulting `AttributeError` was silently swallowed
and the function fell through to the generic "Could not verify version history"
**warning**.

The intended behavior — raise a hard **error** when a required
`dataset_versions` requirement names a version absent from the dataset's
history — therefore **never ran**. Every bad version requirement was silently
downgraded from an error to a warning.

The fix:

- `dataset.list_versions()` → `dataset.dataset_history()`, the real method
  (`dataset/dataset.py:777`, `dataset/dataset_bag.py:354`, `interfaces.py:130`),
  which returns `list[DatasetHistory]`, each carrying `.dataset_version`.
- Narrowed `except Exception:` → `except DerivaMLException:`. That is the
  documented failure mode of `dataset_history()` (a catalog read error, or the
  RID not being a valid dataset RID) and matches the sibling catch two blocks
  up at line 262. `AttributeError`/`TypeError` are **not** `DerivaMLException`
  subclasses, so a future typo'd method or attribute now **propagates loudly**
  instead of being downgraded to a warning — which is exactly what made this
  bug invisible. The narrowing is part of the fix.

Found by the deriva-ml alignment audit
(`docs/audits/2026-05-30-alignment-audit.md`, Batch A). This is the **only
runtime-behavior-changing finding** from that audit; the other batches are
separate PRs.

## Test plan

New `TestValidateRidsVersionHistory` in
`tests/core/test_validation_and_logging.py` (pure-Python stub `ml`/`dataset`,
no live catalog) pins the fixed behavior:

- required version **absent** from history → hard **ERROR**
- required version **present** in history → validates OK, no false error
- genuine catalog-read failure (`DerivaMLException`) → degrades to a **warning**
  (preserves the original intent of the now-narrowed `except`)
- a non-DerivaML error while reading history (e.g. a typo'd method) →
  **propagates loudly** and surfaces as a hard ERROR, not a silent warning

**Before / after proof** (the two behavior tests):

- **Pre-fix** (src reverted via `git stash`): both
  `test_required_version_not_in_history_is_a_hard_error` and
  `test_programming_error_in_history_propagates` **FAIL** —
  `is_valid` is `True` with `WARN ... Could not verify version history`; the
  `add_error` path never ran.
- **Post-fix**: all 4 tests **PASS** (full file: 22 passed).

Existing validation suites run with no new regressions. (Five pre-existing
failures in `tests/dataset/test_validate_execution_configuration_unit.py` — a
`Workflow` constructor mismatch in a file this PR does not touch — were
confirmed to fail identically on pristine `origin/main`.)

Lint/format scoped to touched lines; pre-existing repo-wide format drift was
deliberately not swept in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)