### PR TITLE
docs: reconcile audit batches D/E/F/H (docs-only)

### DIFF
--- a/docs/configuration/experiments.md
+++ b/docs/configuration/experiments.md
@@ -99,7 +99,7 @@ Named multiruns create a parent-child execution structure in the catalog:
 - **Parent execution**: Contains the markdown description and links to all children
 - **Child executions**: One per parameter combination, each with full provenance
 
-Use `list_parent_executions()` and `list_nested_executions()` to navigate this
+Use `list_execution_parents()` and `list_execution_children()` to navigate this
 hierarchy.
 
 ## Code Provenance

--- a/docs/user-guide/denormalization.md
+++ b/docs/user-guide/denormalization.md
@@ -669,9 +669,10 @@ authoritative; file an issue against the user-facing prose.
 This section is the single design reference for engineers
 working on `deriva_ml.local_db.denormalize`,
 `local_db.denormalizer`, `local_db.paged_fetcher`, and
-`model.denormalize_planner`. Audit findings are referenced
-inline using their SC-NN / TC-NN / RB-NN identifiers from
-`docs/audits/2026-05-26-denormalize-audit.md`.
+`model.denormalize_planner`. Findings are tagged inline with
+stable SC-NN / TC-NN / RB-NN identifiers used as internal
+labels within this document (the original standalone audit
+report they came from is no longer maintained separately).
 
 ---
 

--- a/docs/user-guide/executions.md
+++ b/docs/user-guide/executions.md
@@ -634,7 +634,7 @@ inputs, it appears once in the tree and subsequent encounters are marked
 produced this Execution's consumed inputs). It does **not** walk
 `Execution_Execution` (orchestration parent-child links — the "this Execution called
 that Execution" relationship). For the orchestration view, use
-`list_nested_executions` instead. The two views answer different questions and are
+`list_execution_children` instead. The two views answer different questions and are
 kept separate by design (see ADR-0001 in `docs/adr/`).
 
 **No producer.** If the artifact has no producing-execution link (manually-inserted

--- a/docs/user-guide/offline.md
+++ b/docs/user-guide/offline.md
@@ -6,7 +6,7 @@ This chapter builds on Chapter 2 (datasets), Chapter 3 (features), and Chapter 4
 
 ## Bags and live catalogs
 
-A live `Dataset` object talks to the server on every operation. A `DatasetBag` wraps the same data stored locally as a BDBag — a directory of CSV files, asset files, a SQLite database, and integrity manifests. The two classes implement the same `DatasetLike` protocol, so most read operations use identical method calls on either object.
+A live `Dataset` object talks to the server on every operation. A `DatasetBag` wraps the same data stored locally as a BDBag — a directory of CSV files, asset files, and integrity manifests — plus a SQLite mirror, built in a separate cache subtree, that backs queries. The two classes implement the same `DatasetLike` protocol, so most read operations use identical method calls on either object.
 
 The key differences are scope and direction. A bag is a point-in-time snapshot: it reflects exactly the rows and files that existed when it was downloaded at a specific version. You cannot add members, increment the version, or write feature values into the bag itself. Writes go back through a live `Execution` object after you reconnect.
 
@@ -42,7 +42,7 @@ Inside an execution the same `DatasetSpec` object works via `exe.download_datase
 
 ```python
 print(bag.path)
-# /home/user/.deriva/bags/1-ABC1/2.0.0/
+# /home/user/.deriva/cache/bags/<checksum>/Dataset_1-ABC1/
 
 # Integrity manifest
 manifest = (bag.path / "manifest-md5.txt").read_text()
@@ -54,22 +54,33 @@ images_csv = bag.path / "data" / "domain" / "Image.csv"
 asset_dir = bag.path / "data" / "asset"
 ```
 
-The directory layout after materialization:
+The cache is content-addressed by the BDBag checksum (ADR-0006). The
+bag directory and the SQLite database that backs bag queries live in
+*separate* subtrees under the cache root:
 
 ```
-<bag-root>/
-  manifest-md5.txt          # BDBag integrity manifest
-  bag-info.txt              # bag metadata
-  data/
-    deriva-ml/              # core ML schema tables (CSV)
-    domain/                 # domain-schema tables (CSV)
-    asset/
-      <RID>/
-        <Table>/
-          <filename>        # materialized asset files
-  *.db                      # SQLite database (bag queries go here)
-  schema.json               # catalog schema snapshot
+<cache-root>/
+  index.sqlite                # per host/catalog cache index
+  bags/
+    <checksum>/
+      Dataset_<RID>/          # the bag directory — this is bag.path
+        manifest-md5.txt      # BDBag integrity manifest
+        bag-info.txt          # bag metadata
+        data/
+          deriva-ml/          # core ML schema tables (CSV)
+          domain/             # domain-schema tables (CSV)
+          asset/
+            <RID>/
+              <Table>/
+                <filename>    # materialized asset files
+          schema.json         # catalog schema snapshot
+  databases/                  # SQLite mirrors (bag queries go here),
+    ...                       # NOT inside the bag directory
 ```
+
+`bag.path` points at the `Dataset_<RID>/` bag directory only. The
+SQLite database it queries is built under the sibling `databases/`
+subtree, so you will not find a `.db` file inside `bag.path`.
 
 The `bag.path` property was added in PR #64 and is available on the current branch. Treat the directory contents as read-only — bags are immutable by contract.
 
@@ -110,7 +121,7 @@ feat = bag.lookup_feature("Image", "Glaucoma")
 
 - `bag.list_dataset_members()` returns members of this dataset only. Pass `recurse=True` to include nested datasets.
 - `bag.get_table_as_dataframe("Subject")` returns all rows in that table, not just those belonging to the dataset. For dataset-scoped rows, combine with `list_dataset_members()`.
-- Feature cache: the first call to `bag.feature_values()` for a given `(table, feature)` pair populates a per-bag cache. Subsequent calls are fast. The cache avoids re-scanning the source CSV on subsequent calls, but every call loads all matching records into memory before yielding the first one — this is not a streaming iterator, same as the live-catalog `feature_values`.
+- Feature reads are not cached: each call to `bag.feature_values()` runs the full denormalize join fresh through the `Denormalizer` (the per-bag `BagFeatureCache` was removed in favor of this single path). Every call loads all matching records into memory before yielding the first one — this is not a streaming iterator, same as the live-catalog `feature_values`.
 - `bag.list_workflow_executions(workflow)` may return an empty list if the `Execution` rows were not exported into the bag. This is a known bag-export limitation; see "What bags can't do" below.
 
 ## What bags can't do
@@ -255,7 +266,7 @@ Top-level subdirectories come from dataset types (`Training` → `training`, `Te
 
 ### Using features as targets
 
-If a name in `targets` matches a feature defined on the asset table (or a table it references via FK), `restructure_assets` reads the feature values from the bag's SQLite cache and uses the vocabulary term as the directory name.
+If a name in `targets` matches a feature defined on the asset table (or a table it references via FK), `restructure_assets` reads the feature values through the `Denormalizer` (a fresh denormalize join over the bag, the same path `bag.feature_values()` uses) and uses the vocabulary term as the directory name.
 
 ```python
 # Group by a feature defined on Image
@@ -330,7 +341,7 @@ def dicom_to_png(src: Path, dest: Path) -> Path:
 
 manifest = bag.restructure_assets(
     output_dir="./ml_data",
-    group_by=["Diagnosis"],
+    targets=["Diagnosis"],
     file_transformer=dicom_to_png,
 )
 # manifest maps: Path(".../bag/.../scan.dcm") -> Path("./ml_data/training/Normal/scan.png")
@@ -385,13 +396,14 @@ ds = bag.as_torch_dataset(
 
 loader = DataLoader(ds, batch_size=32, shuffle=True, num_workers=4)
 
-for images, labels in loader:
-    # images: (B, 3, 224, 224) tensor; labels: (B,) int tensor
+for images, labels, rids in loader:
+    # images: (B, 3, 224, 224) tensor; labels: (B,) int tensor;
+    # rids: tuple of B element RIDs (the trailing item is always the RID)
     loss = criterion(model(images), labels)
     loss.backward()
 ```
 
-Labels come from features. `targets=["Glaucoma"]` tells the adapter to look up the `Glaucoma` feature for each `Image` row via `bag.feature_values("Image", "Glaucoma")`. The `target_transform` receives a `FeatureRecord` and must return whatever your loss function expects — typically an integer class index. The adapter never builds its own encoder; that decision stays in your code where train/val/test consistency is your responsibility.
+Each `__getitem__` returns `(sample, target, rid)` when `targets` is set and `(sample, rid)` when `targets=None` — the element's RID is always the trailing item, so unpack it (or slice it off) in your training loop. Labels come from features. `targets=["Glaucoma"]` tells the adapter to look up the `Glaucoma` feature for each `Image` row via `bag.feature_values("Image", "Glaucoma")`. The `target_transform` receives a `FeatureRecord` and must return whatever your loss function expects — typically an integer class index. The adapter never builds its own encoder; that decision stays in your code where train/val/test consistency is your responsibility.
 
 `sample_loader` is required for asset tables. It receives the absolute `Path` to the materialized file and the raw row dict; return whatever your model consumes. The error message at construction time names common loaders (`PIL.Image.open`, `nibabel.load`, `h5py.File`) if you forget to supply one.
 
@@ -412,7 +424,7 @@ ds = bag.as_torch_dataset(
 )
 ```
 
-Non-asset element types default to returning the raw row dict as the sample; no `sample_loader` is needed. Each `__getitem__` returns `(row_dict, target)`.
+Non-asset element types default to returning the raw row dict as the sample; no `sample_loader` is needed. Each `__getitem__` returns `(row_dict, target, rid)` — the element's RID is always the trailing item.
 
 *Multi-target — two features become a dict target:*
 
@@ -428,7 +440,7 @@ ds = bag.as_torch_dataset(
         "cdr":   float(recs["Cup_Disc_Ratio"].Cup_Disc_Ratio),
     },
 )
-# __getitem__ returns (image_tensor, {"grade": int, "cdr": float})
+# __getitem__ returns (image_tensor, {"grade": int, "cdr": float}, rid)
 ```
 
 When `targets` lists more than one feature name, `target_transform` receives `dict[str, FeatureRecord]` keyed by feature name.
@@ -478,7 +490,9 @@ ds = bag.as_tf_dataset(
     target_transform=lambda rec: CLASS_TO_IDX[rec.Glaucoma],
 )
 
-# Standard tf.data pipeline
+# Each element is (sample, target, rid). Keras model.fit expects (x, y),
+# so drop the trailing RID before batching.
+ds = ds.map(lambda sample, target, rid: (sample, target))
 ds = ds.batch(32).prefetch(tf.data.AUTOTUNE)
 
 model.compile(optimizer="adam", loss="sparse_categorical_crossentropy")
@@ -487,17 +501,20 @@ model.fit(ds, epochs=10)
 
 **`output_signature` — when to let it infer, when to set it explicitly**
 
-`as_tf_dataset` builds its generator via `tf.data.Dataset.from_generator`, which requires a type/shape signature. By default (`output_signature=None`) the adapter eagerly reads the first `(sample, target)` pair at construction time, derives a `tf.TensorSpec` from it via `tf.type_spec_from_value`, and re-wraps the generator so that first sample is not skipped during iteration. This adds one extra sample load at startup — acceptable for research workflows.
+`as_tf_dataset` builds its generator via `tf.data.Dataset.from_generator`, which requires a type/shape signature. By default (`output_signature=None`) the adapter eagerly reads the first yielded element at construction time — a `(sample, target, rid)` 3-tuple (`(sample, rid)` when `targets=None`) — derives a `tf.TensorSpec` from it via `tf.type_spec_from_value`, and re-wraps the generator so that first sample is not skipped during iteration. This adds one extra sample load at startup — acceptable for research workflows.
 
 Pass `output_signature` explicitly in two situations:
+
+The signature must match the full yielded element: `(sample, target, rid)` when `targets` is set, `(sample, rid)` when `targets=None`. The RID is yielded as a Python `str`, so its spec is `tf.TensorSpec(shape=(), dtype=tf.string)`.
 
 1. **Production pipelines** where you want deterministic startup with no eager reads:
    ```python
    # doctest: +SKIP
    import tensorflow as tf
    sig = (
-       tf.TensorSpec(shape=(224, 224, 3), dtype=tf.float32),
-       tf.TensorSpec(shape=(),            dtype=tf.int32),
+       tf.TensorSpec(shape=(224, 224, 3), dtype=tf.float32),  # sample
+       tf.TensorSpec(shape=(),            dtype=tf.int32),     # target
+       tf.TensorSpec(shape=(),            dtype=tf.string),    # rid
    )
    ds = bag.as_tf_dataset("Image", ..., output_signature=sig)
    ```
@@ -507,7 +524,8 @@ Pass `output_signature` explicitly in two situations:
    # doctest: +SKIP
    sig = (
        tf.TensorSpec(shape=(None, None, 3), dtype=tf.float32),  # variable H x W
-       tf.TensorSpec(shape=(),              dtype=tf.int32),
+       tf.TensorSpec(shape=(),              dtype=tf.int32),     # target
+       tf.TensorSpec(shape=(),              dtype=tf.string),    # rid
    )
    ds = bag.as_tf_dataset("Image", ..., output_signature=sig)
    ```
@@ -601,19 +619,27 @@ os.environ["KERAS_BACKEND"] = "tensorflow"
 import keras
 import tensorflow as tf
 
-ds = bag.as_tf_dataset(
-    "Image",
-    sample_loader=load_image,
-    targets=["Glaucoma"],
-    target_transform=lambda rec: CLASS_TO_IDX[rec.Glaucoma],
-).batch(32).prefetch(tf.data.AUTOTUNE)
+ds = (
+    bag.as_tf_dataset(
+        "Image",
+        sample_loader=load_image,
+        targets=["Glaucoma"],
+        target_transform=lambda rec: CLASS_TO_IDX[rec.Glaucoma],
+    )
+    # Elements are (sample, target, rid); model.fit wants (x, y), so drop the RID.
+    .map(lambda sample, target, rid: (sample, target))
+    .batch(32)
+    .prefetch(tf.data.AUTOTUNE)
+)
 
 model = keras.applications.ResNet50(weights=None, classes=4)
 model.compile(optimizer="adam", loss="sparse_categorical_crossentropy")
 model.fit(ds, epochs=10)
 ```
 
-**JAX backend** — either adapter works. Keras 3 on JAX accepts any Python iterable of `(x, y)` tuples. Pass a `DataLoader` wrapping `as_torch_dataset`, or chain `as_tf_dataset` through a generator, or materialize to NumPy arrays directly. The JAX backend does not add requirements beyond what Keras itself needs.
+The torch-backend example above feeds a `DataLoader` whose batches are `(sample, target, rid)`; Keras reads the first two positional items as `(x, y)` and ignores the trailing RID, so no `.map()` is needed there.
+
+**JAX backend** — either adapter works. Keras 3 on JAX accepts any Python iterable of `(x, y)` tuples; drop the trailing RID (`.map()` for `tf.data`, or slice it off in a wrapper for the `DataLoader`) before passing the data in. Pass a `DataLoader` wrapping `as_torch_dataset`, or chain `as_tf_dataset` through a generator, or materialize to NumPy arrays directly. The JAX backend does not add requirements beyond what Keras itself needs.
 
 **Note:** Set `KERAS_BACKEND` before importing Keras — the backend is selected at import time and cannot change in the same process.
 

--- a/src/deriva_ml/core/mixins/dataset.py
+++ b/src/deriva_ml/core/mixins/dataset.py
@@ -445,8 +445,9 @@ class DatasetMixin:
         committing to a bag export.
 
         The return shape is aligned with :meth:`estimate_bag_size` and
-        is **NOT the same** as the dataset-scoped 12-key plan dict from
-        :meth:`Dataset.describe_denormalized` (spec §5). Do not confuse
+        is **NOT the same** as the dataset-scoped 13-key plan dict from
+        :meth:`Dataset.describe_denormalized`
+        (``docs/user-guide/denormalization.md`` §8.3.2). Do not confuse
         the two.
 
         Args:

--- a/src/deriva_ml/core/validation.py
+++ b/src/deriva_ml/core/validation.py
@@ -373,26 +373,21 @@ def validate_execution_config(
     It catches configuration errors (typos in RIDs, wrong catalog, missing versions)
     early with clear messages.
 
-    Parameters
-    ----------
-    ml : DerivaML
-        Connected DerivaML instance.
-    datasets : list
-        Resolved dataset specifications (DatasetSpec objects or dicts with rid/version).
-    assets : list
-        Resolved asset specifications (AssetSpec objects, dicts, or bare RID strings).
+    Args:
+        ml: Connected DerivaML instance.
+        datasets: Resolved dataset specifications (``DatasetSpec`` objects or
+            dicts with ``rid``/``version``).
+        assets: Resolved asset specifications (``AssetSpec`` objects, dicts, or
+            bare RID strings).
 
-    Returns
-    -------
-    ValidationResult
-        Validation result with errors for missing RIDs or versions, and warnings
-        for stale versions.
+    Returns:
+        ValidationResult: Validation result with errors for missing RIDs or
+        versions, and warnings for stale versions.
 
-    Example
-    -------
-    >>> result = validate_execution_config(ml, datasets, assets)  # doctest: +SKIP
-    >>> if not result.is_valid:  # doctest: +SKIP
-    ...     raise DerivaMLException(f"Config validation failed:\\n{result}")
+    Example:
+        >>> result = validate_execution_config(ml, datasets, assets)  # doctest: +SKIP
+        >>> if not result.is_valid:  # doctest: +SKIP
+        ...     raise DerivaMLException(f"Config validation failed:\\n{result}")
     """
     # Extract dataset RIDs and versions
     dataset_rids: list[str] = []

--- a/src/deriva_ml/dataset/aux_classes.py
+++ b/src/deriva_ml/dataset/aux_classes.py
@@ -208,11 +208,17 @@ class DatasetHistory(BaseModel):
     Class representing a dataset history.
 
     Attributes:
-        dataset_version (DatasetVersion): A DatasetVersion object which captures the semantic versioning of the dataset.
+        dataset_version (DatasetVersion): A DatasetVersion object which captures the PEP 440 version of the dataset.
         dataset_rid (RID): The RID of the dataset.
         version_rid (RID): The RID of the version record for the dataset in the Dataset_Version table.
+        execution_rid (RID | None): RID of the execution that created this
+            version, or None when the version was created outside an execution.
+        description (str | None): Human-readable description recorded with this
+            version (empty string when none was supplied).
         minid (str): The URL that represents the handle of the dataset bag.  This will be None if a MINID has not
                      been created yet.
+        spec_hash (str | None): Hash of the dataset spec used to build this
+            version, or None when not recorded. Used to detect cache hits.
         snapshot (str): Catalog snapshot ID of when the version record was created.
     """
 
@@ -241,7 +247,7 @@ class DatasetMinid(BaseModel):
     """Represent information about a MINID that refers to a dataset
 
     Attributes:
-        dataset_version (DatasetVersion): A DatasetVersion object which captures the semantic versioning of the dataset.
+        dataset_version (DatasetVersion): A DatasetVersion object which captures the PEP 440 version of the dataset.
         metadata (dict): A dictionary containing metadata from the MINID landing page.
         minid (str): The URL that represents the handle of the MINID associated with the dataset.
         bag_url (str): The URL to the dataset bag
@@ -309,13 +315,17 @@ class DatasetSpec(BaseModel):
     Attributes:
         rid (RID): A dataset_table RID
         materialize (bool): If False do not materialize datasets, only download table data, no assets.  Defaults to True
-        version (DatasetVersion): The version of the dataset.  Should follow semantic versioning.
+        version (DatasetVersion): The version of the dataset.  Should follow PEP 440 (see ADR-0004).
+        description (str): Optional human-readable note describing this spec's
+            role in the configuration. Defaults to the empty string.
         exclude_tables (set[str] | None): Optional set of table names to exclude from FK path
             traversal during bag export. Tables in this set will not be visited, pruning branches
             of the FK graph. Useful for avoiding query timeouts on large tables.
         timeout (tuple[int, int] | None): Optional (connect_timeout, read_timeout) in seconds
             for network requests during bag download. Defaults to (10, 610) if not specified.
             Increase read_timeout for large datasets with deep FK joins.
+        fetch_concurrency (int): Number of concurrent fetch threads for asset
+            download during materialization. Defaults to 8.
     """
 
     rid: RID

--- a/src/deriva_ml/dataset/bag_builder.py
+++ b/src/deriva_ml/dataset/bag_builder.py
@@ -726,7 +726,7 @@ class DatasetBagBuilder:
         The dataset's root row is the primary anchor; each nested
         child dataset becomes an additional :class:`RIDAnchor`.
         The traversal depth is bounded by
-        :meth:`DatasetLike.dataset_children` chains.
+        :meth:`DatasetLike.list_dataset_children` chains.
 
         This is the bag-pipeline-shaped representation of "what
         rows does the walker start from for this dataset?". When

--- a/src/deriva_ml/dataset/dataset_bag.py
+++ b/src/deriva_ml/dataset/dataset_bag.py
@@ -1069,7 +1069,7 @@ class DatasetBag:
         Shortcut for
         :meth:`~deriva_ml.local_db.denormalizer.Denormalizer.describe` —
         returns the full plan dict (see that method's docstring for the
-        exact 12-key shape). Never raises on ambiguity.
+        exact 13-key shape). Never raises on ambiguity.
 
         Args:
             include_tables: Tables whose columns would appear in the output.
@@ -1077,7 +1077,7 @@ class DatasetBag:
             via: Optional path-only intermediates (Rule 6).
 
         Returns:
-            dict: Planning metadata with 12 keys including ``anchor``,
+            dict: Planning metadata with 13 keys including ``anchors``,
             ``row_per``, ``join_path``, ``columns``, ``ambiguities``,
             and related diagnostics. See ``Denormalizer.describe`` for
             the full shape.
@@ -1085,7 +1085,7 @@ class DatasetBag:
         Example::
 
             plan = bag.describe_denormalized(["Image", "Subject"])
-            print(plan["anchor"], plan["row_per"])
+            print(plan["anchors"], plan["row_per"])
         """
         from deriva_ml.local_db.denormalizer import Denormalizer
 

--- a/src/deriva_ml/dataset/dataset_bag.py
+++ b/src/deriva_ml/dataset/dataset_bag.py
@@ -196,8 +196,12 @@ class DatasetBag:
         """Filesystem path to this bag's root directory.
 
         The bag is a self-contained, immutable snapshot on disk. ``path``
-        is the directory containing ``data/``, ``manifest-md5.txt``, and
-        the bag's SQLite database. Use it to:
+        is the BDBag directory containing ``data/`` (the CSV tables and
+        materialized asset files) and ``manifest-md5.txt``. The SQLite
+        database that backs queries is **not** inside this directory — it
+        lives in a separate ``databases/`` subtree of the cache root
+        (the cache is content-addressed by BDBag checksum per ADR-0006).
+        Use ``path`` to:
 
         - Read materialized asset files relative to the bag.
         - Diagnose "which bag is this?" errors in logs.
@@ -207,7 +211,9 @@ class DatasetBag:
         mutate anything inside it — bags are immutable by contract.
 
         Returns:
-            Path: Root directory of the materialized bag on disk.
+            Path: Root directory of the materialized BDBag on disk
+            (parent of ``data/``). The SQLite mirror is stored
+            elsewhere, under the cache's ``databases/`` subtree.
 
         Example:
             >>> spec = DatasetSpec(rid="1-abc123", version="1.2.0")  # doctest: +SKIP

--- a/src/deriva_ml/execution/asset_upload.py
+++ b/src/deriva_ml/execution/asset_upload.py
@@ -200,6 +200,14 @@ def set_asset_descriptions(
         on a localhost SSD that meant ~10K SQL round-trips
         (~19 minutes). The single-read pattern is preserved
         here.
+
+    Example:
+        >>> set_asset_descriptions(  # doctest: +SKIP
+        ...     execution,
+        ...     uploaded_assets,
+        ...     metadata_descriptions={"uv.lock": "Locked dependencies"},
+        ...     env_snapshot_description="Runtime environment snapshot",
+        ... )
     """
     manifest = execution._get_manifest()
     pb = execution._ml_object.pathBuilder()
@@ -264,6 +272,14 @@ def save_runtime_environment(
             ``ExecMetadataType`` enum import.
         env_snapshot_description: The description string for
             the staged metadata asset.
+
+    Example:
+        >>> from deriva_ml.core.enums import ExecMetadataType  # doctest: +SKIP
+        >>> save_runtime_environment(  # doctest: +SKIP
+        ...     execution,
+        ...     runtime_env_asset_type=ExecMetadataType.runtime_env.value,
+        ...     env_snapshot_description="Runtime environment snapshot",
+        ... )
     """
     runtime_env_path = execution.asset_file_path(
         asset_name="Execution_Metadata",
@@ -323,6 +339,16 @@ def upload_hydra_config_assets(
         execution_metadata_asset_name: ``MLAsset.execution_metadata``
             — passed in as a value, not imported, so the helper
             stays decoupled from the ``MLAsset`` enum import.
+
+    Example:
+        >>> from deriva_ml.core.enums import ExecMetadataType, MLAsset  # doctest: +SKIP
+        >>> upload_hydra_config_assets(  # doctest: +SKIP
+        ...     execution,
+        ...     hydra_config_asset_type=ExecMetadataType.hydra_config.value,
+        ...     metadata_descriptions={},
+        ...     env_snapshot_description="Runtime environment snapshot",
+        ...     execution_metadata_asset_name=MLAsset.execution_metadata,
+        ... )
     """
     hydra_runtime_output_dir = execution._ml_object.hydra_runtime_output_dir
     if not hydra_runtime_output_dir:
@@ -373,6 +399,10 @@ def clean_folder_contents(folder_path: Path, remove_folder: bool = True, *, logg
         they're never tuned at the call site (and over-
         parameterizing would just add an arg that's always
         passed the same way).
+
+    Example:
+        >>> from pathlib import Path  # doctest: +SKIP
+        >>> clean_folder_contents(Path("/tmp/staging"), remove_folder=False)  # doctest: +SKIP
     """
     if logger is None:
         logger = logging.getLogger(__name__)
@@ -500,6 +530,19 @@ def update_asset_execution_table(
         asset_type_path_fn: The ``asset_type_path`` function
             from ``core.upload_layout`` — passed in to keep
             the helper free of that import.
+
+    Example:
+        >>> from deriva_ml.core.definitions import MLVocab, ExecAssetType  # doctest: +SKIP
+        >>> from deriva_ml.core.upload_layout import asset_type_path  # doctest: +SKIP
+        >>> update_asset_execution_table(  # doctest: +SKIP
+        ...     execution,
+        ...     uploaded_assets,
+        ...     asset_role="Input",
+        ...     asset_role_vocab_term=MLVocab.asset_role,
+        ...     input_file_tag=ExecAssetType.input_file.value,
+        ...     output_file_tag=ExecAssetType.output_file.value,
+        ...     asset_type_path_fn=asset_type_path,
+        ... )
     """
     if execution._dry_run:
         # Don't do any updates if we are doing a dry run.

--- a/src/deriva_ml/execution/base_config.py
+++ b/src/deriva_ml/execution/base_config.py
@@ -101,6 +101,10 @@ class BaseConfig:
             This is automatically populated by get_notebook_configuration() with the
             Hydra runtime choices (e.g., {"model_config": "cifar10_quick", "assets": "roc_quick"}).
             Useful for tracking which configurations were used in an execution.
+        script_config: Optional alternate hydra-zen callable for the code to
+            run. When set, ``run_model`` invokes it instead of ``model_config``
+            (it takes precedence) and it is the only callable exercised during a
+            dry run. Defaults to ``None`` (use ``model_config``).
 
     Example:
         >>> from dataclasses import dataclass

--- a/src/deriva_ml/execution/dataset_collection.py
+++ b/src/deriva_ml/execution/dataset_collection.py
@@ -12,7 +12,7 @@ Why not :class:`collections.abc.Mapping`?
     ``__iter__`` yields keys, and any caller that types a
     parameter ``Mapping[str, DatasetBag]`` then writes
     ``for k in m: m[k]`` would break. The audit at
-    ``docs/design/deriva-ml-audit-2026-05-phase3-execution.md``
+    ``docs/archive/2026-05-audit-working-drafts/deriva-ml-audit-2026-05-phase3-execution.md``
     §4.7 flagged the violation. We chose the value-iteration
     ergonomics (overwhelmingly what callers want), so we drop
     the ``Mapping`` advertisement instead of restoring the

--- a/src/deriva_ml/execution/execution.py
+++ b/src/deriva_ml/execution/execution.py
@@ -227,7 +227,8 @@ class Execution:
 
     Attributes:
         dataset_rids (list[RID]): RIDs of datasets used in the execution.
-        datasets (list[DatasetBag]): Materialized dataset objects.
+        datasets (DatasetCollection): Collection wrapping the materialized
+            ``DatasetBag`` objects (iterable, indexable; not a plain list).
         configuration (ExecutionConfiguration): Execution settings and parameters.
         workflow_rid (RID): RID of the associated workflow.
         status (ExecutionStatus): Current execution status (read-through from SQLite).
@@ -1213,10 +1214,10 @@ class Execution:
                 materialization options.
 
         Returns:
-            DatasetBag: Object containing:
-                - path: Local filesystem path to downloaded dataset
-                - rid: Dataset's Resource Identifier
-                - minid: Dataset's Minimal Viable Identifier
+            DatasetBag: Object exposing, among others:
+                - ``path``: local filesystem path to the materialized bag
+                - ``dataset_rid``: the dataset's Resource Identifier
+                - ``current_version``: the resolved dataset version
 
         Raises:
             DerivaMLException: If download or materialization fails.
@@ -1224,7 +1225,7 @@ class Execution:
         Example:
             >>> spec = DatasetSpec(rid="1-abc123", version="1.2.0")  # doctest: +SKIP
             >>> bag = execution.download_dataset_bag(spec)  # doctest: +SKIP
-            >>> print(f"Downloaded to {bag.path}")  # doctest: +SKIP
+            >>> print(f"Downloaded {bag.dataset_rid} to {bag.path}")  # doctest: +SKIP
         """
         return self._ml_object.download_dataset_bag(dataset)
 

--- a/src/deriva_ml/execution/runner.py
+++ b/src/deriva_ml/execution/runner.py
@@ -395,76 +395,67 @@ def run_model(
     ml_class: type["DerivaML"] | None = None,
     script_config: Any = None,
 ) -> None:
-    """
-    Execute a machine learning model within a DerivaML execution context.
+    """Execute a machine learning model within a DerivaML execution context.
 
     This function serves as the main entry point called by hydra-zen after
     configuration resolution. It orchestrates the complete execution lifecycle:
     connecting to Deriva, creating an execution record, running the model,
-    and uploading results.
+    and (when not a dry run) uploading results.
 
     In multirun mode, this function also:
     - Creates a parent execution on the first job to group all sweep jobs
     - Links each child execution to the parent with sequence ordering
 
-    Parameters
-    ----------
-    deriva_ml : DerivaMLConfig
-        Configuration for the DerivaML connection. Contains server URL,
-        catalog ID, credentials, and other connection parameters.
+    Args:
+        deriva_ml: Configuration for the DerivaML connection. Contains server
+            URL, catalog ID, credentials, and other connection parameters.
+        datasets: Specifications for datasets to use in this execution. Each
+            ``DatasetSpec`` identifies a dataset in the Deriva catalog to be
+            made available to the model.
+        assets: Resource IDs (RIDs) of assets to include in the execution.
+            Typically model weight files, pretrained checkpoints, or other
+            artifacts needed by the model.
+        description: Human-readable description of this execution run. Stored
+            in the Deriva catalog for provenance tracking. In multirun mode,
+            this is also used for the parent execution if running via
+            ``multirun_config``.
+        workflow: The workflow definition to associate with this execution.
+            Defines the computational pipeline and its metadata.
+        model_config: A hydra-zen callable that wraps the actual model code.
+            When called with ``ml_instance`` and ``execution`` arguments, it
+            runs the model training or inference logic.
+        dry_run: If True, create the execution record but skip the model run
+            and the result upload. When ``script_config`` is set, the script
+            is still invoked once with ``execution=None`` to print a preview;
+            a plain ``model_config`` is skipped entirely (it may not handle
+            ``execution=None``). Useful for testing configuration without
+            running expensive computations. Defaults to False.
+        ml_class: The DerivaML class (or subclass) to instantiate. If None,
+            uses the base DerivaML class. Use this to instantiate
+            domain-specific classes like EyeAI or GUDMAP.
+        script_config: Optional alternate hydra-zen callable that, when
+            provided, **takes precedence over** ``model_config`` as the code
+            to invoke. Lets skill-generated scripts share this runner while
+            living in their own config group. It is also the only path that
+            runs during a dry run (see ``dry_run``).
 
-    datasets : list[DatasetSpec]
-        Specifications for datasets to use in this execution. Each DatasetSpec
-        identifies a dataset in the Deriva catalog to be made available to
-        the model.
+    Returns:
+        None. On a non-dry run, results are committed to the Deriva catalog as
+        execution output assets; on a dry run, nothing is uploaded.
 
-    assets : list[RID]
-        Resource IDs (RIDs) of assets to include in the execution. Typically
-        used for model weight files, pretrained checkpoints, or other
-        artifacts needed by the model.
+    Example:
+        This function is typically not called directly, but through hydra::
 
-    description : str
-        Human-readable description of this execution run. Stored in the
-        Deriva catalog for provenance tracking. In multirun mode, this is
-        also used for the parent execution if running via multirun_config.
+            # From the command line:
+            # python deriva_run.py +experiment=cifar10_cnn dry_run=True
 
-    workflow : Workflow
-        The workflow definition to associate with this execution. Defines
-        the computational pipeline and its metadata.
+            # Multirun (creates parent + child executions):
+            # python deriva_run.py --multirun \
+            #     +experiment=cifar10_quick,cifar10_extended
 
-    model_config : Any
-        A hydra-zen callable that wraps the actual model code. When called
-        with `ml_instance` and `execution` arguments, it runs the model
-        training or inference logic.
-
-    dry_run : bool, optional
-        If True, create the execution record but skip actual model execution.
-        Useful for testing configuration without running expensive computations.
-        Default is False.
-
-    ml_class : type[DerivaML], optional
-        The DerivaML class (or subclass) to instantiate. If None, uses the
-        base DerivaML class. Use this to instantiate domain-specific classes
-        like EyeAI or GUDMAP.
-
-    Returns
-    -------
-    None
-        Results are uploaded to the Deriva catalog as execution outputs.
-
-    Examples
-    --------
-    This function is typically not called directly, but through hydra:
-
-        # From command line:
-        python deriva_run.py +experiment=cifar10_cnn dry_run=True
-
-        # Multirun (creates parent + child executions):
-        python deriva_run.py --multirun +experiment=cifar10_quick,cifar10_extended
-
-        # With a custom DerivaML subclass (in your script):
-        from functools import partial
-        run_model_eyeai = partial(run_model, ml_class=EyeAI)
+            # With a custom DerivaML subclass (in your script):
+            >>> from functools import partial  # doctest: +SKIP
+            >>> run_model_eyeai = partial(run_model, ml_class=EyeAI)  # doctest: +SKIP
     """
     global _multirun_state
 

--- a/src/deriva_ml/execution/state_store.py
+++ b/src/deriva_ml/execution/state_store.py
@@ -9,7 +9,7 @@ also defined ``execution_state__pending_rows`` and
 ``execution_state__directory_rules`` tables for an upload-engine
 that was superseded by the bag-commit path before its writer
 shipped. That surface was retired in the Phase 3 cleanup
-(audit ``docs/design/deriva-ml-audit-2026-05-phase3-execution.md``
+(audit ``docs/archive/2026-05-audit-working-drafts/deriva-ml-audit-2026-05-phase3-execution.md``
 §1.5). Three reader methods —
 :meth:`ExecutionStateStore.count_pending_rows`,
 :meth:`~ExecutionStateStore.count_pending_by_kind`,

--- a/src/deriva_ml/execution/workflow.py
+++ b/src/deriva_ml/execution/workflow.py
@@ -8,7 +8,9 @@ computational workflow in a Deriva catalog. Key responsibilities:
   kernel path, or local file path) when ``url`` is not provided explicitly.
 - Supports catalog write-back for ``description`` and ``workflow_type`` when
   the workflow is bound to a live catalog instance.
-- Deduplicates workflows by checksum via ``DerivaML.add_workflow()``.
+- Deduplicates workflows by checksum on insert (the private
+  ``DerivaML._add_workflow()`` dedup path; create workflows via the
+  public ``DerivaML.create_workflow()``).
 """
 
 from __future__ import annotations
@@ -368,11 +370,17 @@ class Workflow(BaseModel):
 
         - ``url`` — set to the resolved source URL of the calling
           script/notebook. Resolution prefers a Docker image
-          identifier (when ``DERIVA_MCP_IN_DOCKER=true``), then falls
-          back to git remote + commit + path, then to a file:// path.
+          identifier (when ``DERIVA_MCP_IN_DOCKER=true``), otherwise a
+          GitHub ``/blob/<commit>/<path>`` URL from the local git
+          checkout. When the script is not in a git repo and
+          ``allow_dirty=True``, ``url`` is left empty (``""``) — there
+          is no ``file://`` fallback.
         - ``checksum`` — set to the git commit SHA of the calling
           script (or the Docker image digest when running in Docker).
-        - ``version`` — set from ``DERIVA_MCP_VERSION`` when present.
+        - ``version`` — in the local-git path (the common case) it is
+          set from ``get_dynamic_version()`` (the version derived from
+          the local git checkout); in the Docker path it is set from
+          ``DERIVA_MCP_VERSION`` instead.
 
         Caller-supplied values are never overwritten — this is a
         "fill in the blanks" validator, not a re-derivation.

--- a/src/deriva_ml/execution/workflow.py
+++ b/src/deriva_ml/execution/workflow.py
@@ -67,6 +67,14 @@ class Workflow(BaseModel):
         workflow_rid (RID | None): Resource Identifier if registered in catalog.
         checksum (str | None): Git hash of workflow source code.
         is_notebook (bool): Whether workflow is a Jupyter notebook.
+        git_root (Path | None): Filesystem root of the git checkout the source
+            was resolved from, when known. Used to scope dynamic-version
+            resolution; ``None`` when no git checkout was detected.
+        allow_dirty (bool): When True, uncommitted changes in the source's git
+            worktree are downgraded from a hard error to a warning (set by the
+            ``--allow-dirty`` CLI flag, dry-run mode, or
+            ``DERIVA_ML_ALLOW_DIRTY``). Defaults to False, which keeps the
+            clean-checkout precondition that makes provenance reproducible.
 
     Note:
         The recommended way to create a Workflow is via :meth:`DerivaML.create_workflow()

--- a/src/deriva_ml/interfaces.py
+++ b/src/deriva_ml/interfaces.py
@@ -432,13 +432,13 @@ class DatasetLike(Protocol):
             via: Optional path-only intermediates.
 
         Returns:
-            12-key planning dict (see
+            13-key planning dict (see
             :meth:`~deriva_ml.local_db.denormalizer.Denormalizer.describe`
             for the detailed shape): ``row_per``, ``row_per_source``,
             ``row_per_candidates``, ``columns``, ``include_tables``,
             ``via``, ``join_path``, ``transparent_intermediates``,
             ``ambiguities``, ``estimated_row_count``, ``anchors``,
-            ``source``.
+            ``source``, ``warnings``.
 
         See Also:
             get_denormalized_as_dataframe: Execute the plan and return a

--- a/src/deriva_ml/interfaces.py
+++ b/src/deriva_ml/interfaces.py
@@ -610,14 +610,15 @@ class AssetLike(Protocol):
     description: str
     execution_rid: RID | None
 
-    def list_executions(self, asset_role: str | None = None) -> list[dict[str, Any]]:
+    def list_executions(self, asset_role: str | None = None) -> list["ExecutionRecord"]:
         """List all executions associated with this asset.
 
         Args:
             asset_role: Optional filter for asset role ('Input' or 'Output').
 
         Returns:
-            List of records with Execution RID and Asset_Role.
+            List of ExecutionRecord objects for the executions associated with
+            this asset.
         """
         ...
 
@@ -984,16 +985,30 @@ class DerivaMLCatalog(DerivaMLCatalogReader, Protocol):
         ...
 
     def add_features(self, features: list[FeatureRecord]) -> int:
-        """Add feature values to the catalog in batch.
+        """Retired — use ``exe.add_features(records)`` inside an execution context.
 
-        Inserts a list of FeatureRecord instances into the appropriate feature table.
-        All records must be from the same feature.
+        ``DerivaML.add_features`` has been retired so that all feature writes go
+        through the execution context, where provenance is tracked and values are
+        staged for atomic upload. The concrete implementation
+        (:meth:`FeatureMixin.add_features`) raises unconditionally; this method is
+        kept on the protocol only to document the replacement.
 
         Args:
-            features: List of FeatureRecord instances to insert.
+            features: List of FeatureRecord instances. Unused — the call always
+                raises before inserting anything.
 
         Returns:
-            Number of feature records inserted.
+            Never returns; the return annotation is retained for historical
+            compatibility with the protocol surface.
+
+        Raises:
+            DerivaMLException: Always. Points at the replacement API.
+
+        Example:
+            Write features through an execution context instead::
+
+                >>> with ml.create_execution(config).execute() as exe:  # doctest: +SKIP
+                ...     exe.add_features(records)
         """
         ...
 

--- a/src/deriva_ml/local_db/denormalize.py
+++ b/src/deriva_ml/local_db/denormalize.py
@@ -109,7 +109,7 @@ class DenormalizeResult:
             between the start of this denormalize call and the *earliest*
             catalog fetch that participated in the SQL JOIN that built this
             result. ``None`` when no live catalog fetch happened
-            (``source='bag'`` / ``source='local'`` / ``source='slice'``, or
+            (``source='local'`` — including bags — or ``source='slice'``, or
             ``source='catalog'`` with all keys already deduped against
             cache — though in practice the dataset-row fetch always
             stamps the ledger). A user re-running denormalize in a

--- a/src/deriva_ml/local_db/denormalizer.py
+++ b/src/deriva_ml/local_db/denormalizer.py
@@ -68,7 +68,8 @@ class Denormalizer:
       (see the method's own docstring and audit finding SC-07).
     - :meth:`columns` — preview ``(column_name, column_type)`` pairs
       without fetching data (model-only).
-    - :meth:`describe` — dry-run: returns a 12-key plan dict (spec §5);
+    - :meth:`describe` — dry-run: returns a 13-key plan dict
+      (``docs/user-guide/denormalization.md`` §8.3.2);
       reports ambiguities rather than raising.
     - :meth:`list_paths` — describe the reachable FK graph from the
       anchor set (useful for discovering what can go into
@@ -813,7 +814,8 @@ class Denormalizer:
             via: Optional path-only intermediates.
 
         Returns:
-            A dict with these 12 keys (see design spec §5):
+            A dict with these 13 keys (see
+            ``docs/user-guide/denormalization.md`` §8.3.2):
 
             - ``row_per``: resolved leaf table name, or ``None`` if the
               planner couldn't resolve one (e.g., multi-leaf or bad

--- a/src/deriva_ml/model/catalog.py
+++ b/src/deriva_ml/model/catalog.py
@@ -179,6 +179,12 @@ class DerivaModel:
         Returns:
             A ``DerivaModel`` wrapping a deriva-py ``Model``
             reconstructed from the dict.
+
+        Example:
+            >>> cached = schema_cache.load(hostname, catalog_id)  # doctest: +SKIP
+            >>> model = DerivaModel.from_cached(  # doctest: +SKIP
+            ...     cached, catalog=catalog_stub, ml_schema="deriva-ml"
+            ... )
         """
         # Model.__init__(catalog, model_doc) stores catalog as
         # self._catalog and exposes it via the .catalog property;
@@ -199,6 +205,12 @@ class DerivaModel:
 
         Returns:
             True if the schema is a system or ML schema.
+
+        Example:
+            >>> model.is_system_schema("public")  # doctest: +SKIP
+            True
+            >>> model.is_system_schema("my_domain")  # doctest: +SKIP
+            False
         """
         return _is_system_schema(schema_name, self.ml_schema)
 
@@ -210,6 +222,12 @@ class DerivaModel:
 
         Returns:
             True if the schema is a domain schema.
+
+        Example:
+            >>> model.is_domain_schema("my_domain")  # doctest: +SKIP
+            True
+            >>> model.is_domain_schema("deriva-ml")  # doctest: +SKIP
+            False
         """
         return schema_name in self.domain_schemas
 
@@ -231,11 +249,42 @@ class DerivaModel:
         return self.default_schema
 
     def refresh_model(self) -> None:
+        """Re-fetch the catalog model and replace ``self.model`` in place.
+
+        Calls ``catalog.getCatalogModel()`` and rebinds the result to
+        ``self.model``. Use this after a schema change (new table, column,
+        or annotation) so subsequent introspection sees the current model.
+
+        Caching note: the asset-execution-table cache
+        (``_asset_execution_tables_cache``) is keyed on the *identity* of
+        ``self.model``, so swapping the model out automatically invalidates it
+        — the next call recomputes. The denormalize-planner cache
+        (``_planner_cache``), if already built, keeps a reference to the
+        previous model; if you depend on the planner reflecting a just-applied
+        schema change, rebuild the instance rather than relying on
+        ``refresh_model`` alone.
+
+        Returns:
+            None. Mutates ``self.model`` as a side effect.
+
+        Example:
+            >>> ml.create_vocabulary("Severity", "Lesion grade")  # doctest: +SKIP
+            >>> ml.refresh_model()  # pick up the new table  # doctest: +SKIP
+        """
         self.model = self.catalog.getCatalogModel()
 
     @property
     def chaise_config(self) -> dict[str, Any]:
-        """Return the chaise configuration."""
+        """Return the chaise configuration.
+
+        Returns:
+            The catalog-level Chaise display configuration annotation as a dict.
+
+        Example:
+            >>> cfg = model.chaise_config  # doctest: +SKIP
+            >>> "navbarBrandText" in cfg  # doctest: +SKIP
+            True
+        """
         return self.model.chaise_config
 
     def get_schema_description(self, include_system_columns: bool = False) -> dict[str, Any]:
@@ -271,6 +320,13 @@ class DerivaModel:
                     }
                 }
             }
+
+        Example:
+            >>> desc = model.get_schema_description()  # doctest: +SKIP
+            >>> sorted(desc["schemas"])  # doctest: +SKIP
+            ['deriva-ml', 'my_domain']
+            >>> desc["schemas"]["my_domain"]["tables"]["Image"]["is_asset"]  # doctest: +SKIP
+            True
         """
         system_columns = {"RID", "RCT", "RMT", "RCB", "RMB"}
         result = {
@@ -379,6 +435,11 @@ class DerivaModel:
 
         Raises:
           DerivaMLTableNotFound: If the table doesn't exist in any searchable schema.
+
+        Example:
+            >>> image = model.name_to_table("Image")  # doctest: +SKIP
+            >>> image.name  # doctest: +SKIP
+            'Image'
         """
         if isinstance(table, Table):
             return table
@@ -415,6 +476,12 @@ class DerivaModel:
         Raises:
             DerivaMLTableNotFound: If the table doesn't exist in any searchable
                 schema (raised by :meth:`name_to_table`).
+
+        Example:
+            >>> model.is_vocabulary("Image_Class")  # doctest: +SKIP
+            True
+            >>> model.is_vocabulary("Image")  # doctest: +SKIP
+            False
         """
         table = self.name_to_table(table)
         return table.is_vocabulary()
@@ -437,6 +504,10 @@ class DerivaModel:
         Raises:
             DerivaMLTableNotFound: If the table doesn't exist (raised by
                 :meth:`name_to_table`).
+
+        Example:
+            >>> model.vocab_columns("Image_Class")  # doctest: +SKIP
+            {'Name': 'Name', 'ID': 'ID', 'URI': 'URI', 'Description': 'Description', 'Synonyms': 'Synonyms'}
         """
         table = self.name_to_table(table)
         col_map = {c.name.upper(): c.name for c in table.columns}
@@ -478,6 +549,12 @@ class DerivaModel:
         Raises:
             DerivaMLTableNotFound: If ``table`` doesn't exist in any searchable
                 schema (raised by :meth:`name_to_table`).
+
+        Example:
+            >>> bool(model.is_association("Dataset_Image"))  # doctest: +SKIP
+            True
+            >>> bool(model.is_association("Image"))  # doctest: +SKIP
+            False
         """
         table = self.name_to_table(table)
         return table.is_association(unqualified=unqualified, pure=pure, min_arity=min_arity, max_arity=max_arity)
@@ -511,6 +588,11 @@ class DerivaModel:
             AmbiguousAssociationException: If multiple association tables
                 connect the two tables. The caller must disambiguate by
                 naming the desired association table directly.
+
+        Example:
+            >>> assoc, c1, c2 = model.find_association("Dataset", "Image")  # doctest: +SKIP
+            >>> assoc.name, c1, c2  # doctest: +SKIP
+            ('Dataset_Image', 'Dataset', 'Image')
         """
         table1 = self.name_to_table(table1)
         table2 = self.name_to_table(table2)
@@ -546,6 +628,12 @@ class DerivaModel:
         Raises:
             DerivaMLTableNotFound: If ``table`` doesn't exist in any searchable
                 schema (raised by :meth:`name_to_table`).
+
+        Example:
+            >>> model.is_asset("Image")  # doctest: +SKIP
+            True
+            >>> model.is_asset("Subject")  # doctest: +SKIP
+            False
         """
         table = self.name_to_table(table)
         return table.is_asset()
@@ -619,11 +707,28 @@ class DerivaModel:
         return result
 
     def find_assets(self) -> list[Table]:
-        """Return the list of asset tables in the current model."""
+        """Return the list of asset tables in the current model.
+
+        Returns:
+            All tables across every schema that satisfy :meth:`is_asset`.
+
+        Example:
+            >>> [t.name for t in model.find_assets()]  # doctest: +SKIP
+            ['Image', 'Execution_Asset']
+        """
         return [t for s in self.model.schemas.values() for t in s.tables.values() if self.is_asset(t)]
 
     def find_vocabularies(self) -> list[Table]:
-        """Return a list of all controlled vocabulary tables in domain and ML schemas."""
+        """Return a list of all controlled vocabulary tables in domain and ML schemas.
+
+        Returns:
+            All tables in the domain and ML schemas that satisfy
+            :meth:`is_vocabulary`.
+
+        Example:
+            >>> [t.name for t in model.find_vocabularies()]  # doctest: +SKIP
+            ['Image_Class', 'Workflow_Type']
+        """
         tables = []
         for schema_name in [*self.domain_schemas, self.ml_schema]:
             schema = self.model.schemas.get(schema_name)
@@ -644,6 +749,11 @@ class DerivaModel:
 
         Returns:
             An iterable of Feature instances describing the features.
+
+        Example:
+            >>> [f.feature_name for f in model.find_features("Image")]  # doctest: +SKIP
+            ['BoundingBox', 'Quality']
+            >>> all_features = list(model.find_features())  # doctest: +SKIP
         """
 
         def is_feature(a: FindAssociationResult) -> bool:
@@ -753,6 +863,11 @@ class DerivaModel:
             DerivaMLTableNotFound: If ``table`` doesn't exist.
             DerivaMLFeatureNotFound: If no feature with
                 ``feature_name`` is defined on ``table``.
+
+        Example:
+            >>> feature = model.lookup_feature("Image", "Quality")  # doctest: +SKIP
+            >>> feature.feature_name  # doctest: +SKIP
+            'Quality'
         """
         table = self.name_to_table(table)
         try:
@@ -781,6 +896,10 @@ class DerivaModel:
             DerivaMLTableTypeError: If ``table`` is not an asset table.
             DerivaMLTableNotFound: If ``table`` doesn't exist (raised by
                 :meth:`name_to_table`).
+
+        Example:
+            >>> sorted(model.asset_metadata("Image"))  # doctest: +SKIP
+            ['Description', 'Image_Class']
         """
         table = self.name_to_table(table)
 
@@ -804,6 +923,10 @@ class DerivaModel:
 
         Raises:
             DerivaMLTableTypeError: If ``table`` is not an asset table.
+
+        Example:
+            >>> [c.name for c in model.asset_metadata_columns("Image")]  # doctest: +SKIP
+            ['Description', 'Image_Class']
         """
         table = self.name_to_table(table)
         if not self.is_asset(table):
@@ -867,6 +990,10 @@ class DerivaModel:
         Raises:
             DerivaMLReadOnlyError: If this DerivaML instance is in offline
                 mode (``self.catalog`` is a ``CatalogStub``).
+
+        Example:
+            >>> table.annotations[Display.tag] = display.to_dict()  # doctest: +SKIP
+            >>> model.apply()  # commit the staged annotation  # doctest: +SKIP
         """
         if isinstance(self.catalog, CatalogStub):
             raise DerivaMLReadOnlyError(
@@ -895,6 +1022,12 @@ class DerivaModel:
         Raises:
             DerivaMLException: If ``rid`` doesn't resolve in the catalog
                 at all (typically an invalid or fabricated RID).
+
+        Example:
+            >>> model.is_dataset_rid("1-abc123")  # doctest: +SKIP
+            True
+            >>> model.is_dataset_rid("1-image01")  # an Image RID  # doctest: +SKIP
+            False
         """
         try:
             rid_info = self.model.catalog.resolve_rid(rid, self.model)
@@ -920,6 +1053,10 @@ class DerivaModel:
         Returns:
             A list of :class:`~deriva.core.ermrest_model.Table`
             objects — one per valid member type.
+
+        Example:
+            >>> [t.name for t in model.list_dataset_element_types()]  # doctest: +SKIP
+            ['Image', 'Subject', 'Dataset']
         """
 
         dataset_table = self.name_to_table("Dataset")
@@ -985,6 +1122,14 @@ class DerivaModel:
 
         Note: @validate_call removed because TableDefinition is now a dataclass from
         deriva.core.typed and Pydantic validation doesn't work well with dataclass fields.
+
+        Example:
+            >>> from deriva_ml.core.definitions import TableDefinition, ColumnDefinition  # doctest: +SKIP
+            >>> table_def = TableDefinition(  # doctest: +SKIP
+            ...     name="Observation",
+            ...     column_defs=[ColumnDefinition(name="Note", type="text")],
+            ... )
+            >>> new_table = model.create_table(table_def, schema="my_domain")  # doctest: +SKIP
         """
         schema = schema or self._require_default_schema()
         # Handle both TableDefinition (dataclass with to_dict) and plain dicts

--- a/src/deriva_ml/model/denormalize_planner.py
+++ b/src/deriva_ml/model/denormalize_planner.py
@@ -179,8 +179,8 @@ The planner is ~1100 LoC of algorithmic code with a narrow consumer
 set (four call sites in total). ``DerivaModel`` is a wide-fan-out
 class touched by every mixin in the codebase, and bundling the
 planner in there muddied its responsibility. Phase 3 (audit §5.2 in
-``docs/design/deriva-ml-audit-2026-05-phase2-model.md``) extracted
-the planner into this module so:
+``docs/archive/2026-05-audit-working-drafts/deriva-ml-audit-2026-05-phase2-model.md``)
+extracted the planner into this module so:
 
 * ``DerivaModel`` becomes a pure introspection class (~1100 LoC,
   consumed everywhere).


### PR DESCRIPTION
## Summary

Docs-only reconciliation of the deriva-ml alignment audit
(`docs/audits/2026-05-30-alignment-audit.md`), batches **D / E / F / H**
combined. No runtime behavior changes. Every item was re-verified against
current `main` (tip after #262–266) before editing; the doctest harness
(`pytest src/ --doctest-modules`, now active in CI) stays green.

The `misd`/`isrd` display-tag finding is **excluded** — handled by the
separate open PR #267. No tag constants were touched.

**Batch D — interfaces.py protocol/impl reconciliation**
- `DerivaMLCatalog.add_features`: protocol docstring now documents it as
  retired (the only impl, `FeatureMixin.add_features`, raises
  unconditionally); points at `exe.add_features(records)`.
- `AssetLike.list_executions`: return type `list[dict]` → `list[ExecutionRecord]`
  to match `Asset.list_executions`.

**Batch E — offline.md + dataset_bag doc refresh**
- Bag layout corrected to the checksum-addressed ADR-0006 form
  (`{cache_root}/bags/{checksum}/Dataset_{rid}/` plus a separate
  `databases/` subtree); the SQLite db is no longer shown inside the bag root.
- torch/tf adapters return a 3-tuple `(sample, target, rid)` /
  `(sample, rid)`: fixed documented shapes, the DataLoader/`model.fit`
  loops (added `.map()` to drop the RID), and the explicit
  `output_signature` examples (now 3 specs incl. `rid: tf.string`).
- `restructure_assets`: `group_by=[...]` → `targets=[...]`.
- Removed the deleted-`BagFeatureCache` "fast cache" claims (Stage 3b, #260);
  feature reads now run a fresh Denormalizer join each call.
- `DatasetBag.path` docstring: SQLite db lives in a separate `databases/`
  subtree, not in the bag dir.

**Batch F — renamed-API prose sweep**
- `list_nested_executions` → `list_execution_children` and
  `list_parent_executions` → `list_execution_parents` (executions.md,
  experiments.md).
- workflow.py module doc: `DerivaML.add_workflow()` → private `_add_workflow`
  dedup path.
- `download_dataset_bag` Returns: `.rid`/`.minid` → `dataset_rid`/`current_version`.
- `Execution.datasets` class attr: `list[DatasetBag]` → `DatasetCollection`.
- `setup_url_checksum` doc: removed the non-existent `file://` fallback;
  documented that `version` comes from `get_dynamic_version()` on the
  dominant local-git path (DERIVA_MCP_VERSION is Docker-only).

**Batch H — convention cleanup**
- Added runnable-or-SKIP Example blocks to the ~19 `DerivaModel` methods
  that lacked one + the five `asset_upload` helpers; added a `refresh_model`
  docstring.
- `run_model` + `validate_execution_config`: NumPy → Google style; documented
  the load-bearing `script_config` param and corrected the unconditional
  "results are uploaded" (upload runs only when `not dry_run`).
- Documented undocumented fields: `Workflow.git_root`/`allow_dirty`,
  `BaseConfig.script_config`, `DatasetSpec.description`/`fetch_concurrency`,
  `DatasetHistory.execution_rid`/`description`/`spec_hash`.
- "12 keys → 13 keys" `describe()` off-by-one fixed in four places
  (+ `anchor` → `anchors` key-name fix); stale "design spec §5" →
  user-guide §8.3.2.
- Stale cross-refs: dead `2026-05-26-denormalize-audit.md` citation;
  moved phase2-model / phase3-execution audits → `docs/archive/...`.
- LOW: "semantic versioning" → PEP 440; phantom `cache_age_seconds`
  `source='bag'` → `'local'`; `dataset_children` → `list_dataset_children`.

## Already-fixed-or-false-positive

Re-verified against current `main`; **not changed**:

- **`find_association` return-type lie (Batch D)** — already fixed by #264;
  signature is `-> tuple[Table, str, str]` and the docstring already says the
  FK columns are returned as *names (str)*.
- **`dataset_bag.py:564` "stale BagFeatureCache reference" (Batch E)** —
  not stale; the line correctly describes `BagFeatureCache` as the *legacy*
  path that the current Denormalizer delegation replaced.
- **`catalog.py:938` phase2-model citation (Batch H)** — false positive;
  that comment says "Phase 3 (audit §5.2)" with no file path. (The real
  stale path refs were in `denormalize_planner.py`, `state_store.py`, and
  `dataset_collection.py` — fixed.)
- **`manifest_store.py:45` `execution_state__features` (Batch H)** —
  false positive; the code constant is already `execution_state__feature_records`
  and the design spec it references uses the correct name. The only
  `execution_state__features` mentions are archived plans correctly
  describing the pre-refactor table.
- **`lookup_feature` raises broader `DerivaMLException` (audit MEDIUM)** —
  already fixed; `name_to_table` now raises `DerivaMLTableNotFound`, so the
  docstring is accurate.

## Test plan

- `uv run pytest src/ --doctest-modules -q` → **49 passed, 363 skipped, 0
  failures** (was 49/334 at the branch point; the delta is the newly added
  SKIP'd examples). Every added/edited Example is runnable or correctly
  `# doctest: +SKIP`.
- `uv run pytest tests/core tests/model tests/config tests/local_db -q` →
  **724 passed, 19 skipped, 0 failures** (no regressions in touched modules).
- `uv run ruff check` on every touched file → clean. Pre-existing repo-wide
  ruff lint/format drift (e.g. `workflow.py` E501s, `core/mixins/dataset.py`
  format) was left untouched per scope.
- Grep sanity: no remaining `list_nested_executions` in user-guide/config
  docs, no `DerivaML.add_workflow()` in the workflow module doc, no
  `group_by` in offline.md.

No implementation bugs were found that warrant a separate PR — every item
was either a genuine doc mismatch (fixed) or already-fixed/false-positive
(listed above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
