### PR TITLE
test: validate generate_association_indexes end-to-end

### DIFF
--- a/docs/audits/2026-06-02-association-index-test-report.md
+++ b/docs/audits/2026-06-02-association-index-test-report.md
@@ -128,7 +128,19 @@ Full file: `/tmp/assoc-idx-test/indexes.sql` (not committed — scratch).
 
 ## 5. Apply result + idempotence
 
-_(filled in Task 5)_
+Applied with
+`docker exec deriva-postgres psql -U ermrest -d _ermrest_catalog_3 -v ON_ERROR_STOP=1 -f /tmp/indexes.sql`
+(default psql autocommit — `CREATE INDEX CONCURRENTLY` is **not** wrapped
+in a transaction, which it cannot be).
+
+| Run | Exit | New indexes created | `already exists, skipping` | Errors |
+|-----|------|---------------------|----------------------------|--------|
+| First apply | 0 | 48 | 0 | 0 |
+| Re-apply (idempotence) | 0 | 0 (all skipped) | 48 | 0 |
+
+The re-run is a clean no-op: every `CREATE INDEX CONCURRENTLY IF NOT
+EXISTS` reports `NOTICE: relation "…" already exists, skipping`. Safe
+to re-run against a live catalog.
 
 ## 6. Index existence (contract gate)
 

--- a/docs/audits/2026-06-02-association-index-test-report.md
+++ b/docs/audits/2026-06-02-association-index-test-report.md
@@ -1,0 +1,38 @@
+# Association-Index Generator — Test Report
+
+**Date:** 2026-06-02
+**Script under test:** `scripts/generate_association_indexes.py`
+**Plan:** `docs/superpowers/plans/2026-06-02-association-index-script-test.md`
+**Environment:** local Docker Deriva stack (`deriva-postgres` postgres:16.13, `deriva-webserver` at https://localhost).
+
+## 1. Catalog under test
+
+_(filled in Task 2)_
+
+## 2. Associations discovered
+
+_(filled in Task 4)_
+
+## 3. Baseline plans (no index)
+
+_(filled in Task 3)_
+
+## 4. Generated SQL
+
+_(filled in Task 4)_
+
+## 5. Apply result + idempotence
+
+_(filled in Task 5)_
+
+## 6. Index existence (contract gate)
+
+_(filled in Task 6)_
+
+## 7. Index usability (planner uses the index)
+
+_(filled in Task 7)_
+
+## 8. Findings / bugs
+
+_(filled in Task 8)_

--- a/docs/audits/2026-06-02-association-index-test-report.md
+++ b/docs/audits/2026-06-02-association-index-test-report.md
@@ -223,4 +223,48 @@ for both — the indexes were genuinely consulted, not merely eligible.
 
 ## 8. Findings / bugs
 
-_(filled in Task 8)_
+**Overall: the script works end-to-end.** Both gates pass — every pure
+binary association ends up with composite indexes in both directions on
+both the live and history tables (§6), and the planner uses them (§7).
+No bugs found in `generate_association_indexes.py`.
+
+**Findings (none block the script; recorded for completeness):**
+
+1. **Feature-value association tables are intentionally not indexed.**
+   `Execution_Subject_Health` (and the other `Execution_<X>_<Feature>`
+   tables) carry 4 user FKs, so `Table.is_association()` (pure binary)
+   rejects them. This is correct behavior, but worth knowing: if the
+   motivation for the indexes is *feature-query* performance, those
+   tables are out of scope for this tool and would need a separate
+   indexing approach. The tool covers dataset-member, nested-dataset,
+   and `{X}_Asset_Type` / `{X}_Execution` link tables.
+
+2. **Planner picks the `rev` index for both orderings at this scale.**
+   Not a defect — B-tree equality is order-insensitive across indexed
+   columns, so both `fwd` and `rev` are eligible and the planner chose
+   one. Both are present and usable (§6, §7). The two directions earn
+   their keep on range/sort-on-leading-column queries, not equality.
+
+3. **`pg_indexes`/`pg_class` substring counting needs care.**
+   `_assoc_fwd_idx` is a substring of `_hist_assoc_fwd_idx`; naive
+   `grep -c '_assoc_fwd_idx'` double-counts. This is a *test-script*
+   gotcha (handled here by anchoring on whole index names), not a
+   script issue.
+
+4. **Environment / auth.** Catalog creation first failed HTTP 401
+   (stale `localhost` bearer token); resolved by a user re-login, after
+   which everything ran. An empty stray catalog (`_ermrest_catalog_2`)
+   was created during the auth probe and could not be auto-deleted
+   (permission guard on shared infra) — **left in place; harmless**
+   (no association tables). Clean it up manually if desired:
+   `curl -k -X DELETE -H "Authorization: Bearer <tok>" https://localhost/ermrest/catalog/2`.
+
+5. **zsh vs the plan's `eval "$PG"` pattern.** The plan's
+   `eval "$PG" -c "<sql>"` idiom breaks under zsh (glob/word-split on
+   the parenthesised SQL). Switched to a `pg()` helper piping SQL via
+   `docker exec -i ... psql` stdin heredocs. A future run of this
+   runbook should use the heredoc form.
+
+## 9. Catalog disposition
+
+_(filled at end of Task 8)_

--- a/docs/audits/2026-06-02-association-index-test-report.md
+++ b/docs/audits/2026-06-02-association-index-test-report.md
@@ -7,7 +7,31 @@
 
 ## 1. Catalog under test
 
-_(filled in Task 2)_
+- **Catalog id:** `3` (`https://localhost/ermrest/catalog/3`)
+- **Postgres DB:** `_ermrest_catalog_3`
+- **Built with:** `create_demo_catalog(hostname="localhost", create_features=True, create_datasets=True, on_exit_delete=False)`
+- **Schemas:** `deriva-ml` (core ML) + `demo-schema` (domain).
+- **Populated** — representative association tables and approximate row counts (post-`ANALYZE`):
+
+  | Table | Kind | Rows |
+  |-------|------|------|
+  | `demo-schema.Execution_Subject_Health` | feature association | 12 |
+  | `demo-schema.Execution_Image_Quality` | feature association | 12 |
+  | `demo-schema.Execution_Image_BoundingBox` | feature association | 12 |
+  | `demo-schema.Dataset_Subject` | dataset-member association | 8 |
+  | `demo-schema.Dataset_Image` | dataset-member association | 4 |
+  | `deriva-ml.Dataset_Dataset` | nested-dataset association | 6 |
+
+- **Note (env):** an empty stray catalog `4`/`_ermrest_catalog_2` was
+  created and partially cleaned during an auth probe before the real
+  build; it contains no association tables and does not affect this
+  test (the generator is run against catalog 3 explicitly). Flagged in
+  §8.
+
+> Auth note: catalog creation initially failed with HTTP 401; the
+> `localhost` bearer token in `~/.deriva/credential.json` was refreshed
+> by the user, after which `POST /ermrest/catalog` returned 201 and the
+> build succeeded.
 
 ## 2. Associations discovered
 

--- a/docs/audits/2026-06-02-association-index-test-report.md
+++ b/docs/audits/2026-06-02-association-index-test-report.md
@@ -173,9 +173,53 @@ associations fully covered: 12 / 12   (incomplete: 0)
 association table has composite-key indexes in both directions on both
 the live table and the history table. **Met.**
 
-## 7. Index usability (planner uses the index)
+## 7. Index usability (planner uses the index) — ✅ PASS
 
-_(filled in Task 7)_
+Representative table: `demo-schema.Dataset_Subject` (live + history,
+both directions). Method per the spec: natural plan, then forced plan
+with `enable_seqscan=off` / `enable_bitmapscan=off`, then an
+`idx_scan` counter check.
+
+**Natural plan (no override):** still `Seq Scan` on both live and
+history — **expected and not a failure**: at 8 rows a seq scan is
+genuinely cheaper than an index lookup, so the cost model correctly
+declines the index.
+
+**Forced plan (`enable_seqscan=off`) — the usability proof:**
+
+| Query | Table kind | Plan | Index used |
+|-------|-----------|------|-----------|
+| `Dataset='5CT' AND Subject='4C6'` | live | Index Only Scan | `Dataset_Subject_assoc_rev_idx` ✓ |
+| `Subject='4C6' AND Dataset='5CT'` | live | Index Only Scan | `Dataset_Subject_assoc_rev_idx` ✓ |
+| `rowdata->>'57W' AND rowdata->>'57Y'` | history | Index Scan | `Dataset_Subject_hist_assoc_rev_idx` ✓ |
+| `rowdata->>'57Y' AND rowdata->>'57W'` | history | Index Scan | `Dataset_Subject_hist_assoc_rev_idx` ✓ |
+
+Every query switches from Seq Scan to an **Index (Only) Scan on one of
+our named composite indexes**, with the `Index Cond` matching both
+predicate columns — including the JSONB `rowdata->>'<col_rid>'`
+expressions on the history side, which is the non-trivial case (the
+expression index must match the query's expression exactly to be
+eligible). The history-side proof is the key result: the script's
+RID-keyed expression indexes are real, correctly-formed, and
+planner-usable.
+
+> **Why `rev` for both orderings (not a defect):** a B-tree composite
+> index supports equality predicates on its columns regardless of the
+> order they appear in the `WHERE` clause, so both the `fwd` and `rev`
+> indexes are eligible for either query; the planner picked `rev` for
+> all four. Both directions' indexes exist (§6) and are usable; having
+> both simply lets a *range/sort* on either leading column be served.
+
+**`idx_scan` corroboration (independent of EXPLAIN):** counter
+`0 → 1` after executing the live and history queries (via
+`EXPLAIN ANALYZE`, which actually runs them):
+
+```
+Dataset_Subject_assoc_rev_idx        0 → 1
+Dataset_Subject_hist_assoc_rev_idx   0 → 1
+```
+`EXPLAIN ANALYZE` reported `Index (Only) Scan ... actual time=… rows=1`
+for both — the indexes were genuinely consulted, not merely eligible.
 
 ## 8. Findings / bugs
 

--- a/docs/audits/2026-06-02-association-index-test-report.md
+++ b/docs/audits/2026-06-02-association-index-test-report.md
@@ -39,7 +39,43 @@ _(filled in Task 4)_
 
 ## 3. Baseline plans (no index)
 
-_(filled in Task 3)_
+**Representative pure-binary association chosen:**
+`demo-schema.Dataset_Subject` — FK pair `(Dataset, Subject)`, table
+RID `57G`, column RIDs `Dataset=57W`, `Subject=57Y`. History table
+`_ermrest_history."t57G"` (8 rows). Real predicate values pulled from a
+live row: `Dataset='5CT'`, `Subject='4C6'`.
+
+> **Scope finding (carried to §8):** feature-value association tables
+> like `demo-schema.Execution_Subject_Health` are **not** pure binary
+> associations — they carry 4 user FKs (`Execution`, `Feature_Name`,
+> `Subject`, `SubjectHealth`), so `Table.is_association()` (pure,
+> binary) correctly rejects them and the script does **not** index
+> them. The pure-binary associations the script targets are the
+> dataset-member (`Dataset_Subject`, `Dataset_Image`), nested-dataset
+> (`Dataset_Dataset`), and `{X}_Execution` / `{X}_Asset_Type` link
+> tables. The second representative table for the usability check is
+> taken from the script's own discovered set in §2/Task 4.
+
+All four targeted queries are **Seq Scan** before indexing (the clean
+"before" state):
+
+```
+-- LIVE Dataset_Subject forward (Dataset, Subject)
+Seq Scan on "Dataset_Subject"  (cost=0.00..1.12 rows=1 width=4)
+  Filter: (("Dataset" = '5CT') AND ("Subject" = '4C6'))
+
+-- LIVE Dataset_Subject reverse (Subject, Dataset)
+Seq Scan on "Dataset_Subject"  (cost=0.00..1.12 rows=1 width=4)
+  Filter: (("Subject" = '4C6') AND ("Dataset" = '5CT'))
+
+-- HIST t57G forward (rowdata->>'57W', rowdata->>'57Y')
+Seq Scan on "t57G"  (cost=0.00..1.16 rows=1 width=4)
+  Filter: (((rowdata ->> '57W') = '5CT') AND ((rowdata ->> '57Y') = '4C6'))
+
+-- HIST t57G reverse (rowdata->>'57Y', rowdata->>'57W')
+Seq Scan on "t57G"  (cost=0.00..1.16 rows=1 width=4)
+  Filter: (((rowdata ->> '57Y') = '4C6') AND ((rowdata ->> '57W') = '5CT'))
+```
 
 ## 4. Generated SQL
 

--- a/docs/audits/2026-06-02-association-index-test-report.md
+++ b/docs/audits/2026-06-02-association-index-test-report.md
@@ -267,4 +267,24 @@ No bugs found in `generate_association_indexes.py`.
 
 ## 9. Catalog disposition
 
-_(filled at end of Task 8)_
+Both test catalogs deleted via the ermrest API (user-authorized):
+
+- **Catalog 3** (the test catalog) — `DELETE /ermrest/catalog/3` → 204;
+  subsequent `GET` → 404.
+- **Catalog 2** (the auth-probe stray) — `DELETE /ermrest/catalog/2` →
+  204; `GET` → 404.
+- **Catalog 1** (pre-existing, untouched) — still `GET` → 200.
+
+(The backing `_ermrest_catalog_2/3` Postgres databases linger until
+ermrest's async reaper drops them; the catalogs are deregistered and
+no longer API-accessible, which is the meaningful deletion.)
+
+---
+
+**Conclusion:** `scripts/generate_association_indexes.py` is validated
+end-to-end. It discovers every pure binary association, emits correct
+composite-pair indexes for the live table and matching JSONB expression
+indexes for the history table in both directions, applies cleanly and
+idempotently via psql, and the resulting indexes are planner-usable
+(including the non-trivial history-side expression indexes). No bugs
+found.

--- a/docs/audits/2026-06-02-association-index-test-report.md
+++ b/docs/audits/2026-06-02-association-index-test-report.md
@@ -142,9 +142,36 @@ The re-run is a clean no-op: every `CREATE INDEX CONCURRENTLY IF NOT
 EXISTS` reports `NOTICE: relation "…" already exists, skipping`. Safe
 to re-run against a live catalog.
 
-## 6. Index existence (contract gate)
+## 6. Index existence (contract gate) — ✅ PASS
 
-_(filled in Task 6)_
+`pg_indexes` confirms **48 indexes** = 12 associations × 4. Per-direction
+totals: live fwd 12, live rev 12, hist fwd 12, hist rev 12. Schema
+split: 24 in `_ermrest_history`, 24 live (16 `deriva-ml`, 8
+`demo-schema`).
+
+**Per-association cross-check — all 12 fully covered, both directions on
+both live + history:**
+
+```
+BoundingBox_Asset_Type          live(fwd=1 rev=1) hist(fwd=1 rev=1)  OK
+Dataset_Image                   live(fwd=1 rev=1) hist(fwd=1 rev=1)  OK
+Dataset_Subject                 live(fwd=1 rev=1) hist(fwd=1 rev=1)  OK
+Image_Asset_Type                live(fwd=1 rev=1) hist(fwd=1 rev=1)  OK
+Dataset_Dataset                 live(fwd=1 rev=1) hist(fwd=1 rev=1)  OK
+Dataset_Dataset_Type            live(fwd=1 rev=1) hist(fwd=1 rev=1)  OK
+Dataset_Execution               live(fwd=1 rev=1) hist(fwd=1 rev=1)  OK
+Dataset_File                    live(fwd=1 rev=1) hist(fwd=1 rev=1)  OK
+Execution_Asset_Asset_Type      live(fwd=1 rev=1) hist(fwd=1 rev=1)  OK
+Execution_Metadata_Asset_Type   live(fwd=1 rev=1) hist(fwd=1 rev=1)  OK
+File_Asset_Type                 live(fwd=1 rev=1) hist(fwd=1 rev=1)  OK
+Workflow_Workflow_Type          live(fwd=1 rev=1) hist(fwd=1 rev=1)  OK
+---
+associations fully covered: 12 / 12   (incomplete: 0)
+```
+
+**This is the literal success criterion from the request:** every
+association table has composite-key indexes in both directions on both
+the live table and the history table. **Met.**
 
 ## 7. Index usability (planner uses the index)
 

--- a/docs/audits/2026-06-02-association-index-test-report.md
+++ b/docs/audits/2026-06-02-association-index-test-report.md
@@ -35,7 +35,27 @@
 
 ## 2. Associations discovered
 
-_(filled in Task 4)_
+The generator found **12 pure binary association tables** across the
+`demo-schema` and `deriva-ml` schemas. All 12 resolved table + column
+RIDs cleanly, so each got the full 4-index set (2 live + 2 history):
+
+| # | Association | FK pair |
+|---|-------------|---------|
+| 1 | `demo-schema.BoundingBox_Asset_Type` | (Asset_Type, BoundingBox) |
+| 2 | `demo-schema.Dataset_Image` | (Dataset, Image) |
+| 3 | `demo-schema.Dataset_Subject` | (Dataset, Subject) |
+| 4 | `demo-schema.Image_Asset_Type` | (Asset_Type, Image) |
+| 5 | `deriva-ml.Dataset_Dataset` | (Dataset, Nested_Dataset) |
+| 6 | `deriva-ml.Dataset_Dataset_Type` | (Dataset, Dataset_Type) |
+| 7 | `deriva-ml.Dataset_Execution` | (Dataset, Execution) |
+| 8 | `deriva-ml.Dataset_File` | (Dataset, File) |
+| 9 | `deriva-ml.Execution_Asset_Asset_Type` | (Asset_Type, Execution_Asset) |
+| 10 | `deriva-ml.Execution_Metadata_Asset_Type` | (Asset_Type, Execution_Metadata) |
+| 11 | `deriva-ml.File_Asset_Type` | (Asset_Type, File) |
+| 12 | `deriva-ml.Workflow_Workflow_Type` | (Workflow, Workflow_Type) |
+
+(Feature-value tables like `Execution_Subject_Health` are absent —
+correctly, as noted in §3, they are not pure binary associations.)
 
 ## 3. Baseline plans (no index)
 
@@ -79,7 +99,32 @@ Seq Scan on "t57G"  (cost=0.00..1.16 rows=1 width=4)
 
 ## 4. Generated SQL
 
-_(filled in Task 4)_
+- **Command:** `uv run python scripts/generate_association_indexes.py --hostname localhost --catalog-id 3 --output /tmp/assoc-idx-test/indexes.sql --verbose`
+- **Exit code:** 0. **Warnings:** none (only a harmless urllib3
+  `InsecureRequestWarning` for the self-signed localhost cert — not a
+  generator warning; no RID-lookup misses).
+- **Shape:** 48 `CREATE INDEX CONCURRENTLY IF NOT EXISTS` statements =
+  12 associations × 4 (live fwd, live rev, hist fwd, hist rev). Counts
+  per direction: live fwd 12, live rev 12, hist fwd 12, hist rev 12.
+
+**Cross-check — the `Dataset_Subject` block matches the RIDs this test
+discovered independently from Postgres `_ermrest` metadata (table
+`57G`, `Dataset=57W`, `Subject=57Y`):**
+
+```sql
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "Dataset_Subject_assoc_fwd_idx"
+  ON "demo-schema"."Dataset_Subject" ("Dataset", "Subject");
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "Dataset_Subject_assoc_rev_idx"
+  ON "demo-schema"."Dataset_Subject" ("Subject", "Dataset");
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "Dataset_Subject_hist_assoc_fwd_idx"
+  ON _ermrest_history."t57G"
+     (((rowdata->>'57W')), ((rowdata->>'57Y')));
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "Dataset_Subject_hist_assoc_rev_idx"
+  ON _ermrest_history."t57G"
+     (((rowdata->>'57Y')), ((rowdata->>'57W')));
+```
+
+Full file: `/tmp/assoc-idx-test/indexes.sql` (not committed — scratch).
 
 ## 5. Apply result + idempotence
 

--- a/docs/superpowers/plans/2026-06-02-association-index-script-test.md
+++ b/docs/superpowers/plans/2026-06-02-association-index-script-test.md
@@ -1,0 +1,625 @@
+# Association-Index Generator Test — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+>
+> **NOTE ON FORM:** This is a **runbook**, not a feature build. The "code" is a sequence of commands run against a live Dockerized catalog; outputs of one phase (catalog id, table names, RIDs, plans) feed the next. There is no library code to TDD. Each task therefore reads: *run command → capture output → assert gate → record in report*. Do not skip the assert/record steps — they are the deliverable.
+
+**Goal:** Prove end-to-end that `scripts/generate_association_indexes.py`, when run against a populated catalog and applied via psql, leaves every pure binary association table with composite indexes in both directions on both the live and `_ermrest_history` tables, and that the Postgres planner will use those indexes.
+
+**Architecture:** Build a fresh populated demo catalog in the local Docker stack → record baseline query plans (Seq Scan) → run the generator to emit `.sql` → apply with `docker exec ... psql` → verify index existence via `pg_indexes` and usability via `EXPLAIN` with `enable_seqscan=off`. No production code changes.
+
+**Tech Stack:** Python (deriva-ml demo-catalog API), the script under test, `docker exec deriva-postgres psql` (postgres:16.13), bash.
+
+**Spec:** `docs/superpowers/specs/2026-06-02-association-index-script-test-design.md`
+
+---
+
+## Conventions used throughout
+
+- **Always chain `cd`** into the project root in one Bash call:
+  `cd /Users/carl/GitHub/DerivaML/deriva-ml && <cmd>`.
+- **Never hard-code a catalog id, DB name, table name, or RID.** Every
+  one is read back from a command and stored in the fixtures file
+  (Task 1) or a later capture file. The Postgres DB name is always
+  `_ermrest_catalog_${CATALOG_ID}`, derived — never typed.
+- **psql access:** `docker exec deriva-postgres psql -U ermrest -d _ermrest_catalog_${CATALOG_ID}`.
+  Use `-tA` for clean machine-readable output, `-c "<sql>"` for one-liners.
+- **Working scratch dir:** `/tmp/assoc-idx-test/` holds the fixtures
+  file, generated SQL, and captured plan output. Created in Task 1.
+- **The report** is appended to incrementally at
+  `docs/audits/2026-06-02-association-index-test-report.md`. Each task
+  that produces evidence writes its section immediately, so a crash
+  mid-run still leaves a partial record.
+
+---
+
+## Task 1: Scratch dir + report skeleton
+
+**Files:**
+- Create: `/tmp/assoc-idx-test/` (scratch, not committed)
+- Create: `docs/audits/2026-06-02-association-index-test-report.md`
+
+- [ ] **Step 0: Create the working branch FIRST (nothing lands on `main`)**
+
+Per repo policy every commit — including this report — goes through a
+PR off a branch. Create it before any commit in this plan:
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml && \
+git checkout -b test/association-index-validation && echo "on $(git branch --show-current)"
+```
+Expected: `on test/association-index-validation`. All later commits in
+Tasks 1–8 land here; Task 8 Step 4 only pushes + opens the PR.
+
+- [ ] **Step 1: Create the scratch directory**
+
+```bash
+mkdir -p /tmp/assoc-idx-test && echo created
+```
+
+- [ ] **Step 2: Write the report skeleton**
+
+Create `docs/audits/2026-06-02-association-index-test-report.md`:
+
+```markdown
+# Association-Index Generator — Test Report
+
+**Date:** 2026-06-02
+**Script under test:** `scripts/generate_association_indexes.py`
+**Plan:** `docs/superpowers/plans/2026-06-02-association-index-script-test.md`
+**Environment:** local Docker Deriva stack (`deriva-postgres` postgres:16.13, `deriva-webserver` at https://localhost).
+
+## 1. Catalog under test
+
+_(filled in Task 2)_
+
+## 2. Associations discovered
+
+_(filled in Task 4)_
+
+## 3. Baseline plans (no index)
+
+_(filled in Task 3)_
+
+## 4. Generated SQL
+
+_(filled in Task 4)_
+
+## 5. Apply result + idempotence
+
+_(filled in Task 5)_
+
+## 6. Index existence (contract gate)
+
+_(filled in Task 6)_
+
+## 7. Index usability (planner uses the index)
+
+_(filled in Task 7)_
+
+## 8. Findings / bugs
+
+_(filled in Task 8)_
+```
+
+- [ ] **Step 3: Commit the skeleton**
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml && \
+git add docs/audits/2026-06-02-association-index-test-report.md && \
+git commit -m "test(assoc-idx): report skeleton for index-generator validation"
+```
+
+---
+
+## Task 2: Build the populated demo catalog
+
+**Files:**
+- Create: `/tmp/assoc-idx-test/fixtures.sh` (runtime values: catalog id, db name)
+
+- [ ] **Step 1: Verify the stack is up**
+
+```bash
+docker ps --format '{{.Names}}' | grep -E 'deriva-postgres|deriva-webserver'
+```
+Expected: both names print. If either is missing, STOP — the stack
+must be running (the catalog HTTP endpoint and Postgres are both
+required).
+
+- [ ] **Step 2: Create + populate the catalog, capture its id**
+
+This writes the catalog id to the fixtures file. `create_demo_catalog`
+clones deriva-ml from GitHub, installs the deriva-ml + demo schema, and
+runs a populate execution; `create_features=True` and
+`create_datasets=True` produce the feature and dataset-member
+association tables. `on_exit_delete=False` keeps the catalog alive
+after the Python process exits.
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml && \
+DERIVA_ML_ALLOW_DIRTY=true uv run python - <<'PY'
+from pathlib import Path
+from deriva_ml.demo_catalog import create_demo_catalog
+
+catalog = create_demo_catalog(
+    hostname="localhost",
+    create_features=True,
+    create_datasets=True,
+    on_exit_delete=False,
+)
+cid = str(catalog.catalog_id)
+Path("/tmp/assoc-idx-test/fixtures.sh").write_text(
+    f'export CATALOG_ID="{cid}"\n'
+    f'export PG="docker exec deriva-postgres psql -U ermrest -d _ermrest_catalog_{cid}"\n'
+)
+print("CATALOG_ID", cid)
+PY
+```
+Expected: prints `CATALOG_ID <n>` (n is opaque — do not assume a
+value). Build takes ~1–3 min (clone + populate). If the GitHub clone
+fails (network), see the fallback note at the end of this task.
+
+- [ ] **Step 3: Sanity-check Postgres sees the catalog DB**
+
+```bash
+source /tmp/assoc-idx-test/fixtures.sh && \
+docker exec deriva-postgres psql -U ermrest -lqt | cut -d'|' -f1 | grep -qw "_ermrest_catalog_${CATALOG_ID}" && \
+echo "DB _ermrest_catalog_${CATALOG_ID} exists"
+```
+Expected: prints the "exists" line.
+
+- [ ] **Step 4: Record catalog under test in the report**
+
+Append the catalog id and the `https://localhost/ermrest/catalog/<id>`
+URL to section 1 of the report. (Read the value from
+`/tmp/assoc-idx-test/fixtures.sh`, write it into the markdown.)
+
+- [ ] **Step 5: Commit the report update**
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml && \
+git add docs/audits/2026-06-02-association-index-test-report.md && \
+git commit -m "test(assoc-idx): record catalog under test"
+```
+
+**Fallback (only if Step 2's GitHub clone fails):** build the catalog
+without the clone via the fixture path —
+`create_ml_catalog("localhost", project_name="ml-test")` then
+`create_domain_schema(catalog, "demo-schema")` then a `DerivaML`
+populate execution as in `tests/catalog_manager.py`. Same association
+tables result. Record in the report which path was used.
+
+---
+
+## Task 3: Capture baseline plans (no index yet)
+
+This MUST run before the generator/apply so the "before" is a true
+no-index baseline. We need real predicate values first.
+
+**Files:**
+- Create: `/tmp/assoc-idx-test/baseline-plans.txt`
+
+- [ ] **Step 1: Pick one feature association and one dataset-member association**
+
+List candidate association tables straight from Postgres (the live
+deriva-ml association tables live in the `deriva-ml` schema; feature
+associations and dataset-member tables are there). Print row counts so
+we pick tables that actually have rows:
+
+```bash
+source /tmp/assoc-idx-test/fixtures.sh && \
+eval "$PG" -tA -c "
+  SELECT n.nspname, c.relname, c.reltuples::bigint
+  FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace
+  WHERE c.relkind='r' AND n.nspname='deriva-ml'
+  ORDER BY c.relname;"
+```
+Expected: a list of `deriva-ml|<Table>|<rowcount>` lines. Choose:
+- one **feature** association (name contains a feature, e.g. an
+  `Image_<Feature>` link or a `..._Image` / `..._Subject` value table
+  that `is_association` will flag), and
+- one **dataset-member** association (e.g. `Dataset_Image`,
+  `Dataset_Subject`, or `Dataset_Dataset`),
+
+each with `reltuples > 0`. Record the two chosen `(schema, table)`
+pairs. **Do not invent names** — copy them from this output.
+
+> Note: the authoritative list of what the *script* targets comes in
+> Task 4 (the generator's own discovery). Here we only need two
+> populated association tables to baseline; Task 6 cross-checks the two
+> we picked are in the generated set.
+
+- [ ] **Step 2: Find the two FK columns + a real value pair for each chosen table**
+
+For each chosen live table, get its FK column names and one existing
+row's value pair (so the predicate matches real data):
+
+```bash
+source /tmp/assoc-idx-test/fixtures.sh && \
+TBL="<ChosenTable>" && \
+eval "$PG" -tA -c "
+  SELECT string_agg(a.attname, ',' ORDER BY a.attnum)
+  FROM pg_attribute a JOIN pg_class c ON c.oid=a.attrelid
+  JOIN pg_namespace n ON n.oid=c.relnamespace
+  WHERE n.nspname='deriva-ml' AND c.relname='$TBL'
+    AND a.attnum>0 AND NOT a.attisdropped
+    AND a.attname LIKE '%RID';" && \
+eval "$PG" -tA -c 'SELECT * FROM "deriva-ml"."'$TBL'" LIMIT 1;'
+```
+Expected: the FK column list (the two `*_RID` columns) and one sample
+row. Record the two FK column names (call them `FK1`, `FK2`) and the
+concrete value pair from the sample row. These are read from the
+catalog — never literals.
+
+- [ ] **Step 3: EXPLAIN the four targeted queries per chosen table (baseline)**
+
+For each chosen live table, with its real `FK1=v1`, `FK2=v2`:
+
+```bash
+source /tmp/assoc-idx-test/fixtures.sh && \
+{
+  echo "=== LIVE $TBL forward (FK1,FK2) ==="
+  eval "$PG" -c 'EXPLAIN SELECT 1 FROM "deriva-ml"."'$TBL'" WHERE "FK1"='\''v1'\'' AND "FK2"='\''v2'\'';'
+  echo "=== LIVE $TBL reverse (FK2,FK1) ==="
+  eval "$PG" -c 'EXPLAIN SELECT 1 FROM "deriva-ml"."'$TBL'" WHERE "FK2"='\''v2'\'' AND "FK1"='\''v1'\'';'
+} | tee -a /tmp/assoc-idx-test/baseline-plans.txt
+```
+Replace `FK1`/`FK2`/`v1`/`v2` with the real names/values from Step 2.
+Expected: each plan is a **Seq Scan** (possibly with a Filter) — no
+index named `*_assoc_*_idx` yet (none exist). If any baseline plan is
+already an Index Scan on such a name, STOP: a prior run left indexes
+behind; drop them or use a fresh catalog before continuing.
+
+- [ ] **Step 4: EXPLAIN the history-side baseline**
+
+Get the table RID and the two column RIDs (history rowdata is keyed by
+column RID), then EXPLAIN the rowdata predicate. The script's
+`_build_rid_lookup` reads these from `/schema`; here we read them from
+Postgres `_ermrest.known_tables` / `known_columns`:
+
+```bash
+source /tmp/assoc-idx-test/fixtures.sh && TBL="<ChosenTable>" && \
+TRID=$(eval "$PG" -tA -c "SELECT \"RID\" FROM _ermrest.known_tables WHERE table_name='$TBL' AND schema_name='deriva-ml';") && \
+echo "table RID: $TRID" && \
+eval "$PG" -tA -c "SELECT \"RID\", column_name FROM _ermrest.known_columns WHERE table_rid='$TRID' AND column_name LIKE '%RID';" && \
+eval "$PG" -c 'EXPLAIN SELECT 1 FROM _ermrest_history."t'$TRID'" WHERE (rowdata->>'\''<col1_rid>'\'')='\''v1'\'' AND (rowdata->>'\''<col2_rid>'\'')='\''v2'\'';' | tee -a /tmp/assoc-idx-test/baseline-plans.txt
+```
+Expected: prints the table RID and the column-name→RID mapping, then a
+**Seq Scan** plan on `t<RID>`. Substitute the real `<col1_rid>`,
+`<col2_rid>`, `v1`, `v2`. Record the RID mapping — Task 7 reuses it.
+
+> If `_ermrest.known_tables` is not queryable in this server build,
+> fall back to reading the RIDs from the script's generated SQL header
+> comments (Task 4 emits `Table RID:` and the column RIDs inline).
+
+- [ ] **Step 5: Record baselines in the report**
+
+Paste the `baseline-plans.txt` content into report section 3, noting
+each plan is a Seq Scan. Commit:
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml && \
+git add docs/audits/2026-06-02-association-index-test-report.md && \
+git commit -m "test(assoc-idx): record baseline Seq Scan plans"
+```
+
+---
+
+## Task 4: Run the generator
+
+**Files:**
+- Create: `/tmp/assoc-idx-test/indexes.sql`
+
+- [ ] **Step 1: Run the script against the catalog**
+
+```bash
+source /tmp/assoc-idx-test/fixtures.sh && \
+cd /Users/carl/GitHub/DerivaML/deriva-ml && \
+DERIVA_ML_ALLOW_DIRTY=true uv run python scripts/generate_association_indexes.py \
+    --hostname localhost \
+    --catalog-id "${CATALOG_ID}" \
+    --output /tmp/assoc-idx-test/indexes.sql \
+    --verbose ; echo "exit=$?"
+```
+Expected: `exit=0`; stderr ends with `Wrote <N> association block(s)`
+where N > 0. Any `Warnings:` lines (RID-lookup misses) are captured —
+they are findings for Task 8, not failures.
+
+- [ ] **Step 2: Assert the SQL shape**
+
+```bash
+echo "associations (blocks):" ; grep -c '^-- ===' /tmp/assoc-idx-test/indexes.sql ; \
+echo "live fwd:" ; grep -c '_assoc_fwd_idx' /tmp/assoc-idx-test/indexes.sql ; \
+echo "live rev:" ; grep -c '_assoc_rev_idx' /tmp/assoc-idx-test/indexes.sql ; \
+echo "hist fwd:" ; grep -c '_hist_assoc_fwd_idx' /tmp/assoc-idx-test/indexes.sql ; \
+echo "hist rev:" ; grep -c '_hist_assoc_rev_idx' /tmp/assoc-idx-test/indexes.sql ; \
+echo "CONCURRENTLY:" ; grep -c 'CREATE INDEX CONCURRENTLY IF NOT EXISTS' /tmp/assoc-idx-test/indexes.sql
+```
+Expected: per association the script emits 2 live indexes always, and 2
+history indexes when RIDs resolved. So `live fwd == live rev == blocks`,
+and `hist fwd == hist rev == (blocks − history-skipped-warnings)`. Note
+the exact counts — Task 6 reconciles them against `pg_indexes`.
+
+- [ ] **Step 3: Confirm the two Task-3 tables are in the generated set**
+
+```bash
+grep -E '<ChosenTable1>|<ChosenTable2>' /tmp/assoc-idx-test/indexes.sql | grep '^-- '
+```
+Expected: both chosen table names appear as block headers. If a chosen
+table is absent, it wasn't a pure binary association — pick a different
+one for the usability check in Task 7 (any table that *is* in the
+generated set and has rows).
+
+- [ ] **Step 4: Record the generated SQL in the report**
+
+Embed (or link) `indexes.sql` into report section 4 and list the
+discovered associations (block headers) into section 2. Commit:
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml && \
+git add docs/audits/2026-06-02-association-index-test-report.md && \
+git commit -m "test(assoc-idx): record generated SQL and discovered associations"
+```
+
+---
+
+## Task 5: Apply the SQL (and prove idempotence)
+
+- [ ] **Step 1: Copy the SQL into the postgres container**
+
+```bash
+docker cp /tmp/assoc-idx-test/indexes.sql deriva-postgres:/tmp/indexes.sql && echo copied
+```
+
+- [ ] **Step 2: Apply it**
+
+`CREATE INDEX CONCURRENTLY` cannot run inside a transaction block.
+Default psql autocommits each statement, so do **not** pass
+`--single-transaction`. `ON_ERROR_STOP=1` makes any failure abort
+loudly.
+
+```bash
+source /tmp/assoc-idx-test/fixtures.sh && \
+docker exec deriva-postgres psql -U ermrest -d "_ermrest_catalog_${CATALOG_ID}" \
+    -v ON_ERROR_STOP=1 -f /tmp/indexes.sql ; echo "exit=$?"
+```
+Expected: `exit=0`; output is a series of `CREATE INDEX` lines (first
+run actually creates them).
+
+- [ ] **Step 3: Re-apply to prove idempotence**
+
+```bash
+source /tmp/assoc-idx-test/fixtures.sh && \
+docker exec deriva-postgres psql -U ermrest -d "_ermrest_catalog_${CATALOG_ID}" \
+    -v ON_ERROR_STOP=1 -f /tmp/indexes.sql 2>&1 | tee /tmp/assoc-idx-test/reapply.txt ; \
+grep -c 'already exists, skipping' /tmp/assoc-idx-test/reapply.txt
+```
+Expected: `exit=0` again; every statement now reports
+`NOTICE: relation "..." already exists, skipping` (the
+`IF NOT EXISTS` no-op). The skip count equals the number of CREATE
+INDEX statements in the file.
+
+- [ ] **Step 4: Record apply + idempotence in the report**
+
+Write the first-apply result and the all-skipped re-apply into report
+section 5. Commit:
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml && \
+git add docs/audits/2026-06-02-association-index-test-report.md && \
+git commit -m "test(assoc-idx): record apply result and idempotent re-run"
+```
+
+---
+
+## Task 6: Verify index existence (the contract gate)
+
+This is the pass/fail gate for the stated success criterion: every
+association has composite indexes in **both** directions on **both** the
+live table and its `_ermrest_history` table.
+
+- [ ] **Step 1: List all created indexes from `pg_indexes`**
+
+```bash
+source /tmp/assoc-idx-test/fixtures.sh && \
+eval "$PG" -c "
+  SELECT schemaname, tablename, indexname, indexdef
+  FROM pg_indexes
+  WHERE indexname LIKE '%\_assoc\_fwd\_idx'
+     OR indexname LIKE '%\_assoc\_rev\_idx'
+     OR indexname LIKE '%\_hist\_assoc\_fwd\_idx'
+     OR indexname LIKE '%\_hist\_assoc\_rev\_idx'
+  ORDER BY tablename, indexname;" | tee /tmp/assoc-idx-test/pg_indexes.txt
+```
+Expected: rows for live (`schemaname='deriva-ml'` or the domain schema)
+and history (`schemaname='_ermrest_history'`) indexes.
+
+- [ ] **Step 2: Reconcile the counts against the generated SQL**
+
+```bash
+echo "live fwd in pg:" ; grep -c '_assoc_fwd_idx' /tmp/assoc-idx-test/pg_indexes.txt ; \
+echo "live rev in pg:" ; grep -c '_assoc_rev_idx' /tmp/assoc-idx-test/pg_indexes.txt ; \
+echo "hist fwd in pg:" ; grep -c '_hist_assoc_fwd_idx' /tmp/assoc-idx-test/pg_indexes.txt ; \
+echo "hist rev in pg:" ; grep -c '_hist_assoc_rev_idx' /tmp/assoc-idx-test/pg_indexes.txt
+```
+Expected — each count equals the corresponding count from Task 4 Step 2:
+- live fwd (pg) == live rev (pg) == number of association blocks,
+- hist fwd (pg) == hist rev (pg) == blocks minus any history-skipped
+  warnings.
+
+**GATE:** if any count is short, the contract is NOT met — record which
+association/direction/table-kind is missing in section 8 and stop
+(this is a real script bug or apply failure, not a test artifact).
+
+- [ ] **Step 3: Confirm both-directions-on-both-tables per association**
+
+For each association block header in `indexes.sql`, confirm all four
+(or two, if history was legitimately skipped) names are present in
+`pg_indexes.txt`. A short cross-check:
+
+```bash
+for t in $(grep '^--   Table RID' -B2 /tmp/assoc-idx-test/indexes.sql | grep '^-- [A-Za-z]' | sed 's/^-- //; s/ .*//'); do
+  fwd=$(grep -c "${t}_assoc_fwd_idx" /tmp/assoc-idx-test/pg_indexes.txt)
+  rev=$(grep -c "${t}_assoc_rev_idx" /tmp/assoc-idx-test/pg_indexes.txt)
+  hfwd=$(grep -c "${t}_hist_assoc_fwd_idx" /tmp/assoc-idx-test/pg_indexes.txt)
+  hrev=$(grep -c "${t}_hist_assoc_rev_idx" /tmp/assoc-idx-test/pg_indexes.txt)
+  echo "$t live(fwd=$fwd rev=$rev) hist(fwd=$hfwd rev=$hrev)"
+done
+```
+Expected: every line shows `live(fwd=1 rev=1)` and `hist(fwd=1 rev=1)`
+— or `hist(fwd=0 rev=0)` only for associations the script explicitly
+warned it skipped (truncated names may not substring-match; for those
+fall back to comparing the truncated name from `indexes.sql`).
+
+- [ ] **Step 4: Record existence verification in the report**
+
+Paste `pg_indexes.txt` and the per-association cross-check into section
+6, with an explicit PASS/FAIL on the contract. Commit:
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml && \
+git add docs/audits/2026-06-02-association-index-test-report.md && \
+git commit -m "test(assoc-idx): verify index existence contract (both dirs, live+history)"
+```
+
+---
+
+## Task 7: Verify the planner uses the indexes
+
+The "indexes are being used" check — holds at any row count.
+
+- [ ] **Step 1: Re-run the two live baseline EXPLAINs (natural plan)**
+
+Re-run the exact Task-3 Step-3 EXPLAINs (same tables, same real values).
+Expected: at demo scale the planner may *still* show Seq Scan purely on
+cost — that is **acceptable, not a failure**. Record the natural plan.
+
+- [ ] **Step 2: Force the planner off seq scans and re-EXPLAIN (live)**
+
+```bash
+source /tmp/assoc-idx-test/fixtures.sh && \
+eval "$PG" -c "
+  SET enable_seqscan = off;
+  SET enable_bitmapscan = off;
+  EXPLAIN SELECT 1 FROM \"deriva-ml\".\"<ChosenTable>\" WHERE \"FK1\"='v1' AND \"FK2\"='v2';" \
+  | tee -a /tmp/assoc-idx-test/usage-plans.txt
+```
+**PASS:** the plan is an `Index Scan` / `Index Only Scan` and the
+`Index Cond` names `<ChosenTable>_assoc_fwd_idx` (or `_rev_idx` for the
+reversed predicate). **FAIL (finding):** still a Seq Scan with seqscan
+disabled → the index does not cover the query; record in section 8.
+Run for both forward and reverse predicate orderings.
+
+- [ ] **Step 3: Force-plan check on the history side**
+
+Reuse the table RID + column RIDs from Task 3 Step 4:
+
+```bash
+source /tmp/assoc-idx-test/fixtures.sh && \
+eval "$PG" -c "
+  SET enable_seqscan = off;
+  SET enable_bitmapscan = off;
+  EXPLAIN SELECT 1 FROM _ermrest_history.\"t<TRID>\"
+    WHERE (rowdata->>'<col1_rid>')='v1' AND (rowdata->>'<col2_rid>')='v2';" \
+  | tee -a /tmp/assoc-idx-test/usage-plans.txt
+```
+**PASS:** `Index Scan` whose `Index Cond` references the expression
+index `t<TRID>_hist_assoc_fwd_idx` (or the truncated name). **FAIL:**
+still Seq Scan → the history expression index doesn't match the query
+(e.g. emitted expression differs from the predicate); record in
+section 8. Run forward and reverse.
+
+- [ ] **Step 4: Corroborate with `pg_stat_user_indexes` (best-effort)**
+
+```bash
+source /tmp/assoc-idx-test/fixtures.sh && \
+eval "$PG" -c "
+  SELECT indexrelname, idx_scan
+  FROM pg_stat_user_indexes
+  WHERE indexrelname LIKE '%\_assoc\_%\_idx'
+  ORDER BY indexrelname;"
+```
+Expected: indexes touched by the forced-plan EXPLAINs above (EXPLAIN
+without ANALYZE does **not** execute, so to actually bump the counter,
+re-run the Step-2/3 queries as `EXPLAIN ANALYZE` or plain `SELECT` once
+with seqscan disabled). A non-zero `idx_scan` corroborates usage; if it
+reads zero at demo scale, note that the forced-plan proof in Steps 2–3
+stands as the usability evidence and say so plainly.
+
+- [ ] **Step 5: Record usability in the report**
+
+Build the index-usage table in section 7: rows of
+`(association, direction, table-kind) → index name → Index Scan ✓ / Seq Scan ✗`,
+plus the `idx_scan` readings. Commit:
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml && \
+git add docs/audits/2026-06-02-association-index-test-report.md && \
+git commit -m "test(assoc-idx): verify planner uses generated indexes (forced-plan proof)"
+```
+
+---
+
+## Task 8: Findings, cleanup, and PR
+
+- [ ] **Step 1: Write findings**
+
+In section 8, list: any generator warnings, any FAIL gates from Task 6
+(missing indexes) or Task 7 (index not picked even with seqscan off),
+truncated-name collisions, or "all clean". If a real script bug was
+found, note it and open a tracking issue / plan a separate fix PR — do
+**not** fix the script in this test PR.
+
+- [ ] **Step 2: Decide catalog disposition**
+
+Ask the user whether to keep the test catalog for inspection or delete
+it. To delete:
+
+```bash
+source /tmp/assoc-idx-test/fixtures.sh && \
+cd /Users/carl/GitHub/DerivaML/deriva-ml && \
+DERIVA_ML_ALLOW_DIRTY=true uv run python - <<PY
+from deriva.core import ErmrestCatalog, get_credential
+cat = ErmrestCatalog("https", "localhost", "${CATALOG_ID}", credentials=get_credential("localhost"))
+cat.delete_ermrest_catalog(really=True)
+print("deleted ${CATALOG_ID}")
+PY
+```
+Record the disposition in the report.
+
+- [ ] **Step 3: Final report commit**
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml && \
+git add docs/audits/2026-06-02-association-index-test-report.md && \
+git commit -m "test(assoc-idx): findings and catalog disposition"
+```
+
+- [ ] **Step 4: Push the branch and open the PR**
+
+The branch `test/association-index-validation` already exists (created
+in Task 1 Step 0) with all the report commits on it. Just push + open:
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml && \
+git push -u origin test/association-index-validation && \
+gh pr create --title "test: validate generate_association_indexes end-to-end" \
+  --body "Runs scripts/generate_association_indexes.py against a populated demo catalog, applies the SQL via psql, and verifies (1) every association has composite indexes in both directions on both the live and _ermrest_history tables, and (2) the planner uses them (forced-plan proof). Report in docs/audits/2026-06-02-association-index-test-report.md."
+```
+Expected: PR URL printed.
+
+---
+
+## Self-review note
+
+- **Branch-first ordering:** resolved — Task 1 Step 0 creates the
+  branch before any commit; Tasks 1–8 commit there; Task 8 Step 4
+  pushes + opens the PR. Nothing lands on `main`.
+- **No hard-coded RIDs/ids:** every catalog id, table name, RID, and
+  value is read from a command and substituted; placeholders like
+  `<ChosenTable>`, `v1`, `<TRID>` are explicitly "fill from prior step
+  output," consistent with the RID-opacity rule.
+- **Spec coverage:** §3 Phase 1→Task 2, Phase 2→Task 3, Phase 3→Task 4,
+  Phase 4→Task 5, Phase 5(a) existence→Task 6, 5(b) usability→Task 7,
+  5(c) idx_scan→Task 7 Step 4; idempotence→Task 5 Step 3; deliverable
+  report→all tasks; cleanup/disposition→Task 8.

--- a/docs/superpowers/specs/2026-06-02-association-index-script-test-design.md
+++ b/docs/superpowers/specs/2026-06-02-association-index-script-test-design.md
@@ -1,0 +1,227 @@
+# Testing the Association-Index Generator — Design
+
+**Date:** 2026-06-02
+**Status:** Draft for review.
+**Subproject:** `deriva-ml`
+**Script under test:** `scripts/generate_association_indexes.py` (added in #271).
+
+## 1. Goal
+
+Validate, end-to-end against a real catalog, that
+`scripts/generate_association_indexes.py` produces SQL which, when
+applied, leaves **every pure binary association table with composite
+indexes in both join directions on both the live table and its
+`_ermrest_history` partner**. Along the way, capture before/after
+query-plan evidence that the composite indexes are actually usable by
+the Postgres planner.
+
+This is a **test/validation exercise**, not a change to the script or
+the library. No production code is modified. The deliverable is a
+documented test run (a report) plus any bugs found in the script.
+
+## 2. Environment (already in place)
+
+The full Deriva stack runs locally in Docker:
+
+| Container          | Role                                              |
+|--------------------|---------------------------------------------------|
+| `deriva-postgres`  | postgres:16.13 backing the catalog (port 5432)    |
+| `deriva-webserver` | serves ermrest/hatrac at `https://localhost`      |
+| `deriva-mcp-test`  | the `dev-localhost` MCP server (same catalog)     |
+
+Postgres is reachable directly with
+`docker exec deriva-postgres psql -U ermrest -d <db>`. There is **no
+local `psql` binary and no pgAdmin app installed** — so the "apply via
+pgAdmin" step from the original request is performed with
+`docker exec ... psql` instead, which is the identical DDL operation.
+If a pgAdmin GUI is later required, that is a separate setup step out
+of scope here.
+
+The catalog DB is named `_ermrest_catalog_<catalog_id>` (e.g. the
+existing catalog 1 is `_ermrest_catalog_1`). The test creates a new
+catalog, so its DB name is derived from the new catalog id at runtime —
+**never hard-coded.**
+
+## 3. Approach
+
+A five-phase pipeline. Phases 2 and 5 (before/after EXPLAIN) bracket
+the apply.
+
+Two distinct kinds of evidence, with different coverage:
+- **Contract verification** (Phase 5, `pg_indexes`) covers **every**
+  association table the script reported — this is the pass/fail gate.
+- **Plan evidence** (Phase 2 + Phase 5 EXPLAIN) covers a
+  **representative subset** (≥1 feature association, ≥1 dataset-member
+  association) — this demonstrates usability, it is not exhaustive.
+
+### Phase 1 — Build the test catalog
+
+Use the one-call demo-catalog entry point, fully populated so the
+standard deriva-ml association tables exist with rows in both the live
+and history tables:
+
+```python
+from deriva_ml.demo_catalog import create_demo_catalog
+catalog = create_demo_catalog(
+    hostname="localhost",
+    create_features=True,    # creates feature association tables
+    create_datasets=True,    # creates Dataset-member association tables
+    on_exit_delete=False,    # keep it alive across the test run
+)
+catalog_id = catalog.catalog_id
+```
+
+`create_demo_catalog` clones deriva-ml from GitHub (network is
+available), installs the `deriva-ml` schema + the `demo-schema` domain
+schema, and runs an execution that populates subjects/images, features,
+and datasets. The resulting catalog contains the association tables the
+script targets: dataset-member associations, feature-value
+associations, and `{Asset}_Execution` link tables.
+
+Run with the dirty-tree override so the populate execution is allowed:
+
+```bash
+DERIVA_ML_ALLOW_DIRTY=true uv run python -c "<phase-1 snippet>"
+```
+
+The new catalog id and its Postgres DB name (`_ermrest_catalog_<id>`)
+are captured and reused for every later phase. Because RIDs and catalog
+ids are opaque, both are read back from the live objects — never
+written as literals.
+
+### Phase 2 — Capture "before" plans
+
+Enumerate the association tables the script *will* target by running
+the script's own discovery logic (import `_walk_associations` and
+`_build_rid_lookup` from the script, or just run the script and read
+its output header). For a representative subset (at minimum: one
+feature association and one dataset-member association) capture, via
+`docker exec deriva-postgres psql -d _ermrest_catalog_<id>`:
+
+- **Live forward join:** `EXPLAIN (ANALYZE, BUFFERS)` of a query
+  filtering/joining on `(FK1, FK2)`.
+- **Live reverse join:** same on `(FK2, FK1)`.
+- **History forward/reverse:** `EXPLAIN (ANALYZE, BUFFERS)` of the
+  equivalent `rowdata->>'<col_rid>'` predicates on
+  `_ermrest_history."t<table_rid>"`.
+
+Expectation before indexing: sequential scans / filters (no composite
+index available). The small row count means timings are sub-millisecond
+— **the evidence is the plan node type (Seq Scan vs Index Scan) and
+buffer counts, not wall-clock ms.** This is recorded honestly.
+
+The exact predicate values (RIDs) are pulled from the populated
+catalog, not invented.
+
+### Phase 3 — Run the generator
+
+```bash
+DERIVA_ML_ALLOW_DIRTY=true uv run python scripts/generate_association_indexes.py \
+    --hostname localhost \
+    --catalog-id <id> \
+    --output /tmp/assoc-indexes-<id>.sql \
+    --verbose
+```
+
+Assertions on the output:
+- Exit code 0; the stderr summary reports a non-zero
+  "associations found" count.
+- The `.sql` file contains, per association, the expected `CREATE INDEX
+  CONCURRENTLY IF NOT EXISTS` statements — 2 live composite-pair
+  (`_assoc_fwd_idx`, `_assoc_rev_idx`) and, when table+column RIDs
+  resolved, 2 history expression (`_hist_assoc_fwd_idx`,
+  `_hist_assoc_rev_idx`).
+- Any warnings (RID-lookup misses) are surfaced and explained — a
+  miss is a finding, not silently ignored.
+
+### Phase 4 — Apply the SQL
+
+`CREATE INDEX CONCURRENTLY` **cannot run inside a transaction block.**
+`psql -f` wraps a file in an implicit transaction only with
+`--single-transaction`; the default is autocommit per statement, which
+is what we want. Apply with:
+
+```bash
+docker cp /tmp/assoc-indexes-<id>.sql deriva-postgres:/tmp/idx.sql
+docker exec deriva-postgres psql -U ermrest -d _ermrest_catalog_<id> \
+    -v ON_ERROR_STOP=1 -f /tmp/idx.sql
+```
+
+`ON_ERROR_STOP=1` makes any failing statement abort the run with a
+non-zero exit so failures are not missed. `IF NOT EXISTS` keeps a
+re-run a safe no-op (we run it twice to confirm idempotence — second
+run produces zero new indexes and exits clean).
+
+### Phase 5 — Verify end-state + capture "after" plans
+
+**Contract verification (the core success criterion).** For every
+association the script reported, query `pg_indexes` to assert all four
+indexes exist:
+
+```sql
+SELECT schemaname, tablename, indexname, indexdef
+FROM pg_indexes
+WHERE indexname LIKE '%\_assoc\_fwd\_idx'
+   OR indexname LIKE '%\_assoc\_rev\_idx'
+   OR indexname LIKE '%\_hist\_assoc\_fwd\_idx'
+   OR indexname LIKE '%\_hist\_assoc\_rev\_idx'
+ORDER BY tablename, indexname;
+```
+
+Cross-check the count: `4 × (associations with resolved RIDs) +
+2 × (associations missing history RIDs)` indexes present. Confirm both
+directions exist on **both** the live table and the
+`_ermrest_history."t<rid>"` table for each association — this is the
+literal restatement of the success criterion in the request.
+
+**After-plans.** Re-run the Phase-2 EXPLAIN queries. Expect the plan to
+switch to an Index Scan / Index Only Scan on the new composite index
+(or at minimum the index appears as a candidate and buffer reads drop).
+Record before vs after side by side.
+
+A subtlety: with tiny tables the planner may *still* choose a seq scan
+because it's cheaper than an index scan for a handful of rows. If so,
+force index usage for the demonstration with
+`SET enable_seqscan = off;` before the EXPLAIN, proving the index is
+*usable* even when the cost model wouldn't pick it at this scale. This
+is documented as the reason, not hidden.
+
+## 4. Deliverable
+
+A short report (written to
+`docs/audits/2026-06-02-association-index-test-report.md`) containing:
+- catalog id used and association tables discovered,
+- the generated `.sql` (or a link to it),
+- before/after EXPLAIN plans for the representative joins,
+- the `pg_indexes` end-state table proving 4-per-association coverage
+  on live + history, both directions,
+- idempotence-rerun result,
+- any script bugs / warnings found.
+
+## 5. Non-goals
+
+- Modifying `generate_association_indexes.py` (unless the test exposes
+  a bug — then a fix goes through the normal PR workflow, separately).
+- Driving the apply through a pgAdmin GUI (psql-in-container is the
+  equivalent; GUI is a separate setup if wanted).
+- Large-scale timing benchmarks. The demo catalog is small by design;
+  plan-shape is the evidence. (A synthetic bulk-load for real ms
+  deltas was considered and deferred — see decision in §3 Phase 2.)
+- Leaving the test catalog behind: it is deleted at the end unless the
+  user wants to keep it for inspection.
+
+## 6. Risks / open points
+
+- **`create_demo_catalog` git-clone dependency.** It shells out to
+  `git clone` of deriva-ml from GitHub. If the network blocks that, the
+  fallback is the `CatalogManager`/`create_ml_catalog` +
+  `create_domain_schema` path used by the test fixtures, which builds
+  the same association tables without a clone.
+- **Postgres role for DDL.** Indexes are created as the `ermrest` role
+  (the catalog owner). `docker exec ... -U ermrest` runs as that role,
+  which owns the `_ermrest_history` tables, so `CREATE INDEX` there is
+  permitted.
+- **History-table index on `rowdata->>` is an expression index** keyed
+  by **column RID**, not column name. Verification reads `indexdef`
+  from `pg_indexes` and confirms the expression references the correct
+  RID — caught by comparing against the script's emitted SQL.

--- a/docs/superpowers/specs/2026-06-02-association-index-script-test-design.md
+++ b/docs/superpowers/specs/2026-06-02-association-index-script-test-design.md
@@ -11,9 +11,17 @@ Validate, end-to-end against a real catalog, that
 `scripts/generate_association_indexes.py` produces SQL which, when
 applied, leaves **every pure binary association table with composite
 indexes in both join directions on both the live table and its
-`_ermrest_history` partner**. Along the way, capture before/after
-query-plan evidence that the composite indexes are actually usable by
-the Postgres planner.
+`_ermrest_history` partner**.
+
+The demo catalog is small by design, so **wall-clock timing is not a
+meaningful signal** — a handful of rows are read fast with or without
+an index, and any ms difference is noise. Instead of measuring
+performance, the test answers the question that *is* meaningful at any
+scale: **does the Postgres planner actually use each generated index
+when running the query it was built for?** That is a yes/no fact about
+plan shape and index-scan counters, not a timing measurement. The
+two are different claims and the test makes the one it can stand
+behind.
 
 This is a **test/validation exercise**, not a change to the script or
 the library. No production code is modified. The deliverable is a
@@ -44,15 +52,25 @@ catalog, so its DB name is derived from the new catalog id at runtime —
 
 ## 3. Approach
 
-A five-phase pipeline. Phases 2 and 5 (before/after EXPLAIN) bracket
-the apply.
+A five-phase pipeline. Phase 2 records the baseline plan (no index
+available); Phases 4–5 apply the indexes and prove the planner uses
+them.
 
-Two distinct kinds of evidence, with different coverage:
-- **Contract verification** (Phase 5, `pg_indexes`) covers **every**
-  association table the script reported — this is the pass/fail gate.
-- **Plan evidence** (Phase 2 + Phase 5 EXPLAIN) covers a
-  **representative subset** (≥1 feature association, ≥1 dataset-member
-  association) — this demonstrates usability, it is not exhaustive.
+Three distinct kinds of evidence, with different coverage:
+- **Existence / contract verification** (Phase 5, `pg_indexes`) covers
+  **every** association table the script reported — this is the
+  pass/fail gate for the stated success criterion.
+- **Usability evidence** (Phase 5, `EXPLAIN` with `enable_seqscan =
+  off`) covers a **representative subset** (≥1 feature association, ≥1
+  dataset-member association, each on live + history, both directions)
+  — it proves the planner *chooses our named index* to satisfy the
+  query when a seq scan is taken off the table. This is the
+  "indexes are being used" check, and it holds regardless of row count.
+- **Real-query touch counter** (Phase 5, `pg_stat_user_indexes`) — run
+  the representative queries normally (no planner override) and read
+  `idx_scan` before/after to confirm a genuine query incremented the
+  index's scan counter. Belt-and-suspenders on top of the plan
+  inspection.
 
 ### Phase 1 — Build the test catalog
 
@@ -89,27 +107,30 @@ are captured and reused for every later phase. Because RIDs and catalog
 ids are opaque, both are read back from the live objects — never
 written as literals.
 
-### Phase 2 — Capture "before" plans
+### Phase 2 — Record the baseline plan (no index yet)
 
 Enumerate the association tables the script *will* target by running
 the script's own discovery logic (import `_walk_associations` and
 `_build_rid_lookup` from the script, or just run the script and read
-its output header). For a representative subset (at minimum: one
-feature association and one dataset-member association) capture, via
-`docker exec deriva-postgres psql -d _ermrest_catalog_<id>`:
+its output header). For the representative subset (≥1 feature
+association, ≥1 dataset-member association) capture, via
+`docker exec deriva-postgres psql -d _ermrest_catalog_<id>`, the plan
+for each query the index targets:
 
-- **Live forward join:** `EXPLAIN (ANALYZE, BUFFERS)` of a query
-  filtering/joining on `(FK1, FK2)`.
-- **Live reverse join:** same on `(FK2, FK1)`.
-- **History forward/reverse:** `EXPLAIN (ANALYZE, BUFFERS)` of the
-  equivalent `rowdata->>'<col_rid>'` predicates on
+- **Live forward:** `EXPLAIN` of a query with an equality predicate on
+  `(FK1, FK2)`.
+- **Live reverse:** same on `(FK2, FK1)`.
+- **History forward/reverse:** `EXPLAIN` of the equivalent
+  `rowdata->>'<col_rid>'` predicates on
   `_ermrest_history."t<table_rid>"`.
 
-Expectation before indexing: sequential scans / filters (no composite
-index available). The small row count means timings are sub-millisecond
-— **the evidence is the plan node type (Seq Scan vs Index Scan) and
-buffer counts, not wall-clock ms.** This is recorded honestly.
+This is the **baseline**: with no composite index present, every plan
+should be a Seq Scan (possibly with a Filter). Recording it makes the
+Phase-5 contrast unambiguous — the *same* query, *same* predicate, goes
+from Seq Scan (now) to Index Scan on our named index (after apply).
 
+The point of Phase 2 is **not** timing. `EXPLAIN` without `ANALYZE` is
+enough to see the plan shape; we capture the node type, not the ms.
 The exact predicate values (RIDs) are pulled from the populated
 catalog, not invented.
 
@@ -152,11 +173,11 @@ non-zero exit so failures are not missed. `IF NOT EXISTS` keeps a
 re-run a safe no-op (we run it twice to confirm idempotence — second
 run produces zero new indexes and exits clean).
 
-### Phase 5 — Verify end-state + capture "after" plans
+### Phase 5 — Verify the indexes exist and are used
 
-**Contract verification (the core success criterion).** For every
-association the script reported, query `pg_indexes` to assert all four
-indexes exist:
+**(a) Existence / contract verification (the core success criterion).**
+For every association the script reported, query `pg_indexes` to assert
+all four indexes exist:
 
 ```sql
 SELECT schemaname, tablename, indexname, indexdef
@@ -174,17 +195,52 @@ directions exist on **both** the live table and the
 `_ermrest_history."t<rid>"` table for each association — this is the
 literal restatement of the success criterion in the request.
 
-**After-plans.** Re-run the Phase-2 EXPLAIN queries. Expect the plan to
-switch to an Index Scan / Index Only Scan on the new composite index
-(or at minimum the index appears as a candidate and buffer reads drop).
-Record before vs after side by side.
+**(b) Usability — does the planner pick the index?** This is the
+"indexes are being used" check that replaces performance measurement.
+For each query in the representative subset:
 
-A subtlety: with tiny tables the planner may *still* choose a seq scan
-because it's cheaper than an index scan for a handful of rows. If so,
-force index usage for the demonstration with
-`SET enable_seqscan = off;` before the EXPLAIN, proving the index is
-*usable* even when the cost model wouldn't pick it at this scale. This
-is documented as the reason, not hidden.
+1. Re-run the Phase-2 `EXPLAIN`. With a few rows the planner may still
+   prefer a Seq Scan purely on cost — that is expected and is **not** a
+   failure, because at this scale a seq scan genuinely is cheaper.
+2. Then take the seq scan off the table and re-EXPLAIN:
+
+   ```sql
+   SET enable_seqscan = off;
+   SET enable_bitmapscan = off;   -- so we see a plain Index Scan, not a fallback
+   EXPLAIN <the same query>;
+   ```
+
+   **Pass:** the plan is an `Index Scan` / `Index Only Scan` whose
+   `Index Cond` names *our* index (`..._assoc_fwd_idx` etc.) and
+   matches both predicate columns in order. This proves the index is
+   eligible for the query it was built for — true at any row count.
+   **Fail (a real finding):** the plan is *still* a Seq Scan even with
+   seqscan disabled, which means the index does not cover the query
+   (wrong column order, wrong expression on the history side, etc.).
+
+Record the disabled-seqscan plan for every direction × {live, history}
+in the subset. A small results table maps each
+(association, direction, table-kind) → index name → "Index Scan ✓ /
+Seq Scan ✗".
+
+**(c) Real-query touch counter (corroboration).** Reset stats, run the
+representative queries *normally* (no planner overrides) against a
+copy/scaled context if available, and read `idx_scan` from
+`pg_stat_user_indexes` for the named indexes:
+
+```sql
+SELECT indexrelname, idx_scan
+FROM pg_stat_user_indexes
+WHERE indexrelname LIKE '%\_assoc\_%\_idx'
+ORDER BY indexrelname;
+```
+
+A non-zero `idx_scan` after a real query confirms the index was
+actually consulted, independent of the EXPLAIN override. (If at demo
+scale every natural query stays on a seq scan, this counter may legitimately
+read zero — in that case (b)'s forced-plan proof stands as the
+usability evidence, and we say so plainly rather than implying a touch
+that didn't happen.)
 
 ## 4. Deliverable
 
@@ -192,9 +248,14 @@ A short report (written to
 `docs/audits/2026-06-02-association-index-test-report.md`) containing:
 - catalog id used and association tables discovered,
 - the generated `.sql` (or a link to it),
-- before/after EXPLAIN plans for the representative joins,
 - the `pg_indexes` end-state table proving 4-per-association coverage
-  on live + history, both directions,
+  on live + history, both directions (the pass/fail gate),
+- the **index-usage table**: for each representative
+  (association, direction, table-kind), the baseline plan (Seq Scan)
+  next to the forced-plan result (Index Scan on our named index ✓ /
+  still Seq Scan ✗),
+- `pg_stat_user_indexes.idx_scan` readings where a natural query
+  touched an index,
 - idempotence-rerun result,
 - any script bugs / warnings found.
 
@@ -204,9 +265,11 @@ A short report (written to
   a bug — then a fix goes through the normal PR workflow, separately).
 - Driving the apply through a pgAdmin GUI (psql-in-container is the
   equivalent; GUI is a separate setup if wanted).
-- Large-scale timing benchmarks. The demo catalog is small by design;
-  plan-shape is the evidence. (A synthetic bulk-load for real ms
-  deltas was considered and deferred — see decision in §3 Phase 2.)
+- **Performance / timing measurement of any kind.** The demo catalog
+  is too small for ms deltas to mean anything; the test deliberately
+  makes the weaker-but-true claim ("the planner uses the index when a
+  seq scan is disabled") instead of an unsupportable performance claim.
+  No `EXPLAIN ANALYZE` timings are reported as evidence.
 - Leaving the test catalog behind: it is deleted at the end unless the
   user wants to keep it for inspection.
 


### PR DESCRIPTION
## What

End-to-end validation of `scripts/generate_association_indexes.py` (added in #271) against a live catalog. **No production code changes** — this PR adds a design spec, a runbook plan, and the test report.

## Method

Ran the full runbook against a fresh populated demo catalog in the local Docker Deriva stack:

1. Built catalog 3 via `create_demo_catalog(create_features=True, create_datasets=True)`.
2. Captured baseline query plans (all Seq Scan) for a representative pure-binary association (`demo-schema.Dataset_Subject`), live + history, both directions.
3. Ran the generator → 12 associations, 48 `CREATE INDEX CONCURRENTLY IF NOT EXISTS` statements, exit 0, no warnings.
4. Applied via `docker exec deriva-postgres psql -f` (psql substitutes for pgAdmin, which isn't installed); proved idempotence on re-run (48 `already exists, skipping`).
5. Verified the contract and index usability.

## Results — both gates pass

- **Existence (contract gate):** 12/12 associations have composite indexes in **both directions** on **both** the live table and the `_ermrest_history` table — the literal success criterion.
- **Usability:** with `enable_seqscan=off`, the planner picks the named composite index for live **and** the JSONB `rowdata->>'<col_rid>'` history expression indexes; `idx_scan` counter 0→1 confirms real consultation. (Natural plans stay on Seq Scan at 8 rows — expected on cost, not a failure. Performance/timing deliberately not measured at this scale; index *usage* is the evidence.)

**No bugs found in the script.**

## Notable finding

Feature-value association tables (e.g. `Execution_Subject_Health`) have 4 FKs, so they are not pure binary associations and are correctly **not** indexed by this tool. Out of scope if feature-query speed is the motivation.

## Artifacts

- Spec: `docs/superpowers/specs/2026-06-02-association-index-script-test-design.md`
- Plan (runbook): `docs/superpowers/plans/2026-06-02-association-index-script-test.md`
- Report: `docs/audits/2026-06-02-association-index-test-report.md`

Test catalogs cleaned up (deleted via ermrest API).

🤖 Generated with [Claude Code](https://claude.com/claude-code)