### PR TITLE
fix(exceptions): raise documented subclasses; complete hierarchy diagram

### DIFF
--- a/src/deriva_ml/core/exceptions.py
+++ b/src/deriva_ml/core/exceptions.py
@@ -16,11 +16,13 @@ Exception Hierarchy:
     │   ├── DerivaMLNotFoundError (entity not found)
     │   │   ├── DerivaMLDatasetNotFound (dataset lookup failures)
     │   │   ├── DerivaMLTableNotFound (table lookup failures)
+    │   │   ├── DerivaMLFeatureNotFound (feature lookup failures)
     │   │   ├── DerivaMLInvalidTerm (vocabulary term not found)
     │   │   ├── DerivaMLRidsNotFound (one or more RIDs unresolved)
     │   │   └── NoAssociationException (find_association: zero matches)
     │   ├── DerivaMLTableTypeError (wrong table type)
     │   ├── DerivaMLValidationError (data validation failures)
+    │   │   └── DerivaMLMaterializeLimitExceeded (result set over materialize_limit)
     │   ├── DerivaMLCycleError (cycle detected in relationships)
     │   ├── DerivaMLStateInconsistency (SQLite/catalog state disagreement)
     │   └── AmbiguousAssociationException (find_association: multiple matches)
@@ -592,13 +594,13 @@ class DerivaMLDirtyWorkflowError(DerivaMLWorkflowError):
         dirty_paths: list[str] | None = None,
     ) -> None:
         """Args:
-            path: Path to the executable file whose workflow is being recorded.
-            dirty_paths: Optional list of git-status-porcelain lines describing
-                the actual offending paths (e.g. ["?? findings/out.txt",
-                " M src/models/train.py"]). When provided, the lines are
-                included in the exception message so the user can see what
-                tripped the check rather than having to run ``git status``
-                themselves.
+        path: Path to the executable file whose workflow is being recorded.
+        dirty_paths: Optional list of git-status-porcelain lines describing
+            the actual offending paths (e.g. ["?? findings/out.txt",
+            " M src/models/train.py"]). When provided, the lines are
+            included in the exception message so the user can see what
+            tripped the check rather than having to run ``git status``
+            themselves.
         """
         self.path = path
         self.dirty_paths = list(dirty_paths) if dirty_paths else []
@@ -617,10 +619,7 @@ class DerivaMLDirtyWorkflowError(DerivaMLWorkflowError):
         else:
             # Backward-compatible single-arg form. Kept for any external
             # caller that constructs this exception without the path list.
-            message = (
-                f"File {path} has uncommitted changes. Commit before running, "
-                f"or use --allow-dirty to override."
-            )
+            message = f"File {path} has uncommitted changes. Commit before running, or use --allow-dirty to override."
         super().__init__(message)
 
 

--- a/src/deriva_ml/dataset/dataset.py
+++ b/src/deriva_ml/dataset/dataset.py
@@ -54,7 +54,11 @@ from deriva_ml.core.definitions import (
     MLVocab,
     VocabularyTerm,
 )
-from deriva_ml.core.exceptions import DerivaMLException
+from deriva_ml.core.exceptions import (
+    DerivaMLCycleError,
+    DerivaMLException,
+    DerivaMLValidationError,
+)
 from deriva_ml.core.logging_config import get_logger
 from deriva_ml.core.mixins.rid_resolution import AnyQuantifier
 from deriva_ml.core.validation import VALIDATION_CONFIG
@@ -1080,9 +1084,14 @@ class Dataset:
             The new released ``DatasetVersion``.
 
         Raises:
-            DerivaMLException: If this dataset has no dev row to
-                promote, or if a concurrent writer modified the dev
-                row between this call's read and write.
+            DerivaMLValidationError: If this dataset has no dev row to
+                promote (per ADR-0003, ``release`` on a dataset with no
+                dev period is a validation error; call ``mark_dev()``
+                first to declare a dev period).
+            DerivaMLException: If a concurrent writer modified the dev
+                row between this call's read and write, or if the
+                catalog is in an inconsistent state (multiple dev rows,
+                or no released version to anchor against).
 
         Example:
             >>> dataset.add_dataset_members(["1-abc", "1-def"])  # doctest: +SKIP
@@ -1098,7 +1107,7 @@ class Dataset:
         history = self.dataset_history()
         dev_entries = [h for h in history if h.dataset_version.is_devrelease]
         if not dev_entries:
-            raise DerivaMLException(
+            raise DerivaMLValidationError(
                 f"Dataset {self.dataset_rid} has no dev period to release "
                 f"(current_version={self.current_version}). To release a "
                 "no-op change, call mark_dev() first to declare a dev "
@@ -2036,10 +2045,12 @@ class Dataset:
             execution_rid: Optional execution RID to associate with changes.
 
         Raises:
+            DerivaMLCycleError: If adding a member dataset would create a
+                cycle in the nested-dataset graph (the member is this
+                dataset or one of its transitive descendants).
             DerivaMLException: If:
                 - Any RID is invalid or cannot be resolved
                 - Any RID belongs to a table that isn't registered as a dataset element type
-                - Adding members would create a cycle (for nested datasets)
                 - Validation finds duplicate members (when validate=True)
 
         See Also:
@@ -2130,7 +2141,10 @@ class Dataset:
                 if rid_info.table_name not in association_map:
                     raise DerivaMLException(f"RID table: {rid_info.table_name} not part of dataset_table")
                 if rid_info.table == self._dataset_table and check_dataset_cycle(rid_info.rid):
-                    raise DerivaMLException("Creating cycle of datasets is not allowed")
+                    raise DerivaMLCycleError(
+                        [self.dataset_rid, rid_info.rid],
+                        msg="Creating cycle of datasets is not allowed",
+                    )
                 dataset_elements.setdefault(rid_info.table_name, []).append(rid_info.rid)
         else:
             dataset_elements = {t: list(set(ms)) for t, ms in members.items()}

--- a/src/deriva_ml/model/catalog.py
+++ b/src/deriva_ml/model/catalog.py
@@ -41,6 +41,7 @@ from deriva_ml.core.exceptions import (
     DerivaMLException,
     DerivaMLFeatureNotFound,
     DerivaMLReadOnlyError,
+    DerivaMLTableNotFound,
     DerivaMLTableTypeError,
     NoAssociationException,
 )
@@ -377,7 +378,7 @@ class DerivaModel:
           Table object.
 
         Raises:
-          DerivaMLException: If the table doesn't exist in any searchable schema.
+          DerivaMLTableNotFound: If the table doesn't exist in any searchable schema.
         """
         if isinstance(table, Table):
             return table
@@ -390,7 +391,7 @@ class DerivaModel:
             s = self.model.schemas[sname]
             if table in s.tables:
                 return s.tables[table]
-        raise DerivaMLException(f"The table {table} doesn't exist.")
+        raise DerivaMLTableNotFound(str(table), msg="Table doesn't exist in any searchable schema")
 
     def is_vocabulary(self, table: TableInput) -> bool:
         """Check if a given table is a controlled vocabulary table.
@@ -412,7 +413,7 @@ class DerivaModel:
             False otherwise.
 
         Raises:
-            DerivaMLException: If the table doesn't exist in any searchable
+            DerivaMLTableNotFound: If the table doesn't exist in any searchable
                 schema (raised by :meth:`name_to_table`).
         """
         table = self.name_to_table(table)
@@ -434,7 +435,7 @@ class DerivaModel:
             or ``{"Name": "Name", "ID": "ID", ...}`` for DerivaML tables.
 
         Raises:
-            DerivaMLException: If the table doesn't exist (raised by
+            DerivaMLTableNotFound: If the table doesn't exist (raised by
                 :meth:`name_to_table`).
         """
         table = self.name_to_table(table)
@@ -475,7 +476,7 @@ class DerivaModel:
             See :meth:`Table.is_association` for the full contract.
 
         Raises:
-            DerivaMLException: If ``table`` doesn't exist in any searchable
+            DerivaMLTableNotFound: If ``table`` doesn't exist in any searchable
                 schema (raised by :meth:`name_to_table`).
         """
         table = self.name_to_table(table)
@@ -543,7 +544,7 @@ class DerivaModel:
             True if all asset-table requirements are satisfied.
 
         Raises:
-            DerivaMLException: If ``table`` doesn't exist in any searchable
+            DerivaMLTableNotFound: If ``table`` doesn't exist in any searchable
                 schema (raised by :meth:`name_to_table`).
         """
         table = self.name_to_table(table)
@@ -778,7 +779,7 @@ class DerivaModel:
 
         Raises:
             DerivaMLTableTypeError: If ``table`` is not an asset table.
-            DerivaMLException: If ``table`` doesn't exist (raised by
+            DerivaMLTableNotFound: If ``table`` doesn't exist (raised by
                 :meth:`name_to_table`).
         """
         table = self.name_to_table(table)

--- a/tests/dataset/test_exception_contracts.py
+++ b/tests/dataset/test_exception_contracts.py
@@ -1,0 +1,151 @@
+"""Regression tests for tightened exception contracts in ``dataset.py``.
+
+Alignment-audit Batch G tightened two raise sites in
+:mod:`deriva_ml.dataset.dataset` to raise the documented subclass of
+:class:`DerivaMLException` instead of the bare base:
+
+- **G1** — :meth:`Dataset.add_dataset_members` raises
+  :class:`DerivaMLCycleError` (not bare ``DerivaMLException``) when a
+  member addition would create a cycle in the nested-dataset graph.
+  Documented in ``docs/user-guide/datasets.md`` and the method
+  docstring.
+- **G2** — :meth:`Dataset.release` raises
+  :class:`DerivaMLValidationError` (not bare ``DerivaMLException``)
+  when called on a dataset with no dev period. Documented in
+  ``docs/adr/0003-dataset-dev-versioning-model.md``.
+
+Each test asserts the **exact** raised type (``excinfo.type is
+<Subclass>``), so it would fail on pre-change code (which raised the
+bare ``DerivaMLException``) even though ``pytest.raises(<Subclass>)``
+alone would not distinguish a base from a subclass. The tests are
+pure unit tests: the ``Dataset`` instance is built via ``__new__`` and
+only the minimal surface each raise path touches is stubbed, so no
+live catalog is required.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from deriva_ml.core.exceptions import (
+    DerivaMLCycleError,
+    DerivaMLException,
+    DerivaMLValidationError,
+)
+from deriva_ml.dataset.dataset import Dataset
+
+# ---------------------------------------------------------------------------
+# G2 — release() on a dataset with no dev period
+# ---------------------------------------------------------------------------
+
+
+class TestReleaseNoDevRowRaisesValidationError:
+    """``release()`` with no dev period raises ``DerivaMLValidationError``.
+
+    Per ADR-0003, ``release`` on a dataset with no dev row is a
+    validation error — the caller must ``mark_dev()`` first.
+    """
+
+    def test_raises_exactly_validation_error(self, monkeypatch) -> None:
+        ds = Dataset.__new__(Dataset)
+        ds.dataset_rid = "1-ABCD"
+        ds.dataset_history = lambda: []  # type: ignore[method-assign]
+        # ``current_version`` is a property on the class; patch it so
+        # the error-message f-string evaluates without a catalog.
+        monkeypatch.setattr(Dataset, "current_version", property(lambda self: "0.1.0"), raising=True)
+
+        with pytest.raises(DerivaMLValidationError) as excinfo:
+            ds.release(bump="minor", description="noop")
+
+        # Exact-type assertion: this is what distinguishes the
+        # post-change subclass from the pre-change bare base. Pre-fix,
+        # ``excinfo.type`` was ``DerivaMLException`` and this assert
+        # would fail.
+        assert excinfo.type is DerivaMLValidationError
+        assert isinstance(excinfo.value, DerivaMLValidationError)
+        # Backward-compatibility: still a DerivaMLException for
+        # ``except DerivaMLException`` catchers.
+        assert isinstance(excinfo.value, DerivaMLException)
+        assert "no dev period" in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# G1 — add_dataset_members cycle case
+# ---------------------------------------------------------------------------
+
+
+class TestAddDatasetMembersCycleRaisesCycleError:
+    """Adding a self-referential dataset member raises ``DerivaMLCycleError``.
+
+    The simplest cycle is a self-reference: adding the dataset's own
+    RID as a (nested-dataset) member. ``check_dataset_cycle`` returns
+    True because the cycle-RID set always contains ``self.dataset_rid``.
+    """
+
+    def _cyclic_dataset(self) -> Dataset:
+        """Build a stub ``Dataset`` that routes a self-RID member to the
+        Dataset table and detects the cycle without any catalog access."""
+        ds = Dataset.__new__(Dataset)
+        ds.dataset_rid = "1-SELF"
+
+        # A sentinel object that stands in for the Dataset table. Both
+        # ``_dataset_table`` and the resolved ``rid_info.table`` point at
+        # this same object so the ``rid_info.table == self._dataset_table``
+        # identity check holds.
+        dataset_table_sentinel = object()
+
+        # ``_dataset_table`` is a property on the class reading from
+        # ``_ml_instance``; build an ``_ml_instance`` whose model returns
+        # the sentinel for ``schemas[ml_schema].tables["Dataset"]``.
+        tables = {"Dataset": dataset_table_sentinel}
+        schema = SimpleNamespace(tables=tables)
+        model = SimpleNamespace(
+            schemas={"deriva-ml": schema},
+            # ``name_to_table`` is called for each association-map key to
+            # build candidate_tables; return the sentinel (value unused
+            # for the cycle assertion).
+            name_to_table=lambda name: dataset_table_sentinel,
+        )
+
+        # ``resolve_rids`` returns ``{rid: rid_info}``. The rid_info must
+        # route to the Dataset association table (table_name in the map)
+        # and resolve to the Dataset table sentinel with the self-RID.
+        rid_info = SimpleNamespace(
+            table_name="Dataset",
+            table=dataset_table_sentinel,
+            rid=ds.dataset_rid,
+        )
+        ml_instance = SimpleNamespace(
+            ml_schema="deriva-ml",
+            model=model,
+            resolve_rids=lambda members, candidate_tables=None: {ds.dataset_rid: rid_info},
+        )
+        ds._ml_instance = ml_instance
+
+        # The association map must include "Dataset" so the member
+        # passes the "is a registered element type" check.
+        ds._element_to_association_map = lambda: {"Dataset": "Nested_Dataset"}  # type: ignore[method-assign]
+        # No descendants → cycle-RID set is exactly {self.dataset_rid},
+        # so adding the self-RID trips the cycle check.
+        ds.list_dataset_children = lambda recurse=False: []  # type: ignore[method-assign]
+        return ds
+
+    def test_raises_exactly_cycle_error(self) -> None:
+        ds = self._cyclic_dataset()
+
+        with pytest.raises(DerivaMLCycleError) as excinfo:
+            # ``validate=False`` skips the duplicate-member pre-check
+            # (which would query ``list_dataset_members``); the cycle
+            # check runs regardless of ``validate``.
+            ds.add_dataset_members([ds.dataset_rid], validate=False)
+
+        # Exact-type assertion distinguishing post-change subclass from
+        # the pre-change bare ``DerivaMLException``.
+        assert excinfo.type is DerivaMLCycleError
+        assert isinstance(excinfo.value, DerivaMLCycleError)
+        assert isinstance(excinfo.value, DerivaMLException)
+        # Structured field carries the nodes involved in the cycle.
+        assert ds.dataset_rid in excinfo.value.cycle_nodes
+        assert "cycle" in str(excinfo.value).lower()

--- a/tests/model/test_exception_contracts.py
+++ b/tests/model/test_exception_contracts.py
@@ -1,0 +1,93 @@
+"""Regression tests for tightened exception contracts in ``model/catalog.py``.
+
+Alignment-audit Batch G (**G3**) tightened
+:meth:`deriva_ml.model.catalog.DerivaModel.name_to_table` to raise the
+documented subclass :class:`DerivaMLTableNotFound` instead of the bare
+:class:`DerivaMLException` when the named table doesn't exist in any
+searchable schema. This propagates to every caller — most notably
+:meth:`DerivaModel.lookup_feature`, whose docstring promises
+``DerivaMLTableNotFound`` for an unknown target table.
+
+The audit chose to tighten ``name_to_table`` itself (rather than only
+``lookup_feature``) because no caller in ``src/`` catches a *sibling*
+subclass or branches on the exact exception type — every catcher that
+can intercept a ``name_to_table`` failure uses ``except
+DerivaMLException`` (the base), which still catches the subclass.
+
+Each test asserts the **exact** raised type (``excinfo.type is
+DerivaMLTableNotFound``), so it would fail on pre-change code (which
+raised the bare ``DerivaMLException``). The model is built from the
+checked-in demo schema JSON — no live catalog required.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from deriva.core.ermrest_model import Model
+
+from deriva_ml.core.exceptions import (
+    DerivaMLException,
+    DerivaMLFeatureNotFound,
+    DerivaMLTableNotFound,
+)
+from deriva_ml.model.catalog import DerivaModel
+
+# The demo schema ships ``deriva-ml`` (ML schema), ``test-schema``
+# (domain), and an ``Image`` table with features defined on it.
+_DEMO_SCHEMA = Path(__file__).parent.parent / "dataset" / "demo-catalog-schema.json"
+
+
+@pytest.fixture
+def demo_model() -> DerivaModel:
+    """A ``DerivaModel`` built from the checked-in demo catalog schema."""
+    model = Model.fromfile("file-system", str(_DEMO_SCHEMA))
+    return DerivaModel(model=model, ml_schema="deriva-ml", domain_schemas={"test-schema"})
+
+
+class TestNameToTableRaisesTableNotFound:
+    """``name_to_table`` on an unknown name raises ``DerivaMLTableNotFound``."""
+
+    def test_raises_exactly_table_not_found(self, demo_model: DerivaModel) -> None:
+        with pytest.raises(DerivaMLTableNotFound) as excinfo:
+            demo_model.name_to_table("DefinitelyNotATable")
+
+        # Exact-type assertion: distinguishes the post-change subclass
+        # from the pre-change bare ``DerivaMLException``.
+        assert excinfo.type is DerivaMLTableNotFound
+        assert isinstance(excinfo.value, DerivaMLTableNotFound)
+        # Backward-compatible: still a DerivaMLException.
+        assert isinstance(excinfo.value, DerivaMLException)
+        # Structured field carries the offending name.
+        assert excinfo.value.table_name == "DefinitelyNotATable"
+
+    def test_existing_table_still_resolves(self, demo_model: DerivaModel) -> None:
+        """Sanity: a real table name resolves without raising."""
+        assert demo_model.name_to_table("Image").name == "Image"
+
+
+class TestLookupFeaturePropagatesTableNotFound:
+    """``lookup_feature`` on an unknown table propagates ``DerivaMLTableNotFound``.
+
+    This is the documented contract the audit was closing: the
+    ``lookup_feature`` docstring promises ``DerivaMLTableNotFound`` for
+    an unknown target table, but pre-change the bare
+    ``DerivaMLException`` leaked out of ``name_to_table``.
+    """
+
+    def test_unknown_table_raises_table_not_found(self, demo_model: DerivaModel) -> None:
+        with pytest.raises(DerivaMLTableNotFound) as excinfo:
+            demo_model.lookup_feature("DefinitelyNotATable", "AnyFeature")
+
+        assert excinfo.type is DerivaMLTableNotFound
+        assert isinstance(excinfo.value, DerivaMLException)
+
+    def test_known_table_unknown_feature_raises_feature_not_found(self, demo_model: DerivaModel) -> None:
+        """A valid table with a missing feature raises ``DerivaMLFeatureNotFound``
+        (the other documented branch) — confirms the table path succeeded."""
+        with pytest.raises(DerivaMLFeatureNotFound) as excinfo:
+            demo_model.lookup_feature("Image", "NoSuchFeatureXYZ")
+
+        assert excinfo.type is DerivaMLFeatureNotFound
+        assert isinstance(excinfo.value, DerivaMLException)


### PR DESCRIPTION
## Summary

Alignment-audit **Batch G**: tighten three exception raise sites that
raised the broad `DerivaMLException` where a specific subclass is
documented, and complete the ASCII hierarchy diagram in
`core/exceptions.py`. Each target subclass already existed in the
hierarchy.

| Site | File | Was | Now | Contract source |
|------|------|-----|-----|-----------------|
| **G1** | `dataset/dataset.py` `add_dataset_members` cycle case | `DerivaMLException` | `DerivaMLCycleError` | method docstring + `docs/user-guide/datasets.md:176` |
| **G2** | `dataset/dataset.py` `release()` no-dev-row case | `DerivaMLException` | `DerivaMLValidationError` | `docs/adr/0003-dataset-dev-versioning-model.md` |
| **G3** | `model/catalog.py` `name_to_table` | `DerivaMLException` | `DerivaMLTableNotFound` | `lookup_feature` docstring (`catalog.py:752`) |

For **G1** and **G2**, only the audited case changes — the sibling
raises in the same methods (RID-not-a-member, multiple-dev-rows,
concurrent-write, etc.) have no documented subclass and stay
`DerivaMLException`.

For **G3**, I tightened `name_to_table` itself (option a) rather than
only `lookup_feature` (option b). `name_to_table` has 111 references
across `src/`; tightening it fixes `lookup_feature`'s documented
contract **and** every other caller's table-not-found semantics —
which is strictly more correct, since a table-not-found should be
`DerivaMLTableNotFound` everywhere. The 5 delegating docstrings that
attribute the raise to `name_to_table` (`is_vocabulary`,
`vocab_columns`, `is_association`, `is_asset`, `asset_metadata`) were
updated to name the now-accurate subclass.

The hierarchy-diagram fix adds two exported-but-undiagrammed classes:
`DerivaMLFeatureNotFound` (under `DerivaMLNotFoundError`) and
`DerivaMLMaterializeLimitExceeded` (under `DerivaMLValidationError`).
Pure docstring edit.

## Behavior change

This **changes the raised exception type** at three sites — a behavior
change. It is **backward-compatible for `except DerivaMLException`
catchers**: every new subclass IS a `DerivaMLException`, so existing
broad catchers still catch it.

**Caller-safety analysis (G3, the broad-blast-radius case):** grepped
every `except DerivaML*` site in `src/`. No caller catches a *sibling*
subclass of `DerivaMLTableNotFound`, and none branches on the exact
exception type. The catchers that can actually intercept a
`name_to_table` failure —
`model/denormalize_planner.py:384`/`:474`/`:1837`/`:1844` and
`local_db/denormalizer.py:1340` — all use `except DerivaMLException`
(the base), which still catches the subclass. (The denormalizer's own
`_resolve_one` re-raises its *own* richer `DerivaMLTableNotFound`, so
it never depended on `name_to_table`'s raised type.) The `match=
"doesn't exist"` tests in `test_get_dataset_minid_helpers.py` target a
different raise (the Minid-not-found case in `bag_download.py`), not
`name_to_table`. Conclusion: narrowing is safe everywhere; option (a)
chosen.

## Test plan

Added one regression test per tightened site
(`tests/dataset/test_exception_contracts.py`,
`tests/model/test_exception_contracts.py`). Each asserts the **exact**
raised type (`excinfo.type is <Subclass>`), so it fails on pre-change
code rather than silently passing on the base.

- **Pre/post distinguished:** temporarily reverted all three raises to
  the bare `DerivaMLException` — the 3 contract tests **fail** (the
  exception propagates uncaught past `pytest.raises(<Subclass>)`);
  reapplied the fixes — all **6 pass**. The sanity/sibling tests
  (existing-table-resolves, missing-feature-on-valid-table) pass in
  both states.
- Tests are pure unit tests: G1/G2 build a `Dataset` via `__new__`
  with minimal stubs (no catalog); G3 builds a `DerivaModel` from the
  checked-in `tests/dataset/demo-catalog-schema.json`.

Verification (worktree off fresh `origin/main`, tip `d11930b8` =
#265 doctest harness merged):

- `uv sync` — clean.
- `uv run ruff check` + `ruff format` (touched files only) — clean.
- `tests/model/` + `tests/local_db/`: **464 passed, 8 skipped**.
- exception + denormalizer + minid-helper suites: **107 passed**.
- dataset unit subset (version/release/minid/split/spec + new contract
  tests): **109 passed**.
- doctests on the 3 changed modules (`--doctest-modules`): green
  (1 passed, 64 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)