### PR TITLE
fix(annotations): display tag must be misd namespace to match deriva-py

### DIFF
--- a/src/deriva_ml/core/mixins/annotation.py
+++ b/src/deriva_ml/core/mixins/annotation.py
@@ -5,7 +5,7 @@ Deriva catalog annotation operations for controlling how data
 is displayed in the Chaise web interface.
 
 Annotation Tags:
-    - display: tag:isrd.isi.edu,2015:display
+    - display: tag:misd.isi.edu,2015:display
     - visible-columns: tag:isrd.isi.edu,2016:visible-columns
     - visible-foreign-keys: tag:isrd.isi.edu,2016:visible-foreign-keys
     - table-display: tag:isrd.isi.edu,2016:table-display
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
 
 
 # Annotation tag URIs
-DISPLAY_TAG = "tag:isrd.isi.edu,2015:display"
+DISPLAY_TAG = "tag:misd.isi.edu,2015:display"
 VISIBLE_COLUMNS_TAG = "tag:isrd.isi.edu,2016:visible-columns"
 VISIBLE_FOREIGN_KEYS_TAG = "tag:isrd.isi.edu,2016:visible-foreign-keys"
 TABLE_DISPLAY_TAG = "tag:isrd.isi.edu,2016:table-display"

--- a/src/deriva_ml/model/annotations.py
+++ b/src/deriva_ml/model/annotations.py
@@ -274,7 +274,7 @@ CONTEXT_ROW_NAME = "row_name"
 # Annotation Tag URIs
 # =============================================================================
 
-TAG_DISPLAY = "tag:isrd.isi.edu,2015:display"
+TAG_DISPLAY = "tag:misd.isi.edu,2015:display"
 TAG_VISIBLE_COLUMNS = "tag:isrd.isi.edu,2016:visible-columns"
 TAG_VISIBLE_FOREIGN_KEYS = "tag:isrd.isi.edu,2016:visible-foreign-keys"
 TAG_TABLE_DISPLAY = "tag:isrd.isi.edu,2016:table-display"

--- a/tests/model/test_annotations.py
+++ b/tests/model/test_annotations.py
@@ -1,44 +1,46 @@
 """Tests for annotation builder classes."""
 
 import pytest
+from deriva.core import tag as deriva_tag
 
+from deriva_ml.core.mixins.annotation import DISPLAY_TAG
 from deriva_ml.model.annotations import (
-    # Builders
-    Display,
-    VisibleColumns,
-    VisibleForeignKeys,
-    TableDisplay,
-    TableDisplayOptions,
+    CONTEXT_COMPACT,
+    # Context constants
+    CONTEXT_DEFAULT,
+    CONTEXT_DETAILED,
+    CONTEXT_ENTRY,
+    TAG_COLUMN_DISPLAY,
+    # Tags
+    TAG_DISPLAY,
+    TAG_TABLE_DISPLAY,
+    TAG_VISIBLE_COLUMNS,
+    TAG_VISIBLE_FOREIGN_KEYS,
+    Aggregate,
+    ArrayUxMode,
     ColumnDisplay,
     ColumnDisplayOptions,
-    PreFormat,
-    PseudoColumn,
-    PseudoColumnDisplay,
+    # Builders
+    Display,
     Facet,
     FacetList,
     FacetRange,
-    SortKey,
-    NameStyle,
+    FacetUxMode,
     # FK helpers
     InboundFK,
+    NameStyle,
     OutboundFK,
-    fk_constraint,
+    PreFormat,
+    PseudoColumn,
+    PseudoColumnDisplay,
+    SortKey,
+    TableDisplay,
+    TableDisplayOptions,
     # Enums
     TemplateEngine,
-    Aggregate,
-    ArrayUxMode,
-    FacetUxMode,
-    # Context constants
-    CONTEXT_DEFAULT,
-    CONTEXT_COMPACT,
-    CONTEXT_DETAILED,
-    CONTEXT_ENTRY,
-    # Tags
-    TAG_DISPLAY,
-    TAG_VISIBLE_COLUMNS,
-    TAG_VISIBLE_FOREIGN_KEYS,
-    TAG_TABLE_DISPLAY,
-    TAG_COLUMN_DISPLAY,
+    VisibleColumns,
+    VisibleForeignKeys,
+    fk_constraint,
 )
 
 
@@ -48,7 +50,9 @@ class TestDisplay:
     def test_simple_name(self):
         """Test display with simple name."""
         display = Display(name="My Table")
-        assert display.tag == TAG_DISPLAY
+        # Pin against deriva-py's authoritative tag, not the local constant
+        # (asserting against TAG_DISPLAY here would be a tautology).
+        assert display.tag == deriva_tag.display
         assert display.to_dict() == {"name": "My Table"}
 
     def test_markdown_name(self):
@@ -600,3 +604,35 @@ class TestExternalConsumerContract:
             "The deriva-skills/use-annotation-builders skill calls it as ml.apply_annotations() "
             "with no arguments — any required arg here is a breaking change for that contract."
         )
+
+
+class TestDisplayTagAuthority:
+    """Pin deriva-ml's 2015 display tag to deriva-py's canonical value.
+
+    The 2015 ``display`` annotation is grandfathered under the historical
+    ``misd`` namespace; Chaise reads display annotations from
+    ``tag:misd.isi.edu,2015:display``. deriva-ml previously hardcoded the
+    ``isrd`` namespace, so display annotations were written under a tag
+    Chaise ignores. These assertions import the authoritative value from
+    ``deriva.core.tag`` (re-exported from
+    ``deriva.core.utils.core_utils``) so the constants can never drift
+    from deriva-py again — and so the tautology that let the original bug
+    survive (asserting a builder's tag against the constant it is set
+    from) cannot reoccur.
+    """
+
+    def test_authority_value_is_misd(self):
+        """deriva-py's canonical display tag is in the misd namespace."""
+        assert deriva_tag.display == "tag:misd.isi.edu,2015:display"
+
+    def test_display_builder_tag_matches_deriva_py(self):
+        """Display builder writes under deriva-py's authoritative tag."""
+        assert Display.tag == deriva_tag.display
+
+    def test_tag_display_constant_matches_deriva_py(self):
+        """annotations.TAG_DISPLAY matches deriva-py's authoritative tag."""
+        assert TAG_DISPLAY == deriva_tag.display
+
+    def test_display_tag_mixin_constant_matches_deriva_py(self):
+        """mixins.annotation.DISPLAY_TAG matches deriva-py's authoritative tag."""
+        assert DISPLAY_TAG == deriva_tag.display


### PR DESCRIPTION
## Summary

The 2015 `display` annotation tag was hardcoded under the **`isrd`**
namespace in two deriva-ml constants. deriva-py's canonical display tag
is `tag:misd.isi.edu,2015:display` (the **`misd`** namespace) — the
2015 `display` tag is grandfathered under the historical `misd`
namespace, while the 2016+ tags (visible-columns, table-display, etc.)
are `isrd`. This is a real namespace quirk, not a typo.

Because `Display.tag = TAG_DISPLAY`, a user doing the documented
`table.annotations[Display.tag] = display.to_dict()` wrote the
annotation under `tag:isrd.isi.edu,2015:display` — but **Chaise reads
display annotations from `tag:misd.isi.edu,2015:display`**, so the
annotation was silently ignored. Same for any path using `DISPLAY_TAG`.

deriva-py defines the canonical display tag in **four** places, all
agreeing on `misd`:

- `deriva/core/utils/core_utils.py:760` — the `tag` AttrDict registry
  (`'display': 'tag:misd.isi.edu,2015:display'`), re-exported as
  `deriva.core.tag` via `deriva/core/__init__.py`'s
  `from deriva.core.utils.core_utils import *`.
- `deriva/core/schemas/display.schema.json:4` — title
  `tag:misd.isi.edu,2015:display`.
- `deriva/core/typed/annotations.py:33` —
  `display = "tag:misd.isi.edu,2015:display"`.
- `deriva/core/typed/annotations.py:184` — docstring.

**The alignment audit had this BACKWARDS.** It flagged
`create_schema.py:641` and `docs/adr/0007-annotation-builders-public-api.md`
(both already `misd`) as a "misd typo, should be isrd." Those are
**correct** and left untouched. The real behavior bug was in
`annotations.py` / `mixins/annotation.py`. This is the one real
behavior finding from the audit's Batch H cluster.

## Behavior change

Display annotations built via the `Display` builder (and any code using
`DISPLAY_TAG`) are now written under `tag:misd.isi.edu,2015:display`,
the tag Chaise actually reads. Previously they were written under
`tag:isrd.isi.edu,2015:display` and silently ignored by Chaise.

Fix (2 constants + 1 docstring → `misd`):
- `src/deriva_ml/model/annotations.py:277` `TAG_DISPLAY`: `isrd` → `misd`.
- `src/deriva_ml/core/mixins/annotation.py:35` `DISPLAY_TAG`: `isrd` → `misd`.
- `src/deriva_ml/core/mixins/annotation.py:8` module docstring: `isrd` → `misd`.

The 2016+ `isrd` tags (visible-columns, visible-foreign-keys,
table-display, column-display, source-definitions) were verified against
deriva-py's `tag` registry and are correct — left untouched.

## Test plan

The existing test was a **tautology**: `assert display.tag == TAG_DISPLAY`
compared the builder's tag to the constant it is set from, so it passed
regardless of correctness and let the bug survive. Replaced/augmented
with assertions that pin deriva-ml's display tag against deriva-py's
**authoritative** value (imported, never hardcoded in the assertion, so
it can't drift again):

- `test_simple_name` now asserts `display.tag == deriva_tag.display`.
- New `TestDisplayTagAuthority` pins `Display.tag`, `TAG_DISPLAY`, and
  `DISPLAY_TAG` against `deriva.core.tag.display`.

Verification (all run with `uv`):

- `uv run ruff check` on touched files — clean.
- `uv run python -m pytest tests/model/test_annotations.py -v` — **51 passed**
  (4 new authority tests + 47 existing).
- **Pre-fix proof:** with the constants reverted to `isrd`, the new
  authority tests + de-tautologized `test_simple_name` **fail** (4 failed,
  1 passed — only `test_authority_value_is_misd`, which checks deriva-py
  itself); restored to `misd` → all pass.
- `uv run pytest src/deriva_ml/model/annotations.py src/deriva_ml/core/mixins/annotation.py --doctest-modules -q` — passes (32 skipped, 0 failed).
- `grep -rn "isrd.isi.edu,2015:display" src/` — empty (no residual).

🤖 Generated with [Claude Code](https://claude.com/claude-code)