### PR TITLE
Find executions by dataset (input/output role, version pinning)

### DIFF
--- a/docs/superpowers/plans/2026-06-02-find-executions-by-dataset.md
+++ b/docs/superpowers/plans/2026-06-02-find-executions-by-dataset.md
@@ -1,0 +1,867 @@
+# Find Executions by Dataset — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make "which executions used dataset X?" a first-class query in the deriva-ml library and the deriva-ml-mcp-plugin MCP tools, with input/output role and version pinning, backed by catalog-native provenance (no config parsing).
+
+**Architecture:** Two non-overlapping sources of truth — output edges live in `Dataset_Version.Execution` (per-version authorship), input edges in the `Dataset_Execution` association table (made input-only, gaining a nullable `Dataset_Version` FK). `find_executions(dataset=RID|DatasetSpec, dataset_role=...)` unions/filters the two. A one-shot idempotent migration adds the column, deletes redundant historical output rows, and best-effort backfills input versions.
+
+**Tech Stack:** Python, deriva-py (ERMrest model + pathBuilder), Pydantic, pytest. Schema via `deriva.core.ermrest_model`. Plugin tools via `@ctx.tool` + `asyncio.to_thread`.
+
+**Spec:** `docs/superpowers/specs/2026-06-02-find-executions-by-dataset-design.md`
+**Branch:** `feature/find-executions-by-dataset` (already created)
+
+**Repo roots:**
+- Library: `/Users/carl/GitHub/DerivaML/deriva-ml`
+- Plugin: `/Users/carl/GitHub/DerivaML/deriva-ml-mcp-plugin`
+
+**Test convention note:** Library live/catalog tests use the demo catalog
+via `tests/catalog_manager.py` fixtures and run with
+`DERIVA_ML_ALLOW_DIRTY=true uv run pytest …`. Plugin tests use the
+`mock_ml` (MagicMock) + `execution_ctx` + `capturing_mcp` fixtures in
+`deriva-ml-mcp-plugin/tests/conftest.py` / `tests/test_execution.py`.
+
+---
+
+## File structure
+
+**Library (`deriva-ml`):**
+- `src/deriva_ml/schema/create_schema.py` — add `Dataset_Version` FK to `Dataset_Execution` (Task 1)
+- `src/deriva_ml/schema/annotations.py` — surface the new FK in Chaise (Task 1)
+- `scripts/migrate_dataset_execution_version.py` — **new**, idempotent migration (Task 2)
+- `src/deriva_ml/dataset/dataset.py` — stop writing output row in `create_dataset` (Task 4)
+- `src/deriva_ml/execution/execution.py` — `add_input_dataset(version=…)` (Task 4)
+- `src/deriva_ml/execution/_helpers.py` — simplify `list_input_datasets`; add version to input-write helper (Tasks 4–5)
+- `src/deriva_ml/core/mixins/execution.py` — extend `find_executions` (Task 5)
+
+**Plugin (`deriva-ml-mcp-plugin`):**
+- `src/deriva_ml_mcp_plugin/_response_models.py` — `DatasetExecutionSummary` (Task 6)
+- `src/deriva_ml_mcp_plugin/tools/execution/read.py` — extend `_list_executions_impl`, `deriva_ml_list_executions`; add `deriva_ml_find_dataset_executions` (Task 6)
+
+---
+
+## Task 1: Schema — add `Dataset_Version` FK to `Dataset_Execution`
+
+**Files:**
+- Modify: `src/deriva_ml/schema/create_schema.py:168-177` (the `Dataset_Execution` association definition)
+- Modify: `src/deriva_ml/schema/annotations.py` (visible_foreign_keys, ~line 525)
+- Test: `tests/schema/test_dataset_execution_version_column.py` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/schema/test_dataset_execution_version_column.py`:
+
+```python
+"""Fresh-catalog schema: Dataset_Execution carries a nullable Dataset_Version FK."""
+from tests.catalog_manager import ensure_demo_catalog  # see existing schema tests for the helper
+
+
+def test_dataset_execution_has_dataset_version_fk(demo_model, ml_schema):
+    """Dataset_Execution has a nullable Dataset_Version column FK'd to Dataset_Version."""
+    de = demo_model.schemas[ml_schema].tables["Dataset_Execution"]
+    cols = {c.name for c in de.columns}
+    assert "Dataset_Version" in cols, "Dataset_Execution must have a Dataset_Version column"
+    dv_col = next(c for c in de.columns if c.name == "Dataset_Version")
+    assert dv_col.nullok is True, "Dataset_Version must be nullable"
+    fk_targets = {
+        fk.referenced_columns[0]["table_name"]
+        for fk in de.foreign_keys
+        if any(c["column_name"] == "Dataset_Version" for c in fk.foreign_key_columns)
+    }
+    assert "Dataset_Version" in fk_targets
+```
+
+(If `demo_model` / `ml_schema` fixtures don't already exist in
+`tests/schema/conftest.py`, mirror the model-loading fixture used by the
+other `tests/schema/` tests — they load the demo catalog model.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/carl/GitHub/DerivaML/deriva-ml && DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/schema/test_dataset_execution_version_column.py -v`
+Expected: FAIL — `"Dataset_Execution must have a Dataset_Version column"`.
+
+- [ ] **Step 3: Add the column + FK in create_schema.py**
+
+The table is built with `Table.define_association`, which doesn't take
+extra columns. Add the column and FK **after** creation. Replace the
+block at `create_schema.py:168-177`:
+
+```python
+    dataset_execution_table = schema.create_table(
+        Table.define_association(
+            associates=[("Dataset", dataset_table), ("Execution", execution_table)],
+            comment=(
+                "Association linking datasets to executions that CONSUMED them "
+                "as inputs. Output (producing) edges are NOT recorded here — they "
+                "live in Dataset_Version.Execution. Each row optionally records "
+                "the consumed version via the Dataset_Version FK."
+            ),
+        )
+    )
+    # Input edges may pin the consumed version. Nullable: legacy/no-version
+    # links (e.g. add_input_dataset without a version) leave it NULL.
+    dataset_execution_table.create_column(
+        Column.define(
+            "Dataset_Version",
+            BuiltinType.text,
+            nullok=True,
+            comment="RID of the Dataset_Version consumed by this input edge (NULL if unknown).",
+        )
+    )
+    dataset_execution_table.create_reference(dataset_version_table)
+    return dataset_table
+```
+
+Notes for the implementer:
+- `dataset_version_table` is the `Dataset_Version` table created earlier
+  in this same function (the one `Dataset.Version` references via
+  `create_reference(("Version", True, dataset_version))` at line ~154).
+  If it isn't already bound to a local name, capture it from its
+  `schema.create_table(...)` return value.
+- `Column` / `BuiltinType` are already imported in this module (see the
+  `ColumnDef`/`BuiltinType` usage elsewhere in the file). If the helper
+  is `ColumnDef` rather than `Column.define`, match the surrounding
+  style.
+
+- [ ] **Step 4: Surface the FK in Chaise annotations**
+
+In `src/deriva_ml/schema/annotations.py`, find the `visible_foreign_keys`
+block for the Execution/Dataset area near line 525 (where
+`Dataset_Execution_Dataset_fkey` is listed) and add the new FK so it
+renders:
+
+```python
+                        {"outbound": [schema, "Dataset_Execution_Dataset_Version_fkey"]},
+```
+
+(Match the exact constraint name deriva-py generates for the new FK; if
+it differs, read it from the created model in a quick REPL or from the
+migration's precondition output once Task 2 exists.)
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/schema/test_dataset_execution_version_column.py -v`
+Expected: PASS.
+
+- [ ] **Step 6: Run the broader schema-creation suite for regressions**
+
+Run: `DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/schema/ -v`
+Expected: PASS (no other schema test broken by the additive column).
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml
+git add src/deriva_ml/schema/create_schema.py src/deriva_ml/schema/annotations.py tests/schema/test_dataset_execution_version_column.py
+git commit -m "feat(schema): add nullable Dataset_Version FK to Dataset_Execution"
+```
+
+---
+
+## Task 2: Migration script — add column, delete stale output rows, backfill input versions
+
+**Files:**
+- Create: `scripts/migrate_dataset_execution_version.py`
+- Test: `tests/test_migrate_dataset_execution_version.py` (create)
+
+Model on `scripts/migrate_workflow_types.py` (same arg/`--dry-run`/
+precondition/`[SKIP]`/verify/short-circuit shape).
+
+- [ ] **Step 1: Write the failing test (idempotency + behavior on a seeded model)**
+
+Create `tests/test_migrate_dataset_execution_version.py`. The migration
+operates on an `ErmrestCatalog`; test against the demo catalog the other
+live tests use (gate with `DERIVA_ML_ALLOW_DIRTY=true`).
+
+```python
+"""Migration: Dataset_Execution gains version FK, output rows removed, input backfilled."""
+import pytest
+from scripts.migrate_dataset_execution_version import (
+    check_preconditions, run_migration,
+)
+
+
+@pytest.mark.integration
+def test_migration_is_idempotent(demo_catalog, ml_schema):
+    """Second run is a no-op; preconditions report 'already migrated'."""
+    run_migration(demo_catalog, ml_schema, dry_run=False)
+    pre = check_preconditions(demo_catalog, ml_schema)
+    assert pre["has_version_column"] is True
+    # Second run changes nothing.
+    summary = run_migration(demo_catalog, ml_schema, dry_run=False)
+    assert summary["columns_added"] == 0
+    assert summary["output_rows_deleted"] == 0
+
+
+@pytest.mark.integration
+def test_migration_removes_output_rows_and_keeps_inputs(demo_catalog, ml_schema, seeded_edges):
+    """Output rows (dataset has a Dataset_Version authored by the execution) are deleted;
+    input rows survive."""
+    run_migration(demo_catalog, ml_schema, dry_run=False)
+    pb = demo_catalog.getPathBuilder()
+    de = pb.schemas[ml_schema].Dataset_Execution
+    rows = list(de.entities().fetch())
+    # No row should correspond to an authored (output) version.
+    for r in rows:
+        assert not seeded_edges.is_output_edge(r["Dataset"], r["Execution"]), (
+            "output edge should have been deleted from Dataset_Execution"
+        )
+```
+
+(`seeded_edges` is a fixture you add in the test file that creates: one
+dataset produced by an execution — i.e. a `Dataset_Version` row with that
+`Execution` — plus a separate input link via `add_input_dataset`. Build it
+with the demo `ml` instance. `is_output_edge` checks the
+`Dataset_Version` authorship for the pair.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/test_migrate_dataset_execution_version.py -v -m integration`
+Expected: FAIL — `ModuleNotFoundError: scripts.migrate_dataset_execution_version`.
+
+- [ ] **Step 3: Write the migration script**
+
+Create `scripts/migrate_dataset_execution_version.py`:
+
+```python
+#!/usr/bin/env python3
+"""Migrate Dataset_Execution to input-only with a Dataset_Version FK.
+
+Steps:
+1. Add a nullable Dataset_Version column + FK (idempotent).
+2. Delete stale OUTPUT rows: Dataset_Execution rows where the dataset has
+   a Dataset_Version authored by that same execution. Output provenance
+   lives in Dataset_Version.Execution, so deletion loses nothing.
+3. Backfill Dataset_Version on remaining (input) rows, best-effort, from
+   the execution's configuration.json metadata (DatasetSpec.version).
+   add_input_dataset links with no recorded version stay NULL.
+4. Verify: no output rows remain; report NULL count by cause.
+
+Usage:
+    python scripts/migrate_dataset_execution_version.py HOST CATALOG_ID --dry-run
+    python scripts/migrate_dataset_execution_version.py HOST CATALOG_ID
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+
+from deriva.core import ErmrestCatalog, get_credential
+from deriva.core.ermrest_model import Column, builtin_types
+
+
+def get_catalog(hostname: str, catalog_id: str) -> ErmrestCatalog:
+    return ErmrestCatalog("https", hostname, catalog_id, credentials=get_credential(hostname))
+
+
+def check_preconditions(catalog: ErmrestCatalog, ml_schema: str) -> dict:
+    model = catalog.getCatalogModel()
+    de = model.schemas[ml_schema].tables["Dataset_Execution"]
+    has_col = "Dataset_Version" in {c.name for c in de.columns}
+    pb = catalog.getPathBuilder()
+    rows = list(pb.schemas[ml_schema].Dataset_Execution.entities().fetch())
+    return {"has_version_column": has_col, "row_count": len(rows)}
+
+
+def _authored_versions(catalog: ErmrestCatalog, ml_schema: str) -> set[tuple[str, str]]:
+    """Set of (Dataset, Execution) pairs where the execution authored a version."""
+    pb = catalog.getPathBuilder()
+    dv = pb.schemas[ml_schema].Dataset_Version
+    pairs = set()
+    for row in dv.entities().fetch():
+        if row.get("Execution") and row.get("Dataset"):
+            pairs.add((row["Dataset"], row["Execution"]))
+    return pairs
+
+
+def step1_add_column(catalog, ml_schema, dry_run) -> int:
+    model = catalog.getCatalogModel()
+    de = model.schemas[ml_schema].tables["Dataset_Execution"]
+    if "Dataset_Version" in {c.name for c in de.columns}:
+        print("  [SKIP] Dataset_Version column already exists")
+        return 0
+    if dry_run:
+        print("  [DRY-RUN] would add Dataset_Version column + FK")
+        return 1
+    de.create_column(Column.define("Dataset_Version", builtin_types.text, nullok=True))
+    dv = model.schemas[ml_schema].tables["Dataset_Version"]
+    de.create_reference(dv)
+    print("  [OK] added Dataset_Version column + FK")
+    return 1
+
+
+def step2_delete_output_rows(catalog, ml_schema, dry_run) -> int:
+    authored = _authored_versions(catalog, ml_schema)
+    pb = catalog.getPathBuilder()
+    de = pb.schemas[ml_schema].Dataset_Execution
+    to_delete = [
+        r["RID"] for r in de.entities().fetch()
+        if (r["Dataset"], r["Execution"]) in authored
+    ]
+    if not to_delete:
+        print("  [SKIP] no stale output rows")
+        return 0
+    if dry_run:
+        print(f"  [DRY-RUN] would delete {len(to_delete)} output rows")
+        return len(to_delete)
+    for rid in to_delete:
+        de.filter(de.RID == rid).delete()
+    print(f"  [OK] deleted {len(to_delete)} output rows")
+    return len(to_delete)
+
+
+def step3_backfill_input_versions(catalog, ml_schema, dry_run) -> dict:
+    """Best-effort: resolve consumed version from each execution's
+    configuration.json. Rows that can't be resolved stay NULL.
+    Returns {"filled": n, "null_config": n, "null_no_record": n}."""
+    # Implementer: read each remaining row's Execution -> its
+    # Execution_Metadata configuration.json asset -> DatasetSpec.version
+    # for the matching dataset rid; set Dataset_Version via the version's
+    # Dataset_Version RID. Skip+count rows whose config is missing.
+    # This is the ONLY place configuration.json is read (migration-time only).
+    raise NotImplementedError  # replace with the resolution loop below
+
+
+def run_migration(catalog, ml_schema: str, dry_run: bool) -> dict:
+    print("== migrate Dataset_Execution version ==")
+    added = step1_add_column(catalog, ml_schema, dry_run)
+    deleted = step2_delete_output_rows(catalog, ml_schema, dry_run)
+    backfill = {"filled": 0, "null_config": 0, "null_no_record": 0}
+    if not dry_run and added == 0:
+        # column present -> safe to backfill
+        backfill = step3_backfill_input_versions(catalog, ml_schema, dry_run)
+    print(f"== summary: +{added} col, -{deleted} output rows, backfill={backfill} ==")
+    return {"columns_added": added, "output_rows_deleted": deleted, "backfill": backfill}
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("hostname")
+    p.add_argument("catalog_id")
+    p.add_argument("--schema", default="deriva-ml")
+    p.add_argument("--dry-run", action="store_true")
+    a = p.parse_args()
+    catalog = get_catalog(a.hostname, a.catalog_id)
+    pre = check_preconditions(catalog, a.schema)
+    print(f"preconditions: {pre}")
+    run_migration(catalog, a.schema, a.dry_run)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+Then implement `step3_backfill_input_versions`'s resolution loop: for each
+remaining `Dataset_Execution` row, fetch the `Execution`'s
+`Execution_Metadata` rows, find the `configuration.json` asset, parse it
+to a list of `DatasetSpec`, match the row's `Dataset` to a spec, look up
+that dataset's `Dataset_Version` RID for `spec.version`, and write it to
+the row's `Dataset_Version`. Count `null_config` when the asset is
+missing/unreadable and `null_no_record` when no spec matches. Wrap each
+row in try/except so one bad config never aborts the run.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/test_migrate_dataset_execution_version.py -v -m integration`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml
+git add scripts/migrate_dataset_execution_version.py tests/test_migrate_dataset_execution_version.py
+git commit -m "feat(scripts): add Dataset_Execution version migration (idempotent, dry-run)"
+```
+
+---
+
+## Task 3: Catalog deployment (MANUAL operational gate — not automated)
+
+> This task is a manual, operator-run checkpoint. It mutates live
+> catalogs and must be run by the user with valid credentials, dev before
+> production. Do NOT script this into CI. Mark each box when the operator
+> confirms completion.
+
+- [ ] **Step 1: Dev dry-run**
+
+Run (operator): `python scripts/migrate_dataset_execution_version.py dev.eye-ai.org eye-ai --dry-run`
+Expected: preview shows column add + N output-row deletions, no changes made.
+
+- [ ] **Step 2: Dev real run**
+
+Run (operator): `python scripts/migrate_dataset_execution_version.py dev.eye-ai.org eye-ai`
+Expected: column added, output rows deleted, input backfill summary printed.
+
+- [ ] **Step 3: Validate on dev with the new tools (after Tasks 5–6 ship)**
+
+Confirm `deriva_ml_find_dataset_executions` on `2-7P5P` returns its input
+executions; a `split_dataset`-origin input row shows `dataset_version=null`;
+no output rows remain in `Dataset_Execution`.
+
+- [ ] **Step 4: Production dry-run then real run**
+
+Run (operator): same script against the production eye-ai host (e.g.
+`eye.rosci.org`), `--dry-run` first, then for real.
+
+- [ ] **Step 5: Re-run safety check**
+
+Re-run the script on dev; confirm it short-circuits (`[SKIP]` everywhere).
+
+---
+
+## Task 4: Library write path — stop writing output rows; record input version
+
+**Files:**
+- Modify: `src/deriva_ml/dataset/dataset.py:347-349` (remove the output `Dataset_Execution.insert`)
+- Modify: `src/deriva_ml/execution/execution.py:1970-2014` (`add_input_dataset` gains `version`)
+- Modify: `src/deriva_ml/execution/_helpers.py` (input-write helper sets `Dataset_Version`)
+- Test: `tests/dataset/test_dataset_execution_write_path.py` (create)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/dataset/test_dataset_execution_write_path.py`:
+
+```python
+"""create_dataset writes no Dataset_Execution row; add_input_dataset records version."""
+import pytest
+
+
+@pytest.mark.integration
+def test_create_dataset_writes_no_dataset_execution_row(demo_ml, an_execution):
+    """Output provenance lives only in Dataset_Version.Execution."""
+    ds = an_execution.create_dataset(dataset_types=["Test"], description="out", version=(1, 0, 0))
+    pb = demo_ml.pathBuilder()
+    de = pb.schemas[demo_ml.ml_schema].Dataset_Execution
+    rows = [r for r in de.entities().fetch() if r["Dataset"] == ds.dataset_rid]
+    assert rows == [], "create_dataset must not write a Dataset_Execution row"
+    # but the version row records the producer:
+    assert demo_ml._producer_of_dataset(ds.dataset_rid) == an_execution.execution_rid
+
+
+@pytest.mark.integration
+def test_add_input_dataset_records_version(demo_ml, an_execution, an_existing_dataset):
+    rid = an_existing_dataset.dataset_rid
+    ver = an_existing_dataset.current_version
+    an_execution.add_input_dataset(rid, version=ver)
+    pb = demo_ml.pathBuilder()
+    de = pb.schemas[demo_ml.ml_schema].Dataset_Execution
+    row = next(r for r in de.entities().fetch()
+               if r["Dataset"] == rid and r["Execution"] == an_execution.execution_rid)
+    assert row["Dataset_Version"] is not None
+
+
+@pytest.mark.integration
+def test_add_input_dataset_without_version_is_null(demo_ml, an_execution, an_existing_dataset):
+    an_execution.add_input_dataset(an_existing_dataset.dataset_rid)  # no version
+    pb = demo_ml.pathBuilder()
+    de = pb.schemas[demo_ml.ml_schema].Dataset_Execution
+    row = next(r for r in de.entities().fetch()
+               if r["Dataset"] == an_existing_dataset.dataset_rid)
+    assert row["Dataset_Version"] is None
+```
+
+(`demo_ml`, `an_execution`, `an_existing_dataset` fixtures: build from
+`tests/catalog_manager.py` — a connected `ml`, a created execution, and a
+pre-existing dataset. Mirror fixtures in `tests/dataset/conftest.py`.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/dataset/test_dataset_execution_write_path.py -v -m integration`
+Expected: FAIL — `create_dataset` still writes the row; `add_input_dataset` has no `version` param.
+
+- [ ] **Step 3: Remove the output-row insert in create_dataset**
+
+In `src/deriva_ml/dataset/dataset.py`, delete lines 347-349:
+
+```python
+        pb.schemas[ml_instance.model.ml_schema].Dataset_Execution.insert(
+            [{"Dataset": dataset_rid, "Execution": execution_rid}]
+        )
+```
+
+(Leave the surrounding dataset-insert and `Dataset(...)` construction
+intact. The `Dataset_Version` row written by `_insert_dataset_versions`
+later in the same method already records the producer.)
+
+- [ ] **Step 4: Add `version` to add_input_dataset**
+
+In `src/deriva_ml/execution/execution.py`, change the signature and the
+insert (around 1970/2014):
+
+```python
+    def add_input_dataset(self, dataset_rid: RID, version: "DatasetVersion | str | None" = None) -> None:
+        # ... existing docstring; add a line documenting `version` (optional;
+        # the consumed version, recorded on the Dataset_Execution row) ...
+        if self._dry_run:
+            return
+        schema_path = self._ml_object.pathBuilder().schemas[self._ml_object.ml_schema]
+        dataset_exec = schema_path.Dataset_Execution
+        already_linked = {
+            row["Dataset"]
+            for row in dataset_exec.filter(dataset_exec.Execution == self.execution_rid).entities().fetch()
+        }
+        if dataset_rid in already_linked:
+            return
+        version_rid = None
+        if version is not None:
+            version_rid = self._ml_object._version_rid(dataset_rid, version)  # see Step 5
+        dataset_exec.insert([{
+            "Dataset": dataset_rid,
+            "Execution": self.execution_rid,
+            "Dataset_Version": version_rid,
+        }])
+```
+
+- [ ] **Step 5: Add a `_version_rid` helper (dataset rid + version -> Dataset_Version RID)**
+
+In `src/deriva_ml/core/mixins/execution.py` (near `_producer_of_dataset`):
+
+```python
+    def _version_rid(self, dataset_rid: RID, version) -> RID | None:
+        """RID of the Dataset_Version row for (dataset_rid, version), or None."""
+        pb = self.pathBuilder()
+        vp = pb.schemas[self.ml_schema].tables["Dataset_Version"]
+        want = str(version)
+        for row in vp.filter(vp.Dataset == dataset_rid).entities().fetch():
+            if (row.get("Version") or "") == want:
+                return row["RID"]
+        return None
+```
+
+Also have the config-input writer (where `ExecutionConfiguration.datasets`
+materialization inserts the `Dataset_Execution` row — `execution.py:658`)
+pass the resolved `Dataset_Version` RID the same way.
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/dataset/test_dataset_execution_write_path.py -v -m integration`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml
+git add src/deriva_ml/dataset/dataset.py src/deriva_ml/execution/execution.py src/deriva_ml/core/mixins/execution.py tests/dataset/test_dataset_execution_write_path.py
+git commit -m "feat(execution): record consumed version on input edge; stop writing output rows"
+```
+
+---
+
+## Task 5: Library read path — simplify `list_input_datasets`; extend `find_executions`
+
+**Files:**
+- Modify: `src/deriva_ml/execution/_helpers.py:203-247` (`list_input_datasets`)
+- Modify: `src/deriva_ml/core/mixins/execution.py:559-653` (`find_executions`)
+- Test: `tests/execution/test_find_executions_by_dataset.py` (create)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/execution/test_find_executions_by_dataset.py`:
+
+```python
+"""find_executions dataset filter: input/output/any, version pin via DatasetSpec."""
+import pytest
+from deriva_ml.dataset.aux_classes import DatasetSpec
+
+
+@pytest.mark.integration
+def test_find_input_executions(demo_ml, dataset_with_input_exec):
+    ds_rid, input_exec = dataset_with_input_exec
+    rids = {e.execution_rid for e in demo_ml.find_executions(dataset=ds_rid, dataset_role="input")}
+    assert input_exec in rids
+
+
+@pytest.mark.integration
+def test_find_output_executions(demo_ml, dataset_with_output_exec):
+    ds_rid, producer = dataset_with_output_exec
+    rids = {e.execution_rid for e in demo_ml.find_executions(dataset=ds_rid, dataset_role="output")}
+    assert producer in rids
+
+
+@pytest.mark.integration
+def test_find_any_is_union(demo_ml, dataset_with_both):
+    ds_rid, producer, consumer = dataset_with_both
+    rids = {e.execution_rid for e in demo_ml.find_executions(dataset=ds_rid, dataset_role="any")}
+    assert {producer, consumer} <= rids
+
+
+@pytest.mark.integration
+def test_version_pin_via_datasetspec(demo_ml, dataset_with_versioned_input):
+    ds_rid, version, exec_rid = dataset_with_versioned_input
+    spec = DatasetSpec(rid=ds_rid, version=version)
+    rids = {e.execution_rid for e in demo_ml.find_executions(dataset=spec, dataset_role="input")}
+    assert exec_rid in rids
+
+
+def test_role_without_dataset_raises(demo_ml):
+    with pytest.raises(ValueError):
+        list(demo_ml.find_executions(dataset_role="input"))
+
+
+@pytest.mark.integration
+def test_list_input_datasets_excludes_produced(demo_ml, an_execution):
+    """Regression: a dataset the execution PRODUCED is not an input."""
+    produced = an_execution.create_dataset(dataset_types=["Test"], description="o", version=(1, 0, 0))
+    inputs = {d.dataset_rid for d in an_execution.list_input_datasets()}
+    assert produced.dataset_rid not in inputs
+
+
+@pytest.mark.integration
+def test_dataset_list_executions_is_input_only(demo_ml, an_execution):
+    """Documented behavior change: Dataset.list_executions no longer returns the producer."""
+    produced = an_execution.create_dataset(dataset_types=["Test"], description="o", version=(1, 0, 0))
+    exec_rids = {e.execution_rid for e in produced.list_executions()}
+    assert an_execution.execution_rid not in exec_rids, (
+        "Dataset.list_executions should be input-only (producer lives in Dataset_Version)"
+    )
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/execution/test_find_executions_by_dataset.py -v`
+Expected: FAIL — `find_executions` has no `dataset`/`dataset_role` params.
+
+- [ ] **Step 3: Simplify list_input_datasets (input-only table)**
+
+In `src/deriva_ml/execution/_helpers.py`, replace the body of
+`list_input_datasets` (203-247) so it no longer subtracts produced
+datasets — every `Dataset_Execution` row is now an input:
+
+```python
+def list_input_datasets(*, ml_instance, execution_rid) -> list:
+    pb = ml_instance.pathBuilder()
+    dataset_exec = pb.schemas[ml_instance.ml_schema].Dataset_Execution
+    records = list(
+        dataset_exec.filter(dataset_exec.Execution == execution_rid).entities().fetch()
+    )
+    return [ml_instance.lookup_dataset(r["Dataset"]) for r in records if r.get("Dataset")]
+```
+
+(Keep the existing docstring's intent; drop the `_producer_of_dataset`
+exclusion paragraph.)
+
+- [ ] **Step 4: Extend find_executions with the dataset filter**
+
+In `src/deriva_ml/core/mixins/execution.py`, add params and filter logic.
+Add to the signature (559-565): `dataset=None, dataset_role="any"`.
+After the existing workflow/status filters build `filtered_path`, and
+before the fetch loop, insert:
+
+```python
+        # Dataset filter (resolve to an allowed Execution RID set, then intersect).
+        from deriva_ml.dataset.aux_classes import DatasetSpec
+        dataset_exec_rids: set[str] | None = None
+        if dataset is not None:
+            if isinstance(dataset, DatasetSpec):
+                ds_rid, ds_version = dataset.rid, str(dataset.version)
+            else:
+                ds_rid, ds_version = dataset, None
+            input_rids, output_rids = set(), set()
+            pb2 = self.pathBuilder()
+            if dataset_role in ("input", "any"):
+                de = pb2.schemas[self.ml_schema].Dataset_Execution
+                for r in de.filter(de.Dataset == ds_rid).entities().fetch():
+                    if ds_version is None or self._version_label(r.get("Dataset_Version")) == ds_version:
+                        input_rids.add(r["Execution"])
+            if dataset_role in ("output", "any"):
+                dv = pb2.schemas[self.ml_schema].tables["Dataset_Version"]
+                for r in dv.filter(dv.Dataset == ds_rid).entities().fetch():
+                    if r.get("Execution") and (ds_version is None or (r.get("Version") or "") == ds_version):
+                        output_rids.add(r["Execution"])
+            dataset_exec_rids = (
+                input_rids if dataset_role == "input"
+                else output_rids if dataset_role == "output"
+                else input_rids | output_rids
+            )
+        elif dataset_role != "any":
+            raise ValueError("dataset_role requires a dataset argument")
+```
+
+Then in the existing `for exec_record in entity_set.fetch():` loop, add an
+early skip:
+
+```python
+            if dataset_exec_rids is not None and exec_record["RID"] not in dataset_exec_rids:
+                continue
+```
+
+Add a small `_version_label(version_rid)` helper next to `_version_rid`
+that maps a `Dataset_Version` RID back to its `Version` string (single
+fetch), used to honor the version pin on input rows:
+
+```python
+    def _version_label(self, version_rid) -> str | None:
+        if not version_rid:
+            return None
+        pb = self.pathBuilder()
+        vp = pb.schemas[self.ml_schema].tables["Dataset_Version"]
+        rows = list(vp.filter(vp.RID == version_rid).entities().fetch())
+        return (rows[0].get("Version") if rows else None)
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/execution/test_find_executions_by_dataset.py -v`
+Expected: PASS.
+
+- [ ] **Step 6: Run the execution + dataset suites for regressions**
+
+Run: `DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/execution tests/dataset -q`
+Expected: PASS (notably `list_input_datasets` callers and `find_executions` callers unbroken).
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml
+git add src/deriva_ml/execution/_helpers.py src/deriva_ml/core/mixins/execution.py tests/execution/test_find_executions_by_dataset.py
+git commit -m "feat(execution): find_executions(dataset=RID|DatasetSpec, dataset_role=...)"
+```
+
+---
+
+## Task 6: Plugin — response model + two tool surfaces
+
+**Files:**
+- Modify: `src/deriva_ml_mcp_plugin/_response_models.py` (add `DatasetExecutionSummary`)
+- Modify: `src/deriva_ml_mcp_plugin/tools/execution/read.py` (extend `_list_executions_impl`, `deriva_ml_list_executions`; add `deriva_ml_find_dataset_executions`)
+- Test: `deriva-ml-mcp-plugin/tests/test_find_dataset_executions.py` (create)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `deriva-ml-mcp-plugin/tests/test_find_dataset_executions.py`:
+
+```python
+"""deriva_ml_find_dataset_executions + list_executions(dataset=) tool surface."""
+import json
+import pytest
+from unittest.mock import MagicMock
+
+
+def _exec(rid, wf="1-WF"):
+    e = MagicMock()
+    e.execution_rid, e.workflow_rid = rid, wf
+    e.status = None
+    e.description = e.start_time = e.stop_time = e.duration = None
+    return e
+
+
+@pytest.mark.anyio
+async def test_find_dataset_executions_returns_role_and_version(execution_ctx, capturing_mcp, mock_ml):
+    mock_ml.find_executions.return_value = [_exec("1-EXEC")]
+    # role/version come from the impl tagging; mock the dataset-edge lookups it uses.
+    res = await capturing_mcp.call_tool(
+        "deriva_ml_find_dataset_executions",
+        {"hostname": "h", "catalog_id": "c", "dataset_rid": "2-DS", "dataset_role": "input"},
+    )
+    payload = json.loads(res)
+    assert payload["executions"][0]["rid"] == "1-EXEC"
+    assert "dataset_role" in payload["executions"][0]
+
+
+@pytest.mark.anyio
+async def test_list_executions_without_dataset_has_no_dataset_fields(execution_ctx, capturing_mcp, mock_ml):
+    mock_ml.find_executions.return_value = [_exec("1-EXEC")]
+    res = await capturing_mcp.call_tool(
+        "deriva_ml_list_executions", {"hostname": "h", "catalog_id": "c"},
+    )
+    payload = json.loads(res)
+    assert "dataset_role" not in payload["executions"][0]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp-plugin && uv run pytest tests/test_find_dataset_executions.py -v`
+Expected: FAIL — tool `deriva_ml_find_dataset_executions` not registered.
+
+- [ ] **Step 3: Add the response model**
+
+In `src/deriva_ml_mcp_plugin/_response_models.py`, add:
+
+```python
+class DatasetExecutionSummary(ExecutionSummary):
+    """ExecutionSummary plus the dataset-edge role/version for dataset-scoped queries."""
+    dataset_role: str  # "input" | "output"
+    dataset_version: str | None = None
+```
+
+- [ ] **Step 4: Extend `_list_executions_impl` to accept + forward the dataset filter**
+
+In `tools/execution/read.py`, add `dataset=None, dataset_role="any"` to
+`_list_executions_impl`, forward them into `ml.find_executions(...)`, and
+when `dataset` is set, wrap each summary as `DatasetExecutionSummary`
+(role from which side matched; version from the association row already
+fetched — no extra fetch). Keep returning plain `ExecutionSummary` when
+`dataset` is None.
+
+- [ ] **Step 5: Extend `deriva_ml_list_executions` and add the intent tool**
+
+Add `dataset`, `dataset_role`, `dataset_version` params to
+`deriva_ml_list_executions`; when `dataset_version` is set, construct
+`DatasetSpec(rid=dataset, version=dataset_version)` and pass as `dataset`,
+else pass the bare RID string. Then add, mirroring
+`deriva_ml_find_workflow_executions`:
+
+```python
+    @ctx.tool(mutates=False)
+    async def deriva_ml_find_dataset_executions(
+        hostname: str, catalog_id: str, dataset_rid: str,
+        dataset_role: str = "any", dataset_version: str | None = None,
+        status: str | None = None, limit: int = 100,
+        after_rid: str | None = None, preflight_count: bool = False, sort: bool = False,
+    ) -> str:
+        """Find executions that used a dataset (input, output, or any).
+
+        Distinct from ``deriva_ml_list_executions(dataset=...)`` to surface
+        the dataset-centric query as a first-class tool. Role is sourced
+        relationally (input = Dataset_Execution; output = Dataset_Version
+        authorship), never from configuration files.
+        """
+        try:
+            with deriva_call():
+                ml = await asyncio.to_thread(_pkg.get_ml, hostname, catalog_id)
+                from deriva_ml.dataset.aux_classes import DatasetSpec
+                ds_arg = DatasetSpec(rid=dataset_rid, version=dataset_version) if dataset_version else dataset_rid
+                # preflight + page via _list_executions_impl(dataset=ds_arg, dataset_role=dataset_role, ...)
+                ...
+            return payload.model_dump_json(by_alias=True)
+        except Exception as exc:
+            return _error_envelope(exc, operation="find_dataset_executions",
+                                   hostname=hostname, catalog_id=catalog_id, audit=False)
+```
+
+(Fill the preflight/page body by copying the exact structure of
+`deriva_ml_find_workflow_executions` in the same file, substituting the
+dataset args.)
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp-plugin && uv run pytest tests/test_find_dataset_executions.py -v`
+Expected: PASS.
+
+- [ ] **Step 7: Run the plugin execution suite for regressions**
+
+Run: `uv run pytest tests/test_execution.py -q`
+Expected: PASS (existing `list_executions` callers see unchanged shape when `dataset` absent).
+
+- [ ] **Step 8: Update the getting-started guide's tool menu**
+
+In `src/deriva_ml_mcp_plugin/` (the getting-started prompt/guide text;
+grep for the execution-tool list), add `deriva_ml_find_dataset_executions`
+to the `execution` domain's verb list and bump the tool count.
+
+- [ ] **Step 9: Commit**
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp-plugin
+git add src/deriva_ml_mcp_plugin/_response_models.py src/deriva_ml_mcp_plugin/tools/execution/read.py tests/test_find_dataset_executions.py src/deriva_ml_mcp_plugin/prompts.py
+git commit -m "feat(tools): add deriva_ml_find_dataset_executions + dataset filter on list_executions"
+```
+
+---
+
+## Final verification
+
+- [ ] Library suite: `cd /Users/carl/GitHub/DerivaML/deriva-ml && DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/schema tests/execution tests/dataset -q`
+- [ ] Plugin suite: `cd /Users/carl/GitHub/DerivaML/deriva-ml-mcp-plugin && uv run pytest -q`
+- [ ] Confirm Task 3 (catalog deployment) boxes are checked by the operator for both dev and production.

--- a/docs/superpowers/plans/2026-06-02-find-executions-by-dataset.md
+++ b/docs/superpowers/plans/2026-06-02-find-executions-by-dataset.md
@@ -80,11 +80,21 @@ other `tests/schema/` tests — they load the demo catalog model.)
 Run: `cd /Users/carl/GitHub/DerivaML/deriva-ml && DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/schema/test_dataset_execution_version_column.py -v`
 Expected: FAIL — `"Dataset_Execution must have a Dataset_Version column"`.
 
-- [ ] **Step 3: Add the column + FK in create_schema.py**
+- [ ] **Step 3: Add the column + FK in create_schema.py — follow the existing impure-association idiom**
 
-The table is built with `Table.define_association`, which doesn't take
-extra columns. Add the column and FK **after** creation. Replace the
-block at `create_schema.py:168-177`:
+The repo already adds extra columns to association tables two ways:
+- **plain column** via `metadata=[ColumnDef(...).to_dict()]` — see the
+  `Sequence` column on the Nested-Execution association
+  (`create_schema.py:405-411`);
+- **FK column** via the same `metadata=` column **plus a separate
+  `create_reference(target_table)`** — see the `Asset_Role` FK on the
+  `{Asset}_Execution` association (`create_asset_table`, the
+  `atable.create_reference(asset_role_table)` call at
+  `create_schema.py:494`).
+
+`Dataset_Version` is an FK column, so follow the **`Asset_Role`
+precedent**: declare the column in `metadata=`, then `create_reference`.
+Replace the `Dataset_Execution` block at `create_schema.py:168-177`:
 
 ```python
     dataset_execution_table = schema.create_table(
@@ -93,21 +103,20 @@ block at `create_schema.py:168-177`:
             comment=(
                 "Association linking datasets to executions that CONSUMED them "
                 "as inputs. Output (producing) edges are NOT recorded here — they "
-                "live in Dataset_Version.Execution. Each row optionally records "
-                "the consumed version via the Dataset_Version FK."
+                "live in Dataset_Version.Execution. The Dataset_Version column "
+                "optionally pins the consumed version."
             ),
+            metadata=[
+                ColumnDef(
+                    name="Dataset_Version",
+                    type=BuiltinType.text,
+                    nullok=True,
+                    comment="RID of the Dataset_Version consumed by this input edge (NULL if unknown).",
+                ).to_dict()  # Convert to dict for Table.define_association()
+            ],
         )
     )
-    # Input edges may pin the consumed version. Nullable: legacy/no-version
-    # links (e.g. add_input_dataset without a version) leave it NULL.
-    dataset_execution_table.create_column(
-        Column.define(
-            "Dataset_Version",
-            BuiltinType.text,
-            nullok=True,
-            comment="RID of the Dataset_Version consumed by this input edge (NULL if unknown).",
-        )
-    )
+    # Wire the FK the same way create_asset_table wires Asset_Role.
     dataset_execution_table.create_reference(dataset_version_table)
     return dataset_table
 ```
@@ -116,12 +125,12 @@ Notes for the implementer:
 - `dataset_version_table` is the `Dataset_Version` table created earlier
   in this same function (the one `Dataset.Version` references via
   `create_reference(("Version", True, dataset_version))` at line ~154).
-  If it isn't already bound to a local name, capture it from its
-  `schema.create_table(...)` return value.
-- `Column` / `BuiltinType` are already imported in this module (see the
-  `ColumnDef`/`BuiltinType` usage elsewhere in the file). If the helper
-  is `ColumnDef` rather than `Column.define`, match the surrounding
-  style.
+  If it isn't already bound to a local name, capture it from that
+  `schema.create_table(...)` / definition site and reuse the binding.
+- `ColumnDef` and `BuiltinType` are already imported and used in this
+  module (e.g. the `Sequence` metadata column at 405-411 and the
+  `Dataset_Version` table columns at ~200). Match that exact style;
+  `.to_dict()` is required on the `ColumnDef` passed to `metadata=`.
 
 - [ ] **Step 4: Surface the FK in Chaise annotations**
 
@@ -248,6 +257,11 @@ import sys
 
 from deriva.core import ErmrestCatalog, get_credential
 from deriva.core.ermrest_model import Column, builtin_types
+# NB: a standalone migration script uses raw deriva-py
+# (Column.define / builtin_types.text — see deriva-py ermrest_model.py:740).
+# This is intentionally DIFFERENT from create_schema.py, which uses the
+# deriva-ml wrappers (ColumnDef / BuiltinType.text). Do not "harmonize"
+# them — each is correct for its context (raw script vs. schema builder).
 
 
 def get_catalog(hostname: str, catalog_id: str) -> ErmrestCatalog:
@@ -275,6 +289,10 @@ def _authored_versions(catalog: ErmrestCatalog, ml_schema: str) -> set[tuple[str
 
 
 def step1_add_column(catalog, ml_schema, dry_run) -> int:
+    # Live-table column add uses the deriva-py Table.create_column /
+    # Table.create_reference API (ermrest_model.py:2054 / :2112) — the
+    # in-place analog of the metadata=/create_reference idiom used at
+    # schema-creation time (create_schema.py Asset_Role precedent).
     model = catalog.getCatalogModel()
     de = model.schemas[ml_schema].tables["Dataset_Execution"]
     if "Dataset_Version" in {c.name for c in de.columns}:
@@ -283,7 +301,14 @@ def step1_add_column(catalog, ml_schema, dry_run) -> int:
     if dry_run:
         print("  [DRY-RUN] would add Dataset_Version column + FK")
         return 1
-    de.create_column(Column.define("Dataset_Version", builtin_types.text, nullok=True))
+    de.create_column(
+        Column.define(
+            "Dataset_Version",
+            builtin_types.text,
+            nullok=True,
+            comment="RID of the Dataset_Version consumed by this input edge (NULL if unknown).",
+        )
+    )
     dv = model.schemas[ml_schema].tables["Dataset_Version"]
     de.create_reference(dv)
     print("  [OK] added Dataset_Version column + FK")

--- a/docs/superpowers/specs/2026-06-02-find-executions-by-dataset-design.md
+++ b/docs/superpowers/specs/2026-06-02-find-executions-by-dataset-design.md
@@ -1,7 +1,8 @@
 # Find Executions by Dataset — Design
 
 **Date:** 2026-06-02
-**Status:** Design — pending review (revised to catalog-native role/version model)
+**Status:** Design — pending review (authorship-canonical model)
+**Branch:** `feature/find-executions-by-dataset`
 **Repos touched:** `deriva-ml` (library + schema), `deriva-ml-mcp-plugin` (MCP tools)
 
 ## Problem
@@ -19,103 +20,110 @@ The existing execution-query surface filters by **workflow**,
   `deriva_ml_find_workflow_executions`, `deriva_ml_find_experiments`,
   `deriva_ml_list_execution_{children,parents}`,
   `deriva_ml_get_lineage` — none takes a dataset.
-- Resources: `execution/{rid}` is per-execution (forward direction);
-  `lineage/{rid}` walks **producing** executions only and is empty for
-  curated root datasets (every version row has `execution_rid = null`).
 
 Today the only way to get the answer is a hand-built ERMrest query
-against the `Dataset_Execution` association table — the exact
+against the `Dataset_Execution` association table — the
 "drop to `query_attribute`" anti-pattern the getting-started guide warns
-against.
+against. "Which experiments used this data?" is a headline provenance
+question for a reproducibility platform.
 
-"Which experiments used this data?" is a headline provenance question
-for a reproducibility platform — arguably more common than the
-producer-direction question the lineage tools already answer well.
+## Two edge types, two sources of truth (the model)
 
-## Root cause: datasets never got the role/version model assets already have
+A dataset relates to an execution in exactly two ways, and the catalog
+**already records each one in its own authoritative place**:
 
-Investigating the question exposed a deeper, structural asymmetry. The
-catalog records dataset↔execution edges and asset↔execution edges very
-differently:
+| Edge | Meaning | Sole source of truth |
+|------|---------|----------------------|
+| **Output** | execution *produced* version V of the dataset | `Dataset_Version.Execution` — the per-version author FK |
+| **Input** | execution *consumed* the dataset | `Dataset_Execution` association row |
 
-| | Recorded in | Role stored? | Version stored? |
-|---|---|---|---|
-| **Asset** ↔ execution | `{Asset}_Execution` tables (`Image_Execution`, …) | **Yes** — `Asset_Role` FK (`Input`/`Output`) | n/a (assets aren't versioned) |
-| **Output dataset** ↔ execution | `Dataset_Version.Execution` FK | implied (authorship) | **Yes** (the authored version row) |
-| **Input dataset** ↔ execution | `Dataset_Execution` association | **No** | **No** (points at version-agnostic `Dataset`) |
+This is the key design decision (resolving an earlier dual-source-of-truth
+concern): **we keep these as two separate, non-overlapping sources rather
+than mirroring output edges into a `Role` column on `Dataset_Execution`.**
 
-Consequences of this split:
+- `Dataset_Version.Execution` stays the **single** source of truth for
+  "who produced version V." `get_lineage` already uses it
+  (`execution.py:865`); `_producer_of_dataset` already reads it
+  (`execution.py:1032`). The `DatasetHistory` value object
+  (`dataset/aux_classes.py:206`) already models it: `dataset_rid`,
+  `dataset_version`, `version_rid`, and `execution_rid` (nullable — `None`
+  when the version was created outside an execution, e.g. curated
+  datasets like `2-7P5P` whose 29 version rows are all null).
+- `Dataset_Execution` becomes **input-only by definition.** Every row is a
+  consume edge. It gains nothing but a nullable `Dataset_Version` FK to
+  record *which version* was consumed.
 
-1. **Dataset role must be *derived*** (linked-but-not-author = input),
-   instead of read from a column the way `Asset_Role` is.
-2. **Input dataset version is lost** at the catalog level. It survives
-   only inside the execution's `configuration.json` metadata asset
-   (`DatasetSpec.version`, a required field) for config-declared inputs;
-   for lightweight `add_input_dataset` links (e.g. `split_dataset`) it is
-   recorded nowhere.
-3. **Input and output datasets are modeled through two different tables**,
-   so they can't be queried uniformly.
+No `Role` column. No overlap. No drift. No sync burden. The producer
+question is answered by version authorship; the consumer question by the
+association table; "any" is their union.
 
-The principle this design follows: **provenance must be queryable
-catalog data, not reconstructed by parsing a config file.** The
-`configuration.json` asset records what was *requested at launch*; it is
-not the catalog's authoritative model of what an execution used. The
-read path must never fetch or parse it.
+**Principle:** provenance is queryable catalog data, never reconstructed
+by parsing a config file. The `configuration.json` asset records what was
+*requested at launch*; it is not consulted on the read path. (It is read
+exactly once, at migration time, as a best-effort backfill source — see
+remediation.)
 
-The fix is to give datasets the same first-class role/version model that
-assets already have — then read everything relationally.
+## How "what produced a dataset" is determined (precise definition)
+
+`Dataset_Version` is a **per-version** table: one row per
+`(dataset, version)`, each row's `Execution` FK = *"RID of the execution
+that produced this version"* (nullable; `null` = produced outside an
+execution / curated / dev row).
+
+So "executions that produced dataset X" = the set of non-null
+`Dataset_Version.Execution` values across X's version history (read via
+`DatasetHistory`). It is naturally **per-version**:
+
+- `dataset_role="output"`, no version pin → **every** execution that
+  authored **any** version of X.
+- version pinned (via `DatasetSpec`, below) → the execution that authored
+  **that** version.
+
+`_producer_of_dataset`'s "highest-semver version" rule stays an internal
+convenience ("the current producer"); it is **not** the tool's output
+semantics.
 
 ## Design
 
-### Layer 0 — Schema: make `Dataset_Execution` role- and version-aware
+### Layer 0 — Schema: one nullable FK on `Dataset_Execution`
 
-Add two columns to the `deriva-ml:Dataset_Execution` association table:
+Add a single column to `deriva-ml:Dataset_Execution`:
 
-- **`Role`** — FK to the existing `Asset_Role` vocabulary (reused, not a
-  new vocab) carrying `Input` / `Output`. Mirrors `{Asset}_Execution`'s
-  `Asset_Role`.
 - **`Dataset_Version`** — nullable FK to `Dataset_Version.RID`, recording
-  the *exact* version of the dataset involved in this edge.
+  the exact version consumed by this input edge.
 
-The existing `Dataset` FK stays (the version-agnostic "which dataset"
-link, needed for the "any version" query and preserved so every current
-reader keeps working). Both new columns are nullable so pre-existing
-rows remain valid.
+The existing `Dataset` FK stays (version-agnostic "which dataset"). No
+`Role` column. In `schema/create_schema.py`, add the column + FK to the
+`Dataset_Execution` definition (near line 170); in `schema/annotations.py`
+(`visible_foreign_keys`, ~line 525) add the new FK so it renders in
+Chaise. `demo_catalog.py` inherits the change for tests.
 
-This collapses the input/output dataset split: every dataset↔execution
-edge becomes one uniform association row
-`(Dataset, Dataset_Version, Execution, Role)` — structurally identical to
-how `{Asset}_Execution` rows already work. Role stops being derived;
-version becomes native on both sides.
+### Layer 1 — Write path
 
-The output side's existing `Dataset_Version.Execution` authorship FK is
-retained as a convenience mirror (and to avoid a larger rewrite); it is
-no longer the *only* source of output-edge truth.
-
-### Layer 1 — Write path: populate Role + Version at link time
-
-Both writers already have the role and version in hand at link time:
-
-- **`create_dataset`** (output): writes `Role="Output"` and the authored
-  `Dataset_Version` RID on the `Dataset_Execution` row it inserts.
+- **`create_dataset`** (output): **stops** writing a `Dataset_Execution`
+  row (`dataset.py:347`). Output provenance is recorded **only** via
+  `Dataset_Version.Execution` (which `_insert_dataset_versions` already
+  writes). This removes the redundant write that caused the dual-source
+  concern. *(Implementation check: confirm no reader depends on output
+  datasets appearing in a `Dataset_Execution` scan — see Blast radius;
+  `Dataset.list_executions` is the one affected, and the change aligns it
+  with its own docstring.)*
 - **`add_input_dataset(rid, version=…)`** (input): gains an optional
-  `version` and writes `Role="Input"` plus the `Dataset_Version` RID when
-  known. `split_dataset` (the canonical caller) passes the source
-  version it already resolved.
+  `version`; writes the `Dataset_Execution` row with the `Dataset_Version`
+  FK populated when known. `split_dataset` (the canonical caller) passes
+  the source version it already resolved.
 - **Config-declared inputs** (`ExecutionConfiguration.datasets`): the
-  `DatasetSpec.version` (required) is written to the association row at
+  required `DatasetSpec.version` is written to the `Dataset_Version` FK at
   materialization time.
 
-Backward compatibility: `add_input_dataset` keeps working without a
-`version` argument (writes `Role="Input"`, `Dataset_Version=null`).
+Backward compatible: `add_input_dataset(rid)` still works, leaving
+`Dataset_Version=null`.
 
 ### Layer 2 — Library: extend `find_executions`
 
 Extend the existing `DerivaML.find_executions` (in
-`core/mixins/execution.py`) with dataset filters, rather than adding a
-separate method — the dataset filter is structurally identical to the
-existing `workflow_type` association-join filter, returns the same
-`ExecutionRecord` type, and keeps the library method count minimal.
+`core/mixins/execution.py`) rather than adding a method — keeps the
+library minimal and the dataset filter composes with the existing ones.
 
 ```python
 def find_executions(
@@ -123,76 +131,99 @@ def find_executions(
     workflow=None,
     workflow_type=None,
     status=None,
-    dataset=None,            # NEW: RID or Dataset
+    dataset=None,            # NEW: RID | DatasetSpec
     dataset_role="any",      # NEW: "input" | "output" | "any"
-    dataset_version=None,    # NEW: pin to a specific version
     sort=None,
 ) -> Iterable["ExecutionRecord"]
 ```
 
-**Filter mechanics** (now a pure relational read — no role derivation,
-no config parsing):
+**The `dataset` argument is `RID | DatasetSpec`** — reusing the existing
+`DatasetSpec` value object (`dataset/aux_classes.py:312`) that
+`ExecutionConfiguration.datasets` already uses, so a spec from an
+execution config can be passed straight in:
 
-1. `dataset` set → select `Dataset_Execution` rows where
-   `Dataset == dataset_rid`, intersect their `Execution` RIDs into the
-   result set (same pattern as `workflow_type`).
-2. `dataset_role` → filters on the stored `Role` column directly
-   (`"any"` = no filter).
-3. `dataset_version` → filters on the stored `Dataset_Version` FK
-   directly. Now meaningful on **both** sides (no longer output-only),
-   because the column is populated for inputs too.
+- **bare RID** → "this dataset, **any** version."
+- **`DatasetSpec`** → pins the version (`spec.rid` + `spec.version`). The
+  spec's bag-download fields (`materialize`, `timeout`, `exclude_tables`,
+  `fetch_concurrency`, `description`) are **ignored** by the filter; only
+  `rid` + `version` are read. Documented explicitly.
 
-**Guardrails:** `dataset_role`/`dataset_version` without `dataset` →
-`ValueError`.
+There is **no separate `dataset_version` scalar** — version travels
+inside the `DatasetSpec`, eliminating incoherent scalar combinations.
 
-Composes with `workflow` / `workflow_type` / `status` (e.g. "Training
-executions that consumed dataset X at version 2.0.0").
+**Filter mechanics** (pure relational reads — no role derivation, no
+config parsing):
 
-### Layer 3 — Library: unify the role classification (cleanup)
+1. Resolve `dataset` to `(rid, version|None)`.
+2. By role:
+   - `"input"` → `Dataset_Execution` rows where `Dataset == rid`
+     (and `Dataset_Version == version` when pinned).
+   - `"output"` → executions from `Dataset_Version.Execution` across the
+     dataset's history (filtered to the pinned version when set) — read
+     via `DatasetHistory`.
+   - `"any"` → union of the two.
+3. Intersect the resulting execution set with the other active filters
+   (`workflow` / `workflow_type` / `status`), same pattern as
+   `workflow_type` today.
 
-With `Role` stored on the association, `list_input_datasets()` no longer
-needs to *derive* role by excluding produced datasets — it filters
-`Dataset_Execution` on `Role == "Input"`. Refactor it (and the
-symmetric output accessor) to read the column. Internal change; public
-signatures unchanged. Removes the `_producer_of_dataset` derivation as
-the source of truth (kept only as a fallback for legacy null-`Role`
-rows during the transition).
+**Guardrails:** `dataset_role` ≠ `"any"` without `dataset` → `ValueError`.
+
+### Layer 3 — Library: simplify `list_input_datasets`
+
+With `Dataset_Execution` now input-only, `list_input_datasets()` no
+longer needs to *subtract* produced datasets (its current
+`_producer_of_dataset` exclusion) — every row is already an input. It
+becomes a plain read of `Dataset_Execution`. Public signature unchanged;
+internals simplified. (Legacy catalogs: the migration removes the stale
+output rows so this holds for historical data too — see remediation.)
 
 ### Layer 4 — Plugin: two tool surfaces over one library method
 
-Mirrors the existing precedent where
-`deriva_ml_list_executions(workflow_rid=...)` and
-`deriva_ml_find_workflow_executions(...)` both wrap `ml.find_executions`
-via the shared `_list_executions_impl` helper, yet exist as two tools —
-tools are shaped by LLM intent, not 1:1 with library methods.
+Mirrors the precedent where `deriva_ml_list_executions(workflow_rid=...)`
+and `deriva_ml_find_workflow_executions(...)` both wrap
+`ml.find_executions` via the shared `_list_executions_impl` helper yet
+exist as two tools — shaped by LLM intent, not 1:1 with methods.
 
-**A. Extend** `deriva_ml_list_executions` with `dataset`,
-`dataset_role="any"`, `dataset_version`. Forwarded into the extended
-`_list_executions_impl`. When `dataset` is `None`, behavior and response
-shape are identical to today — zero change for existing callers.
+The MCP wire surface can't pass a Python `DatasetSpec`, so the tools take
+scalars and construct the spec internally:
+
+**A. Extend** `deriva_ml_list_executions` with `dataset: str | None`,
+`dataset_role: str = "any"`, `dataset_version: str | None`. When
+`dataset_version` is set, the tool builds `DatasetSpec(rid=dataset,
+version=dataset_version)`; otherwise passes the bare RID. When `dataset`
+is `None`, behavior/shape are identical to today.
 
 **B. Add** `deriva_ml_find_dataset_executions(dataset_rid,
 dataset_role="any", dataset_version=None, status=None, limit, after_rid,
 preflight_count, sort)`. Body shape identical to
-`find_workflow_executions`; calls `_list_executions_impl`. Docstring
-opens with the "Distinct from `deriva_ml_list_executions(dataset=...)`"
-framing.
+`find_workflow_executions`; constructs the spec and calls
+`_list_executions_impl`. Docstring opens with "Distinct from
+`deriva_ml_list_executions(dataset=...)`".
 
 Both share `_list_executions_impl`, so wire shapes cannot drift.
+
+*(The scalar `dataset` + `dataset_version` on the MCP boundary is a
+transport concession — the typed `DatasetSpec` lives in the Python API.
+The tool layer immediately lifts the scalars into a spec, so the
+"incoherent scalar combination" risk is confined to one well-tested
+construction site, not spread across the API.)*
 
 ### Layer 5 — Plugin: response shape
 
 Introduce `DatasetExecutionSummary` extending `ExecutionSummary` with two
-fields read **directly from the association row** (no extra fetch):
+derived fields:
 
-- `dataset_role: "input" | "output"`
-- `dataset_version: str | None` — the stored version. Now populated on
-  **both** sides for new rows; `null` only for legacy rows written before
-  Layer 0, or for `add_input_dataset` calls that supplied no version.
+- `dataset_role: "input" | "output"` — **which source the edge came
+  from** (input = `Dataset_Execution`; output = `Dataset_Version`
+  authorship), not a stored column.
+- `dataset_version: str | None` — the version. For input edges, read from
+  the `Dataset_Execution.Dataset_Version` FK (null for legacy/no-version
+  `add_input_dataset` links). For output edges, the authored version from
+  `DatasetHistory`. No extra catalog fetch beyond the rows already read.
 
 Used only on the dataset-scoped paths (`find_dataset_executions` always;
 `list_executions` only when `dataset` is set). Plain `ExecutionSummary`
-retained otherwise. Wire shape:
+otherwise. Wire shape:
 
 ```json
 {"executions": [{"rid": "...", "workflow_rid": "...", "status": "...",
@@ -202,198 +233,162 @@ retained otherwise. Wire shape:
  "count": N, "truncated": false, "next_after_rid": null}
 ```
 
+## Behavior change to call out
+
+`Dataset.list_executions` (`dataset.py:2426`) is documented as *"all
+executions that used this dataset as **input**"* but currently scans all
+`Dataset_Execution` rows — which today **include** the output rows
+`create_dataset` writes. Making the table input-only (Layer 1) **fixes
+this method to match its own docstring**: it stops returning the
+producing execution. This is an intentional, documented behavior change;
+callers wanting producers use the output side of `find_executions` /
+`get_lineage`.
+
 ## Schema creation update (fresh catalogs)
 
-`schema/create_schema.py` builds `Dataset_Execution` today as a bare
-`(Dataset, Execution)` association (the table is defined via the
-`associates=[("Dataset", …), ("Execution", …)]` helper near
-`create_schema.py:170`). Update the definition to add:
-
-- a **`Role`** column with a `create_reference(asset_role_table)` FK to
-  the `Asset_Role` vocabulary (mirroring how `{Asset}_Execution` tables
-  get their `Asset_Role` reference at `create_schema.py:494`); and
-- a nullable **`Dataset_Version`** column with a `create_reference`
-  / `ForeignKeyDef` to `Dataset_Version.RID` (the same `Dataset_Version`
-  table created in this module).
-
-`schema/annotations.py` (`visible_foreign_keys`, line ~525) gains the two
-new FK constraint names so the columns render in the Chaise UI. The
-fresh-catalog path therefore produces role/version-aware catalogs with no
-migration needed. `demo_catalog.py` (used by the test suite) inherits the
-change automatically.
+`create_schema.py`: add the nullable `Dataset_Version` column + FK to the
+`Dataset_Execution` definition. `annotations.py`: add the FK to
+`visible_foreign_keys`. Fresh catalogs are version-aware with no
+migration; `demo_catalog.py` (test suite) inherits it.
 
 ## Catalog deployment & old-data remediation (existing catalogs)
 
-There is **no migration framework** in `deriva-ml` — schema changes are
-applied imperatively via ERMrest model calls, with standalone scripts in
-`scripts/`. This work ships **one idempotent migration script**,
-modeled on the existing `scripts/migrate_workflow_types.py` (same shape:
-`(hostname, catalog_id)` positional args, `--dry-run`, `--schema`,
-`check_preconditions`, per-step `[SKIP]` guards, a verification pass, and
-a "migration already complete" short-circuit).
+No migration framework exists; changes are applied imperatively via
+standalone scripts in `scripts/`. Ship one idempotent script,
+`scripts/migrate_dataset_execution_version.py`, modeled on
+`scripts/migrate_workflow_types.py` (same shape: `(hostname, catalog_id)`
+args, `--dry-run`, `--schema`, `check_preconditions`, per-step `[SKIP]`
+guards, verification, "already complete" short-circuit).
 
-`scripts/migrate_dataset_execution_role_version.py` steps:
+Steps:
 
-1. **Preconditions:** report whether `Role` / `Dataset_Version` columns
-   and FKs already exist, and count `Dataset_Execution` rows. Short-circuit
-   if already migrated.
-2. **Add columns + FKs** (`Role` → `Asset_Role`, `Dataset_Version` →
-   `Dataset_Version`). Idempotent: `[SKIP]` if present. Additive and
-   nullable, so no existing reader breaks at this step.
-3. **Backfill `Role`** — complete for every existing row via the current
-   authorship rule: a row whose dataset has a `Dataset_Version` authored
-   by this execution → `Output`; otherwise → `Input`. (This is exactly
-   the `_producer_of_dataset` logic `list_input_datasets` uses today, run
-   once over the whole table.)
-4. **Backfill `Dataset_Version`** — best-effort:
-   - **Output rows:** set to the authored `Dataset_Version` RID (known
-     from the authorship link). Complete.
-   - **Input rows, config-declared:** resolve from the execution's
-     `configuration.json` metadata asset (`DatasetSpec.version`) **at
-     migration time only** — this is a one-time backfill, not the steady-
-     state read path (which never touches the config). Best-effort: skip
-     rows whose config asset is missing/unreadable, logging each.
-   - **Input rows from `add_input_dataset`:** **irreducibly `null`** — no
-     version was ever recorded. Reported in the summary as the known gap.
-5. **Verify:** every row has a non-null `Role`; report the count of
-   `Dataset_Version` nulls broken down by cause (legacy
-   `add_input_dataset` vs. unreadable config) so the residual is visible,
-   not silent.
+1. **Preconditions:** report whether the `Dataset_Version` column/FK
+   exists and count rows. Short-circuit if migrated.
+2. **Add column + FK** (idempotent, additive, nullable — no reader breaks
+   at this step).
+3. **Remove stale output rows** — delete `Dataset_Execution` rows that
+   correspond to an *output* edge (the dataset has a `Dataset_Version`
+   authored by that execution). These are the redundant rows
+   `create_dataset` historically wrote; output provenance is preserved in
+   `Dataset_Version.Execution`, so deletion loses no information and
+   de-duplicates the model. **This is the data-remediation core.**
+4. **Backfill input `Dataset_Version`** — best-effort for the remaining
+   (input) rows:
+   - **Config-declared inputs:** resolve the consumed version from the
+     execution's `configuration.json` (`DatasetSpec.version`) — read
+     **at migration time only**, never on the steady-state read path.
+   - **`add_input_dataset` links:** **irreducibly `null`** — no version
+     was ever recorded. Reported in the summary as the known gap.
+5. **Verify:** no output rows remain in `Dataset_Execution`; report the
+   count of `Dataset_Version` nulls by cause (legacy `add_input_dataset`
+   vs. unreadable config) so the residual is visible, not silent.
 
 **Deployment order — dev first, then production:**
 
-1. Run with `--dry-run` against **`dev.eye-ai.org` / eye-ai** (catalog
-   `eye-ai`, ~88 datasets, the `Dataset_Execution` table with the 48-link
-   `2-7P5P` history we already inspected). Review the preview.
-2. Run for real on **dev**. Validate with the new tools end-to-end
-   (`find_dataset_executions` on `2-7P5P`, role/version populated; spot-
-   check a `split_dataset`-origin input row shows `Role="Input"`,
-   `Dataset_Version=null`).
-3. After dev validation, repeat `--dry-run` then real run on
-   **production `eye.rosci.org`** (or the production eye-ai host) — same
-   script, same idempotency guarantees.
-4. The script is safe to re-run; the precondition short-circuit makes a
-   second invocation a no-op.
+1. `--dry-run` on **`dev.eye-ai.org` / eye-ai** (the catalog with the
+   48-link `2-7P5P` history we inspected); review.
+2. Real run on **dev**; validate end-to-end with the new tools
+   (`find_dataset_executions` on `2-7P5P`; confirm a `split_dataset`-origin
+   input row shows `dataset_version=null`; confirm no output rows linger).
+3. `--dry-run` then real run on **production** (`eye.rosci.org` / prod
+   eye-ai) — same script, same idempotency.
+4. Re-runnable: the precondition short-circuit makes a second run a no-op.
 
-**Sequencing constraint:** deploy the schema + backfill **before**
-upgrading the library write path on any client that writes to these
-catalogs, so writers populating the new columns never hit a catalog that
-lacks them. The columns being nullable means an un-upgraded writer
-remains compatible during the rollout window.
+**Sequencing constraint:** deploy schema + remediation **before** the
+library write-path upgrade on any client writing to these catalogs.
+Nullable column ⇒ un-upgraded writers stay compatible during rollout.
 
-**eye-ai-ml repo note:** the eye-ai project keeps catalog-management
-migrations under `eye-ai-ml/scripts/catalog_management/` (e.g. the recent
-junction-table migrations). If the team prefers eye-ai catalog changes to
-live there rather than in `deriva-ml/scripts/`, the generic migration
-script stays in `deriva-ml` and a thin eye-ai wrapper (pinning the two
-hostnames/catalog ids) lives in `catalog_management/`.
+**eye-ai-ml repo note:** eye-ai keeps catalog migrations under
+`eye-ai-ml/scripts/catalog_management/`. The generic script lives in
+`deriva-ml/scripts/`; a thin eye-ai wrapper pinning the two hosts/catalogs
+may live in `catalog_management/` if the team prefers.
 
 ## Blast radius (verified)
 
-- **Writers (2):** `create_dataset` (`dataset.py:347`), input path
-  (`execution.py:658`, `add_input_dataset` at `2007`). Both updated to
-  set `Role` (+ `Dataset_Version`).
-- **Readers (4):** `_helpers.list_input_datasets`,
-  `Dataset.list_executions` (`dataset.py:2426`),
-  `DatasetBag.list_executions` (`dataset_bag.py:906`), and the new
-  filter. All currently select `Dataset`/`Execution` explicitly — none
-  breaks on added columns; `list_input_datasets` is upgraded to read
-  `Role`.
-- **Bag export / offline ORM:** export traverses whole FK-connected
-  tables (`dataset.py:2517`), and the offline SQLite ORM is
-  reflection-based (SQLAlchemy `MetaData`), so the new columns round-trip
-  automatically. Only new code that *reads* them needs writing.
+- **Writers (2):** `create_dataset` (`dataset.py:347`) — *stops* writing
+  the output row; input path (`execution.py:658`, `add_input_dataset` at
+  `2007`) — writes the `Dataset_Version` FK.
+- **Readers (4):** `_helpers.list_input_datasets` (simplified — no more
+  authorship subtraction), `Dataset.list_executions` (`dataset.py:2426`,
+  now correctly input-only — see Behavior change), `DatasetBag.list_executions`
+  (`dataset_bag.py:906`, input-only offline mirror; unchanged query),
+  the new filter. None breaks on an added column.
+- **`get_lineage` / `_producer_of_dataset`:** already read
+  `Dataset_Version.Execution` for producers — **unaffected** and now the
+  sole producer source, exactly as intended.
+- **Bag export / offline ORM:** whole-table FK traversal
+  (`dataset.py:2517`) + reflection-based SQLite ORM ⇒ new column
+  round-trips automatically.
 - **`catalog.py`:** only *excludes* `Dataset_Execution` from asset-table
-  discovery (`find_asset_execution_tables`) — untouched by added columns.
+  discovery — untouched.
 
 ## Unification notes
 
-- **Input datasets ↔ output datasets:** unified by Layer 0 — one
-  association row with a `Role` column, exactly like `{Asset}_Execution`.
-  This is the core of the design, not a side effect.
-- **Output datasets ↔ output assets:** unified at the **API surface**,
-  not storage. They remain different entity kinds (datasets are versioned
-  collections; assets are files), so they keep separate tables. But once
-  datasets carry `Role`, both edges read as `(thing, execution, role)`,
-  making a future unified accessor (`record.list_outputs()`) or an
-  asset-keyed `find_executions(asset=…)` twin a natural follow-on. Out of
-  scope here; noted as the obvious next symmetry.
-- **`list_*` accessor unification** (`list_execution_parents/children`
-  etc.) remains deferred — deliberate naming symmetry with the dataset
-  hierarchy API; a separate breaking refactor / future ADR.
+- **Input ↔ output datasets:** unified at the *query* level —
+  `find_executions(dataset=, dataset_role=)` answers both from their
+  respective canonical sources, with `DatasetSpec` pinning version on
+  either side. Storage stays appropriately separate (authorship vs.
+  association).
+- **Output datasets ↔ output assets:** API-surface symmetry only (an
+  asset-keyed `find_executions(asset=…)` twin is the natural follow-on);
+  different entity kinds keep different tables. Deferred.
+- **`list_*` accessor unification:** deferred (deliberate naming symmetry
+  with the dataset-hierarchy API; future ADR).
 
 ## Testing (new test cases)
 
-New tests are required at every layer; this is not covered by existing
-suites because the role/version columns and the dataset filter are new.
+**Schema creation:** fresh catalog's `Dataset_Execution` has the nullable
+`Dataset_Version` column + FK to `Dataset_Version`.
 
-**Schema creation** (`tests/` against `demo_catalog`):
-- A freshly created catalog's `Dataset_Execution` table has the `Role`
-  and `Dataset_Version` columns and both FKs.
-- The `Role` FK targets `Asset_Role`; `Dataset_Version` FK targets
-  `Dataset_Version` and is nullable.
-
-**Write path** (`tests/test_execution.py` / dataset tests):
-- `create_dataset` writes `Role="Output"` and the authored
-  `Dataset_Version` RID on the association row.
-- `add_input_dataset(rid, version=v)` writes `Role="Input"` and the
-  `Dataset_Version` RID.
-- `add_input_dataset(rid)` (no version) writes `Role="Input"`,
-  `Dataset_Version=null` — backward-compatible signature.
-- `split_dataset` records its source as `Role="Input"` with the resolved
-  source version.
+**Write path:**
+- `create_dataset` writes **no** `Dataset_Execution` row; output
+  provenance present only via `Dataset_Version.Execution`.
+- `add_input_dataset(rid, version=v)` writes the row with `Dataset_Version`
+  set; `add_input_dataset(rid)` leaves it null (back-compat).
+- `split_dataset` records its source input with the resolved version.
 
 **Library read path:**
-- `find_executions(dataset=X)` returns all linked executions;
-  `dataset_role="input"|"output"` filter each return the correct subset;
-  `dataset_version=v` filters on the stored column (both sides).
-- `ValueError` when `dataset_role`/`dataset_version` passed without
-  `dataset`.
-- Composition: `find_executions(dataset=X, workflow_type="Training",
-  status="Uploaded")` intersects correctly.
-- `list_input_datasets()` reads `Role` and returns the same set as the
-  legacy authorship derivation (regression guard), including on a fixture
-  row left with `Role=null` (fallback path still works).
+- `find_executions(dataset=rid)` (any version) returns inputs + outputs
+  (union); `dataset_role="input"|"output"` each return the correct subset
+  from the correct source.
+- `find_executions(dataset=DatasetSpec(rid, version))` filters both sides
+  to that version; bag-download fields on the spec are ignored.
+- `ValueError` when `dataset_role` given without `dataset`.
+- Composition with `workflow_type` / `status`.
+- `list_input_datasets()` returns only inputs (regression: a dataset the
+  execution produced does **not** appear), via the simplified read.
 
-**Migration script** (`tests/` against a seeded demo catalog):
-- Idempotency: a second run is a no-op (`[SKIP]` on every step;
-  "already complete" short-circuit).
-- `--dry-run` makes no changes (preconditions re-checked unchanged after).
-- After a real run: every row has a non-null `Role`; output rows and
-  config-declared input rows have a `Dataset_Version`; an
-  `add_input_dataset`-origin fixture row ends `Dataset_Version=null` and
-  is counted in the residual summary.
-- `Role` backfill matches the authorship rule on a mixed fixture
-  (known inputs, known outputs).
+**Migration script** (seeded demo catalog):
+- Idempotency (second run no-op); `--dry-run` makes no changes.
+- After run: **no output rows remain** in `Dataset_Execution`; input rows
+  from config have a `Dataset_Version`; an `add_input_dataset`-origin row
+  is null and counted in the residual summary.
+- Stale-output-row deletion targets exactly the authored-version rows and
+  leaves input rows intact.
 
-**Plugin** (`tests/test_execution.py` patterns):
-- Both tool surfaces (`list_executions` with `dataset` set;
-  `find_dataset_executions`) return shape-identical payloads via
-  `_list_executions_impl`.
+**Plugin:**
+- Both surfaces share-shape via `_list_executions_impl`.
 - `DatasetExecutionSummary` carries `dataset_role` + `dataset_version`
-  read from the association row with **no extra catalog fetch** (assert no
-  config/Hatrac call).
-- Plain `ExecutionSummary` (no new fields) returned when `dataset` is
-  absent — existing-caller regression guard.
-- Preflight count; `_error_envelope` on bad dataset RID.
+  with **no extra catalog/Hatrac fetch** (asserted).
+- Plain `ExecutionSummary` when `dataset` absent (existing-caller guard).
+- `dataset_version` scalar lifts into a `DatasetSpec` correctly; preflight;
+  `_error_envelope` on bad RID.
 
 ## Implementation order
 
-1. **Schema (library):** update `create_schema.py` to add `Role` +
-   `Dataset_Version` columns/FKs to `Dataset_Execution`; update
-   `annotations.py` visible-FKs. Schema-creation tests.
-2. **Migration script:** `scripts/migrate_dataset_execution_role_version.py`
-   (idempotent, `--dry-run`, backfill + verification), modeled on
-   `migrate_workflow_types.py`. Migration tests against a seeded catalog.
-3. **Catalog deployment:** dry-run → run on **dev** (`dev.eye-ai.org`
-   eye-ai); validate with the new tools; then dry-run → run on
-   **production**. (Schema/backfill lands before client write-path upgrade.)
-4. **Library write path:** `create_dataset`, `add_input_dataset(version=…)`,
-   config-input writer populate the new columns. Write-path tests.
-5. **Library read path:** refactor `list_input_datasets` to read `Role`
-   (authorship fallback for null rows); extend `find_executions` with the
-   dataset filters. Read-path tests.
-6. **Plugin:** extend `_list_executions_impl`; add `DatasetExecutionSummary`;
+1. **Schema:** `create_schema.py` + `annotations.py` add the
+   `Dataset_Version` column/FK. Schema-creation tests.
+2. **Migration script:** `migrate_dataset_execution_version.py` (add FK →
+   delete stale output rows → backfill input version → verify),
+   `--dry-run`, idempotent. Migration tests.
+3. **Catalog deployment:** dev dry-run → dev run → validate → production
+   dry-run → production run. (Before client write-path upgrade.)
+4. **Library write path:** `create_dataset` stops writing the output row;
+   `add_input_dataset(version=…)` + config writer set the FK. Write tests.
+5. **Library read path:** simplify `list_input_datasets`; extend
+   `find_executions` with `dataset: RID|DatasetSpec` + `dataset_role`.
+   Read tests.
+6. **Plugin:** extend `_list_executions_impl`; `DatasetExecutionSummary`;
    extend `deriva_ml_list_executions`; add
    `deriva_ml_find_dataset_executions`. Plugin tests; update the
    getting-started guide's tool menu.

--- a/docs/superpowers/specs/2026-06-02-find-executions-by-dataset-design.md
+++ b/docs/superpowers/specs/2026-06-02-find-executions-by-dataset-design.md
@@ -1,8 +1,8 @@
 # Find Executions by Dataset — Design
 
 **Date:** 2026-06-02
-**Status:** Approved design (pre-implementation)
-**Repos touched:** `deriva-ml` (library), `deriva-ml-mcp-plugin` (MCP tools)
+**Status:** Design — pending review (revised to catalog-native role/version model)
+**Repos touched:** `deriva-ml` (library + schema), `deriva-ml-mcp-plugin` (MCP tools)
 
 ## Problem
 
@@ -26,58 +26,96 @@ The existing execution-query surface filters by **workflow**,
 Today the only way to get the answer is a hand-built ERMrest query
 against the `Dataset_Execution` association table — the exact
 "drop to `query_attribute`" anti-pattern the getting-started guide warns
-against. The capability is one association join; it has simply never
-been surfaced.
+against.
 
 "Which experiments used this data?" is a headline provenance question
 for a reproducibility platform — arguably more common than the
 producer-direction question the lineage tools already answer well.
 
-## Schema constraints (these drive the design)
+## Root cause: datasets never got the role/version model assets already have
 
-`deriva-ml:Dataset_Execution` is a bare many-to-many association:
-columns are just `Dataset` and `Execution` (plus system columns). The
-table comment states it covers both "consume or produce". Critically:
+Investigating the question exposed a deeper, structural asymmetry. The
+catalog records dataset↔execution edges and asset↔execution edges very
+differently:
 
-1. **No role column.** Unlike assets — whose `{Asset}_Execution` rows
-   carry an `Asset_Role` ("Input"/"Output") column that
-   `list_assets(asset_role=...)` filters on directly — `Dataset_Execution`
-   cannot natively distinguish inputs from outputs.
+| | Recorded in | Role stored? | Version stored? |
+|---|---|---|---|
+| **Asset** ↔ execution | `{Asset}_Execution` tables (`Image_Execution`, …) | **Yes** — `Asset_Role` FK (`Input`/`Output`) | n/a (assets aren't versioned) |
+| **Output dataset** ↔ execution | `Dataset_Version.Execution` FK | implied (authorship) | **Yes** (the authored version row) |
+| **Input dataset** ↔ execution | `Dataset_Execution` association | **No** | **No** (points at version-agnostic `Dataset`) |
 
-2. **No version column.** A link records `(Dataset, Execution)` but not
-   *which version* of the dataset was involved.
+Consequences of this split:
 
-The library already has a source of truth for role on the dataset side:
-**`Dataset_Version.Execution` authorship.** An execution *produced*
-(output) a dataset if a `Dataset_Version` row for that dataset points
-its `Execution` FK back at the execution. `list_input_datasets()`
-already relies on exactly this (see
-`execution/_helpers.py::list_input_datasets`, which excludes
-datasets the execution produced via `_producer_of_dataset`).
+1. **Dataset role must be *derived*** (linked-but-not-author = input),
+   instead of read from a column the way `Asset_Role` is.
+2. **Input dataset version is lost** at the catalog level. It survives
+   only inside the execution's `configuration.json` metadata asset
+   (`DatasetSpec.version`, a required field) for config-declared inputs;
+   for lightweight `add_input_dataset` links (e.g. `split_dataset`) it is
+   recorded nowhere.
+3. **Input and output datasets are modeled through two different tables**,
+   so they can't be queried uniformly.
 
-This is why the asset side has a clean `asset_role=` parameter while the
-dataset side has a name-baked `list_input_datasets()` — role is *stored*
-for assets but must be *derived* for datasets. Our design honors that:
-the dataset filter derives role rather than pretending a column exists.
+The principle this design follows: **provenance must be queryable
+catalog data, not reconstructed by parsing a config file.** The
+`configuration.json` asset records what was *requested at launch*; it is
+not the catalog's authoritative model of what an execution used. The
+read path must never fetch or parse it.
+
+The fix is to give datasets the same first-class role/version model that
+assets already have — then read everything relationally.
 
 ## Design
 
-### Layer 1 — Library: extend `find_executions`
+### Layer 0 — Schema: make `Dataset_Execution` role- and version-aware
 
-Rather than add a new method, extend the existing
-`DerivaML.find_executions` (in `core/mixins/execution.py`) with three
-optional, keyword-only dataset filters. This was chosen over a
-standalone `find_dataset_executions` library method because:
+Add two columns to the `deriva-ml:Dataset_Execution` association table:
 
-- The dataset filter is structurally identical to the existing
-  `workflow_type` filter — a join through an association table
-  (`Dataset_Execution`, mirroring `Workflow_Workflow_Type`).
-- It returns the same type (`ExecutionRecord`), unlike `find_experiments`
-  (which returns `Experiment` and earned its own method).
-- Keeps the library method count minimal; one method that already
-  filters executions gains one more filter axis.
+- **`Role`** — FK to the existing `Asset_Role` vocabulary (reused, not a
+  new vocab) carrying `Input` / `Output`. Mirrors `{Asset}_Execution`'s
+  `Asset_Role`.
+- **`Dataset_Version`** — nullable FK to `Dataset_Version.RID`, recording
+  the *exact* version of the dataset involved in this edge.
 
-New signature:
+The existing `Dataset` FK stays (the version-agnostic "which dataset"
+link, needed for the "any version" query and preserved so every current
+reader keeps working). Both new columns are nullable so pre-existing
+rows remain valid.
+
+This collapses the input/output dataset split: every dataset↔execution
+edge becomes one uniform association row
+`(Dataset, Dataset_Version, Execution, Role)` — structurally identical to
+how `{Asset}_Execution` rows already work. Role stops being derived;
+version becomes native on both sides.
+
+The output side's existing `Dataset_Version.Execution` authorship FK is
+retained as a convenience mirror (and to avoid a larger rewrite); it is
+no longer the *only* source of output-edge truth.
+
+### Layer 1 — Write path: populate Role + Version at link time
+
+Both writers already have the role and version in hand at link time:
+
+- **`create_dataset`** (output): writes `Role="Output"` and the authored
+  `Dataset_Version` RID on the `Dataset_Execution` row it inserts.
+- **`add_input_dataset(rid, version=…)`** (input): gains an optional
+  `version` and writes `Role="Input"` plus the `Dataset_Version` RID when
+  known. `split_dataset` (the canonical caller) passes the source
+  version it already resolved.
+- **Config-declared inputs** (`ExecutionConfiguration.datasets`): the
+  `DatasetSpec.version` (required) is written to the association row at
+  materialization time.
+
+Backward compatibility: `add_input_dataset` keeps working without a
+`version` argument (writes `Role="Input"`, `Dataset_Version=null`).
+
+### Layer 2 — Library: extend `find_executions`
+
+Extend the existing `DerivaML.find_executions` (in
+`core/mixins/execution.py`) with dataset filters, rather than adding a
+separate method — the dataset filter is structurally identical to the
+existing `workflow_type` association-join filter, returns the same
+`ExecutionRecord` type, and keeps the library method count minimal.
 
 ```python
 def find_executions(
@@ -85,182 +123,166 @@ def find_executions(
     workflow=None,
     workflow_type=None,
     status=None,
-    dataset=None,            # NEW: RID or Dataset — executions linked to this dataset
+    dataset=None,            # NEW: RID or Dataset
     dataset_role="any",      # NEW: "input" | "output" | "any"
-    dataset_version=None,    # NEW: pin to a specific version (output side only)
+    dataset_version=None,    # NEW: pin to a specific version
     sort=None,
 ) -> Iterable["ExecutionRecord"]
 ```
 
-**Filter mechanics** (mirrors the `workflow_type` association-join +
-set-intersection pattern at execution.py:626-634):
+**Filter mechanics** (now a pure relational read — no role derivation,
+no config parsing):
 
-1. When `dataset` is set, collect candidate `Execution` RIDs from
-   `Dataset_Execution` where `Dataset == dataset_rid`.
-2. Derive role for each candidate via a shared helper (Layer 2): an
-   execution is **output** for the dataset if a `Dataset_Version` row
-   for that dataset has `Execution ==` it; otherwise **input**.
-3. `dataset_role` filters the candidate set:
-   - `"any"` (default) — all linked executions, no role filter.
-   - `"input"` — linked but not a producer of any version.
-   - `"output"` — produced at least one version of the dataset.
-4. `dataset_version`, when set, narrows the **output**-side match to the
-   execution(s) that authored that specific `Dataset_Version`. It does
-   **not** constrain the input side (no per-version link exists), and is
-   a documented no-op when combined with `dataset_role="input"`.
-5. The derived role and authored version travel with each result so the
-   tool layer can surface them without recomputation.
+1. `dataset` set → select `Dataset_Execution` rows where
+   `Dataset == dataset_rid`, intersect their `Execution` RIDs into the
+   result set (same pattern as `workflow_type`).
+2. `dataset_role` → filters on the stored `Role` column directly
+   (`"any"` = no filter).
+3. `dataset_version` → filters on the stored `Dataset_Version` FK
+   directly. Now meaningful on **both** sides (no longer output-only),
+   because the column is populated for inputs too.
 
-**Guardrails:** passing `dataset_role` (≠ "any") or `dataset_version`
-without `dataset` raises `ValueError` (fail fast on a nonsensical
-combination).
+**Guardrails:** `dataset_role`/`dataset_version` without `dataset` →
+`ValueError`.
 
-The existing `workflow` / `workflow_type` / `status` filters compose
-with the dataset filters (e.g. "Training-type executions that consumed
-dataset X"), via the same intersect-into-result-set approach already
-used for `workflow_type`.
+Composes with `workflow` / `workflow_type` / `status` (e.g. "Training
+executions that consumed dataset X at version 2.0.0").
 
-### Layer 2 — Library: shared role-derivation helper
+### Layer 3 — Library: unify the role classification (cleanup)
 
-Factor the "classify a dataset↔execution link by role" logic into
-`execution/_helpers.py`, consumed by **both**:
+With `Role` stored on the association, `list_input_datasets()` no longer
+needs to *derive* role by excluding produced datasets — it filters
+`Dataset_Execution` on `Role == "Input"`. Refactor it (and the
+symmetric output accessor) to read the column. Internal change; public
+signatures unchanged. Removes the `_producer_of_dataset` derivation as
+the source of truth (kept only as a fallback for legacy null-`Role`
+rows during the transition).
 
-- the new `find_executions` dataset filter, and
-- the existing `list_input_datasets()` (which currently inlines the
-  "exclude produced datasets" logic via `_producer_of_dataset`).
+### Layer 4 — Plugin: two tool surfaces over one library method
 
-This is an **internal DRY refactor — no public signature changes** to
-`list_input_datasets()`. The helper returns, for a `(dataset, candidate
-executions)` pair, each execution's derived role plus the authored
-version (where it is a producer). Both call sites consume the same
-classification so they cannot drift.
+Mirrors the existing precedent where
+`deriva_ml_list_executions(workflow_rid=...)` and
+`deriva_ml_find_workflow_executions(...)` both wrap `ml.find_executions`
+via the shared `_list_executions_impl` helper, yet exist as two tools —
+tools are shaped by LLM intent, not 1:1 with library methods.
 
-### Layer 3 — Plugin: two tool surfaces over one library method
+**A. Extend** `deriva_ml_list_executions` with `dataset`,
+`dataset_role="any"`, `dataset_version`. Forwarded into the extended
+`_list_executions_impl`. When `dataset` is `None`, behavior and response
+shape are identical to today — zero change for existing callers.
 
-Mirrors the existing precedent where `deriva_ml_list_executions(
-workflow_rid=...)` and `deriva_ml_find_workflow_executions(...)` both
-wrap `ml.find_executions` via the shared `_list_executions_impl` helper,
-yet exist as two tools — tools are shaped by **LLM intent**, not by 1:1
-correspondence to library methods.
+**B. Add** `deriva_ml_find_dataset_executions(dataset_rid,
+dataset_role="any", dataset_version=None, status=None, limit, after_rid,
+preflight_count, sort)`. Body shape identical to
+`find_workflow_executions`; calls `_list_executions_impl`. Docstring
+opens with the "Distinct from `deriva_ml_list_executions(dataset=...)`"
+framing.
 
-**A. Extend the browser** `deriva_ml_list_executions`:
-Add `dataset: str | None = None`, `dataset_role: str = "any"`,
-`dataset_version: str | None = None` alongside the current filters.
-They forward into the (extended) `_list_executions_impl` →
-`ml.find_executions(...)`. Combinable with the existing filters. When
-`dataset` is `None`, behavior and response shape are **identical to
-today** — zero change for existing callers. The preflight branch picks
-up the new filters for free.
+Both share `_list_executions_impl`, so wire shapes cannot drift.
 
-**B. Add the intent tool** `deriva_ml_find_dataset_executions`:
+### Layer 5 — Plugin: response shape
 
-```python
-@ctx.tool(mutates=False)
-async def deriva_ml_find_dataset_executions(
-    hostname: str, catalog_id: str,
-    dataset_rid: str,
-    dataset_role: str = "any",          # "input" | "output" | "any"
-    dataset_version: str | None = None,
-    status: str | None = None,
-    limit: int = 100,
-    after_rid: str | None = None,
-    preflight_count: bool = False,
-    sort: bool = False,
-) -> str
-```
+Introduce `DatasetExecutionSummary` extending `ExecutionSummary` with two
+fields read **directly from the association row** (no extra fetch):
 
-Body shape identical to `deriva_ml_find_workflow_executions`:
-`asyncio.to_thread(_pkg.get_ml, …)` inside `with deriva_call():`, drain
-the generator in the worker thread, `_paginate`,
-`_error_envelope(operation="find_dataset_executions", audit=False)`.
-Calls `_list_executions_impl(dataset=dataset_rid, dataset_role=...,
-dataset_version=...)`. Preflight message:
-`"Found N executions that <role> dataset {dataset_rid}. Choose a
-limit…"`.
+- `dataset_role: "input" | "output"`
+- `dataset_version: str | None` — the stored version. Now populated on
+  **both** sides for new rows; `null` only for legacy rows written before
+  Layer 0, or for `add_input_dataset` calls that supplied no version.
 
-Docstring opens with the "Distinct from
-`deriva_ml_list_executions(dataset=...)`" framing (mirroring the
-workflow tool) and carries the two caveats below.
-
-Both surfaces share `_list_executions_impl`, so their wire shapes cannot
-drift — the same guarantee the workflow pair relies on.
-
-### Layer 4 — Plugin: response shape
-
-Introduce `DatasetExecutionSummary` extending the existing
-`ExecutionSummary` (in `_response_models.py`) with two derived fields:
-
-- `dataset_role: "input" | "output"` — the per-execution derived role.
-- `dataset_version: str | None` — the dataset version the execution is
-  associated with. **Populated on the output side** (authored version
-  known via `Dataset_Version`); **`null` on the input side**
-  (`Dataset_Execution` has no per-version link, so the consumed version
-  cannot be determined without deeper inference).
-
-Used **only** on the dataset-scoped paths:
-- `deriva_ml_find_dataset_executions` always.
-- `deriva_ml_list_executions` only when `dataset` is set.
-
-When `dataset` is not set, `deriva_ml_list_executions` returns the plain
-`ExecutionSummary` exactly as today. Wire shape:
+Used only on the dataset-scoped paths (`find_dataset_executions` always;
+`list_executions` only when `dataset` is set). Plain `ExecutionSummary`
+retained otherwise. Wire shape:
 
 ```json
 {"executions": [{"rid": "...", "workflow_rid": "...", "status": "...",
   "description": "...", "start_time": "...", "stop_time": "...",
-  "duration": "...", "dataset_role": "input", "dataset_version": null}],
+  "duration": "...", "dataset_role": "input",
+  "dataset_version": "2.0.0"}],
  "count": N, "truncated": false, "next_after_rid": null}
 ```
 
-## Documented caveats (must appear in tool/method docstrings)
+## Migration
 
-1. **Role is derived, not stored.** `dataset_role` is computed from
-   `Dataset_Version` authorship — an execution is `output` if it authored
-   a version of the dataset, otherwise `input`. There is no role column
-   on `Dataset_Execution`.
-2. **Version pinning is output-side only.** `dataset_version` constrains
-   only the producing (output) side; on the input side it is a no-op,
-   and the returned `dataset_version` is `null` for input executions.
+There is **no migration framework** in `deriva-ml` (the `schema/` package
+has only `create_schema.py` for fresh-catalog DDL and `annotations.py`).
+Schema changes are applied imperatively via ERMrest column/FK calls.
 
-## Out of scope (deferred)
+- **New catalogs:** add the two columns + FKs in `create_schema.py`.
+- **Existing catalogs** (e.g. `dev.eye-ai.org`): a one-shot upgrade
+  script adds the `Role` + `Dataset_Version` columns and FKs, then
+  **best-effort backfills**:
+  - `Role`: derivable for every existing row via the current authorship
+    rule (`Dataset_Version.Execution` authorship → `Output`, else
+    `Input`). Backfill is complete.
+  - `Dataset_Version`: backfillable for **output** rows (the authored
+    version is known) and for **config-declared inputs** where the
+    historical `configuration.json` is still readable. **Irreducibly
+    `null`** for legacy `add_input_dataset` links that never recorded a
+    version. This is a one-time historical gap; all new writes are clean.
+- **Chaise annotations** (`annotations.py:525-526`): the existing
+  `visible_foreign_keys` lists the two current FK constraint names; the
+  new FKs are additive. Optionally add the `Role` / `Dataset_Version` FKs
+  so they render in the Chaise UI (cosmetic).
 
-**Unifying the `list_*` relation accessors** (`list_input_datasets`,
-`list_assets`, `list_execution_parents`, `list_execution_children`).
-These already share parameterized helpers underneath
-(`fetch_nested_execution_rows(direction=...)`,
-`list_assets(asset_role=...)`); the duplication is confined to thin
-public façades. The `parents`/`children` split is a deliberate naming
-mirror of `list_dataset_parents`/`list_dataset_children`, established in
-a documented "R5.1 hard cutover" with no compat alias. Collapsing the
-execution pair alone would break that symmetry and cascade into the
-dataset API. This is a separate, breaking refactor — a candidate future
-ADR, not part of this additive change.
+## Blast radius (verified)
 
-An **asset-keyed twin** (`find_executions(asset=...)`) is the obvious
-future symmetric capability; this design's parameter-naming convention
-(`dataset_role` mirroring `asset_role`) is chosen to make that twin a
-natural follow-on.
+- **Writers (2):** `create_dataset` (`dataset.py:347`), input path
+  (`execution.py:658`, `add_input_dataset` at `2007`). Both updated to
+  set `Role` (+ `Dataset_Version`).
+- **Readers (4):** `_helpers.list_input_datasets`,
+  `Dataset.list_executions` (`dataset.py:2426`),
+  `DatasetBag.list_executions` (`dataset_bag.py:906`), and the new
+  filter. All currently select `Dataset`/`Execution` explicitly — none
+  breaks on added columns; `list_input_datasets` is upgraded to read
+  `Role`.
+- **Bag export / offline ORM:** export traverses whole FK-connected
+  tables (`dataset.py:2517`), and the offline SQLite ORM is
+  reflection-based (SQLAlchemy `MetaData`), so the new columns round-trip
+  automatically. Only new code that *reads* them needs writing.
+- **`catalog.py`:** only *excludes* `Dataset_Execution` from asset-table
+  discovery (`find_asset_execution_tables`) — untouched by added columns.
+
+## Unification notes
+
+- **Input datasets ↔ output datasets:** unified by Layer 0 — one
+  association row with a `Role` column, exactly like `{Asset}_Execution`.
+  This is the core of the design, not a side effect.
+- **Output datasets ↔ output assets:** unified at the **API surface**,
+  not storage. They remain different entity kinds (datasets are versioned
+  collections; assets are files), so they keep separate tables. But once
+  datasets carry `Role`, both edges read as `(thing, execution, role)`,
+  making a future unified accessor (`record.list_outputs()`) or an
+  asset-keyed `find_executions(asset=…)` twin a natural follow-on. Out of
+  scope here; noted as the obvious next symmetry.
+- **`list_*` accessor unification** (`list_execution_parents/children`
+  etc.) remains deferred — deliberate naming symmetry with the dataset
+  hierarchy API; a separate breaking refactor / future ADR.
 
 ## Testing
 
-- **Library unit tests** (`tests/`): `find_executions` with each
-  `dataset_role` value against a fixture catalog with known
-  input-only, output-only, and both-role executions; `dataset_version`
-  output-side pinning; `ValueError` guardrails; composition with
-  `status`/`workflow_type`. Assert the shared helper produces identical
-  role classification as `list_input_datasets()` for the input case.
-- **Plugin tests** (`tests/test_execution.py` patterns): both tool
-  surfaces return shape-identical payloads via `_list_executions_impl`;
-  `dataset_role`/`dataset_version` surfaced on `DatasetExecutionSummary`;
-  plain `ExecutionSummary` retained when `dataset` is absent; preflight
-  counts; `_error_envelope` on bad RID.
+- **Schema/migration:** upgrade script adds columns + FKs idempotently;
+  backfill assigns correct `Role` to every existing row and
+  `Dataset_Version` where recoverable; `add_input_dataset` legacy rows
+  end up `Role="Input"`, `Dataset_Version=null`.
+- **Library:** `find_executions` with each `dataset_role`;
+  `dataset_version` filtering on both sides; `ValueError` guardrails;
+  composition with `status`/`workflow_type`; `list_input_datasets` reads
+  `Role` and matches legacy derivation on null-`Role` rows.
+- **Plugin:** both tool surfaces share-shape via `_list_executions_impl`;
+  `DatasetExecutionSummary` carries `dataset_role` + `dataset_version`
+  from the association row with no extra fetch; plain summary retained
+  when `dataset` absent; preflight; `_error_envelope` on bad RID.
 
 ## Implementation order
 
-1. Library: shared role-derivation helper in `execution/_helpers.py`;
-   refactor `list_input_datasets()` to consume it (no API change).
-2. Library: extend `find_executions` with the three params + guardrails.
-3. Plugin: extend `_list_executions_impl` to forward the dataset params.
-4. Plugin: `DatasetExecutionSummary` response model.
-5. Plugin: extend `deriva_ml_list_executions`; add
+1. Schema: add `Role` + `Dataset_Version` columns/FKs (`create_schema.py`
+   + standalone upgrade/backfill script).
+2. Library write path: `create_dataset`, `add_input_dataset(version=…)`,
+   config-input writer populate the new columns.
+3. Library read path: refactor `list_input_datasets` to read `Role`;
+   extend `find_executions` with the dataset filters.
+4. Plugin: extend `_list_executions_impl`; `DatasetExecutionSummary`;
+   extend `deriva_ml_list_executions`; add
    `deriva_ml_find_dataset_executions`.
-6. Tests at both layers; update the getting-started guide's tool menu.
+5. Tests at every layer; update the getting-started guide's tool menu.

--- a/docs/superpowers/specs/2026-06-02-find-executions-by-dataset-design.md
+++ b/docs/superpowers/specs/2026-06-02-find-executions-by-dataset-design.md
@@ -1,0 +1,266 @@
+# Find Executions by Dataset — Design
+
+**Date:** 2026-06-02
+**Status:** Approved design (pre-implementation)
+**Repos touched:** `deriva-ml` (library), `deriva-ml-mcp-plugin` (MCP tools)
+
+## Problem
+
+There is no first-class way to answer **"which executions used dataset
+X?"** — neither in the `deriva-ml` Python library nor in the
+`deriva-ml-mcp-plugin` MCP surface.
+
+The existing execution-query surface filters by **workflow**,
+**workflow type**, or **status** only:
+
+- Library: `DerivaML.find_executions(workflow, workflow_type, status, sort)`
+  — no dataset parameter.
+- Plugin tools: `deriva_ml_list_executions`,
+  `deriva_ml_find_workflow_executions`, `deriva_ml_find_experiments`,
+  `deriva_ml_list_execution_{children,parents}`,
+  `deriva_ml_get_lineage` — none takes a dataset.
+- Resources: `execution/{rid}` is per-execution (forward direction);
+  `lineage/{rid}` walks **producing** executions only and is empty for
+  curated root datasets (every version row has `execution_rid = null`).
+
+Today the only way to get the answer is a hand-built ERMrest query
+against the `Dataset_Execution` association table — the exact
+"drop to `query_attribute`" anti-pattern the getting-started guide warns
+against. The capability is one association join; it has simply never
+been surfaced.
+
+"Which experiments used this data?" is a headline provenance question
+for a reproducibility platform — arguably more common than the
+producer-direction question the lineage tools already answer well.
+
+## Schema constraints (these drive the design)
+
+`deriva-ml:Dataset_Execution` is a bare many-to-many association:
+columns are just `Dataset` and `Execution` (plus system columns). The
+table comment states it covers both "consume or produce". Critically:
+
+1. **No role column.** Unlike assets — whose `{Asset}_Execution` rows
+   carry an `Asset_Role` ("Input"/"Output") column that
+   `list_assets(asset_role=...)` filters on directly — `Dataset_Execution`
+   cannot natively distinguish inputs from outputs.
+
+2. **No version column.** A link records `(Dataset, Execution)` but not
+   *which version* of the dataset was involved.
+
+The library already has a source of truth for role on the dataset side:
+**`Dataset_Version.Execution` authorship.** An execution *produced*
+(output) a dataset if a `Dataset_Version` row for that dataset points
+its `Execution` FK back at the execution. `list_input_datasets()`
+already relies on exactly this (see
+`execution/_helpers.py::list_input_datasets`, which excludes
+datasets the execution produced via `_producer_of_dataset`).
+
+This is why the asset side has a clean `asset_role=` parameter while the
+dataset side has a name-baked `list_input_datasets()` — role is *stored*
+for assets but must be *derived* for datasets. Our design honors that:
+the dataset filter derives role rather than pretending a column exists.
+
+## Design
+
+### Layer 1 — Library: extend `find_executions`
+
+Rather than add a new method, extend the existing
+`DerivaML.find_executions` (in `core/mixins/execution.py`) with three
+optional, keyword-only dataset filters. This was chosen over a
+standalone `find_dataset_executions` library method because:
+
+- The dataset filter is structurally identical to the existing
+  `workflow_type` filter — a join through an association table
+  (`Dataset_Execution`, mirroring `Workflow_Workflow_Type`).
+- It returns the same type (`ExecutionRecord`), unlike `find_experiments`
+  (which returns `Experiment` and earned its own method).
+- Keeps the library method count minimal; one method that already
+  filters executions gains one more filter axis.
+
+New signature:
+
+```python
+def find_executions(
+    self,
+    workflow=None,
+    workflow_type=None,
+    status=None,
+    dataset=None,            # NEW: RID or Dataset — executions linked to this dataset
+    dataset_role="any",      # NEW: "input" | "output" | "any"
+    dataset_version=None,    # NEW: pin to a specific version (output side only)
+    sort=None,
+) -> Iterable["ExecutionRecord"]
+```
+
+**Filter mechanics** (mirrors the `workflow_type` association-join +
+set-intersection pattern at execution.py:626-634):
+
+1. When `dataset` is set, collect candidate `Execution` RIDs from
+   `Dataset_Execution` where `Dataset == dataset_rid`.
+2. Derive role for each candidate via a shared helper (Layer 2): an
+   execution is **output** for the dataset if a `Dataset_Version` row
+   for that dataset has `Execution ==` it; otherwise **input**.
+3. `dataset_role` filters the candidate set:
+   - `"any"` (default) — all linked executions, no role filter.
+   - `"input"` — linked but not a producer of any version.
+   - `"output"` — produced at least one version of the dataset.
+4. `dataset_version`, when set, narrows the **output**-side match to the
+   execution(s) that authored that specific `Dataset_Version`. It does
+   **not** constrain the input side (no per-version link exists), and is
+   a documented no-op when combined with `dataset_role="input"`.
+5. The derived role and authored version travel with each result so the
+   tool layer can surface them without recomputation.
+
+**Guardrails:** passing `dataset_role` (≠ "any") or `dataset_version`
+without `dataset` raises `ValueError` (fail fast on a nonsensical
+combination).
+
+The existing `workflow` / `workflow_type` / `status` filters compose
+with the dataset filters (e.g. "Training-type executions that consumed
+dataset X"), via the same intersect-into-result-set approach already
+used for `workflow_type`.
+
+### Layer 2 — Library: shared role-derivation helper
+
+Factor the "classify a dataset↔execution link by role" logic into
+`execution/_helpers.py`, consumed by **both**:
+
+- the new `find_executions` dataset filter, and
+- the existing `list_input_datasets()` (which currently inlines the
+  "exclude produced datasets" logic via `_producer_of_dataset`).
+
+This is an **internal DRY refactor — no public signature changes** to
+`list_input_datasets()`. The helper returns, for a `(dataset, candidate
+executions)` pair, each execution's derived role plus the authored
+version (where it is a producer). Both call sites consume the same
+classification so they cannot drift.
+
+### Layer 3 — Plugin: two tool surfaces over one library method
+
+Mirrors the existing precedent where `deriva_ml_list_executions(
+workflow_rid=...)` and `deriva_ml_find_workflow_executions(...)` both
+wrap `ml.find_executions` via the shared `_list_executions_impl` helper,
+yet exist as two tools — tools are shaped by **LLM intent**, not by 1:1
+correspondence to library methods.
+
+**A. Extend the browser** `deriva_ml_list_executions`:
+Add `dataset: str | None = None`, `dataset_role: str = "any"`,
+`dataset_version: str | None = None` alongside the current filters.
+They forward into the (extended) `_list_executions_impl` →
+`ml.find_executions(...)`. Combinable with the existing filters. When
+`dataset` is `None`, behavior and response shape are **identical to
+today** — zero change for existing callers. The preflight branch picks
+up the new filters for free.
+
+**B. Add the intent tool** `deriva_ml_find_dataset_executions`:
+
+```python
+@ctx.tool(mutates=False)
+async def deriva_ml_find_dataset_executions(
+    hostname: str, catalog_id: str,
+    dataset_rid: str,
+    dataset_role: str = "any",          # "input" | "output" | "any"
+    dataset_version: str | None = None,
+    status: str | None = None,
+    limit: int = 100,
+    after_rid: str | None = None,
+    preflight_count: bool = False,
+    sort: bool = False,
+) -> str
+```
+
+Body shape identical to `deriva_ml_find_workflow_executions`:
+`asyncio.to_thread(_pkg.get_ml, …)` inside `with deriva_call():`, drain
+the generator in the worker thread, `_paginate`,
+`_error_envelope(operation="find_dataset_executions", audit=False)`.
+Calls `_list_executions_impl(dataset=dataset_rid, dataset_role=...,
+dataset_version=...)`. Preflight message:
+`"Found N executions that <role> dataset {dataset_rid}. Choose a
+limit…"`.
+
+Docstring opens with the "Distinct from
+`deriva_ml_list_executions(dataset=...)`" framing (mirroring the
+workflow tool) and carries the two caveats below.
+
+Both surfaces share `_list_executions_impl`, so their wire shapes cannot
+drift — the same guarantee the workflow pair relies on.
+
+### Layer 4 — Plugin: response shape
+
+Introduce `DatasetExecutionSummary` extending the existing
+`ExecutionSummary` (in `_response_models.py`) with two derived fields:
+
+- `dataset_role: "input" | "output"` — the per-execution derived role.
+- `dataset_version: str | None` — the dataset version the execution is
+  associated with. **Populated on the output side** (authored version
+  known via `Dataset_Version`); **`null` on the input side**
+  (`Dataset_Execution` has no per-version link, so the consumed version
+  cannot be determined without deeper inference).
+
+Used **only** on the dataset-scoped paths:
+- `deriva_ml_find_dataset_executions` always.
+- `deriva_ml_list_executions` only when `dataset` is set.
+
+When `dataset` is not set, `deriva_ml_list_executions` returns the plain
+`ExecutionSummary` exactly as today. Wire shape:
+
+```json
+{"executions": [{"rid": "...", "workflow_rid": "...", "status": "...",
+  "description": "...", "start_time": "...", "stop_time": "...",
+  "duration": "...", "dataset_role": "input", "dataset_version": null}],
+ "count": N, "truncated": false, "next_after_rid": null}
+```
+
+## Documented caveats (must appear in tool/method docstrings)
+
+1. **Role is derived, not stored.** `dataset_role` is computed from
+   `Dataset_Version` authorship — an execution is `output` if it authored
+   a version of the dataset, otherwise `input`. There is no role column
+   on `Dataset_Execution`.
+2. **Version pinning is output-side only.** `dataset_version` constrains
+   only the producing (output) side; on the input side it is a no-op,
+   and the returned `dataset_version` is `null` for input executions.
+
+## Out of scope (deferred)
+
+**Unifying the `list_*` relation accessors** (`list_input_datasets`,
+`list_assets`, `list_execution_parents`, `list_execution_children`).
+These already share parameterized helpers underneath
+(`fetch_nested_execution_rows(direction=...)`,
+`list_assets(asset_role=...)`); the duplication is confined to thin
+public façades. The `parents`/`children` split is a deliberate naming
+mirror of `list_dataset_parents`/`list_dataset_children`, established in
+a documented "R5.1 hard cutover" with no compat alias. Collapsing the
+execution pair alone would break that symmetry and cascade into the
+dataset API. This is a separate, breaking refactor — a candidate future
+ADR, not part of this additive change.
+
+An **asset-keyed twin** (`find_executions(asset=...)`) is the obvious
+future symmetric capability; this design's parameter-naming convention
+(`dataset_role` mirroring `asset_role`) is chosen to make that twin a
+natural follow-on.
+
+## Testing
+
+- **Library unit tests** (`tests/`): `find_executions` with each
+  `dataset_role` value against a fixture catalog with known
+  input-only, output-only, and both-role executions; `dataset_version`
+  output-side pinning; `ValueError` guardrails; composition with
+  `status`/`workflow_type`. Assert the shared helper produces identical
+  role classification as `list_input_datasets()` for the input case.
+- **Plugin tests** (`tests/test_execution.py` patterns): both tool
+  surfaces return shape-identical payloads via `_list_executions_impl`;
+  `dataset_role`/`dataset_version` surfaced on `DatasetExecutionSummary`;
+  plain `ExecutionSummary` retained when `dataset` is absent; preflight
+  counts; `_error_envelope` on bad RID.
+
+## Implementation order
+
+1. Library: shared role-derivation helper in `execution/_helpers.py`;
+   refactor `list_input_datasets()` to consume it (no API change).
+2. Library: extend `find_executions` with the three params + guardrails.
+3. Plugin: extend `_list_executions_impl` to forward the dataset params.
+4. Plugin: `DatasetExecutionSummary` response model.
+5. Plugin: extend `deriva_ml_list_executions`; add
+   `deriva_ml_find_dataset_executions`.
+6. Tests at both layers; update the getting-started guide's tool menu.

--- a/docs/superpowers/specs/2026-06-02-find-executions-by-dataset-design.md
+++ b/docs/superpowers/specs/2026-06-02-find-executions-by-dataset-design.md
@@ -202,28 +202,91 @@ retained otherwise. Wire shape:
  "count": N, "truncated": false, "next_after_rid": null}
 ```
 
-## Migration
+## Schema creation update (fresh catalogs)
 
-There is **no migration framework** in `deriva-ml` (the `schema/` package
-has only `create_schema.py` for fresh-catalog DDL and `annotations.py`).
-Schema changes are applied imperatively via ERMrest column/FK calls.
+`schema/create_schema.py` builds `Dataset_Execution` today as a bare
+`(Dataset, Execution)` association (the table is defined via the
+`associates=[("Dataset", …), ("Execution", …)]` helper near
+`create_schema.py:170`). Update the definition to add:
 
-- **New catalogs:** add the two columns + FKs in `create_schema.py`.
-- **Existing catalogs** (e.g. `dev.eye-ai.org`): a one-shot upgrade
-  script adds the `Role` + `Dataset_Version` columns and FKs, then
-  **best-effort backfills**:
-  - `Role`: derivable for every existing row via the current authorship
-    rule (`Dataset_Version.Execution` authorship → `Output`, else
-    `Input`). Backfill is complete.
-  - `Dataset_Version`: backfillable for **output** rows (the authored
-    version is known) and for **config-declared inputs** where the
-    historical `configuration.json` is still readable. **Irreducibly
-    `null`** for legacy `add_input_dataset` links that never recorded a
-    version. This is a one-time historical gap; all new writes are clean.
-- **Chaise annotations** (`annotations.py:525-526`): the existing
-  `visible_foreign_keys` lists the two current FK constraint names; the
-  new FKs are additive. Optionally add the `Role` / `Dataset_Version` FKs
-  so they render in the Chaise UI (cosmetic).
+- a **`Role`** column with a `create_reference(asset_role_table)` FK to
+  the `Asset_Role` vocabulary (mirroring how `{Asset}_Execution` tables
+  get their `Asset_Role` reference at `create_schema.py:494`); and
+- a nullable **`Dataset_Version`** column with a `create_reference`
+  / `ForeignKeyDef` to `Dataset_Version.RID` (the same `Dataset_Version`
+  table created in this module).
+
+`schema/annotations.py` (`visible_foreign_keys`, line ~525) gains the two
+new FK constraint names so the columns render in the Chaise UI. The
+fresh-catalog path therefore produces role/version-aware catalogs with no
+migration needed. `demo_catalog.py` (used by the test suite) inherits the
+change automatically.
+
+## Catalog deployment & old-data remediation (existing catalogs)
+
+There is **no migration framework** in `deriva-ml` — schema changes are
+applied imperatively via ERMrest model calls, with standalone scripts in
+`scripts/`. This work ships **one idempotent migration script**,
+modeled on the existing `scripts/migrate_workflow_types.py` (same shape:
+`(hostname, catalog_id)` positional args, `--dry-run`, `--schema`,
+`check_preconditions`, per-step `[SKIP]` guards, a verification pass, and
+a "migration already complete" short-circuit).
+
+`scripts/migrate_dataset_execution_role_version.py` steps:
+
+1. **Preconditions:** report whether `Role` / `Dataset_Version` columns
+   and FKs already exist, and count `Dataset_Execution` rows. Short-circuit
+   if already migrated.
+2. **Add columns + FKs** (`Role` → `Asset_Role`, `Dataset_Version` →
+   `Dataset_Version`). Idempotent: `[SKIP]` if present. Additive and
+   nullable, so no existing reader breaks at this step.
+3. **Backfill `Role`** — complete for every existing row via the current
+   authorship rule: a row whose dataset has a `Dataset_Version` authored
+   by this execution → `Output`; otherwise → `Input`. (This is exactly
+   the `_producer_of_dataset` logic `list_input_datasets` uses today, run
+   once over the whole table.)
+4. **Backfill `Dataset_Version`** — best-effort:
+   - **Output rows:** set to the authored `Dataset_Version` RID (known
+     from the authorship link). Complete.
+   - **Input rows, config-declared:** resolve from the execution's
+     `configuration.json` metadata asset (`DatasetSpec.version`) **at
+     migration time only** — this is a one-time backfill, not the steady-
+     state read path (which never touches the config). Best-effort: skip
+     rows whose config asset is missing/unreadable, logging each.
+   - **Input rows from `add_input_dataset`:** **irreducibly `null`** — no
+     version was ever recorded. Reported in the summary as the known gap.
+5. **Verify:** every row has a non-null `Role`; report the count of
+   `Dataset_Version` nulls broken down by cause (legacy
+   `add_input_dataset` vs. unreadable config) so the residual is visible,
+   not silent.
+
+**Deployment order — dev first, then production:**
+
+1. Run with `--dry-run` against **`dev.eye-ai.org` / eye-ai** (catalog
+   `eye-ai`, ~88 datasets, the `Dataset_Execution` table with the 48-link
+   `2-7P5P` history we already inspected). Review the preview.
+2. Run for real on **dev**. Validate with the new tools end-to-end
+   (`find_dataset_executions` on `2-7P5P`, role/version populated; spot-
+   check a `split_dataset`-origin input row shows `Role="Input"`,
+   `Dataset_Version=null`).
+3. After dev validation, repeat `--dry-run` then real run on
+   **production `eye.rosci.org`** (or the production eye-ai host) — same
+   script, same idempotency guarantees.
+4. The script is safe to re-run; the precondition short-circuit makes a
+   second invocation a no-op.
+
+**Sequencing constraint:** deploy the schema + backfill **before**
+upgrading the library write path on any client that writes to these
+catalogs, so writers populating the new columns never hit a catalog that
+lacks them. The columns being nullable means an un-upgraded writer
+remains compatible during the rollout window.
+
+**eye-ai-ml repo note:** the eye-ai project keeps catalog-management
+migrations under `eye-ai-ml/scripts/catalog_management/` (e.g. the recent
+junction-table migrations). If the team prefers eye-ai catalog changes to
+live there rather than in `deriva-ml/scripts/`, the generic migration
+script stays in `deriva-ml` and a thin eye-ai wrapper (pinning the two
+hostnames/catalog ids) lives in `catalog_management/`.
 
 ## Blast radius (verified)
 
@@ -259,30 +322,78 @@ Schema changes are applied imperatively via ERMrest column/FK calls.
   etc.) remains deferred — deliberate naming symmetry with the dataset
   hierarchy API; a separate breaking refactor / future ADR.
 
-## Testing
+## Testing (new test cases)
 
-- **Schema/migration:** upgrade script adds columns + FKs idempotently;
-  backfill assigns correct `Role` to every existing row and
-  `Dataset_Version` where recoverable; `add_input_dataset` legacy rows
-  end up `Role="Input"`, `Dataset_Version=null`.
-- **Library:** `find_executions` with each `dataset_role`;
-  `dataset_version` filtering on both sides; `ValueError` guardrails;
-  composition with `status`/`workflow_type`; `list_input_datasets` reads
-  `Role` and matches legacy derivation on null-`Role` rows.
-- **Plugin:** both tool surfaces share-shape via `_list_executions_impl`;
-  `DatasetExecutionSummary` carries `dataset_role` + `dataset_version`
-  from the association row with no extra fetch; plain summary retained
-  when `dataset` absent; preflight; `_error_envelope` on bad RID.
+New tests are required at every layer; this is not covered by existing
+suites because the role/version columns and the dataset filter are new.
+
+**Schema creation** (`tests/` against `demo_catalog`):
+- A freshly created catalog's `Dataset_Execution` table has the `Role`
+  and `Dataset_Version` columns and both FKs.
+- The `Role` FK targets `Asset_Role`; `Dataset_Version` FK targets
+  `Dataset_Version` and is nullable.
+
+**Write path** (`tests/test_execution.py` / dataset tests):
+- `create_dataset` writes `Role="Output"` and the authored
+  `Dataset_Version` RID on the association row.
+- `add_input_dataset(rid, version=v)` writes `Role="Input"` and the
+  `Dataset_Version` RID.
+- `add_input_dataset(rid)` (no version) writes `Role="Input"`,
+  `Dataset_Version=null` — backward-compatible signature.
+- `split_dataset` records its source as `Role="Input"` with the resolved
+  source version.
+
+**Library read path:**
+- `find_executions(dataset=X)` returns all linked executions;
+  `dataset_role="input"|"output"` filter each return the correct subset;
+  `dataset_version=v` filters on the stored column (both sides).
+- `ValueError` when `dataset_role`/`dataset_version` passed without
+  `dataset`.
+- Composition: `find_executions(dataset=X, workflow_type="Training",
+  status="Uploaded")` intersects correctly.
+- `list_input_datasets()` reads `Role` and returns the same set as the
+  legacy authorship derivation (regression guard), including on a fixture
+  row left with `Role=null` (fallback path still works).
+
+**Migration script** (`tests/` against a seeded demo catalog):
+- Idempotency: a second run is a no-op (`[SKIP]` on every step;
+  "already complete" short-circuit).
+- `--dry-run` makes no changes (preconditions re-checked unchanged after).
+- After a real run: every row has a non-null `Role`; output rows and
+  config-declared input rows have a `Dataset_Version`; an
+  `add_input_dataset`-origin fixture row ends `Dataset_Version=null` and
+  is counted in the residual summary.
+- `Role` backfill matches the authorship rule on a mixed fixture
+  (known inputs, known outputs).
+
+**Plugin** (`tests/test_execution.py` patterns):
+- Both tool surfaces (`list_executions` with `dataset` set;
+  `find_dataset_executions`) return shape-identical payloads via
+  `_list_executions_impl`.
+- `DatasetExecutionSummary` carries `dataset_role` + `dataset_version`
+  read from the association row with **no extra catalog fetch** (assert no
+  config/Hatrac call).
+- Plain `ExecutionSummary` (no new fields) returned when `dataset` is
+  absent — existing-caller regression guard.
+- Preflight count; `_error_envelope` on bad dataset RID.
 
 ## Implementation order
 
-1. Schema: add `Role` + `Dataset_Version` columns/FKs (`create_schema.py`
-   + standalone upgrade/backfill script).
-2. Library write path: `create_dataset`, `add_input_dataset(version=…)`,
-   config-input writer populate the new columns.
-3. Library read path: refactor `list_input_datasets` to read `Role`;
-   extend `find_executions` with the dataset filters.
-4. Plugin: extend `_list_executions_impl`; `DatasetExecutionSummary`;
+1. **Schema (library):** update `create_schema.py` to add `Role` +
+   `Dataset_Version` columns/FKs to `Dataset_Execution`; update
+   `annotations.py` visible-FKs. Schema-creation tests.
+2. **Migration script:** `scripts/migrate_dataset_execution_role_version.py`
+   (idempotent, `--dry-run`, backfill + verification), modeled on
+   `migrate_workflow_types.py`. Migration tests against a seeded catalog.
+3. **Catalog deployment:** dry-run → run on **dev** (`dev.eye-ai.org`
+   eye-ai); validate with the new tools; then dry-run → run on
+   **production**. (Schema/backfill lands before client write-path upgrade.)
+4. **Library write path:** `create_dataset`, `add_input_dataset(version=…)`,
+   config-input writer populate the new columns. Write-path tests.
+5. **Library read path:** refactor `list_input_datasets` to read `Role`
+   (authorship fallback for null rows); extend `find_executions` with the
+   dataset filters. Read-path tests.
+6. **Plugin:** extend `_list_executions_impl`; add `DatasetExecutionSummary`;
    extend `deriva_ml_list_executions`; add
-   `deriva_ml_find_dataset_executions`.
-5. Tests at every layer; update the getting-started guide's tool menu.
+   `deriva_ml_find_dataset_executions`. Plugin tests; update the
+   getting-started guide's tool menu.

--- a/scripts/migrate_dataset_execution_version.py
+++ b/scripts/migrate_dataset_execution_version.py
@@ -1,0 +1,496 @@
+#!/usr/bin/env python3
+"""Migrate an existing catalog's ``Dataset_Execution`` to the input-only shape.
+
+The "authorship-canonical" provenance model makes ``Dataset_Execution`` the
+*input-only* edge table: each row records that an execution **consumed** a
+dataset. Output edges (which execution **produced** a dataset version) live in
+``Dataset_Version.Execution``, NOT here.
+
+Historically ``create_dataset`` wrote BOTH a ``Dataset_Version`` row authored by
+the producing execution AND a redundant output row into ``Dataset_Execution``.
+This script brings a live catalog to the new shape, idempotently:
+
+1. Add a nullable ``Dataset_Version`` column + FK to ``Dataset_Execution``
+   (pins the exact version an input edge consumed). Skipped if present.
+2. Delete the redundant **output** rows from ``Dataset_Execution``: a
+   ``(Dataset, Execution)`` pair is an output edge iff some ``Dataset_Version``
+   row for that dataset is authored by that execution (``Dataset_Version.Execution``
+   points back). Deleting these loses no information — output provenance stays
+   in ``Dataset_Version.Execution``.
+3. BEST-EFFORT backfill the consumed version on each surviving **input** row by
+   reading the execution's ``configuration.json`` (an ``Execution_Metadata``
+   asset) and matching its ``DatasetSpec.version`` to a ``Dataset_Version`` RID.
+   Rows whose config is missing/unreadable, or whose ``add_input_dataset`` call
+   recorded no version, stay NULL. This is the ONLY place ``configuration.json``
+   is read, and ONLY at migration time.
+
+The migration short-circuits when there is nothing to do.
+
+Usage:
+    # Dry run (preview only, no changes)
+    python scripts/migrate_dataset_execution_version.py dev.eye-ai.org CATALOG_ID --dry-run
+
+    # Execute migration
+    python scripts/migrate_dataset_execution_version.py dev.eye-ai.org CATALOG_ID
+
+    # With custom schema name
+    python scripts/migrate_dataset_execution_version.py dev.eye-ai.org CATALOG_ID --schema deriva-ml
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import tempfile
+from pathlib import Path
+
+from deriva.core import ErmrestCatalog, get_credential
+
+_DV_COLUMN = "Dataset_Version"
+_DV_COMMENT = "RID of the Dataset_Version consumed by this input edge (NULL if unknown)."
+_CONFIG_FILENAME = "configuration.json"
+
+
+def get_catalog(hostname: str, catalog_id: str) -> ErmrestCatalog:
+    """Connect to an ERMrest catalog."""
+    credentials = get_credential(hostname)
+    return ErmrestCatalog("https", hostname, catalog_id, credentials=credentials)
+
+
+# ---------------------------------------------------------------------------
+# Preconditions
+# ---------------------------------------------------------------------------
+def check_preconditions(catalog: ErmrestCatalog, ml_schema: str) -> dict:
+    """Report the current state of ``Dataset_Execution``.
+
+    Returns:
+        dict with keys:
+            - has_column: bool - Dataset_Execution has the Dataset_Version column
+            - has_fk: bool - that column has an FK to the Dataset_Version table
+            - row_count: int - number of Dataset_Execution rows
+    """
+    model = catalog.getCatalogModel()
+    de = model.schemas[ml_schema].tables["Dataset_Execution"]
+
+    col_names = {c.name for c in de.columns}
+    has_column = _DV_COLUMN in col_names
+
+    has_fk = has_column and any(
+        any(c.name == _DV_COLUMN for c in fk.foreign_key_columns) for fk in de.foreign_keys
+    )
+
+    pb = catalog.getPathBuilder()
+    de_path = pb.schemas[ml_schema].Dataset_Execution
+    row_count = len(list(de_path.entities().fetch()))
+
+    return {"has_column": has_column, "has_fk": has_fk, "row_count": row_count}
+
+
+# ---------------------------------------------------------------------------
+# Step 1: add the nullable Dataset_Version column + FK
+# ---------------------------------------------------------------------------
+def step1_add_column(catalog: ErmrestCatalog, ml_schema: str, dry_run: bool) -> bool:
+    """Add the nullable ``Dataset_Version`` column + FK to ``Dataset_Execution``.
+
+    Returns:
+        True if the column was added (or would be, in dry-run); False if it
+        already exists.
+    """
+    model = catalog.getCatalogModel()
+    schema = model.schemas[ml_schema]
+    de = schema.tables["Dataset_Execution"]
+
+    if _DV_COLUMN in {c.name for c in de.columns}:
+        print(f"  [SKIP] {_DV_COLUMN} column already present on Dataset_Execution")
+        return False
+
+    if dry_run:
+        print(f"  [DRY-RUN] Would add nullable {_DV_COLUMN} column + FK to Dataset_Execution")
+        return True
+
+    dataset_version_table = schema.tables["Dataset_Version"]
+    # The ``(base_name, nullok, target)`` tuple form of ``create_reference``
+    # adds BOTH the nullable ``Dataset_Version`` column and its FK to the
+    # Dataset_Version table in one step — the same idiom the fresh-catalog
+    # schema uses (create_schema.py). Passing the bare table instead would
+    # auto-generate a *second*, NOT-NULL column (``Dataset_Version2``).
+    dv_cols, _fk = de.create_reference((_DV_COLUMN, True, dataset_version_table))
+    dv_cols[0].alter(comment=_DV_COMMENT)
+    print(f"  [OK] Added nullable {_DV_COLUMN} column + FK to Dataset_Execution")
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Output-edge identification
+# ---------------------------------------------------------------------------
+def _authored_pairs(catalog: ErmrestCatalog, ml_schema: str) -> set[tuple[str, str]]:
+    """Set of ``(Dataset, Execution)`` pairs authored via ``Dataset_Version``.
+
+    A pair is in this set iff some ``Dataset_Version`` row for that dataset has
+    a non-null ``Execution`` equal to that execution. These are the output
+    edges.
+
+    DELIBERATELY broader than the runtime rule. The runtime
+    ``_producer_of_dataset`` / ``list_input_datasets`` only consider the
+    *latest* version's author; this migration considers *every* version's
+    author. That is intentional and spec-endorsed: every version author is an
+    output producer, so an execution that produced a now-superseded version
+    still left a redundant output row in ``Dataset_Execution`` that must be
+    de-duplicated here. Do NOT narrow this to match ``_producer_of_dataset`` —
+    doing so would leave legacy output rows on superseded versions behind.
+    """
+    pb = catalog.getPathBuilder()
+    dv_path = pb.schemas[ml_schema].Dataset_Version
+    pairs: set[tuple[str, str]] = set()
+    for row in dv_path.entities().fetch():
+        execution = row.get("Execution")
+        dataset = row.get("Dataset")
+        if execution and dataset:
+            pairs.add((dataset, execution))
+    return pairs
+
+
+# ---------------------------------------------------------------------------
+# Step 2: delete redundant output rows
+# ---------------------------------------------------------------------------
+def step2_delete_output_rows(catalog: ErmrestCatalog, ml_schema: str, dry_run: bool) -> int:
+    """Delete ``Dataset_Execution`` rows whose pair is an output edge.
+
+    Returns:
+        Number of rows deleted (or that would be, in dry-run).
+    """
+    pb = catalog.getPathBuilder()
+    de_path = pb.schemas[ml_schema].Dataset_Execution
+
+    authored = _authored_pairs(catalog, ml_schema)
+    rows = list(de_path.entities().fetch())
+    output_rows = [r for r in rows if (r.get("Dataset"), r.get("Execution")) in authored]
+
+    if not output_rows:
+        print("  [SKIP] No output rows to delete from Dataset_Execution")
+        return 0
+
+    if dry_run:
+        print(f"  [DRY-RUN] Would delete {len(output_rows)} output row(s) from Dataset_Execution")
+        for r in output_rows[:5]:
+            print(f"    (Dataset={r.get('Dataset')}, Execution={r.get('Execution')})")
+        if len(output_rows) > 5:
+            print(f"    ... and {len(output_rows) - 5} more")
+        return len(output_rows)
+
+    # Delete by RID. Filtering ``RID == r["RID"]`` per row keeps the delete
+    # narrow and avoids any reliance on multi-column delete predicates.
+    for r in output_rows:
+        de_path.filter(de_path.RID == r["RID"]).delete()
+    print(f"  [OK] Deleted {len(output_rows)} output row(s) from Dataset_Execution")
+    return len(output_rows)
+
+
+# ---------------------------------------------------------------------------
+# Step 3: best-effort backfill of the consumed version on input rows
+# ---------------------------------------------------------------------------
+def _config_metadata_url_for_execution(catalog: ErmrestCatalog, ml_schema: str) -> dict[str, str]:
+    """Map ``execution_rid -> configuration.json hatrac URL``.
+
+    Joins ``Execution_Metadata`` (the asset rows) to its
+    ``Execution_Metadata_Execution`` association table, keeping only rows whose
+    ``Filename`` is ``configuration.json``. An execution normally has exactly
+    one ``configuration.json`` (written once at init time); on the rare chance
+    more than one is associated, any one is picked. RID strings are not strictly
+    creation-ordered, so there is no meaningful "latest" to prefer — first match
+    wins.
+    """
+    pb = catalog.getPathBuilder()
+    schema = pb.schemas[ml_schema]
+
+    # asset RID -> URL for configuration.json assets
+    config_url_by_meta: dict[str, str] = {}
+    for meta in schema.Execution_Metadata.entities().fetch():
+        if meta.get("Filename") == _CONFIG_FILENAME and meta.get("URL"):
+            config_url_by_meta[meta["RID"]] = meta["URL"]
+
+    if not config_url_by_meta:
+        return {}
+
+    url_by_exec: dict[str, str] = {}
+    for assoc in schema.Execution_Metadata_Execution.entities().fetch():
+        meta_rid = assoc.get("Execution_Metadata")
+        exec_rid = assoc.get("Execution")
+        if exec_rid and meta_rid in config_url_by_meta:
+            # First config.json seen for this execution wins; we don't try to
+            # rank multiple configs since RIDs aren't strictly creation-ordered.
+            url_by_exec.setdefault(exec_rid, config_url_by_meta[meta_rid])
+    return url_by_exec
+
+
+def _version_rid_index(catalog: ErmrestCatalog, ml_schema: str) -> dict[tuple[str, str], str]:
+    """Map ``(Dataset, Version-string) -> Dataset_Version RID``."""
+    pb = catalog.getPathBuilder()
+    index: dict[tuple[str, str], str] = {}
+    for row in pb.schemas[ml_schema].Dataset_Version.entities().fetch():
+        dataset = row.get("Dataset")
+        version = row.get("Version")
+        if dataset and version:
+            index[(dataset, str(version))] = row["RID"]
+    return index
+
+
+def _read_consumed_versions(hostname: str, url: str) -> dict[str, str]:
+    """Download + parse a ``configuration.json`` from hatrac.
+
+    Returns:
+        ``{dataset_rid: version_string}`` for every ``DatasetSpec`` whose
+        version serializes to a non-empty string. Empty dict on any failure
+        (the caller treats this as "config unreadable").
+    """
+    # Local import: HatracStore carries network deps. Mirrors deriva_ml's own
+    # lazy-import idiom in asset_upload.download_asset.
+    from deriva.core.hatrac_store import HatracStore
+
+    from deriva_ml.execution.execution_configuration import ExecutionConfiguration
+
+    credential = get_credential(hostname)
+    hs = HatracStore("https", hostname, credentials=credential)
+    with tempfile.TemporaryDirectory() as tmp:
+        dest = Path(tmp) / _CONFIG_FILENAME
+        hs.get_obj(path=url, destfilename=dest.as_posix())
+        config = ExecutionConfiguration.load_configuration(dest)
+
+    consumed: dict[str, str] = {}
+    for spec in config.datasets:
+        # DatasetSpec.version is a DatasetVersion; its str() is the same
+        # PEP-440 form stored in Dataset_Version.Version (e.g. "0.1.0").
+        version_str = str(spec.version)
+        if spec.rid and version_str:
+            consumed[spec.rid] = version_str
+    return consumed
+
+
+def step3_backfill_input_versions(
+    catalog: ErmrestCatalog, hostname: str, ml_schema: str, dry_run: bool
+) -> dict:
+    """Best-effort backfill of ``Dataset_Version`` on surviving input rows.
+
+    For each remaining ``Dataset_Execution`` row that has no ``Dataset_Version``
+    yet, resolve the consumed version from the execution's ``configuration.json``
+    (a ``DatasetSpec.version`` whose ``rid`` matches the row's ``Dataset``) and
+    set the row's ``Dataset_Version`` to the matching ``Dataset_Version`` RID.
+
+    Each row is wrapped in try/except so one unreadable config never aborts the
+    run. Rows that cannot be resolved stay NULL.
+
+    Returns:
+        dict with counts:
+            - filled: rows set to a Dataset_Version RID
+            - null_config: rows whose execution has no readable configuration.json
+            - null_no_record: rows whose config has no matching DatasetSpec/version
+            - errors: rows skipped due to an unexpected internal failure
+              (distinct from "config unreadable" so a summary doesn't mislead)
+    """
+    pb = catalog.getPathBuilder()
+    de_path = pb.schemas[ml_schema].Dataset_Execution
+
+    # Only consider rows that still need a value.
+    rows = [
+        r
+        for r in de_path.entities().fetch()
+        if r.get("Dataset") and not r.get(_DV_COLUMN)
+    ]
+
+    counts = {"filled": 0, "null_config": 0, "null_no_record": 0, "errors": 0}
+    if not rows:
+        print("  [SKIP] No input rows need version backfill")
+        return counts
+
+    url_by_exec = _config_metadata_url_for_execution(catalog, ml_schema)
+    version_index = _version_rid_index(catalog, ml_schema)
+    # Cache parsed configs per execution so we download each config once.
+    consumed_cache: dict[str, dict[str, str] | None] = {}
+
+    updates: list[dict[str, str]] = []
+    for r in rows:
+        try:
+            exec_rid = r.get("Execution")
+            dataset_rid = r.get("Dataset")
+            url = url_by_exec.get(exec_rid)
+            if not url:
+                counts["null_config"] += 1
+                continue
+
+            if exec_rid not in consumed_cache:
+                try:
+                    consumed_cache[exec_rid] = _read_consumed_versions(hostname, url)
+                except Exception as exc:  # noqa: BLE001 - one bad config must not abort
+                    print(f"    [WARN] Could not read config for execution {exec_rid}: {exc}")
+                    consumed_cache[exec_rid] = None
+
+            consumed = consumed_cache[exec_rid]
+            if not consumed:
+                counts["null_config"] += 1
+                continue
+
+            version_str = consumed.get(dataset_rid)
+            if not version_str:
+                counts["null_no_record"] += 1
+                continue
+
+            dv_rid = version_index.get((dataset_rid, version_str))
+            if not dv_rid:
+                counts["null_no_record"] += 1
+                continue
+
+            updates.append({"RID": r["RID"], _DV_COLUMN: dv_rid})
+            counts["filled"] += 1
+        except Exception as exc:  # noqa: BLE001 - defensive: never abort the run
+            print(f"    [WARN] Skipping row {r.get('RID')} during backfill: {exc}")
+            counts["errors"] += 1
+
+    detail = (
+        f"null_config={counts['null_config']}, "
+        f"null_no_record={counts['null_no_record']}, "
+        f"errors={counts['errors']}"
+    )
+    if dry_run:
+        print(f"  [DRY-RUN] Would backfill {counts['filled']} input row(s) ({detail})")
+        return counts
+
+    if updates:
+        de_path.update(updates)
+        print(f"  [OK] Backfilled {counts['filled']} input row(s) ({detail})")
+    else:
+        print(f"  [SKIP] No input rows resolvable from config ({detail})")
+    return counts
+
+
+# ---------------------------------------------------------------------------
+# Verify (folded into the run summary)
+# ---------------------------------------------------------------------------
+def _verify(catalog: ErmrestCatalog, ml_schema: str) -> dict:
+    """Post-run verification.
+
+    Returns:
+        dict with keys:
+            - output_rows_remaining: int - output edges still in Dataset_Execution
+              (should be 0 after a real run)
+            - null_version_count: int - surviving rows with NULL Dataset_Version
+    """
+    pb = catalog.getPathBuilder()
+    de_path = pb.schemas[ml_schema].Dataset_Execution
+    rows = list(de_path.entities().fetch())
+
+    authored = _authored_pairs(catalog, ml_schema)
+    output_remaining = sum(1 for r in rows if (r.get("Dataset"), r.get("Execution")) in authored)
+    null_versions = sum(1 for r in rows if not r.get(_DV_COLUMN))
+    return {"output_rows_remaining": output_remaining, "null_version_count": null_versions}
+
+
+# ---------------------------------------------------------------------------
+# Orchestration
+# ---------------------------------------------------------------------------
+def run_migration(catalog: ErmrestCatalog, ml_schema: str, dry_run: bool) -> dict:
+    """Run the full migration against an already-connected catalog.
+
+    Returns:
+        ``{"columns_added": n, "output_rows_deleted": n, "backfill": {...}}``.
+    """
+    hostname = catalog.deriva_server.server
+
+    print("\nStep 1: Add nullable Dataset_Version column + FK")
+    columns_added = 1 if step1_add_column(catalog, ml_schema, dry_run) else 0
+
+    print("\nStep 2: Delete redundant output rows")
+    output_rows_deleted = step2_delete_output_rows(catalog, ml_schema, dry_run)
+
+    print("\nStep 3: Backfill consumed version on input rows (best-effort)")
+    # The column must exist to backfill. In dry-run on a legacy catalog it does
+    # not exist yet, so skip backfill and report zero counts.
+    if dry_run and columns_added == 1:
+        print("  [DRY-RUN] Skipping backfill preview (column does not exist yet)")
+        backfill = {"filled": 0, "null_config": 0, "null_no_record": 0, "errors": 0}
+    else:
+        backfill = step3_backfill_input_versions(catalog, hostname, ml_schema, dry_run)
+
+    result = {
+        "columns_added": columns_added,
+        "output_rows_deleted": output_rows_deleted,
+        "backfill": backfill,
+    }
+
+    print("\nSummary:")
+    print(f"  Columns added:       {columns_added}")
+    print(f"  Output rows deleted: {output_rows_deleted}")
+    print(
+        f"  Backfilled versions: {backfill['filled']} "
+        f"(null_config={backfill['null_config']}, "
+        f"null_no_record={backfill['null_no_record']}, "
+        f"errors={backfill['errors']})"
+    )
+
+    if not dry_run:
+        verify = _verify(catalog, ml_schema)
+        print("\nVerification:")
+        print(f"  Output rows remaining in Dataset_Execution: {verify['output_rows_remaining']}")
+        print(f"  Surviving rows with NULL Dataset_Version:   {verify['null_version_count']}")
+        if verify["output_rows_remaining"]:
+            print("  [WARN] Output rows still present — re-run or investigate.")
+        result["verify"] = verify
+
+    return result
+
+
+def migrate(hostname: str, catalog_id: str, ml_schema: str = "deriva-ml", dry_run: bool = False) -> bool:
+    """Connect, report preconditions, short-circuit, and run the migration.
+
+    Returns:
+        True on success.
+    """
+    mode = "[DRY-RUN] " if dry_run else ""
+    print(f"\n{mode}Migrating Dataset_Execution to the input-only shape")
+    print(f"  Catalog: {hostname}/{catalog_id}")
+    print(f"  Schema:  {ml_schema}")
+
+    catalog = get_catalog(hostname, catalog_id)
+
+    print("\nChecking preconditions...")
+    info = check_preconditions(catalog, ml_schema)
+    print(f"  Dataset_Version column present: {info['has_column']}")
+    print(f"  Dataset_Version FK present:     {info['has_fk']}")
+    print(f"  Dataset_Execution row count:    {info['row_count']}")
+
+    # Short-circuit: nothing to do when the column already exists AND no output
+    # rows remain to delete. (Backfill is best-effort and never the sole reason
+    # to keep re-running; the NULL rows that remain are expected.)
+    if info["has_column"] and info["has_fk"]:
+        authored = _authored_pairs(catalog, ml_schema)
+        pb = catalog.getPathBuilder()
+        rows = list(pb.schemas[ml_schema].Dataset_Execution.entities().fetch())
+        output_remaining = any((r.get("Dataset"), r.get("Execution")) in authored for r in rows)
+        if not output_remaining:
+            print("\nMigration already complete (column present, no output rows). Nothing to do.")
+            return True
+
+    run_migration(catalog, ml_schema, dry_run)
+    print(f"\n{mode}Migration complete!")
+    return True
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Migrate Dataset_Execution to the input-only provenance shape"
+    )
+    parser.add_argument("hostname", help="Catalog hostname (e.g., dev.eye-ai.org)")
+    parser.add_argument("catalog_id", help="Catalog ID")
+    parser.add_argument("--schema", default="deriva-ml", help="ML schema name (default: deriva-ml)")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Preview migration without making changes",
+    )
+    args = parser.parse_args()
+
+    success = migrate(args.hostname, args.catalog_id, args.schema, args.dry_run)
+    sys.exit(0 if success else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/deriva_ml/core/mixins/execution.py
+++ b/src/deriva_ml/core/mixins/execution.py
@@ -562,6 +562,8 @@ class ExecutionMixin:
         workflow_type: str | None = None,
         status: ExecutionStatus | None = None,
         sort: SortSpec = None,
+        dataset: "RID | DatasetSpec | None" = None,
+        dataset_role: str = "any",
     ) -> Iterable["ExecutionRecord"]:
         """Search the live catalog for executions matching the given filters.
 
@@ -588,6 +590,25 @@ class ExecutionMixin:
                   Execution table path and returns one or more
                   path-builder sort keys (e.g. ``path.RCT.desc``,
                   or ``[path.Status, path.RCT.desc]``).
+            dataset: Optional dataset filter. A dataset RID (``str``)
+                or a :class:`DatasetSpec`. When a ``DatasetSpec`` is
+                given, its ``version`` pins the filter to executions
+                that touched that specific dataset version. Only
+                executions with an edge to this dataset (per
+                ``dataset_role``) are yielded.
+            dataset_role: Which dataset edge to match when ``dataset``
+                is given. One of:
+
+                - ``"input"``: executions that *consumed* the dataset
+                  (``Dataset_Execution`` rows).
+                - ``"output"``: executions that *produced* the dataset
+                  (``Dataset_Version.Execution`` authorship).
+                - ``"any"`` (default): union of input and output.
+
+                Authorship-canonical model: output edges live only in
+                ``Dataset_Version.Execution``; input edges live in
+                ``Dataset_Execution``. Raises ``ValueError`` if a
+                non-``"any"`` role is given without a ``dataset``.
 
         Returns:
             Iterable of live ``ExecutionRecord`` objects.
@@ -609,11 +630,55 @@ class ExecutionMixin:
             ...     pass
         """
         # Import for type checking
+        from deriva_ml.dataset.aux_classes import DatasetSpec
         from deriva_ml.execution.workflow import Workflow as WorkflowClass
 
         # Get datapath to the Execution table
         pb = self.pathBuilder()
         execution_path = pb.schemas[self.ml_schema].Execution
+
+        # Build the allowed-execution-RID set from the dataset filter.
+        # None means "no dataset filter applied" (don't intersect).
+        allowed_exec_rids: set[str] | None = None
+        if dataset is None:
+            if dataset_role != "any":
+                raise ValueError("dataset_role requires a dataset argument")
+        else:
+            if isinstance(dataset, DatasetSpec):
+                ds_rid, ds_version = dataset.rid, str(dataset.version)
+            else:
+                ds_rid, ds_version = dataset, None
+
+            # Resolve a version pin once to a Dataset_Version RID so the
+            # input-edge filter is a direct RID comparison (no per-row
+            # _version_label query).
+            pinned_version_rid = self._version_rid(ds_rid, ds_version) if ds_version is not None else None
+
+            input_rids: set[str] = set()
+            if dataset_role in ("input", "any"):
+                ds_exec = pb.schemas[self.ml_schema].Dataset_Execution
+                for row in ds_exec.filter(ds_exec.Dataset == ds_rid).entities().fetch():
+                    if ds_version is not None and row.get("Dataset_Version") != pinned_version_rid:
+                        continue
+                    if row.get("Execution"):
+                        input_rids.add(row["Execution"])
+
+            output_rids: set[str] = set()
+            if dataset_role in ("output", "any"):
+                vp = pb.schemas[self.ml_schema].tables["Dataset_Version"]
+                for row in vp.filter(vp.Dataset == ds_rid).entities().fetch():
+                    if not row.get("Execution"):
+                        continue
+                    if ds_version is not None and (row.get("Version") or "") != ds_version:
+                        continue
+                    output_rids.add(row["Execution"])
+
+            if dataset_role == "input":
+                allowed_exec_rids = input_rids
+            elif dataset_role == "output":
+                allowed_exec_rids = output_rids
+            else:  # any
+                allowed_exec_rids = input_rids | output_rids
 
         # Apply filters
         filtered_path = execution_path
@@ -649,6 +714,9 @@ class ExecutionMixin:
         for exec_record in entity_set.fetch():
             # If filtering by workflow type, check the execution's workflow is in the matching set
             if matching_workflow_rids is not None and exec_record.get("Workflow") not in matching_workflow_rids:
+                continue
+            # If filtering by dataset, skip executions outside the allowed set
+            if allowed_exec_rids is not None and exec_record.get("RID") not in allowed_exec_rids:
                 continue
             yield self.lookup_execution(exec_record["RID"])
 
@@ -1071,6 +1139,22 @@ class ExecutionMixin:
             if (row.get("Version") or "") == want:
                 return row["RID"]
         return None
+
+    def _version_label(self, version_rid) -> str | None:
+        """Map a ``Dataset_Version`` RID to its ``Version`` string, or None.
+
+        Inverse of :meth:`_version_rid`. Used by :meth:`find_executions`
+        to resolve the ``Dataset_Execution.Dataset_Version`` FK on an
+        input edge back to its semantic-version label for comparison
+        against a caller's version pin. Returns None when ``version_rid``
+        is falsy or no matching version row exists.
+        """
+        if not version_rid:
+            return None
+        pb = self.pathBuilder()
+        vp = pb.schemas[self.ml_schema].tables["Dataset_Version"]
+        rows = list(vp.filter(vp.RID == version_rid).entities().fetch())
+        return rows[0].get("Version") if rows else None
 
     def _producer_of_asset(self, asset_rid: RID, asset_table: Any) -> RID | None:
         """Return the Execution RID that produced ``asset_rid`` (asset_role="Output").

--- a/src/deriva_ml/core/mixins/execution.py
+++ b/src/deriva_ml/core/mixins/execution.py
@@ -1054,6 +1054,24 @@ class ExecutionMixin:
         latest = max(rows, key=_key)
         return latest.get("Execution")
 
+    def _version_rid(self, dataset_rid: RID, version: Any) -> RID | None:
+        """RID of the ``Dataset_Version`` row for (``dataset_rid``, ``version``), or None.
+
+        Maps a (dataset, version) pair to the RID of its ``Dataset_Version``
+        row so the consumed version can be recorded on the
+        ``Dataset_Execution.Dataset_Version`` FK (the input edge). ``version``
+        may be a :class:`DatasetVersion`, a version string, or anything whose
+        ``str(...)`` matches the catalog's stored ``Version`` text (e.g.
+        ``"1.0.0"``). Returns None when no matching version row exists.
+        """
+        pb = self.pathBuilder()
+        vp = pb.schemas[self.ml_schema].tables["Dataset_Version"]
+        want = str(version)
+        for row in vp.filter(vp.Dataset == dataset_rid).entities().fetch():
+            if (row.get("Version") or "") == want:
+                return row["RID"]
+        return None
+
     def _producer_of_asset(self, asset_rid: RID, asset_table: Any) -> RID | None:
         """Return the Execution RID that produced ``asset_rid`` (asset_role="Output").
 

--- a/src/deriva_ml/core/mixins/execution.py
+++ b/src/deriva_ml/core/mixins/execution.py
@@ -640,6 +640,8 @@ class ExecutionMixin:
         # Build the allowed-execution-RID set from the dataset filter.
         # None means "no dataset filter applied" (don't intersect).
         allowed_exec_rids: set[str] | None = None
+        if dataset_role not in {"input", "output", "any"}:
+            raise ValueError(f"invalid dataset_role: {dataset_role!r} (expected 'input', 'output', or 'any')")
         if dataset is None:
             if dataset_role != "any":
                 raise ValueError("dataset_role requires a dataset argument")
@@ -651,17 +653,25 @@ class ExecutionMixin:
 
             # Resolve a version pin once to a Dataset_Version RID so the
             # input-edge filter is a direct RID comparison (no per-row
-            # _version_label query).
+            # version-label lookup). None means the requested version does
+            # not exist.
             pinned_version_rid = self._version_rid(ds_rid, ds_version) if ds_version is not None else None
 
             input_rids: set[str] = set()
             if dataset_role in ("input", "any"):
-                ds_exec = pb.schemas[self.ml_schema].Dataset_Execution
-                for row in ds_exec.filter(ds_exec.Dataset == ds_rid).entities().fetch():
-                    if ds_version is not None and row.get("Dataset_Version") != pinned_version_rid:
-                        continue
-                    if row.get("Execution"):
-                        input_rids.add(row["Execution"])
+                # A version was requested but could not be resolved to a
+                # Dataset_Version RID -> the requested version doesn't exist,
+                # so no input edge can match. Skip the fetch entirely; otherwise
+                # `None != None` would wrongly admit NULL-version input edges.
+                if ds_version is not None and pinned_version_rid is None:
+                    pass
+                else:
+                    ds_exec = pb.schemas[self.ml_schema].Dataset_Execution
+                    for row in ds_exec.filter(ds_exec.Dataset == ds_rid).entities().fetch():
+                        if ds_version is not None and row.get("Dataset_Version") != pinned_version_rid:
+                            continue
+                        if row.get("Execution"):
+                            input_rids.add(row["Execution"])
 
             output_rids: set[str] = set()
             if dataset_role in ("output", "any"):
@@ -1139,22 +1149,6 @@ class ExecutionMixin:
             if (row.get("Version") or "") == want:
                 return row["RID"]
         return None
-
-    def _version_label(self, version_rid) -> str | None:
-        """Map a ``Dataset_Version`` RID to its ``Version`` string, or None.
-
-        Inverse of :meth:`_version_rid`. Used by :meth:`find_executions`
-        to resolve the ``Dataset_Execution.Dataset_Version`` FK on an
-        input edge back to its semantic-version label for comparison
-        against a caller's version pin. Returns None when ``version_rid``
-        is falsy or no matching version row exists.
-        """
-        if not version_rid:
-            return None
-        pb = self.pathBuilder()
-        vp = pb.schemas[self.ml_schema].tables["Dataset_Version"]
-        rows = list(vp.filter(vp.RID == version_rid).entities().fetch())
-        return rows[0].get("Version") if rows else None
 
     def _producer_of_asset(self, asset_rid: RID, asset_table: Any) -> RID | None:
         """Return the Execution RID that produced ``asset_rid`` (asset_role="Output").

--- a/src/deriva_ml/dataset/dataset.py
+++ b/src/deriva_ml/dataset/dataset.py
@@ -344,9 +344,11 @@ class Dataset:
             ]
         )[0]["RID"]
 
-        pb.schemas[ml_instance.model.ml_schema].Dataset_Execution.insert(
-            [{"Dataset": dataset_rid, "Execution": execution_rid}]
-        )
+        # NOTE: Under the authorship-canonical provenance model, an output
+        # edge (this execution PRODUCED the dataset) is recorded solely via
+        # ``Dataset_Version.Execution`` (written by ``_insert_dataset_versions``
+        # below). It must NOT be written to ``Dataset_Execution``, which is the
+        # input-only edge table. See ADR / Task 4.
         dataset = Dataset(
             catalog=ml_instance,
             dataset_rid=dataset_rid,

--- a/src/deriva_ml/execution/_helpers.py
+++ b/src/deriva_ml/execution/_helpers.py
@@ -229,11 +229,7 @@ def list_input_datasets(
     """
     pb = ml_instance.pathBuilder()
     dataset_exec = pb.schemas[ml_instance.ml_schema].Dataset_Execution
-    records = list(
-        dataset_exec.filter(dataset_exec.Execution == execution_rid)
-        .entities()
-        .fetch()
-    )
+    records = dataset_exec.filter(dataset_exec.Execution == execution_rid).entities().fetch()
     return [ml_instance.lookup_dataset(record["Dataset"]) for record in records if record.get("Dataset")]
 
 

--- a/src/deriva_ml/execution/_helpers.py
+++ b/src/deriva_ml/execution/_helpers.py
@@ -208,11 +208,11 @@ def list_input_datasets(
     """Return the input :class:`Dataset` list for an execution.
 
     Filters the ``Dataset_Execution`` association table for rows
-    referencing ``execution_rid``, then drops any dataset that
-    this same execution itself *produced* (its
-    ``Dataset_Version.Execution`` link points back). The
-    catalog has no role column on ``Dataset_Execution``, so
-    authorship via the version row is the source of truth.
+    referencing ``execution_rid``. Under the authorship-canonical
+    model ``Dataset_Execution`` is **input-only** — output edges
+    (a dataset an execution produced) live in
+    ``Dataset_Version.Execution``, never here — so every row is an
+    input and no producer subtraction is needed.
 
     Replaces parallel implementations on
     :meth:`Execution.list_input_datasets` (dry-run fallback)
@@ -225,8 +225,7 @@ def list_input_datasets(
 
     Returns:
         List of :class:`Dataset` objects. Empty when the
-        execution has no input datasets or every dataset on
-        the association table was produced by this execution.
+        execution has no input datasets.
     """
     pb = ml_instance.pathBuilder()
     dataset_exec = pb.schemas[ml_instance.ml_schema].Dataset_Execution
@@ -235,16 +234,7 @@ def list_input_datasets(
         .entities()
         .fetch()
     )
-    datasets = []
-    for record in records:
-        dataset_rid = record.get("Dataset")
-        if not dataset_rid:
-            continue
-        producer = ml_instance._producer_of_dataset(dataset_rid)
-        if producer == execution_rid:
-            continue
-        datasets.append(ml_instance.lookup_dataset(dataset_rid))
-    return datasets
+    return [ml_instance.lookup_dataset(record["Dataset"]) for record in records if record.get("Dataset")]
 
 
 def list_assets(

--- a/src/deriva_ml/execution/execution.py
+++ b/src/deriva_ml/execution/execution.py
@@ -655,8 +655,19 @@ class Execution:
 
         schema_path = self._ml_object.pathBuilder().schemas[self._ml_object.ml_schema]
         if self.dataset_rids and not (reload or self._dry_run):
+            # Config-declared datasets are *inputs* (consume edges). Record the
+            # consumed version on each input edge via the
+            # ``Dataset_Execution.Dataset_Version`` FK, resolved from the
+            # ``DatasetSpec.version`` (authorship-canonical model, Task 4).
             schema_path.Dataset_Execution.insert(
-                [{"Dataset": d, "Execution": self.execution_rid} for d in self.dataset_rids]
+                [
+                    {
+                        "Dataset": dataset.rid,
+                        "Execution": self.execution_rid,
+                        "Dataset_Version": self._ml_object._version_rid(dataset.rid, dataset.version),
+                    }
+                    for dataset in self.configuration.datasets
+                ]
             )
 
     def _download_input_assets(self, reload: RID | None) -> None:
@@ -1967,7 +1978,7 @@ class Execution:
             description=description,
         )
 
-    def add_input_dataset(self, dataset_rid: RID) -> None:
+    def add_input_dataset(self, dataset_rid: RID, version: DatasetVersion | str | None = None) -> None:
         """Record an existing dataset as an *input* consumed by this execution.
 
         Writes a single ``Dataset_Execution`` association row linking
@@ -1987,6 +1998,12 @@ class Execution:
         :func:`deriva_ml.dataset.split.split_dataset`, which records its
         source dataset as an input of the splitting execution.
 
+        When ``version`` is supplied, the consumed version is recorded on
+        the input edge via the ``Dataset_Execution.Dataset_Version`` FK
+        (resolved through :meth:`_version_rid`). When ``version`` is
+        ``None`` the ``Dataset_Version`` column is left NULL — fully
+        backward-compatible with callers that pass only a RID.
+
         The link is idempotent: if ``dataset_rid`` is already associated
         with this execution, no duplicate row is inserted. In dry-run
         mode this is a no-op (the dry-run contract forbids catalog
@@ -1995,6 +2012,9 @@ class Execution:
         Args:
             dataset_rid: RID of the already-existing dataset that this
                 execution consumed as an input.
+            version: Optional consumed dataset version. May be a
+                :class:`DatasetVersion` or a version string. When given,
+                recorded on the input edge's ``Dataset_Version`` FK.
 
         Example:
             >>> with ml.create_execution(cfg) as exe:  # doctest: +SKIP
@@ -2011,7 +2031,10 @@ class Execution:
         }
         if dataset_rid in already_linked:
             return
-        dataset_exec.insert([{"Dataset": dataset_rid, "Execution": self.execution_rid}])
+        version_rid = self._ml_object._version_rid(dataset_rid, version) if version is not None else None
+        dataset_exec.insert(
+            [{"Dataset": dataset_rid, "Execution": self.execution_rid, "Dataset_Version": version_rid}]
+        )
 
     @validate_call(config=VALIDATION_CONFIG)
     def add_files(

--- a/src/deriva_ml/schema/annotations.py
+++ b/src/deriva_ml/schema/annotations.py
@@ -530,6 +530,14 @@ def generate_annotation(model: Model, schema: str) -> dict:
                 },
                 {
                     "source": [
+                        {"inbound": [schema, "Dataset_Execution_Execution_fkey"]},
+                        {"outbound": [schema, "Dataset_Execution_Dataset_Version_fkey"]},
+                        "RID",
+                    ],
+                    "markdown_name": "Input Dataset Version",
+                },
+                {
+                    "source": [
                         {
                             "inbound": [
                                 schema,

--- a/src/deriva_ml/schema/create_schema.py
+++ b/src/deriva_ml/schema/create_schema.py
@@ -165,15 +165,26 @@ def create_dataset_table(
             ),
         )
     )
-    schema.create_table(
+    dataset_execution = schema.create_table(
         Table.define_association(
             associates=[("Dataset", dataset_table), ("Execution", execution_table)],
             comment=(
-                "Many-to-many association between datasets and executions. "
-                "An execution can consume or produce multiple datasets; a "
-                "dataset can be referenced by multiple executions over time."
+                "Input-only association between datasets and executions: each "
+                "row records that an execution *consumed* a dataset. Output "
+                "edges (which execution *produced* a dataset version) live in "
+                "`Dataset_Version.Execution`, not here. The optional "
+                "`Dataset_Version` FK pins the exact version that was consumed."
             ),
         )
+    )
+    # Nullable FK recording which Dataset_Version this input edge consumed.
+    # The (base_name, nullok, target) tuple form creates both the
+    # `Dataset_Version` column and its FK to the Dataset_Version table in one
+    # step — mirrors `dataset_table.create_reference(("Version", True, ...))`
+    # above. NULL means the consumed version is unknown (e.g. legacy rows).
+    dv_cols, _ = dataset_execution.create_reference(("Dataset_Version", True, dataset_version))
+    dv_cols[0].alter(
+        comment="RID of the Dataset_Version consumed by this input edge (NULL if unknown)."
     )
     return dataset_table
 

--- a/tests/dataset/test_dataset_execution_write_path.py
+++ b/tests/dataset/test_dataset_execution_write_path.py
@@ -1,0 +1,127 @@
+"""Write-path tests for the authorship-canonical provenance model.
+
+Under the authorship-canonical model:
+
+* **Output edges** (an execution *produced* a dataset version) live ONLY in
+  ``Dataset_Version.Execution`` (the per-version author FK). They must NOT be
+  written to ``Dataset_Execution``.
+* **Input edges** (an execution *consumed* a dataset) live in
+  ``Dataset_Execution``, whose new nullable ``Dataset_Version`` FK records the
+  consumed version.
+
+These integration tests pin the WRITE path (Task 4):
+
+1. ``create_dataset`` under an execution writes NO ``Dataset_Execution`` row for
+   that dataset, while ``_producer_of_dataset`` still resolves to the creating
+   execution (via the ``Dataset_Version.Execution`` link).
+2. ``add_input_dataset(rid, version=v)`` records the consumed version on the
+   ``Dataset_Execution`` row's ``Dataset_Version`` FK.
+3. ``add_input_dataset(rid)`` (no version) leaves ``Dataset_Version`` NULL.
+
+Requires a live catalog (``DERIVA_HOST``); each test uses the ``test_ml``
+fixture, which resets the session catalog to a clean state.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from deriva_ml import MLVocab as vc
+from deriva_ml.dataset.aux_classes import DatasetVersion
+from deriva_ml.execution.execution_configuration import ExecutionConfiguration
+
+
+def _dataset_execution_rows(ml, dataset_rid, execution_rid):
+    """Return ``Dataset_Execution`` rows for the (dataset, execution) pair."""
+    pb = ml.pathBuilder()
+    dataset_exec = pb.schemas[ml.ml_schema].Dataset_Execution
+    return [
+        row
+        for row in dataset_exec.filter(dataset_exec.Execution == execution_rid).entities().fetch()
+        if row.get("Dataset") == dataset_rid
+    ]
+
+
+def _make_execution(ml, *, datasets=None):
+    """Create a workflow + execution; return the execution context."""
+    ml.add_term(vc.workflow_type, "WritePath Test", description="write-path smoke")
+    wf = ml.create_workflow(
+        name="WritePath smoke workflow",
+        workflow_type="WritePath Test",
+        description="write-path smoke test workflow",
+    )
+    return ml.create_execution(
+        ExecutionConfiguration(
+            workflow=wf,
+            description="write-path exe",
+            datasets=datasets or [],
+        ),
+    )
+
+
+@pytest.mark.integration
+def test_create_dataset_writes_no_dataset_execution_row(test_ml):
+    """create_dataset records the producer via Dataset_Version, not Dataset_Execution."""
+    test_ml.add_term(vc.dataset_type, "WritePathTest", description="write-path smoke")
+    exe = _make_execution(test_ml)
+    ds = exe.create_dataset(
+        dataset_types="WritePathTest",
+        description="write-path created dataset",
+        version=DatasetVersion(1, 0, 0),
+    )
+
+    # No Dataset_Execution row for the produced dataset.
+    rows = _dataset_execution_rows(test_ml, ds.dataset_rid, exe.execution_rid)
+    assert rows == [], (
+        "create_dataset must NOT write a Dataset_Execution row for an output dataset; "
+        f"found {rows!r}"
+    )
+
+    # Producer is recorded via the Dataset_Version.Execution link.
+    assert test_ml._producer_of_dataset(ds.dataset_rid) == exe.execution_rid
+
+
+@pytest.mark.integration
+def test_add_input_dataset_with_version_records_dataset_version(test_ml):
+    """add_input_dataset(rid, version=v) sets the Dataset_Version FK on the input edge."""
+    test_ml.add_term(vc.dataset_type, "WritePathTest", description="write-path smoke")
+
+    # Producer execution creates the source dataset.
+    producer = _make_execution(test_ml)
+    ds = producer.create_dataset(
+        dataset_types="WritePathTest",
+        description="source dataset",
+        version=DatasetVersion(1, 0, 0),
+    )
+
+    # Consumer execution records the dataset as an input at a specific version.
+    consumer = _make_execution(test_ml)
+    consumer.add_input_dataset(ds.dataset_rid, version=ds.current_version)
+
+    rows = _dataset_execution_rows(test_ml, ds.dataset_rid, consumer.execution_rid)
+    assert len(rows) == 1, f"expected exactly one input edge, found {rows!r}"
+    assert rows[0].get("Dataset_Version") is not None, (
+        "add_input_dataset(version=...) must set the Dataset_Version FK on the input edge"
+    )
+
+
+@pytest.mark.integration
+def test_add_input_dataset_without_version_leaves_dataset_version_null(test_ml):
+    """add_input_dataset(rid) (no version) leaves Dataset_Version NULL — backward compatible."""
+    test_ml.add_term(vc.dataset_type, "WritePathTest", description="write-path smoke")
+
+    producer = _make_execution(test_ml)
+    ds = producer.create_dataset(
+        dataset_types="WritePathTest",
+        description="source dataset",
+        version=DatasetVersion(1, 0, 0),
+    )
+
+    consumer = _make_execution(test_ml)
+    consumer.add_input_dataset(ds.dataset_rid)
+
+    rows = _dataset_execution_rows(test_ml, ds.dataset_rid, consumer.execution_rid)
+    assert len(rows) == 1, f"expected exactly one input edge, found {rows!r}"
+    assert rows[0].get("Dataset_Version") is None, (
+        "add_input_dataset() with no version must leave Dataset_Version NULL"
+    )

--- a/tests/dataset/test_datasets.py
+++ b/tests/dataset/test_datasets.py
@@ -415,6 +415,14 @@ class TestDataset:
         assert len(remaining) == 1
         assert remaining[0].dataset_rid == ds3.dataset_rid
 
+    @pytest.mark.xfail(
+        reason="Read path not yet updated for authorship-canonical model (Task 5). "
+        "Under the new model the producing execution's output edge lives in "
+        "Dataset_Version.Execution, not Dataset_Execution; Dataset.list_executions "
+        "still reads only Dataset_Execution and so omits the producer until "
+        "find_executions/list_executions are updated in Task 5.",
+        strict=True,
+    )
     def test_dataset_list_executions(self, test_ml):
         """Test listing executions associated with a dataset."""
         ml_instance = test_ml

--- a/tests/dataset/test_datasets.py
+++ b/tests/dataset/test_datasets.py
@@ -415,16 +415,15 @@ class TestDataset:
         assert len(remaining) == 1
         assert remaining[0].dataset_rid == ds3.dataset_rid
 
-    @pytest.mark.xfail(
-        reason="Read path not yet updated for authorship-canonical model (Task 5). "
-        "Under the new model the producing execution's output edge lives in "
-        "Dataset_Version.Execution, not Dataset_Execution; Dataset.list_executions "
-        "still reads only Dataset_Execution and so omits the producer until "
-        "find_executions/list_executions are updated in Task 5.",
-        strict=True,
-    )
     def test_dataset_list_executions(self, test_ml):
-        """Test listing executions associated with a dataset."""
+        """``Dataset.list_executions`` returns input (consumer) executions only.
+
+        Authorship-canonical model: ``Dataset.list_executions`` reads the
+        ``Dataset_Execution`` association table, which is **input-only**.
+        It returns executions that *consumed* the dataset as input and
+        does NOT return the pure producer (whose output edge lives in
+        ``Dataset_Version.Execution``).
+        """
         ml_instance = test_ml
 
         # Add required vocabulary terms
@@ -438,32 +437,22 @@ class TestDataset:
             description="Testing list_executions",
         )
 
-        # Create an execution that will use a dataset
+        # Execution 1 PRODUCES a dataset (output edge -> Dataset_Version.Execution).
         execution1 = ml_instance.create_execution(ExecutionConfiguration(description="Execution 1", workflow=workflow))
-
-        # Create a dataset within this execution
         dataset = execution1.create_dataset(dataset_types=["TestSet"], description="Test dataset")
 
-        # Test list_executions - should return the execution that created the dataset
-        executions = dataset.list_executions()
-        assert len(executions) == 1
-        assert executions[0].execution_rid == execution1.execution_rid
+        # The pure producer is NOT an input -> list_executions is empty.
+        assert dataset.list_executions() == []
 
-        # Create a second execution that uses the same dataset
-        execution2 = ml_instance.create_execution(
-            ExecutionConfiguration(
-                description="Execution 2",
-                workflow=workflow,
-                datasets=[DatasetSpec(rid=dataset.dataset_rid, version=dataset.current_version)],
-            )
-        )
+        # Execution 2 CONSUMES the same dataset as input (input edge -> Dataset_Execution).
+        execution2 = ml_instance.create_execution(ExecutionConfiguration(description="Execution 2", workflow=workflow))
+        execution2.add_input_dataset(dataset.dataset_rid, version=dataset.current_version)
 
-        # Now list_executions should return both executions
+        # Now list_executions returns the consumer, and only the consumer.
         executions = dataset.list_executions()
-        assert len(executions) == 2
         execution_rids = {exe.execution_rid for exe in executions}
-        assert execution1.execution_rid in execution_rids
         assert execution2.execution_rid in execution_rids
+        assert execution1.execution_rid not in execution_rids
 
     def test_add_dataset_members_rejects_self_reference_cycle(self, dataset_test, tmp_path):
         """Adding a dataset as a member of itself raises a cycle exception.

--- a/tests/execution/test_execution.py
+++ b/tests/execution/test_execution.py
@@ -1316,7 +1316,15 @@ class TestExecutionDatasets:
     """Tests for dataset operations within executions."""
 
     def test_create_dataset_in_execution(self, basic_execution):
-        """Test creating a dataset within an execution."""
+        """Test creating a dataset within an execution.
+
+        Under the authorship-canonical provenance model, an output edge (this
+        execution *produced* the dataset) is recorded solely via
+        ``Dataset_Version.Execution`` — NOT in ``Dataset_Execution`` (which is
+        the input-only edge table). So no ``Dataset_Execution`` row exists for
+        the produced dataset, and the producing execution is resolved via
+        ``_producer_of_dataset``.
+        """
         with basic_execution.execute() as execution:
             # Use "File" which is a standard dataset type
             dataset = execution.create_dataset(
@@ -1325,15 +1333,15 @@ class TestExecutionDatasets:
             )
             assert dataset is not None
             assert dataset.dataset_rid is not None
-            # Note: execution_rid is not returned on the dataset object;
-            # the link is stored in Dataset_Execution table
+            # No Dataset_Execution (input-edge) row is written for an output.
             ml = execution._ml_object
             pb = ml.pathBuilder().schemas[ml.ml_schema]
             ds_exec = pb.Dataset_Execution
             query = ds_exec.filter(ds_exec.Dataset == dataset.dataset_rid)
             links = list(query.entities().fetch())
-            assert len(links) == 1
-            assert links[0]["Execution"] == execution.execution_rid
+            assert links == []
+            # Producer is recorded via Dataset_Version.Execution.
+            assert ml._producer_of_dataset(dataset.dataset_rid) == execution.execution_rid
 
     def test_download_dataset_in_execution(self, dataset_test, tmp_path):
         """Test downloading a dataset within an execution."""

--- a/tests/execution/test_find_executions_by_dataset.py
+++ b/tests/execution/test_find_executions_by_dataset.py
@@ -104,10 +104,47 @@ def test_find_executions_dataset_spec_version_pin(producer_and_consumer):
     assert consumer_rid not in rids_bogus
 
 
+@pytest.mark.integration
+def test_find_executions_bogus_version_pin_excludes_null_version_input(producer_and_consumer):
+    """Regression: a bogus version pin must NOT match a NULL-version input edge.
+
+    ``add_input_dataset(rid)`` (no version) leaves ``Dataset_Execution.Dataset_Version``
+    NULL. A ``DatasetSpec`` pinned to a version the dataset never had resolves to no
+    ``Dataset_Version`` RID. The input filter must then match NOTHING -- the consumer
+    that recorded a NULL-version edge must not be returned just because the pin also
+    failed to resolve.
+    """
+    ml, _producer_rid, _consumer_rid, dataset_rid, _version = producer_and_consumer
+
+    # A consumer that records an input edge WITHOUT a version -> Dataset_Version is NULL.
+    workflow = _setup_workflow(ml)
+    null_consumer = ml.create_execution(
+        ExecutionConfiguration(description="NULL-version consumer", workflow=workflow)
+    )
+    null_consumer.add_input_dataset(dataset_rid)  # no version -> Dataset_Version NULL
+
+    # Sanity: with no version pin the NULL-version consumer IS returned.
+    rids = {r.execution_rid for r in ml.find_executions(dataset=dataset_rid, dataset_role="input")}
+    assert null_consumer.execution_rid in rids
+
+    # A bogus version pin (dataset never had it) must match NOTHING on the input side.
+    bogus = DatasetSpec(rid=dataset_rid, version="99.0.0")
+    rids_bogus = {r.execution_rid for r in ml.find_executions(dataset=bogus, dataset_role="input")}
+    assert null_consumer.execution_rid not in rids_bogus
+    assert rids_bogus == set()
+
+
 def test_find_executions_role_without_dataset_raises(test_ml):
     """dataset_role without a dataset argument raises ValueError early."""
     with pytest.raises(ValueError, match="dataset_role requires a dataset"):
         list(test_ml.find_executions(dataset_role="input"))
+
+
+def test_find_executions_invalid_role_raises(test_ml):
+    """An invalid dataset_role raises ValueError (find_executions is a generator,
+    so the guard fires on iteration -- wrap in list())."""
+    with pytest.raises(ValueError, match="invalid dataset_role"):
+        list(test_ml.find_executions(dataset="1-ABC0", dataset_role="in"))
 
 
 @pytest.mark.integration

--- a/tests/execution/test_find_executions_by_dataset.py
+++ b/tests/execution/test_find_executions_by_dataset.py
@@ -1,0 +1,124 @@
+"""Integration tests for ``find_executions(dataset=..., dataset_role=...)``.
+
+Catalog-required (except the ValueError guard, which raises before any
+catalog work). Validates the dataset filter against the
+authorship-canonical model:
+
+  - Output edges (PRODUCED) live in ``Dataset_Version.Execution``.
+  - Input edges (CONSUMED) live in ``Dataset_Execution`` (with an
+    optional ``Dataset_Version`` FK pinning the consumed version).
+
+Also a regression that a dataset a *pure producer* created does NOT
+show up in that producer's ``list_input_datasets()``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from deriva_ml import MLVocab as vc
+from deriva_ml.dataset.aux_classes import DatasetSpec
+from deriva_ml.execution.execution_configuration import ExecutionConfiguration
+
+
+def _setup_workflow(ml):
+    """Register the vocab terms and a workflow used by the tests."""
+    ml.add_term(vc.workflow_type, "DS Filter Workflow", description="find_executions dataset filter tests")
+    ml.add_term(vc.dataset_type, "TestSet", description="A test dataset type")
+    return ml.create_workflow(
+        name="ds_filter_test",
+        workflow_type="DS Filter Workflow",
+        description="Workflow for find_executions dataset filter tests",
+    )
+
+
+@pytest.fixture
+def producer_and_consumer(test_ml):
+    """Create a producer execution + dataset and a consumer execution.
+
+    Returns ``(ml, producer_rid, consumer_rid, dataset_rid, version)``:
+
+      - ``producer`` created ``dataset`` via ``create_dataset`` (output
+        edge in ``Dataset_Version.Execution``).
+      - ``consumer`` consumed ``dataset`` via ``add_input_dataset`` at
+        ``dataset.current_version`` (input edge in ``Dataset_Execution``
+        with the version pinned on ``Dataset_Version``).
+    """
+    ml = test_ml
+    workflow = _setup_workflow(ml)
+
+    producer = ml.create_execution(
+        ExecutionConfiguration(description="Producer", workflow=workflow)
+    )
+    dataset = producer.create_dataset(dataset_types=["TestSet"], description="Produced dataset")
+    version = dataset.current_version
+
+    consumer = ml.create_execution(
+        ExecutionConfiguration(description="Consumer", workflow=workflow)
+    )
+    consumer.add_input_dataset(dataset.dataset_rid, version=version)
+
+    return ml, producer.execution_rid, consumer.execution_rid, dataset.dataset_rid, version
+
+
+@pytest.mark.integration
+def test_find_executions_input_returns_consumer(producer_and_consumer):
+    """dataset_role='input' returns the execution that CONSUMED the dataset."""
+    ml, producer_rid, consumer_rid, dataset_rid, _version = producer_and_consumer
+    rids = {r.execution_rid for r in ml.find_executions(dataset=dataset_rid, dataset_role="input")}
+    assert consumer_rid in rids
+    assert producer_rid not in rids
+
+
+@pytest.mark.integration
+def test_find_executions_output_returns_producer(producer_and_consumer):
+    """dataset_role='output' returns the execution that PRODUCED the dataset."""
+    ml, producer_rid, consumer_rid, dataset_rid, _version = producer_and_consumer
+    rids = {r.execution_rid for r in ml.find_executions(dataset=dataset_rid, dataset_role="output")}
+    assert producer_rid in rids
+    assert consumer_rid not in rids
+
+
+@pytest.mark.integration
+def test_find_executions_any_returns_union(producer_and_consumer):
+    """dataset_role='any' returns both producer and consumer."""
+    ml, producer_rid, consumer_rid, dataset_rid, _version = producer_and_consumer
+    rids = {r.execution_rid for r in ml.find_executions(dataset=dataset_rid, dataset_role="any")}
+    assert producer_rid in rids
+    assert consumer_rid in rids
+
+
+@pytest.mark.integration
+def test_find_executions_dataset_spec_version_pin(producer_and_consumer):
+    """A DatasetSpec(rid, version) input filter matches only the consumed version."""
+    ml, _producer_rid, consumer_rid, dataset_rid, version = producer_and_consumer
+
+    # The consumed version matches -> consumer is returned.
+    spec = DatasetSpec(rid=dataset_rid, version=str(version))
+    rids = {r.execution_rid for r in ml.find_executions(dataset=spec, dataset_role="input")}
+    assert consumer_rid in rids
+
+    # A version the dataset never had -> no input executions match.
+    bogus = DatasetSpec(rid=dataset_rid, version="99.0.0")
+    rids_bogus = {r.execution_rid for r in ml.find_executions(dataset=bogus, dataset_role="input")}
+    assert consumer_rid not in rids_bogus
+
+
+def test_find_executions_role_without_dataset_raises(test_ml):
+    """dataset_role without a dataset argument raises ValueError early."""
+    with pytest.raises(ValueError, match="dataset_role requires a dataset"):
+        list(test_ml.find_executions(dataset_role="input"))
+
+
+@pytest.mark.integration
+def test_produced_dataset_not_in_inputs(producer_and_consumer):
+    """Regression: a dataset a producer created is NOT among its inputs.
+
+    The producer's ``list_input_datasets()`` reads ``Dataset_Execution``
+    (input-only). Since the producer recorded no input edge, the dataset
+    it produced must not appear.
+    """
+    ml, producer_rid, _consumer_rid, dataset_rid, _version = producer_and_consumer
+    producer = ml.lookup_execution(producer_rid)
+    input_rids = {d.dataset_rid for d in producer.list_input_datasets()}
+    assert dataset_rid not in input_rids

--- a/tests/schema/conftest.py
+++ b/tests/schema/conftest.py
@@ -1,0 +1,48 @@
+"""Shared fixtures for ``tests/schema/``.
+
+The schema tests that assert on the *generated* catalog model (FK
+conventions, ACL bindings, the Dataset_Execution version FK) need a live
+catalog produced by ``create_ml_catalog`` — the same mechanism the existing
+integration tests in this directory already use (see
+``test_vocab_fk_convention.py``).
+
+These fixtures create that catalog once per session and hand back the
+introspected model + the ML schema name, deleting the catalog on teardown.
+They are session-scoped because catalog creation is the slow part (~15s) and
+the model is read-only for these assertions.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+
+@pytest.fixture(scope="session")
+def _schema_catalog():
+    """Create one fresh DerivaML catalog for the schema test session.
+
+    Yields the ``ErmrestCatalog`` and deletes it on teardown. Mirrors the
+    create/introspect/delete pattern in ``test_vocab_fk_convention.py``.
+    """
+    from deriva_ml.schema.create_schema import create_ml_catalog
+
+    hostname = os.environ.get("DERIVA_HOST", "localhost")
+    catalog = create_ml_catalog(hostname=hostname, project_name="s1b_schema_test")
+    try:
+        yield catalog
+    finally:
+        catalog.delete_ermrest_catalog(really=True)
+
+
+@pytest.fixture(scope="session")
+def demo_model(_schema_catalog):
+    """The introspected catalog model for the fresh schema-test catalog."""
+    return _schema_catalog.getCatalogModel()
+
+
+@pytest.fixture(scope="session")
+def ml_schema() -> str:
+    """The name of the deriva-ml schema in the fresh catalog."""
+    return "deriva-ml"

--- a/tests/schema/test_dataset_execution_version_column.py
+++ b/tests/schema/test_dataset_execution_version_column.py
@@ -1,0 +1,39 @@
+"""Fresh-catalog schema: Dataset_Execution carries a nullable Dataset_Version FK.
+
+The "authorship-canonical" provenance model makes ``Dataset_Execution`` the
+*input-only* edge table (output edges live in ``Dataset_Version.Execution``).
+To record *which* version of a dataset an execution consumed, the input edge
+gains a nullable ``Dataset_Version`` FK. This test pins that the fresh-catalog
+schema produced by ``create_ml_catalog`` actually carries that column + FK.
+
+Pattern follows ``test_vocab_fk_convention.py``: create a fresh catalog,
+introspect the live ``deriva-ml`` schema, delete on teardown. Requires
+DERIVA_HOST.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.integration
+def test_dataset_execution_has_dataset_version_fk(demo_model, ml_schema):
+    """Dataset_Execution has a nullable Dataset_Version column FK'd to Dataset_Version."""
+    de = demo_model.schemas[ml_schema].tables["Dataset_Execution"]
+    cols = {c.name for c in de.columns}
+    assert "Dataset_Version" in cols, "Dataset_Execution must have a Dataset_Version column"
+
+    dv_col = next(c for c in de.columns if c.name == "Dataset_Version")
+    assert dv_col.nullok is True, "Dataset_Version must be nullable"
+
+    # deriva-py FK objects expose ``foreign_key_columns`` (the referencing
+    # columns on this table) and ``referenced_columns`` (the target columns),
+    # both as lists of Column instances with ``.name`` and ``.table.name``.
+    fk_targets = {
+        fk.referenced_columns[0].table.name
+        for fk in de.foreign_keys
+        if any(c.name == "Dataset_Version" for c in fk.foreign_key_columns)
+    }
+    assert "Dataset_Version" in fk_targets, (
+        "Dataset_Execution.Dataset_Version must FK to the Dataset_Version table"
+    )

--- a/tests/test_migrate_dataset_execution_version.py
+++ b/tests/test_migrate_dataset_execution_version.py
@@ -82,10 +82,20 @@ def _dataset_execution_rows(catalog) -> list[dict]:
 def _seed_output_edge(ml) -> tuple[str, str]:
     """Create an OUTPUT edge: an execution that PRODUCED a dataset version.
 
-    ``create_dataset`` writes BOTH a ``Dataset_Execution`` row (the legacy,
-    redundant output row this migration deletes) AND a ``Dataset_Version`` row
-    authored by the same execution (``Dataset_Version.Execution`` points back).
-    That is exactly the pre-migration output shape.
+    Reproduces the LEGACY pre-write-path-change output shape, which had BOTH:
+      (a) a ``Dataset_Version`` row authored by the producing execution
+          (``Dataset_Version.Execution`` points back) — current
+          ``create_dataset`` still writes this; and
+      (b) a redundant ``Dataset_Execution`` output row
+          ``{Dataset, Execution}`` — which the OLD ``create_dataset`` wrote but
+          the CURRENT one does NOT (the write path now records output
+          provenance ONLY via ``Dataset_Version.Execution``).
+
+    Because current ``create_dataset`` no longer emits (b), this helper now
+    SIMULATES the legacy output edge with a direct ``pathBuilder`` insert of the
+    ``Dataset_Execution`` row, using the SAME execution that authored the
+    version. That makes the migration's ``_authored_pairs`` classify the pair as
+    an output edge to delete — exactly the pre-migration state under test.
 
     Returns:
         ``(dataset_rid, execution_rid)`` of the produced dataset.
@@ -93,6 +103,12 @@ def _seed_output_edge(ml) -> tuple[str, str]:
     workflow = ml.create_workflow(name="Producer Workflow", workflow_type="Test Workflow")
     execution = ml.create_execution(ExecutionConfiguration(description="Produce", workflow=workflow))
     dataset = execution.create_dataset(dataset_types=["TestDS"], description="Produced dataset")
+    # Directly insert the legacy redundant output row that the OLD create_dataset
+    # used to write; the current write path no longer does.
+    pb = ml.pathBuilder()
+    pb.schemas[ML_SCHEMA].Dataset_Execution.insert(
+        [{"Dataset": dataset.dataset_rid, "Execution": execution.execution_rid}]
+    )
     return dataset.dataset_rid, execution.execution_rid
 
 
@@ -113,11 +129,23 @@ def _seed_input_edge(ml, dataset_rid: str) -> str:
 
 
 def _seed_input_edge_with_config(ml, dataset_rid: str, version: str) -> str:
-    """Create an INPUT edge whose execution recorded the consumed version.
+    """Create a LEGACY INPUT edge whose consumed version lives only in config.
 
-    A consuming execution records ``dataset_rid`` as an input AND uploads a
-    ``configuration.json`` declaring ``DatasetSpec(rid=dataset_rid, version)``.
-    This is the shape ``step3_backfill_input_versions`` can resolve.
+    Reproduces the pre-write-path-change shape that ``step3_backfill_input_versions``
+    is designed to repair: an input ``Dataset_Execution`` row with a NULL
+    ``Dataset_Version`` whose consumed version is recoverable ONLY from the
+    execution's ``configuration.json``.
+
+    A consuming execution declares ``DatasetSpec(rid=dataset_rid, version)`` in
+    its configuration (so a real ``configuration.json`` is uploaded as an
+    ``Execution_Metadata`` asset) and records ``dataset_rid`` as an input. The
+    CURRENT write path, however, no longer leaves the input edge NULL: at init
+    ``_materialize_input_datasets`` already resolves and populates the input
+    row's ``Dataset_Version`` FK from the ``DatasetSpec.version``. To recreate
+    the legacy NULL-version edge (the only shape there is anything to backfill),
+    this helper resets that row's ``Dataset_Version`` back to NULL via a direct
+    ``pathBuilder`` update after init. The consumed version then survives ONLY in
+    ``configuration.json`` — exactly what the backfill step must resolve.
 
     Returns:
         The consuming ``execution_rid``.
@@ -133,6 +161,25 @@ def _seed_input_edge_with_config(ml, dataset_rid: str, version: str) -> str:
     with ml.create_execution(cfg) as exe:
         exe.add_input_dataset(dataset_rid)
     exe.commit_output_assets(clean_folder=True)
+
+    # The current write path auto-populates Dataset_Version on the config-declared
+    # input edge. Reset it to NULL to reproduce the legacy edge whose version is
+    # recoverable only from configuration.json (the state step3 backfills).
+    #
+    # The shared session catalog may currently be in the pre-Task-1 (legacy)
+    # shape with the column dropped (an earlier dry-run test leaves it dropped).
+    # When the column is absent there is nothing to reset — the edge is already
+    # in the legacy NULL-version shape — so guard on column presence to avoid a
+    # write against a non-existent column.
+    if _has_version_column(ml.catalog):
+        de = ml.pathBuilder().schemas[ML_SCHEMA].Dataset_Execution
+        in_rows = [
+            r
+            for r in de.entities().fetch()
+            if r["Execution"] == exe.execution_rid and r["Dataset"] == dataset_rid and r.get("Dataset_Version")
+        ]
+        if in_rows:
+            de.update([{"RID": r["RID"], "Dataset_Version": None} for r in in_rows])
     return exe.execution_rid
 
 

--- a/tests/test_migrate_dataset_execution_version.py
+++ b/tests/test_migrate_dataset_execution_version.py
@@ -1,0 +1,328 @@
+"""Integration tests for ``scripts/migrate_dataset_execution_version.py``.
+
+These tests exercise the live-catalog migration that makes
+``Dataset_Execution`` the input-only provenance edge:
+
+1. add a nullable ``Dataset_Version`` column + FK to ``Dataset_Execution``
+   (idempotent — skipped if already present),
+2. delete the redundant *output* rows (a ``(Dataset, Execution)`` pair is an
+   output edge iff some ``Dataset_Version`` row for that dataset was authored
+   by that execution), and
+3. best-effort backfill the consumed version on the surviving input rows.
+
+The tests run against a live catalog (``DERIVA_HOST``, default ``localhost``),
+seeding the exact pre-migration shape with the public DerivaML write path
+(``create_dataset`` for output edges, ``add_input_dataset`` for input edges)
+plus a couple of direct ``pathBuilder`` inserts where that is the cleanest way
+to build a legacy shape. They are gated ``@pytest.mark.integration`` and rely
+on the suite-wide ``DERIVA_ML_ALLOW_DIRTY=true`` for workflow creation in a
+dirty repo.
+
+Run with::
+
+    DERIVA_ML_ALLOW_DIRTY=true uv run pytest \
+        tests/test_migrate_dataset_execution_version.py -v
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+from deriva_ml import ExecutionConfiguration, MLVocab
+
+# ---------------------------------------------------------------------------
+# Load the migration module by path (scripts/ is not an importable package).
+# ---------------------------------------------------------------------------
+_SCRIPT_PATH = Path(__file__).resolve().parent.parent / "scripts" / "migrate_dataset_execution_version.py"
+_spec = importlib.util.spec_from_file_location("migrate_dataset_execution_version", _SCRIPT_PATH)
+migrate = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(migrate)
+
+ML_SCHEMA = "deriva-ml"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def _de_table(model):
+    return model.schemas[ML_SCHEMA].tables["Dataset_Execution"]
+
+
+def _has_version_column(catalog) -> bool:
+    de = _de_table(catalog.getCatalogModel())
+    return "Dataset_Version" in {c.name for c in de.columns}
+
+
+def _drop_version_column_if_present(catalog) -> None:
+    """Simulate a pre-Task-1 (legacy) catalog by removing the FK + column.
+
+    Fresh catalogs created by ``create_ml_catalog`` now carry the
+    ``Dataset_Version`` column (Task 1). To test that ``step1_add_column``
+    actually adds it, we first strip it back to the legacy shape.
+    """
+    model = catalog.getCatalogModel()
+    de = _de_table(model)
+    if "Dataset_Version" not in {c.name for c in de.columns}:
+        return
+    # Drop any FK that references the Dataset_Version column first.
+    for fk in list(de.foreign_keys):
+        if any(c.name == "Dataset_Version" for c in fk.foreign_key_columns):
+            fk.drop()
+    de.columns["Dataset_Version"].drop()
+
+
+def _dataset_execution_rows(catalog) -> list[dict]:
+    pb = catalog.getPathBuilder()
+    return list(pb.schemas[ML_SCHEMA].Dataset_Execution.entities().fetch())
+
+
+def _seed_output_edge(ml) -> tuple[str, str]:
+    """Create an OUTPUT edge: an execution that PRODUCED a dataset version.
+
+    ``create_dataset`` writes BOTH a ``Dataset_Execution`` row (the legacy,
+    redundant output row this migration deletes) AND a ``Dataset_Version`` row
+    authored by the same execution (``Dataset_Version.Execution`` points back).
+    That is exactly the pre-migration output shape.
+
+    Returns:
+        ``(dataset_rid, execution_rid)`` of the produced dataset.
+    """
+    workflow = ml.create_workflow(name="Producer Workflow", workflow_type="Test Workflow")
+    execution = ml.create_execution(ExecutionConfiguration(description="Produce", workflow=workflow))
+    dataset = execution.create_dataset(dataset_types=["TestDS"], description="Produced dataset")
+    return dataset.dataset_rid, execution.execution_rid
+
+
+def _seed_input_edge(ml, dataset_rid: str) -> str:
+    """Create an INPUT edge: an execution that CONSUMED an existing dataset.
+
+    A *second* execution (which did not author ``dataset_rid``) records it via
+    ``add_input_dataset`` — a single ``Dataset_Execution`` row with no authoring
+    ``Dataset_Version``. This is the row the migration must PRESERVE.
+
+    Returns:
+        The consuming ``execution_rid``.
+    """
+    workflow = ml.create_workflow(name="Consumer Workflow", workflow_type="Test Workflow")
+    with ml.create_execution(ExecutionConfiguration(description="Consume", workflow=workflow)) as exe:
+        exe.add_input_dataset(dataset_rid)
+    return exe.execution_rid
+
+
+def _seed_input_edge_with_config(ml, dataset_rid: str, version: str) -> str:
+    """Create an INPUT edge whose execution recorded the consumed version.
+
+    A consuming execution records ``dataset_rid`` as an input AND uploads a
+    ``configuration.json`` declaring ``DatasetSpec(rid=dataset_rid, version)``.
+    This is the shape ``step3_backfill_input_versions`` can resolve.
+
+    Returns:
+        The consuming ``execution_rid``.
+    """
+    from deriva_ml.dataset.aux_classes import DatasetSpec
+
+    workflow = ml.create_workflow(name="Config Consumer", workflow_type="Test Workflow")
+    cfg = ExecutionConfiguration(
+        description="Consume with config",
+        workflow=workflow,
+        datasets=[DatasetSpec(rid=dataset_rid, version=version, materialize=False)],
+    )
+    with ml.create_execution(cfg) as exe:
+        exe.add_input_dataset(dataset_rid)
+    exe.commit_output_assets(clean_folder=True)
+    return exe.execution_rid
+
+
+@pytest.fixture()
+def seeded_ml(test_ml):
+    """A clean ML instance with the vocab terms the seed helpers need."""
+    test_ml.add_term(MLVocab.workflow_type, "Test Workflow", description="Test workflow")
+    test_ml.add_term(MLVocab.dataset_type, "TestDS", description="Test dataset type")
+    return test_ml
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+@pytest.mark.integration
+def test_check_preconditions_reports_column_and_count(seeded_ml):
+    """check_preconditions reports column presence and the row count."""
+    ml = seeded_ml
+    catalog = ml.catalog
+    ds_rid, _ = _seed_output_edge(ml)
+    _seed_input_edge(ml, ds_rid)
+
+    info = migrate.check_preconditions(catalog, ML_SCHEMA)
+    assert info["has_column"] is True  # fresh (post-Task-1) catalog
+    assert info["row_count"] == len(_dataset_execution_rows(catalog))
+    assert info["row_count"] >= 2  # one output edge + one input edge
+
+
+@pytest.mark.integration
+def test_step1_adds_column_when_missing(seeded_ml):
+    """On a legacy catalog (no column), step1 adds the nullable FK column."""
+    ml = seeded_ml
+    catalog = ml.catalog
+    _drop_version_column_if_present(catalog)
+    assert _has_version_column(catalog) is False
+
+    added = migrate.step1_add_column(catalog, ML_SCHEMA, dry_run=False)
+    assert added is True
+    assert _has_version_column(catalog) is True
+
+    # Column is nullable and FKs to the Dataset_Version table.
+    de = _de_table(catalog.getCatalogModel())
+    dv_col = next(c for c in de.columns if c.name == "Dataset_Version")
+    assert dv_col.nullok is True
+    fk_targets = {
+        fk.referenced_columns[0].table.name
+        for fk in de.foreign_keys
+        if any(c.name == "Dataset_Version" for c in fk.foreign_key_columns)
+    }
+    assert "Dataset_Version" in fk_targets
+
+
+@pytest.mark.integration
+def test_step1_skips_when_present(seeded_ml):
+    """step1 is a no-op when the column already exists (idempotent)."""
+    ml = seeded_ml
+    catalog = ml.catalog
+    assert _has_version_column(catalog) is True  # fresh catalog
+    added = migrate.step1_add_column(catalog, ML_SCHEMA, dry_run=False)
+    assert added is False
+    assert _has_version_column(catalog) is True
+
+
+@pytest.mark.integration
+def test_output_rows_deleted_input_rows_survive(seeded_ml):
+    """Output edges are deleted from Dataset_Execution; input edges survive."""
+    ml = seeded_ml
+    catalog = ml.catalog
+    out_ds, out_exec = _seed_output_edge(ml)
+    in_exec = _seed_input_edge(ml, out_ds)
+
+    before = _dataset_execution_rows(catalog)
+    before_pairs = {(r["Dataset"], r["Execution"]) for r in before}
+    assert (out_ds, out_exec) in before_pairs, "legacy output row should be present pre-migration"
+    assert (out_ds, in_exec) in before_pairs, "input row should be present pre-migration"
+
+    result = migrate.run_migration(catalog, ML_SCHEMA, dry_run=False)
+
+    after = _dataset_execution_rows(catalog)
+    after_pairs = {(r["Dataset"], r["Execution"]) for r in after}
+    # The output edge (dataset authored by that execution) is gone.
+    assert (out_ds, out_exec) not in after_pairs
+    # The input edge (consumed, not authored) survives.
+    assert (out_ds, in_exec) in after_pairs
+    assert result["output_rows_deleted"] >= 1
+
+    # Output provenance is preserved in Dataset_Version.Execution.
+    pb = catalog.getPathBuilder()
+    dv = pb.schemas[ML_SCHEMA].Dataset_Version
+    authored = {
+        (r["Dataset"], r["Execution"])
+        for r in dv.entities().fetch()
+        if r.get("Execution")
+    }
+    assert (out_ds, out_exec) in authored
+
+
+@pytest.mark.integration
+def test_idempotent(seeded_ml):
+    """A second run reports nothing added and nothing deleted."""
+    ml = seeded_ml
+    catalog = ml.catalog
+    out_ds, _ = _seed_output_edge(ml)
+    _seed_input_edge(ml, out_ds)
+
+    first = migrate.run_migration(catalog, ML_SCHEMA, dry_run=False)
+    assert first["output_rows_deleted"] >= 1
+
+    second = migrate.run_migration(catalog, ML_SCHEMA, dry_run=False)
+    assert second["columns_added"] == 0
+    assert second["output_rows_deleted"] == 0
+
+
+@pytest.mark.integration
+def test_dry_run_makes_no_changes(seeded_ml):
+    """--dry-run leaves the catalog identical (preconditions unchanged)."""
+    ml = seeded_ml
+    catalog = ml.catalog
+    # Legacy shape so a real run *would* both add the column and delete rows.
+    _drop_version_column_if_present(catalog)
+    out_ds, out_exec = _seed_output_edge(ml)
+    _seed_input_edge(ml, out_ds)
+
+    before = migrate.check_preconditions(catalog, ML_SCHEMA)
+    result = migrate.run_migration(catalog, ML_SCHEMA, dry_run=True)
+    after = migrate.check_preconditions(catalog, ML_SCHEMA)
+
+    assert before == after, "dry-run must not change catalog state"
+    assert before["has_column"] is False  # still legacy shape
+    # Dry-run still reports what it *would* do.
+    assert result["columns_added"] == 1
+    assert result["output_rows_deleted"] >= 1
+
+
+@pytest.mark.integration
+def test_step3_backfills_input_version_from_config(seeded_ml, tmp_path):
+    """Best-effort backfill fills Dataset_Version for an input edge whose
+    execution recorded the consumed version in its configuration.json.
+
+    Seeds the legacy shape directly: a released Dataset_Version row plus an
+    input Dataset_Execution row, then writes a configuration.json
+    Execution_Metadata asset declaring that version as a DatasetSpec.
+    """
+    ml = seeded_ml
+    catalog = ml.catalog
+
+    out_ds, _ = _seed_output_edge(ml)
+    # The output edge's version row is the one we expect the input edge to
+    # resolve to (DatasetSpec.version == that version).
+    pb = catalog.getPathBuilder()
+    dv_rows = [r for r in pb.schemas[ML_SCHEMA].Dataset_Version.entities().fetch() if r["Dataset"] == out_ds]
+    assert dv_rows, "produced dataset should have a Dataset_Version row"
+    target_version = dv_rows[0]["Version"]
+    target_dv_rid = dv_rows[0]["RID"]
+
+    # A consuming execution records the dataset as an input AND uploads a
+    # configuration.json declaring DatasetSpec(rid=out_ds, version=target).
+    in_exec = _seed_input_edge_with_config(ml, out_ds, target_version)
+
+    result = migrate.run_migration(catalog, ML_SCHEMA, dry_run=False)
+    backfill = result["backfill"]
+    assert backfill["filled"] >= 1, f"expected to backfill the configured input edge: {backfill}"
+
+    # The input edge row now points at the matching Dataset_Version RID.
+    de_rows = _dataset_execution_rows(catalog)
+    in_rows = [r for r in de_rows if r["Execution"] == in_exec and r["Dataset"] == out_ds]
+    assert in_rows, "input edge must survive migration"
+    assert in_rows[0].get("Dataset_Version") == target_dv_rid
+
+
+@pytest.mark.integration
+def test_dry_run_does_not_backfill_when_column_present(seeded_ml, tmp_path):
+    """With the column already present and a resolvable config, --dry-run
+    reports the would-fill count but performs no write to Dataset_Version."""
+    ml = seeded_ml
+    catalog = ml.catalog
+
+    out_ds, _ = _seed_output_edge(ml)
+    pb = catalog.getPathBuilder()
+    dv_rows = [r for r in pb.schemas[ML_SCHEMA].Dataset_Version.entities().fetch() if r["Dataset"] == out_ds]
+    assert dv_rows, "produced dataset should have a Dataset_Version row"
+    target_version = dv_rows[0]["Version"]
+
+    in_exec = _seed_input_edge_with_config(ml, out_ds, target_version)
+    assert migrate.check_preconditions(catalog, ML_SCHEMA)["has_column"] is True
+
+    result = migrate.run_migration(catalog, ML_SCHEMA, dry_run=True)
+    # Dry-run still reports what it *would* backfill...
+    assert result["backfill"]["filled"] >= 1
+    # ...but the input row's Dataset_Version is still NULL (no write happened).
+    in_rows = [r for r in _dataset_execution_rows(catalog) if r["Execution"] == in_exec and r["Dataset"] == out_ds]
+    assert in_rows, "input edge must still be present"
+    assert in_rows[0].get("Dataset_Version") is None


### PR DESCRIPTION
## Summary
Adds a first-class way to answer **"which executions used dataset X?"** — by input (consumed) or output (produced) role, with optional version pinning. Built on an authorship-canonical provenance model.

- **Schema:** `Dataset_Execution` gains a nullable `Dataset_Version` FK and becomes **input-only**. Output (producing) edges live solely in `Dataset_Version.Execution` (per-version author) — no dual source of truth.
- **Write path:** `create_dataset` no longer writes a `Dataset_Execution` output row; `add_input_dataset(rid, version=…)` and the config-input materializer record the consumed version on the new FK.
- **Read path:** `find_executions(dataset=RID|DatasetSpec, dataset_role="input"|"output"|"any")` — input from `Dataset_Execution`, output from `Dataset_Version.Execution`, union for `any`; `DatasetSpec` pins a version. `list_input_datasets` simplified to a plain input-only read.
- **Migration:** `scripts/migrate_dataset_execution_version.py` — idempotent, `--dry-run`; adds the column/FK, deletes stale legacy output rows, best-effort backfills input versions from `configuration.json` (migration-time only).

## Behavior change
`Dataset.list_executions` is now **input-only** (no longer returns the producing execution) — this aligns it with its existing docstring ("executions that used this dataset as input"). Producers are available via `find_executions(dataset_role="output")` / `get_lineage`.

## Test Plan
- [x] New tests: schema FK, migration (idempotency/dry-run/output-row deletion/backfill), write path, `find_executions` dataset filter (input/output/any, version pin, bogus-version exclusion, role validation).
- [x] 34 feature tests pass against a live localhost catalog (`DERIVA_HOST=localhost DERIVA_ML_ALLOW_DIRTY=true`).
- [ ] **Deploy migration to dev then production** (manual, operator-run): `--dry-run` first; **re-apply model annotations** afterward so migrated catalogs surface the new "Input Dataset Version" visible-FK in Chaise.
- [ ] Cut a release so the deriva-ml-mcp-plugin PR (which exposes `deriva_ml_find_dataset_executions`) can pin to it.

Design + plan: `docs/superpowers/specs/2026-06-02-find-executions-by-dataset-design.md`, `docs/superpowers/plans/2026-06-02-find-executions-by-dataset.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)