### PR TITLE
feat(split): record source dataset as execution input for walkable provenance

### DIFF
--- a/docs/user-guide/datasets.md
+++ b/docs/user-guide/datasets.md
@@ -281,6 +281,28 @@ Split (parent, type: "Split")
 └── Testing (child, type: "Testing")
 ```
 
+### How the split relates to its source
+
+A common point of confusion: the source dataset you split is **not** part of the `Split` hierarchy above. The new `Split` is a standalone dataset; the source is **not** its parent, and the `Split` is **not** nested under the source. `source.list_dataset_children()` and `list_dataset_relations(source)` will **not** show the split — and that is correct, not a missing link. Nesting a split under its source would re-partition the source's own members into itself and flip the source's version on every split.
+
+The derivation is recorded as **execution provenance** instead. `split_dataset` registers the source as an *input* of the splitting execution and the partitions as that execution's *outputs*, so the walkable path is:
+
+```
+source ──(input of)──▶ split execution ──(output)──▶ Split / Training / Testing
+```
+
+```python
+with ml.create_execution(config) as exe:
+    result = split_dataset(ml, source_dataset_rid, exe, test_size=0.2, seed=42)
+    # The source is now a recorded input of this execution:
+    assert source_dataset_rid in {ds.dataset_rid for ds in exe.list_input_datasets()}
+exe.commit_output_assets(clean_folder=True)
+```
+
+`deriva_ml_get_lineage` walks this edge from either end, and `result.source` carries the source RID directly. (`split_dataset` records the input without downloading the source's bag — declaring the source in `ExecutionConfiguration(datasets=[...])` would, so don't do that just for provenance.)
+
+**Membership consequence — the split shares rows with its source.** Each partition is carved from the source's elements, so the partitions *share element rows* with the source (a two-way split's `Training ∪ Testing` reconstructs the source's element set). The train/eval boundary lives in *shared membership*, not in a parent/child edge: training a model on the source and evaluating it on one of these partitions would leak. Reason about overlap with member sets (`list_dataset_members`), never by inspecting the dataset hierarchy.
+
 ### Wrap split_dataset in an execution
 
 `split_dataset` runs inside an `Execution` the caller has already opened. The caller's workflow identifies the code making the splitting decision; deriva-ml never invents a workflow on the caller's behalf. Set this up once and reuse the same `exe` for every example below:

--- a/src/deriva_ml/dataset/split.py
+++ b/src/deriva_ml/dataset/split.py
@@ -1053,6 +1053,20 @@ def _create_split_hierarchy(
     split_ds.add_dataset_members(child_rids, validate=False)
     logger.info("  Linked child datasets to Split dataset")
 
+    # Record the source dataset as an INPUT consumed by this execution.
+    # The split datasets above are OUTPUTS (this execution authored
+    # them); the source is not nested under them and is not a
+    # ``Dataset_Dataset`` parent of the Split. Recording the source as
+    # an execution input is what makes the derivation walkable —
+    # ``execution.list_input_datasets()`` and lineage walks can then
+    # reach the source from the split, and vice versa — without the bag
+    # download that declaring it in ``ExecutionConfiguration.datasets``
+    # would force. The call is idempotent and a no-op under dry-run
+    # (this helper only runs on the live path, but the guard is there
+    # regardless).
+    execution.add_input_dataset(source_dataset_rid)
+    logger.info("  Recorded source dataset %s as execution input", source_dataset_rid)
+
     # Add members to each partition (batched).
     batch_size = 500
     for part_name, ds in [
@@ -1152,6 +1166,40 @@ def split_dataset(
 
     This function is generic and works with any DerivaML dataset
     that has registered element types.
+
+    Provenance — the source dataset's relationship to the split:
+        The new Split is a **standalone, self-contained** dataset
+        hierarchy. The ``source_dataset_rid`` you pass in is **NOT**
+        a parent of the Split and the Split is **NOT** nested under
+        the source: there is no ``Dataset_Dataset`` edge between them,
+        and ``source.list_dataset_children()`` /
+        ``list_dataset_relations(source)`` will **not** list the Split.
+        That is intentional — the source is an *input* the split
+        *consumed*, not a container the split lives inside (nesting
+        the Split under the source would re-partition the source's own
+        members and flip the source's version on every split).
+
+        The derivation is instead recorded as **execution provenance**:
+        ``split_dataset`` registers ``source_dataset_rid`` as an input
+        of ``execution`` (via :meth:`Execution.add_input_dataset`), and
+        the Split / Training / Testing / Validation datasets as that
+        execution's outputs. So the walkable path is
+        ``source -> (input of) -> execution -> (output) -> split``:
+        ``execution.list_input_datasets()`` returns the source, and a
+        lineage walk (``deriva_ml_get_lineage``) reaches the splits
+        from the source and vice versa. The ``SplitResult.source``
+        field returned by this call also carries the source RID for
+        immediate use.
+
+        Membership consequence: the Training / Testing / Validation
+        partitions are carved from the source's elements, so they
+        **share element rows with the source** (and, in a two-way
+        split, ``Training`` ∪ ``Testing`` reconstructs the source's
+        element set). The train/eval relationship therefore lives in
+        *shared membership*, not in a parent/child lineage edge —
+        evaluating a model trained on the source against one of these
+        partitions would leak. Reason about overlap via member sets,
+        not via the dataset hierarchy.
 
     Args:
         ml: Connected DerivaML instance.

--- a/src/deriva_ml/execution/execution.py
+++ b/src/deriva_ml/execution/execution.py
@@ -1967,6 +1967,52 @@ class Execution:
             description=description,
         )
 
+    def add_input_dataset(self, dataset_rid: RID) -> None:
+        """Record an existing dataset as an *input* consumed by this execution.
+
+        Writes a single ``Dataset_Execution`` association row linking
+        ``dataset_rid`` to this execution. Because this execution did
+        not *author* ``dataset_rid`` (its ``Dataset_Version.Execution``
+        link points at whichever execution created it), the
+        input/output inference used by :meth:`list_input_datasets`
+        classifies it as an **input** — a consume edge — not an output.
+
+        This is the counterpart of :meth:`create_dataset` (which records
+        an *output*). Use it when an execution reads a dataset it did not
+        produce and you want that consumption recorded as walkable
+        provenance (so :meth:`list_input_datasets` and lineage walks can
+        reach the consumed dataset), *without* the bag download that
+        declaring the dataset in ``ExecutionConfiguration.datasets``
+        would trigger. The most common caller is
+        :func:`deriva_ml.dataset.split.split_dataset`, which records its
+        source dataset as an input of the splitting execution.
+
+        The link is idempotent: if ``dataset_rid`` is already associated
+        with this execution, no duplicate row is inserted. In dry-run
+        mode this is a no-op (the dry-run contract forbids catalog
+        mutations).
+
+        Args:
+            dataset_rid: RID of the already-existing dataset that this
+                execution consumed as an input.
+
+        Example:
+            >>> with ml.create_execution(cfg) as exe:  # doctest: +SKIP
+            ...     exe.add_input_dataset("1-ABC0")  # doctest: +SKIP
+            ...     # "1-ABC0" now appears in exe.list_input_datasets()
+        """
+        if self._dry_run:
+            return
+        schema_path = self._ml_object.pathBuilder().schemas[self._ml_object.ml_schema]
+        dataset_exec = schema_path.Dataset_Execution
+        already_linked = {
+            row["Dataset"]
+            for row in dataset_exec.filter(dataset_exec.Execution == self.execution_rid).entities().fetch()
+        }
+        if dataset_rid in already_linked:
+            return
+        dataset_exec.insert([{"Dataset": dataset_rid, "Execution": self.execution_rid}])
+
     @validate_call(config=VALIDATION_CONFIG)
     def add_files(
         self,

--- a/tests/dataset/test_split.py
+++ b/tests/dataset/test_split.py
@@ -818,6 +818,66 @@ class TestSplitDataset:
         assert "Labeled" in training_ds.dataset_types
         assert "Labeled" in testing_ds.dataset_types
 
+    def test_split_records_source_as_execution_input(self, test_ml):
+        """The source dataset is recorded as an INPUT of the split execution.
+
+        Regression for the e2e finding where a split's source dataset
+        was not discoverable from the catalog: ``split_dataset`` creates
+        a self-contained Split hierarchy (Split -> Training/Testing) but
+        the *source* it was derived from was recorded only in description
+        prose and the returned ``SplitResult.source`` field, never as a
+        walkable catalog edge. After the fix, the source is linked to the
+        splitting execution as a consume edge so
+        ``Execution.list_input_datasets()`` (and lineage walks) can reach
+        it. The split's own children are OUTPUTS, not inputs, and must
+        not appear.
+        """
+        ml = test_ml
+        source_rid = self._setup_splittable_dataset(ml)
+
+        workflow = ml.create_workflow(
+            name="Input-Provenance Split Workflow",
+            workflow_type="Dataset_Split",
+            description="Splitting workflow for the source-input test",
+        )
+        with ml.create_execution(
+            ExecutionConfiguration(workflow=workflow, description="Split with input provenance")
+        ) as exe:
+            result = split_dataset(ml, source_rid, exe, test_size=4, seed=42)
+            input_rids = {ds.dataset_rid for ds in exe.list_input_datasets()}
+        exe.commit_output_assets(clean_folder=True)
+
+        # The source is recorded as a consumed input...
+        assert source_rid in input_rids, (
+            f"source {source_rid} should be an input of the split execution; got inputs {input_rids}"
+        )
+        # ...and the split's outputs are NOT inputs (they were authored by
+        # this execution, so the input/output inference must exclude them).
+        assert result.split.rid not in input_rids
+        assert result.training.rid not in input_rids
+        assert result.testing.rid not in input_rids
+
+    def test_split_dry_run_records_no_input_edge(self, test_ml):
+        """A dry-run split must not write the source-input edge.
+
+        ``split_dataset(dry_run=True)`` returns a plan without mutating
+        the catalog, so recording the source as an execution input would
+        be a side effect that violates the dry-run contract.
+        """
+        ml = test_ml
+        source_rid = self._setup_splittable_dataset(ml)
+
+        workflow = ml.create_workflow(
+            name="Dry-Run Split Workflow",
+            workflow_type="Dataset_Split",
+            description="Dry-run splitting workflow for the input-edge test",
+        )
+        with ml.create_execution(ExecutionConfiguration(workflow=workflow, description="Dry-run split")) as exe:
+            split_dataset(ml, source_rid, exe, test_size=4, seed=42, dry_run=True)
+            input_rids = {ds.dataset_rid for ds in exe.list_input_datasets()}
+
+        assert source_rid not in input_rids, "dry_run split must not record the source as an execution input"
+
     def test_dry_run(self, test_ml):
         """Test dry run mode returns plan without modifying catalog."""
         ml = test_ml


### PR DESCRIPTION
## Summary

`split_dataset()` builds a correct, self-contained `Split` hierarchy (`Split → Training/Testing`), but the **source dataset** it was derived from was recorded only in description prose and the returned `SplitResult.source` field — never as a *walkable catalog edge*. A reader inspecting `list_dataset_relations(source)` sees no children and can reasonably (but wrongly) conclude a lineage edge is missing. (This is exactly the false "missing split-registration" finding a recent e2e review produced.)

The source is an **input** the split *consumed*, **not** a `Dataset_Dataset` parent — nesting the split under the source would re-partition the source's own members into itself and flip the source's version on every split. So the right place to record the derivation is **execution provenance**.

## What changed

- **`Execution.add_input_dataset(rid)`** (new public method): inserts a single `Dataset_Execution` association row — the table's documented "consume" edge. Idempotent, no-op under `dry_run`, and — unlike declaring the dataset in `ExecutionConfiguration(datasets=[...])` — it does **not** download the dataset's bag. The existing input/output inference (`linked-but-not-authored = input`, via `Dataset_Version.Execution`) classifies it correctly as an input. It's the consume-side counterpart to `create_dataset()` (the produce side).
- **`split_dataset()`** now calls `execution.add_input_dataset(source_dataset_rid)` after building the split, so every split is walkable:
  `source → (input of) → execution → (output) → Split / Training / Testing`
  via `Execution.list_input_datasets()` and `deriva_ml_get_lineage`.
- **Docs** (docstring + `docs/user-guide/datasets.md`) now state the provenance model explicitly: the source is an **input, not a parent**; the split is **not nested** under the source; and the partitions **share element rows** with the source, so the train/eval boundary is a *membership* fact, not a hierarchy edge. This closes the documentation gap that produced the original false finding.

## Why not the alternatives

- *Nest the split under the source via `add_dataset_members`* — wrong: flips the source's version, risks cycles, and semantically misrepresents a re-partition as containment.
- *Declare the source in `ExecutionConfiguration(datasets=[...])`* — works, but forces a redundant full bag download of the source (`_materialize_input_datasets`) purely to get a provenance edge, and makes the caller pass the source twice.

## Tests

- `test_split_records_source_as_execution_input` — after a split, the source appears in `exe.list_input_datasets()`; the split's own outputs (Split/Training/Testing) do **not**.
- `test_split_dry_run_records_no_input_edge` — a `dry_run=True` split records no input edge.
- Full `tests/dataset/test_split.py` + `tests/execution/test_execution.py` + lineage suite green (**167 passed, 1 skipped**). Change is purely additive (+176 lines); no existing logic altered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)