### PR TITLE
Accept legacy `rid` key in Workflow configs (unblocks Dataset_Execution backfill)

### DIFF
--- a/src/deriva_ml/execution/workflow.py
+++ b/src/deriva_ml/execution/workflow.py
@@ -143,6 +143,37 @@ class Workflow(BaseModel):
     _ml_instance: "DerivaMLCatalog | None" = PrivateAttr(default=None)
     _logger: logging.Logger = PrivateAttr(default_factory=lambda: get_logger(__name__))
 
+    @model_validator(mode="before")
+    @classmethod
+    def _migrate_legacy_rid_key(cls, data: Any) -> Any:
+        """Map the pre-#226 legacy ``rid`` key to ``workflow_rid``.
+
+        Workflow substructures serialized before the ``rid -> workflow_rid``
+        rename (#226) -- e.g. the ``workflow`` block of older
+        ``configuration.json`` execution-metadata files -- carry a ``rid``
+        key. The current model renamed that field and sets ``extra="forbid"``
+        (see ``model_config`` below), so those legacy payloads would otherwise
+        fail to parse with ``rid -- extra_forbidden``.
+
+        This normalizer renames ``rid`` to ``workflow_rid`` *before* validation
+        so legacy configs load, WITHOUT relaxing ``extra="forbid"`` -- a
+        genuinely-unknown field (the case #226's guard exists to catch) still
+        raises. The canonical ``workflow_rid`` always wins when both keys are
+        present (including an explicit ``workflow_rid=None``, via
+        ``setdefault``), so a correctly-shaped payload is never altered.
+
+        Only dict inputs are touched; non-dict inputs (e.g. an already-built
+        ``Workflow`` instance) pass through untouched.
+        """
+        if isinstance(data, dict) and "rid" in data:
+            # Copy rather than mutate the caller's dict -- a validator must not
+            # have side effects on its input (the same payload may be reused).
+            data = dict(data)
+            legacy_rid = data.pop("rid")
+            # Don't clobber a canonical value if both keys somehow appear.
+            data.setdefault("workflow_rid", legacy_rid)
+        return data
+
     @field_validator("workflow_type", mode="before")
     @classmethod
     def _normalize_workflow_type(cls, v: str | list[str]) -> list[str]:

--- a/tests/execution/test_workflow_legacy_rid.py
+++ b/tests/execution/test_workflow_legacy_rid.py
@@ -1,0 +1,92 @@
+"""Unit tests for the Workflow legacy ``rid`` -> ``workflow_rid`` normalizer.
+
+Background: pre-#226 ``configuration.json`` files serialize the workflow
+substructure with a ``rid`` key (the old name for ``workflow_rid``). The
+current ``Workflow`` model renamed the field and sets ``extra="forbid"``
+to catch the #226 silent-drop regression, which makes those legacy
+configs fail to parse with ``rid -- extra_forbidden``. A
+``model_validator(mode="before")`` maps the legacy key to the new field
+name WITHOUT relaxing ``extra="forbid"`` (so genuinely-unknown fields
+still raise).
+
+These are pure model-construction tests -- no catalog required.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from deriva_ml.execution.workflow import Workflow
+
+# The exact legacy workflow substructure observed in a real
+# dev.eye-ai.org configuration.json (note the ``rid`` key):
+_LEGACY_WORKFLOW = {
+    "name": "API Workflow",
+    "url": "https://github.com/informatics-isi-edu/deriva-ml/blob/62d5dc2--/src/deriva_ml/demo_catalog.py",
+    "workflow_type": "Feature Notebook Workflow",
+    "version": None,
+    "description": "",
+    "rid": None,
+    "checksum": "793f7dadfa14ecc227d353e400cebc449bd2ec94",
+}
+
+
+def test_legacy_rid_key_parses_and_maps_to_workflow_rid():
+    """A legacy config with ``rid`` parses; the value lands on ``workflow_rid``."""
+    wf = Workflow.model_validate(_LEGACY_WORKFLOW)
+    assert wf.name == "API Workflow"
+    assert wf.workflow_rid is None  # legacy rid was null
+    assert wf.checksum == "793f7dadfa14ecc227d353e400cebc449bd2ec94"
+
+
+def test_legacy_rid_with_value_maps_to_workflow_rid():
+    """A non-null legacy ``rid`` is carried over to ``workflow_rid``."""
+    data = {**_LEGACY_WORKFLOW, "rid": "1-ABCD"}
+    wf = Workflow.model_validate(data)
+    assert wf.workflow_rid == "1-ABCD"
+
+
+def test_new_shape_workflow_rid_still_parses():
+    """The current (post-rename) shape with ``workflow_rid`` is unaffected."""
+    data = {
+        "name": "API Workflow",
+        "workflow_type": "Feature Notebook Workflow",
+        "workflow_rid": "2-WXYZ",
+        "checksum": "abc",
+    }
+    wf = Workflow.model_validate(data)
+    assert wf.workflow_rid == "2-WXYZ"
+
+
+def test_workflow_rid_takes_precedence_when_both_present():
+    """If both keys appear, the canonical ``workflow_rid`` wins and no error is raised."""
+    data = {
+        "name": "API Workflow",
+        "workflow_type": "Feature Notebook Workflow",
+        "workflow_rid": "2-WXYZ",  # valid RID form
+        "rid": "1-ABCD",  # legacy key, should be ignored in favor of workflow_rid
+    }
+    wf = Workflow.model_validate(data)
+    assert wf.workflow_rid == "2-WXYZ"
+
+
+def test_validator_does_not_mutate_caller_input():
+    """The before-validator copies its input; the caller's dict is left intact.
+
+    Guards the property whose earlier absence caused an order-dependent test
+    failure: the validator must not pop ``rid`` out of the passed dict.
+    """
+    original = dict(_LEGACY_WORKFLOW)  # has a "rid" key
+    Workflow.model_validate(original)
+    assert "rid" in original, "validator must not mutate the caller's dict"
+    assert original["rid"] is None
+
+
+def test_genuinely_unknown_field_still_forbidden():
+    """The #226 guard is preserved: an unknown field (not the legacy alias) still raises."""
+    data = {
+        "name": "API Workflow",
+        "workflow_type": "Feature Notebook Workflow",
+        "bogus_field": "should not be allowed",
+    }
+    with pytest.raises(ValidationError):
+        Workflow.model_validate(data)


### PR DESCRIPTION
## Summary
Pre-#226 `configuration.json` files serialize the workflow substructure with a legacy `rid` key (the old name for `workflow_rid`). The current `Workflow` model renamed that field and sets `extra="forbid"` — deliberately, to catch the #226 silent-drop regression. As a result, **every legacy config fails to parse** with `rid -- extra_forbidden`.

This surfaced when running the `Dataset_Execution` version-backfill migration on `dev.eye-ai.org`: all **579** input rows fell into `null_config` because `ExecutionConfiguration.load_configuration` rejected every historical config (`#278` follow-up).

## Fix
Add a `@model_validator(mode="before")` to `Workflow` that renames a legacy `rid` key to `workflow_rid` **without relaxing `extra="forbid"`**:
- Legacy configs (with `rid`) now parse; the value lands on `workflow_rid`.
- The #226 guard is intact — a genuinely-unknown field still raises `ValidationError`.
- Canonical `workflow_rid` wins when both keys are present (incl. explicit `None`, via `setdefault`).
- The validator copies its input (no caller-dict mutation).

## Test Plan
- [x] New `tests/execution/test_workflow_legacy_rid.py`: legacy-null maps, legacy-value maps, new-shape unaffected, both-present precedence, unknown-field-still-forbidden, **input-not-mutated** (6 tests, all pass).
- [x] Tested against the exact legacy `workflow` substructure observed in a real dev.eye-ai.org config.
- [x] 84 workflow-construction tests unaffected.
- [ ] After merge + release: **re-run the Dataset_Execution migration backfill** on dev (then prod) to recover the 579 input versions (the migration is idempotent — re-running only runs the backfill step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)