### PR TITLE
docs(examples): fix unrunnable docstring examples (audit Batch B)

### DIFF
--- a/src/deriva_ml/dataset/dataset.py
+++ b/src/deriva_ml/dataset/dataset.py
@@ -1617,9 +1617,10 @@ class Dataset:
             DerivaMLException: If dataset_rid is invalid.
 
         Example:
-            >>> members = ml.list_dataset_members("1-abc123", recurse=True)  # doctest: +SKIP
+            >>> dataset = ml.lookup_dataset("1-abc123")  # doctest: +SKIP
+            >>> members = dataset.list_dataset_members(recurse=True)  # doctest: +SKIP
             >>> for type_name, records in members.items():  # doctest: +SKIP
-            ...     print(f"{type_name}: {len(records)} records")
+            ...     print(f"{type_name}: {len(records)} records")  # doctest: +SKIP
         """
         # Initialize visited set for recursion guard
         if _visited is None:

--- a/src/deriva_ml/dataset/dataset_bag.py
+++ b/src/deriva_ml/dataset/dataset_bag.py
@@ -1365,8 +1365,9 @@ class DatasetBag:
             targets: Source of label data. Three shapes are accepted:
 
                 - ``None`` (default) — unlabeled dataset. Each element is
-                  just the sample (not a tuple). Useful for inference loops
-                  and self-supervised pretext tasks.
+                  the 2-tuple ``(sample, rid)`` (the trailing RID lets you
+                  trace a sample back to its catalog row). Useful for
+                  inference loops and self-supervised pretext tasks.
                 - ``list[str]`` — feature names read via
                   ``bag.feature_values(element_type, name)`` with no
                   selector. One ``FeatureRecord`` is resolved per element.

--- a/src/deriva_ml/dataset/split.py
+++ b/src/deriva_ml/dataset/split.py
@@ -63,8 +63,8 @@ Example:
         result = split_dataset(
             ml, "28D0", exe,
             test_size=0.2,
-            stratify_by_column="Image_Classification.Image_Class",
-            include_tables=["Image", "Image_Classification"],
+            stratify_by_column="Image_Class.Name",
+            include_tables=["Image", "Image_Class"],
         )
 
     Custom selection function::
@@ -153,8 +153,8 @@ class SelectionFunction(Protocol):
 
     Args:
         df: Denormalized DataFrame from ``dataset.get_denormalized_as_dataframe()``.
-            Columns are prefixed with table names (e.g., ``Image_RID``,
-            ``Image_Classification_Image_Class``).
+            Columns use dot notation ``Table.column`` (e.g., ``Image.RID``,
+            ``Image_Class.Name``) — see :func:`denormalize_column_name`.
         partition_sizes: Dict mapping partition names (e.g., "Training",
             "Testing", "Validation") to the number of records for each.
         seed: Random seed for reproducibility.
@@ -164,7 +164,7 @@ class SelectionFunction(Protocol):
         into the DataFrame.
 
     Example:
-        >>> def balanced_selector(df, partition_sizes, seed):
+        >>> def balanced_selector(df, partition_sizes, seed):  # doctest: +SKIP
         ...     rng = np.random.default_rng(seed)
         ...     # ... balance classes ...
         ...     return {"Training": train_indices, "Testing": test_indices}
@@ -225,7 +225,7 @@ def stratified_split(
 
     Args:
         stratify_column: Column name in the denormalized DataFrame to
-            stratify by (e.g., ``Image_Classification_Image_Class``).
+            stratify by, in dot notation (e.g., ``Image_Class.Name``).
         missing: Policy for handling null/NaN values in the stratify column.
             - ``"error"`` (default): Raise ``ValueError`` if any values
               are missing. Reports the count and percentage of nulls.
@@ -244,12 +244,12 @@ def stratified_split(
             contains null values.
 
     Example:
-        >>> selector = stratified_split("Image_Classification_Image_Class")
-        >>> partitions = selector(df, {"Training": 400, "Testing": 100}, seed=42)
+        >>> selector = stratified_split("Image_Class.Name")  # doctest: +SKIP
+        >>> partitions = selector(df, {"Training": 400, "Testing": 100}, seed=42)  # doctest: +SKIP
 
         >>> # Drop rows with missing labels
-        >>> selector = stratified_split("Diagnosis_Label", missing="drop")
-        >>> partitions = selector(df, {"Training": 300, "Testing": 100}, seed=42)
+        >>> selector = stratified_split("Image_Class.Name", missing="drop")  # doctest: +SKIP
+        >>> partitions = selector(df, {"Training": 300, "Testing": 100}, seed=42)  # doctest: +SKIP
     """
     if missing not in ("error", "drop", "include"):
         raise ValueError(f"missing must be 'error', 'drop', or 'include', got '{missing}'")
@@ -549,7 +549,7 @@ def _validate_split_inputs(
         raise ValueError(
             "include_tables is required when using stratify_by_column. "
             "Specify the tables needed for denormalization "
-            "(e.g., include_tables=['Image', 'Image_Classification'])."
+            "(e.g., include_tables=['Image', 'Image_Class'])."
         )
 
     if selection_fn and not include_tables:
@@ -1185,7 +1185,7 @@ def split_dataset(
         seed: Random seed for reproducibility. Default: 42.
         stratify_by_column: Column name for stratified splitting.
             Must be a column in the denormalized DataFrame using dot notation
-            (e.g., ``Image_Classification.Image_Class``). Use
+            (e.g., ``Image_Class.Name``). Use
             :meth:`Dataset.list_denormalized_columns` to discover available columns.
             Mutually exclusive with ``selection_fn``.
         stratify_missing: Policy for null values in the stratify column.
@@ -1310,20 +1310,32 @@ def split_dataset(
             parameters conflict.
 
     Example:
-        Simple random 80/20 split::
+        ``split_dataset`` always runs inside an Execution the caller has
+        already opened — the ``execution`` argument is required. Every
+        example below assumes ``exe`` is the live execution from::
 
             from deriva_ml import DerivaML
             from deriva_ml.dataset.split import split_dataset
+            from deriva_ml.execution import ExecutionConfiguration
 
             ml = DerivaML("localhost", "9")
-            result = split_dataset(ml, "28D0", test_size=0.2, seed=42)
+            workflow = ml.create_workflow(
+                name="My splitting script",
+                workflow_type="Dataset_Split",
+            )
+            config = ExecutionConfiguration(workflow=workflow)
+
+        Simple random 80/20 split::
+
+            with ml.create_execution(config) as exe:
+                result = split_dataset(ml, "28D0", exe, test_size=0.2, seed=42)
             print(f"Training: {result.training.rid} ({result.training.count} samples)")
             print(f"Testing:  {result.testing.rid} ({result.testing.count} samples)")
 
         Three-way train/val/test split::
 
             result = split_dataset(
-                ml, "28D0",
+                ml, "28D0", exe,
                 test_size=0.2,
                 val_size=0.1,
                 seed=42,
@@ -1333,7 +1345,7 @@ def split_dataset(
         Fixed-count split with labeled types::
 
             result = split_dataset(
-                ml, "28D0",
+                ml, "28D0", exe,
                 test_size=100,
                 train_size=400,
                 seed=42,
@@ -1355,7 +1367,7 @@ def split_dataset(
             # ``row_per="Image"``. Stratify on the dotted column
             # against the vocab table.
             result = split_dataset(
-                ml, "28D0",
+                ml, "28D0", exe,
                 test_size=0.2,
                 stratify_by_column="Image_Class.Name",
                 include_tables=["Image", "Image_Class"],
@@ -1383,7 +1395,7 @@ def split_dataset(
             # the join when the shorthand is used with an explicit
             # feature-assoc ``row_per``).
             result = split_dataset(
-                ml, "28D0",
+                ml, "28D0", exe,
                 test_size=0.2,
                 stratify_by_column="Execution_Image_Image_Classification.Image_Class",
                 include_tables=["Image", "Image_Classification"],
@@ -1407,7 +1419,7 @@ def split_dataset(
         Stratified split dropping rows with missing labels::
 
             result = split_dataset(
-                ml, "28D0",
+                ml, "28D0", exe,
                 test_size=0.2,
                 stratify_by_column="Image_Class.Name",
                 stratify_missing="drop",
@@ -1422,7 +1434,7 @@ def split_dataset(
 
             def balanced_selector(df, partition_sizes, seed):
                 rng = np.random.default_rng(seed)
-                label_col = "Image_Class_Name"
+                label_col = "Image_Class.Name"
                 classes = df[label_col].unique()
                 result = {name: [] for name in partition_sizes}
                 for cls in classes:
@@ -1436,7 +1448,7 @@ def split_dataset(
                 return {name: np.array(idx) for name, idx in result.items()}
 
             result = split_dataset(
-                ml, "28D0",
+                ml, "28D0", exe,
                 test_size=100,
                 selection_fn=balanced_selector,
                 include_tables=["Image", "Image_Class"],
@@ -1447,7 +1459,7 @@ def split_dataset(
         Dry run to preview the split plan without modifying the catalog::
 
             result = split_dataset(
-                ml, "28D0",
+                ml, "28D0", exe,
                 test_size=0.2,
                 dry_run=True,
             )
@@ -1458,7 +1470,7 @@ def split_dataset(
 
             from deriva_ml.dataset import DatasetSpecConfig
 
-            result = split_dataset(ml, "28D0", test_size=0.2, seed=42)
+            result = split_dataset(ml, "28D0", exe, test_size=0.2, seed=42)
             split_config = DatasetSpecConfig(
                 rid=result.split.rid,
                 version=result.split.version,
@@ -1467,7 +1479,7 @@ def split_dataset(
         Train directly from the split partitions (composition with
         framework adapters)::
 
-            result = split_dataset(ml, "28D0", test_size=0.2, seed=42)
+            result = split_dataset(ml, "28D0", exe, test_size=0.2, seed=42)
             train_bag = ml.lookup_dataset(result.training.rid).download_dataset_bag(
                 version=result.training.version
             )
@@ -1641,11 +1653,13 @@ def main() -> int:
             deriva-ml-split-dataset --hostname localhost --catalog-id 9 \\
                 --dataset-rid 28D0 --val-size 0.1
 
-            # Stratified split by class label
+            # Stratified split by class label (stratify on the vocab
+            # table's Name column, reached transparently through the
+            # Image_Classification feature)
             deriva-ml-split-dataset --hostname localhost --catalog-id 9 \\
                 --dataset-rid 28D0 \\
-                --stratify-by-column Image_Classification_Image_Class \\
-                --include-tables Image,Image_Classification
+                --stratify-by-column Image_Class.Name \\
+                --include-tables Image,Image_Class
 
             # Fixed-count split
             deriva-ml-split-dataset --hostname localhost --catalog-id 9 \\
@@ -1715,8 +1729,8 @@ def main() -> int:
     )
     parser.add_argument(
         "--stratify-by-column",
-        help="Column name in denormalized DataFrame for stratified splitting "
-        "(e.g., Image_Classification_Image_Class). Requires --include-tables.",
+        help="Column name in denormalized DataFrame (dot notation) for stratified "
+        "splitting (e.g., Image_Class.Name). Requires --include-tables.",
     )
     parser.add_argument(
         "--stratify-missing",
@@ -1734,8 +1748,7 @@ def main() -> int:
     )
     parser.add_argument(
         "--include-tables",
-        help="Comma-separated tables for denormalization "
-        "(e.g., Image,Image_Classification). Required for stratified splitting.",
+        help="Comma-separated tables for denormalization (e.g., Image,Image_Class). Required for stratified splitting.",
     )
     parser.add_argument(
         "--row-per",

--- a/src/deriva_ml/execution/execution.py
+++ b/src/deriva_ml/execution/execution.py
@@ -1993,12 +1993,12 @@ class Execution:
         Examples:
             Add a single file type:
                 >>> files = [FileSpec(url="path/to/file.txt", md5="abc123", length=1000)]  # doctest: +SKIP
-                >>> rids = exe.add_files(files, file_types="text")  # doctest: +SKIP
+                >>> rids = exe.add_files(files, dataset_types="text")  # doctest: +SKIP
 
             Add multiple file types:
                 >>> rids = exe.add_files(  # doctest: +SKIP
                 ...     files=[FileSpec(url="image.png", md5="def456", length=2000)],  # doctest: +SKIP
-                ...     file_types=["image", "png"],  # doctest: +SKIP
+                ...     dataset_types=["image", "png"],  # doctest: +SKIP
                 ... )  # doctest: +SKIP
         """
         return self._ml_object.add_files(

--- a/src/deriva_ml/feature.py
+++ b/src/deriva_ml/feature.py
@@ -26,10 +26,13 @@ Selector classmethod suite (``FeatureRecord`` class methods):
     ``FeatureRecord.select_majority_vote(column)`` — Returns a selector that
         picks the most common value for a column (consensus labeling).
 
-Typical usage:
+Typical usage (the generated record carries one field per feature
+column, plus a *required* field named after the target table — here
+``Image`` — that holds the target row's RID)::
+
     >>> feature = ml.lookup_feature("Image", "Diagnosis")  # doctest: +SKIP
     >>> DiagnosisRecord = feature.feature_record_class()  # doctest: +SKIP
-    >>> record = DiagnosisRecord(Diagnosis="benign", Confidence=0.97)  # doctest: +SKIP
+    >>> record = DiagnosisRecord(Image="1-abc123", Diagnosis="benign", Confidence=0.97)  # doctest: +SKIP
 """
 
 from collections import Counter, defaultdict
@@ -710,9 +713,13 @@ class Feature:
             DerivaMLException: If the feature table schema cannot be read.
 
         Example:
+            The generated model has one field per feature column plus a
+            *required* field named after the target table (``Image``)
+            that holds the target row's RID::
+
             >>> feature = ml.lookup_feature("Image", "Diagnosis")  # doctest: +SKIP
             >>> DiagnosisRecord = feature.feature_record_class()  # doctest: +SKIP
-            >>> rec = DiagnosisRecord(Diagnosis="benign")  # doctest: +SKIP
+            >>> rec = DiagnosisRecord(Image="1-abc123", Diagnosis="benign")  # doctest: +SKIP
         """
         # Compute the asset-column-name set once; map_type is called
         # for every column on the feature, and re-computing this

--- a/src/deriva_ml/model/annotations.py
+++ b/src/deriva_ml/model/annotations.py
@@ -16,26 +16,34 @@ https://docs.derivacloud.org/chaise/annotation/
 
 Quick Start
 -----------
-Basic usage with a TableHandle::
+Build an annotation with one of the builder classes, assign its
+``to_dict()`` payload to ``table.annotations[Builder.tag]``, then push
+all staged changes to the catalog with ``ml.apply_annotations()`` (see
+ADR-0007 for the public-API contract)::
 
-    from deriva_ml.model import TableHandle, Display, VisibleColumns, TableDisplay
+    from deriva_ml import DerivaML
+    from deriva_ml.model import Display, VisibleColumns, TableDisplay
 
-    # Get a table handle
-    handle = TableHandle(table)
+    ml = DerivaML("localhost", "9")
+    table = ml.model.schemas["my-domain"].tables["Subject"]
 
     # Set display name
-    handle.set_annotation(Display(name="Research Subjects"))
+    display = Display(name="Research Subjects")
+    table.annotations[Display.tag] = display.to_dict()
 
     # Configure visible columns
     vc = VisibleColumns()
     vc.compact(["RID", "Name", "Status"])
     vc.detailed(["RID", "Name", "Status", "Description", "Created"])
-    handle.set_annotation(vc)
+    table.annotations[VisibleColumns.tag] = vc.to_dict()
 
     # Set row name pattern
     td = TableDisplay()
     td.row_name("{{{Name}}} ({{{RID}}})")
-    handle.set_annotation(td)
+    table.annotations[TableDisplay.tag] = td.to_dict()
+
+    # Push every staged annotation change to the catalog
+    ml.apply_annotations()
 
 Available Builders
 ------------------
@@ -353,10 +361,14 @@ class Display(AnnotationBuilder):
         ValueError: If both name and markdown_name are provided
 
     Example:
-        Basic display name::
+        Build the annotation, then stage it on the table and push to
+        the catalog (the apply path is the same for every builder —
+        ``table.annotations[Builder.tag] = builder.to_dict()`` followed
+        by ``ml.apply_annotations()``)::
 
             >>> display = Display(name="Research Subjects")  # doctest: +SKIP
-            >>> handle.set_annotation(display)
+            >>> table.annotations[Display.tag] = display.to_dict()  # doctest: +SKIP
+            >>> ml.apply_annotations()  # doctest: +SKIP
 
         With description/tooltip::
 
@@ -759,13 +771,16 @@ class VisibleColumns(AnnotationBuilder):
     - ``*``: Default for all contexts
 
     Example:
-        Basic column lists for different contexts::
+        Basic column lists for different contexts, then stage and apply
+        (same ``table.annotations[VisibleColumns.tag] = vc.to_dict();
+        ml.apply_annotations()`` path as every builder)::
 
-            >>> vc = VisibleColumns()
-            >>> vc.compact(["RID", "Name", "Status"])
-            >>> vc.detailed(["RID", "Name", "Status", "Description", "Created"])
-            >>> vc.entry(["Name", "Status", "Description"])
-            >>> handle.set_annotation(vc)
+            >>> vc = VisibleColumns()  # doctest: +SKIP
+            >>> vc.compact(["RID", "Name", "Status"])  # doctest: +SKIP
+            >>> vc.detailed(["RID", "Name", "Status", "Description", "Created"])  # doctest: +SKIP
+            >>> vc.entry(["Name", "Status", "Description"])  # doctest: +SKIP
+            >>> table.annotations[VisibleColumns.tag] = vc.to_dict()  # doctest: +SKIP
+            >>> ml.apply_annotations()  # doctest: +SKIP
 
         Method chaining::
 

--- a/src/deriva_ml/model/catalog.py
+++ b/src/deriva_ml/model/catalog.py
@@ -481,7 +481,7 @@ class DerivaModel:
         table = self.name_to_table(table)
         return table.is_association(unqualified=unqualified, pure=pure, min_arity=min_arity, max_arity=max_arity)
 
-    def find_association(self, table1: TableInput, table2: TableInput) -> tuple[Table, Column, Column]:
+    def find_association(self, table1: TableInput, table2: TableInput) -> tuple[Table, str, str]:
         """Return the unique association table linking ``table1`` and ``table2``.
 
         Searches all associations on ``table1`` for one whose other-side
@@ -495,8 +495,11 @@ class DerivaModel:
 
         Returns:
             ``(assoc_table, table1_link_column, table2_link_column)``
-            — the association table itself plus the two FK columns on it
-            (one referencing ``table1``, one referencing ``table2``).
+            — the association :class:`Table` itself plus the *names* (as
+            ``str``) of the two FK columns on it (one referencing
+            ``table1``, one referencing ``table2``). The column names are
+            returned as strings because every caller uses them directly
+            as ``datapath`` ``.columns[...]`` keys or insert-row dict keys.
 
         Raises:
             NoAssociationException: If no association table connects the


### PR DESCRIPTION
## Summary

Fixes the HIGH "unrunnable examples" cluster from the
[2026-05-30 alignment audit](docs/audits/2026-05-30-alignment-audit.md)
(Batch B, plus the split.py CLI stragglers from Batch C's
underscore→dot rename). Every published docstring example in scope is
now runnable against the current API. Each item was re-verified against
live code before editing.

**Docs/examples only — no runtime behavior change.** The single
type-annotation change (`find_association`) makes the hint match the
existing implementation; the only runtime string touched is an
`include_tables` error-message hint in `split.py`.

### Items fixed (file:location — was → now)

1. **`dataset/split.py` — `split_dataset` examples omit required `execution`.** Every function-level + module-preamble example now passes `exe` (signature is `split_dataset(ml, rid, execution, *, ...)`). Was → `TypeError: missing positional 'execution'`.
2. **`dataset/split.py` — `SelectionFunction` Protocol doc + `stratified_split` doctests used underscore columns.** `Image_RID`/`Image_Classification_Image_Class`/`Diagnosis_Label` → dot-notation `Image.RID`/`Image_Class.Name` (what `denormalize_column_name` emits).
3. **`dataset/split.py` — custom-selector `label_col = "Image_Class_Name"`** → `"Image_Class.Name"` (matches `include_tables=["Image","Image_Class"]`). Was → `KeyError`.
4. **`dataset/split.py` CLI — epilog/`--stratify-by-column`/`--include-tables` help + `include_tables` error hint** used underscore columns and the `Image_Classification` shorthand → `Image_Class.Name` / `Image,Image_Class` (the vocab table, finishing task #38's migration).
5. **`execution/execution.py` — `Execution.add_files` examples used `file_types=`** → `dataset_types=` (the real kwarg, confirmed against `core/mixins/file.py`). Was → `TypeError`.
6. **`model/annotations.py` — module Quick Start + `Display`/`VisibleColumns` examples called `handle.set_annotation(...)`** (no such method on `TableHandle`; `hasattr` is False) → the ADR-0007 path `table.annotations[Builder.tag] = builder.to_dict(); ml.apply_annotations()`. Verified `.tag`/`.to_dict()`/`apply_annotations()` all exist; the `tests/model/test_annotations.py::TestExternalConsumerContract` suite (47 passing) covers exactly this boundary.
7. **`model/catalog.py` — `find_association` return annotation `tuple[Table, Column, Column]`** (doc said "FK columns") but the body returns column *name strings* via `.name`, and every caller uses them as `datapath .columns[...]` keys / insert-row dict keys → annotation+doc fixed to `tuple[Table, str, str]`. **Annotation/doc only; impl is correct.**
8. **`feature.py` — module example + `feature_record_class` Example constructed `DiagnosisRecord(Diagnosis="benign", ...)` without the required target-table field.** Generated record has one field per feature column PLUS a *required* field named after the target table (`Image`). Added `Image="1-abc123"` (reproduced the `create_model` field map to confirm). Was → `pydantic.ValidationError`.
9. **`dataset/dataset_bag.py` — `as_tf_dataset` `targets=None` Args text said "just the sample (not a tuple)"** contradicting its own Returns + `tf_adapter.py:152-153` which yield `(sample, rid)` → Args aligned to the real 2-tuple.
10. **`dataset/dataset.py` — `list_dataset_members` Example passed a RID positionally** (first positional param is `recurse: bool`; RID is bound to `self`) → instance form `dataset = ml.lookup_dataset("1-abc123"); dataset.list_dataset_members(recurse=True)`. Was → `TypeError`.

## Doctest harness assessment (audit pattern #1)

The audit assumed the doctest harness "isn't actually exercised." That's **partly inaccurate** and worth recording:

- `pyproject.toml` *does* configure `--doctest-modules` and pytest *does* read it (`configfile: pyproject.toml`, DoctestItems collect per-file). **But the config table is `[tool.pytest]`, which is not pytest's recognized table** — the recognized one is `[tool.pytest.ini_options]`. Despite this, the current pytest version still applies the addopts, so doctests run per-file today.
- **However, a whole-`src/` doctest run aborts at collection** because two pre-existing docstrings (`asset/asset.py:14`, `asset/aux_classes.py:16`) put `# doctest: +SKIP` on a *comment line with no `>>>` example*, which is a hard `ValueError`. This is the exact "mis-placed +SKIP" failure mode the audit flagged, and it's why the harness appears dead in aggregate. (Not in this PR's item scope; left untouched.)
- Several `annotations.py` builder examples (`VisibleColumns`, `TableDisplay`, etc.) and `dataset_bag.py::DatasetBag.path` have **pre-existing** doctest failures (NameError on `Display`/`VisibleColumns`/`DatasetSpec` not seeded in the doctest namespace). Confirmed identical on base `origin/main`; out of scope here.

For the examples this PR touched: each is **either** consistently `# doctest: +SKIP` on every executing line **or** genuinely runnable. This PR *reduced* `annotations.py` doctest failures 9→8 (fixed `Display`) with no new failures introduced anywhere.

### Follow-up recommendation (separate PR)

1. Rename `[tool.pytest]` → `[tool.pytest.ini_options]` so the doctest config is on a supported table (currently load-bearing by accident).
2. Fix the two malformed `+SKIP`-on-comment directives (`asset/asset.py`, `asset/aux_classes.py`) that abort whole-`src` collection — a ~2-line change that unblocks `pytest src/ --doctest-modules` for CI.
3. Then either seed the annotation builders into `src/deriva_ml/conftest.py`'s doctest namespace (so construction-only examples run as real doctests) or `+SKIP` the remaining NameError examples. Rough scope: ~10 builder examples + `DatasetBag.path` need either seeding or SKIP; the bulk of catalog-dependent examples already use `+SKIP`. Low risk, but noisy enough to warrant its own PR — do **not** enable repo-wide doctest execution in a docs PR.

## Test plan

- `uv sync`; `ruff check` + `ruff format` scoped to the 7 touched files (clean; one auto-format on a `split.py` help string I shortened).
- Statically confirmed each fixed example matches the real API (signatures / kwargs / fields), including reproducing `feature_record_class`'s field map and checking `hasattr(TableHandle, "set_annotation") is False`.
- `tests/model/test_annotations.py` → **47 passed** (incl. the external-consumer contract for the apply path).
- `tests/feature/test_select_by_workflow.py` → **7 passed**; `tests/dataset/test_split_helpers.py` + `test_split_partition_by.py` → **30 passed**.
- Doctest collection on touched files: no new failures; the only failure (`dataset_bag.py::DatasetBag.path`, a `DatasetSpec` NameError) is pre-existing on base in an untouched docstring.
- Catalog-backed `tests/model/`+`tests/feature/` integration tests and `test_find_association.py` were not run here (need a live catalog); the changes are docstring-only and `find_association`'s impl is unchanged.

## False positives / nuances

- **Item 1 module preamble (`split.py:41-50`)** was already correct (used the `with ml.create_execution(config) as exe:` form). I updated only its *stratify column* (`Image_Classification.Image_Class` → `Image_Class.Name`) for consistency with the migrated form.
- **Item 8 is a partial false positive on the stated cause.** The `Diagnosis` field name is *valid* for a feature whose value column is named `Diagnosis` (field names come from the feature's columns, not the feature name). The genuine defect was the **missing required target-table field** (`Image=`), which is what I fixed.

## Not done here (flagged, not fixed)

- No impl bug found in item 7 — the `find_association` implementation is correct (callers rely on the string return). Fixed the annotation/doc to match; no behavior change, nothing to flag for a separate PR.

Cites the audit Batch B (and the split.py CLI portion of Batch C).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
