### PR TITLE
fix: skip provenance derivation when Workflow is loaded from a catalog row

### DIFF
--- a/src/deriva_ml/execution/workflow.py
+++ b/src/deriva_ml/execution/workflow.py
@@ -267,7 +267,9 @@ class Workflow(BaseModel):
         if self._ml_instance is not None:
             _, atable_path = self._get_workflow_type_association_table()
             wt_types = (
-                atable_path.filter(atable_path.Workflow == self.workflow_rid).attributes(atable_path.Workflow_Type).fetch()
+                atable_path.filter(atable_path.Workflow == self.workflow_rid)
+                .attributes(atable_path.Workflow_Type)
+                .fetch()
             )
             return [wt[MLVocab.workflow_type] for wt in wt_types]
         return list(self.workflow_type)
@@ -321,7 +323,9 @@ class Workflow(BaseModel):
             return
 
         _, atable_path = self._get_workflow_type_association_table()
-        atable_path.filter((atable_path.Workflow == self.workflow_rid) & (atable_path.Workflow_Type == vocab_term.name)).delete()
+        atable_path.filter(
+            (atable_path.Workflow == self.workflow_rid) & (atable_path.Workflow_Type == vocab_term.name)
+        ).delete()
 
     def add_workflow_types(self, workflow_types: str | VocabularyTerm | list[str | VocabularyTerm]) -> None:
         """Add one or more workflow types to this workflow.
@@ -365,7 +369,9 @@ class Workflow(BaseModel):
 
         # Insert new type associations
         if new_workflow_types:
-            atable_path.insert([{MLVocab.workflow_type: wt, "Workflow": self.workflow_rid} for wt in new_workflow_types])
+            atable_path.insert(
+                [{MLVocab.workflow_type: wt, "Workflow": self.workflow_rid} for wt in new_workflow_types]
+            )
 
     @model_validator(mode="after")
     def setup_url_checksum(self) -> "Workflow":
@@ -418,6 +424,18 @@ class Workflow(BaseModel):
                 repo, Docker env vars missing, no explicit overrides).
         """
         self._logger = get_logger(__name__)
+
+        # Loaded from a catalog row: provenance is already known.
+        # ``workflow_rid`` is set only for a workflow that already exists in
+        # the catalog (``lookup_workflow`` / ``find_workflows`` pass it; the
+        # create path does not). Its ``url`` / ``checksum`` / ``version`` are
+        # stored columns, so re-deriving them from the runtime environment is
+        # both wrong and fragile -- the derivation calls setuptools-scm and
+        # raises in any non-git, non-Docker working directory. Trust the
+        # stored values and skip all derivation.
+        if self.workflow_rid is not None:
+            return self
+
         # Check if running in Docker container (no git repo available)
         if os.environ.get("DERIVA_MCP_IN_DOCKER", "").lower() == "true":
             # Use Docker image metadata for provenance

--- a/tests/execution/test_workflow_from_catalog.py
+++ b/tests/execution/test_workflow_from_catalog.py
@@ -1,0 +1,82 @@
+"""Tests for Workflow reconstruction from a catalog row (the read path).
+
+When a Workflow is rebuilt from an existing catalog row (it carries a
+``workflow_rid``), its provenance fields are already known and must NOT be
+re-derived from the runtime environment. Re-deriving previously crashed in
+non-Docker, non-git environments::
+
+    LookupError: setuptools-scm was unable to detect version for /app.
+
+(seen when deriva-ml-mcp-plugin read Execution/Workflow rows on a server
+whose working directory is not a git checkout). The ``setup_url_checksum``
+validator must short-circuit for catalog-loaded workflows.
+"""
+
+import pytest
+
+from deriva_ml.execution.workflow import Workflow
+
+
+@pytest.fixture
+def non_docker_non_git_cwd(tmp_path, monkeypatch):
+    """Force the worst-case env: no Docker/notebook escape, CWD not a git repo.
+
+    This is exactly the condition under which the create-time provenance
+    derivation would call setuptools-scm and crash.
+    """
+    # Remove the env-var escape hatches that would otherwise short-circuit
+    # the validator before it reaches git/setuptools-scm introspection.
+    for var in (
+        "DERIVA_MCP_IN_DOCKER",
+        "DERIVA_ML_WORKFLOW_URL",
+        "DERIVA_ML_WORKFLOW_CHECKSUM",
+        "DERIVA_ML_NOTEBOOK_PATH",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    # A directory with no .git, so Path.cwd() / setuptools-scm has no repo.
+    workdir = tmp_path / "no_git_here"
+    workdir.mkdir()
+    monkeypatch.chdir(workdir)
+    assert not (workdir / ".git").exists()
+    return workdir
+
+
+def test_workflow_from_catalog_row_skips_derivation(non_docker_non_git_cwd):
+    """A Workflow loaded from a catalog row builds without re-deriving provenance.
+
+    Mirrors how ``lookup_workflow`` / ``find_workflows`` reconstruct a row:
+    ``workflow_rid`` is set and ``url`` / ``checksum`` come from the row. Even
+    with a blank stored ``version`` and no git/Docker environment, this must
+    not raise -- and the stored fields must be preserved verbatim.
+    """
+    workflow = Workflow(
+        name="Reconstructed",
+        url="https://github.com/org/repo/blob/abc123/train.py",
+        workflow_type=[],
+        version="",  # blank stored version -- the worst case
+        description="loaded from catalog",
+        workflow_rid="1-ABCD",
+        checksum="abc123",
+    )
+
+    # Stored provenance preserved, not re-derived.
+    assert workflow.url == "https://github.com/org/repo/blob/abc123/train.py"
+    assert workflow.checksum == "abc123"
+    assert workflow.version == ""
+    assert workflow.workflow_rid == "1-ABCD"
+
+
+def test_fresh_workflow_still_derives(non_docker_non_git_cwd):
+    """A Workflow with no workflow_rid (a fresh create) is NOT short-circuited.
+
+    The guard must key on 'loaded from catalog' (workflow_rid set), so the
+    create path is unaffected. With no git repo and no Docker env, deriving
+    provenance for a fresh workflow still fails -- proving the guard did not
+    wrongly swallow the create path.
+    """
+    with pytest.raises(Exception):  # noqa: B017 - git/setuptools-scm derivation failure
+        Workflow(
+            name="Fresh",
+            workflow_type=[],
+            description="not yet in catalog",
+        )


### PR DESCRIPTION
## Problem (Error 2)

Reading Execution/Workflow rows crashes in non-git, non-Docker environments:

```
LookupError: setuptools-scm was unable to detect version for /app.
  File ".../deriva_ml/execution/workflow.py", line 472, in setup_url_checksum
    self.version = self.version or Workflow.get_dynamic_version(root=str(self.git_root or Path.cwd()))
```

Observed in `deriva-ml-mcp-plugin`'s RAG hook: `_fetch_execution_rows` → `find_executions` → `lookup_execution` → `lookup_workflow` → `Workflow(...)`.

## Root cause

`setup_url_checksum` is a `@model_validator(mode="after")` — it runs on **every** `Workflow(...)` construction. Its job is **create-time** provenance derivation (fill in `url`/`checksum`/`version` from git/Docker/setuptools-scm).

But `lookup_workflow` / `find_workflows` reconstruct a `Workflow` from a **catalog row** whose `url`, `checksum`, and `version` are **already stored columns**. The validator still runs and re-derives them — which is pointless on the read path, and fatal when the stored `version` is blank, the env isn't Docker/notebook, and the CWD isn't a git repo (setuptools-scm raises).

It was only masked by `DERIVA_MCP_IN_DOCKER=true` short-circuiting the validator. Any environment reading these rows without that env (CI, scripts, a non-`/app` container) hits it. **Every read-path consumer is affected:** `lookup_workflow`, `find_workflows`, `lookup_execution`, `find_executions`.

## Fix

Short-circuit the validator when `workflow_rid` is set — the signal that the `Workflow` came from the catalog (the create path leaves `workflow_rid=None`). Trust the stored columns; skip all environment introspection.

```python
if self.workflow_rid is not None:
    return self
```

One line, at the top of the validator. No call-site changes — every read path inherits it. Independent of `DERIVA_MCP_IN_DOCKER`.

## Verification (TDD)

- New `tests/execution/test_workflow_from_catalog.py`:
  - `test_workflow_from_catalog_row_skips_derivation` — a from-catalog row (has `workflow_rid`, blank `version`) in a non-Docker, non-git CWD builds without raising and preserves stored fields. **Reproduced the exact `LookupError` before the fix; passes after.**
  - `test_fresh_workflow_still_derives` — a fresh workflow (`workflow_rid=None`) is *not* short-circuited, so the create path is unaffected.
- `tests/execution/test_dirty_workflow.py` (30) and `TestWorkflowDocker` (4) stay green.
- **End-to-end:** with `DERIVA_MCP_IN_DOCKER` unset in a non-git CWD (the exact failing condition), a `lookup_workflow`-shaped construction now builds successfully.
- ruff clean. (`ruff format` reflowed 3 pre-existing >120-col lines in the touched file — mechanical, no logic change.)

## Note

Pre-existing integration failures in `test_execution.py` (`TestWorkflow`, `TestExecutionIntegration`) require a live catalog and fail identically on `main` — unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
