### PR TITLE
Add --backfill-only to re-run Dataset_Execution version backfill

### DIFF
--- a/scripts/migrate_dataset_execution_version.py
+++ b/scripts/migrate_dataset_execution_version.py
@@ -438,14 +438,30 @@ def run_migration(catalog: ErmrestCatalog, ml_schema: str, dry_run: bool) -> dic
     return result
 
 
-def migrate(hostname: str, catalog_id: str, ml_schema: str = "deriva-ml", dry_run: bool = False) -> bool:
+def migrate(
+    hostname: str,
+    catalog_id: str,
+    ml_schema: str = "deriva-ml",
+    dry_run: bool = False,
+    backfill_only: bool = False,
+) -> bool:
     """Connect, report preconditions, short-circuit, and run the migration.
+
+    Args:
+        backfill_only: When True, skip the structural steps (add column / delete
+            output rows) and the "already complete" short-circuit, and run ONLY
+            the best-effort version backfill (Step 3) against existing
+            NULL-version input rows. Use this to re-attempt backfill on an
+            already-structurally-migrated catalog after a change makes more
+            ``configuration.json`` files resolvable (e.g. a config-parser fix).
+            Requires the ``Dataset_Version`` column to already exist.
 
     Returns:
         True on success.
     """
     mode = "[DRY-RUN] " if dry_run else ""
-    print(f"\n{mode}Migrating Dataset_Execution to the input-only shape")
+    action = "Backfilling input versions for" if backfill_only else "Migrating"
+    print(f"\n{mode}{action} Dataset_Execution")
     print(f"  Catalog: {hostname}/{catalog_id}")
     print(f"  Schema:  {ml_schema}")
 
@@ -457,9 +473,35 @@ def migrate(hostname: str, catalog_id: str, ml_schema: str = "deriva-ml", dry_ru
     print(f"  Dataset_Version FK present:     {info['has_fk']}")
     print(f"  Dataset_Execution row count:    {info['row_count']}")
 
+    if backfill_only:
+        # Explicit operator intent to re-run ONLY the backfill. Bypass the
+        # short-circuit and the structural steps. The column must already exist.
+        if not info["has_column"]:
+            print(
+                "\n[ERROR] --backfill-only requires the Dataset_Version column to "
+                "exist; run the full migration first."
+            )
+            return False
+        print("\nStep 3 (only): Backfill consumed version on input rows (best-effort)")
+        backfill = step3_backfill_input_versions(catalog, hostname, ml_schema, dry_run)
+        print("\nSummary:")
+        print(
+            f"  Backfilled versions: {backfill['filled']} "
+            f"(null_config={backfill['null_config']}, "
+            f"null_no_record={backfill['null_no_record']}, "
+            f"errors={backfill['errors']})"
+        )
+        if not dry_run:
+            verify = _verify(catalog, ml_schema)
+            print("\nVerification:")
+            print(f"  Surviving rows with NULL Dataset_Version:   {verify['null_version_count']}")
+        print(f"\n{mode}Backfill complete!")
+        return True
+
     # Short-circuit: nothing to do when the column already exists AND no output
     # rows remain to delete. (Backfill is best-effort and never the sole reason
-    # to keep re-running; the NULL rows that remain are expected.)
+    # to keep re-running; the NULL rows that remain are expected. Use
+    # --backfill-only to deliberately re-attempt backfill after a parser fix.)
     if info["has_column"] and info["has_fk"]:
         authored = _authored_pairs(catalog, ml_schema)
         pb = catalog.getPathBuilder()
@@ -467,6 +509,7 @@ def migrate(hostname: str, catalog_id: str, ml_schema: str = "deriva-ml", dry_ru
         output_remaining = any((r.get("Dataset"), r.get("Execution")) in authored for r in rows)
         if not output_remaining:
             print("\nMigration already complete (column present, no output rows). Nothing to do.")
+            print("  (To re-attempt version backfill, re-run with --backfill-only.)")
             return True
 
     run_migration(catalog, ml_schema, dry_run)
@@ -486,9 +529,25 @@ def main() -> None:
         action="store_true",
         help="Preview migration without making changes",
     )
+    parser.add_argument(
+        "--backfill-only",
+        action="store_true",
+        help=(
+            "Skip the structural steps and the short-circuit; run only the "
+            "best-effort version backfill against existing NULL-version input "
+            "rows. Use to re-attempt backfill on an already-migrated catalog "
+            "(requires the Dataset_Version column to already exist)."
+        ),
+    )
     args = parser.parse_args()
 
-    success = migrate(args.hostname, args.catalog_id, args.schema, args.dry_run)
+    success = migrate(
+        args.hostname,
+        args.catalog_id,
+        args.schema,
+        args.dry_run,
+        backfill_only=args.backfill_only,
+    )
     sys.exit(0 if success else 1)
 
 

--- a/tests/test_migrate_dataset_execution_version.py
+++ b/tests/test_migrate_dataset_execution_version.py
@@ -373,3 +373,73 @@ def test_dry_run_does_not_backfill_when_column_present(seeded_ml, tmp_path):
     in_rows = [r for r in _dataset_execution_rows(catalog) if r["Execution"] == in_exec and r["Dataset"] == out_ds]
     assert in_rows, "input edge must still be present"
     assert in_rows[0].get("Dataset_Version") is None
+
+
+@pytest.mark.integration
+def test_backfill_only_runs_backfill_past_short_circuit(seeded_ml, tmp_path):
+    """``migrate(..., backfill_only=True)`` backfills NULL-version input rows on an
+    already-structurally-migrated catalog, where a normal run would short-circuit.
+
+    Reproduces the prod/dev second-pass scenario: the column+FK exist and no output
+    rows remain (so the normal short-circuit fires), but an input row still has a
+    NULL Dataset_Version that became resolvable after a config-parser fix.
+    """
+    ml = seeded_ml
+    catalog = ml.catalog
+    hostname = catalog.deriva_server.server
+
+    # 1. Bring the catalog to the fully-structurally-migrated state.
+    out_ds, _ = _seed_output_edge(ml)
+    pb = catalog.getPathBuilder()
+    dv_rows = [r for r in pb.schemas[ML_SCHEMA].Dataset_Version.entities().fetch() if r["Dataset"] == out_ds]
+    target_version = dv_rows[0]["Version"]
+    target_dv_rid = dv_rows[0]["RID"]
+    in_exec = _seed_input_edge_with_config(ml, out_ds, target_version)
+    migrate.run_migration(catalog, ML_SCHEMA, dry_run=False)
+
+    # Force the input row's Dataset_Version back to NULL to simulate a row that
+    # could not be backfilled on the first pass (e.g. parser couldn't read config yet).
+    de = pb.schemas[ML_SCHEMA].Dataset_Execution
+    in_row = next(r for r in de.entities().fetch() if r["Execution"] == in_exec and r["Dataset"] == out_ds)
+    de.update([{"RID": in_row["RID"], "Dataset_Version": None}], [de.RID])
+    assert next(r for r in _dataset_execution_rows(catalog)
+                if r["RID"] == in_row["RID"])["Dataset_Version"] is None
+
+    # 2. A NORMAL migrate() would short-circuit (column present, no output rows) and
+    #    leave the NULL row untouched.
+    migrate.migrate(hostname, catalog.catalog_id, ML_SCHEMA, dry_run=False)
+    still_null = next(r for r in _dataset_execution_rows(catalog) if r["RID"] == in_row["RID"])
+    assert still_null.get("Dataset_Version") is None, "normal run should short-circuit, not backfill"
+
+    # 3. backfill_only=True bypasses the short-circuit and fills the row.
+    migrate.migrate(hostname, catalog.catalog_id, ML_SCHEMA, dry_run=False, backfill_only=True)
+    filled = next(r for r in _dataset_execution_rows(catalog) if r["RID"] == in_row["RID"])
+    assert filled.get("Dataset_Version") == target_dv_rid
+
+
+# NOTE: the column-absent error path (backfill_only=True with no Dataset_Version
+# column -> returns False) is not unit-tested here. A freshly-created catalog is
+# born WITH the column (create_schema.py adds it); a column-absent state only
+# arises transiently if a prior test drops it (reset() clears data, not schema),
+# which is order-dependent and not reliable to depend on -- so a robust test would
+# need a deliberate column-drop dance. The guard is a trivial
+# `if not info["has_column"]: return False`, verified by inspection instead.
+
+
+@pytest.mark.integration
+def test_backfill_only_does_not_add_columns_or_delete_rows(seeded_ml):
+    """``backfill_only=True`` must not run Step 1 (add column) or Step 2 (delete output rows)."""
+    ml = seeded_ml
+    catalog = ml.catalog
+    hostname = catalog.deriva_server.server
+
+    out_ds, out_exec = _seed_output_edge(ml)
+    _seed_input_edge(ml, out_ds)
+    # Structurally migrate first so the column exists and output rows are gone.
+    migrate.run_migration(catalog, ML_SCHEMA, dry_run=False)
+    rows_before = len(_dataset_execution_rows(catalog))
+
+    # backfill_only on the already-migrated catalog: no structural change, no deletions.
+    migrate.migrate(hostname, catalog.catalog_id, ML_SCHEMA, dry_run=False, backfill_only=True)
+    rows_after = len(_dataset_execution_rows(catalog))
+    assert rows_after == rows_before, "backfill_only must not delete or add rows"


### PR DESCRIPTION
## Summary
The `Dataset_Execution` migration short-circuits when the `Dataset_Version` column exists and no output rows remain, treating leftover NULL-version input rows as the expected irreducible tail. That assumption broke once the config-parser fix (#279) made previously-unreadable `configuration.json` files resolvable: a plain re-run short-circuits instead of backfilling the now-recoverable versions.

Add a **`--backfill-only`** flag (`migrate(..., backfill_only=True)`) that bypasses the short-circuit and the structural steps (add column / delete output rows) and runs **only** the best-effort version backfill against existing NULL-version input rows. Requires the column to already exist (errors otherwise). Normal runs are unchanged.

## Why
On `dev.eye-ai.org`, the first migration pass left 579 input rows with NULL `Dataset_Version` because the parser rejected every legacy config (pre-#279). With #279 released, those versions are recoverable — but only by re-running the backfill, which the short-circuit blocked. This flag enables the second pass (needed for dev now, and prod later).

## Test Plan
- [x] `test_backfill_only_runs_backfill_past_short_circuit`: structurally-migrated catalog with a NULL-version input row → normal run short-circuits (leaves NULL), `--backfill-only` fills it to the correct Dataset_Version RID.
- [x] `test_backfill_only_does_not_add_columns_or_delete_rows`: no structural change under `--backfill-only`.
- [x] 10/10 migration tests pass; `--dry-run` composes (preview, no writes).
- [ ] After merge + release: run `migrate_dataset_execution_version.py dev.eye-ai.org eye-ai --backfill-only` (then prod) to recover the 579 versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)