### PR TITLE
feat(core): restore DerivaML.user_list() with regression test

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,3 +1,18 @@
+Migration notes — corrections (2026-06-03)
+
+**Documentation backfill for previously under-documented public-API breakages.** The
+changes below already shipped in earlier releases but were missing from (or only
+partially covered by) these notes. They are recorded here because they break
+external callers — notably domain subclasses of `DerivaML` such as `EyeAI` — and a
+consumer migrating across these versions needs them.
+
+| Change | Shipped in | Migration |
+|--------|-----------|-----------|
+| `DatasetBag.denormalize_as_dataframe(...)` renamed to **`DatasetBag.get_denormalized_as_dataframe(...)`** | ~v1.30.6 (the denormalize sugar-method refactor; old names removed) | Rename the call. Arguments are unchanged: the positional `include_tables` list and the `include_tables=`, `row_per=`, `via=`, `selector=` keywords all carry over. The dict variant is likewise `get_denormalized_as_dict(...)`. There is no deprecation shim — the old name raises `AttributeError`. |
+| Public `DerivaML.domain_path` property removed; replaced by the **`_domain_path()` method** | mixin refactor (path-builder accessors moved to `PathBuilderMixin`) | Change `self.domain_path.<Table>...` to `self._domain_path().<Table>...` (note the parentheses — it is now a method). `_domain_path(schema=None)` returns the path builder for the domain schema (defaulting to `default_schema`); pass a schema name for a non-default one. |
+| `check_auth` removed — **also from the `DerivaML.__init__` constructor**, not only from `DerivaMLConfig` | v1.37.x auth refactor (see the existing 1.37.0 note) | The existing note says to drop `check_auth` from hydra-zen configs / `DerivaMLConfig`. It is *also* gone from the `DerivaML(...)` constructor signature: subclasses that accepted `check_auth` and forwarded it via `super().__init__(check_auth=...)` now raise `TypeError`. Remove the parameter and the forwarded keyword. |
+| `DerivaML.__init__` gained a **`mode` parameter** (`ConnectionMode`, default `online`) | the mode-branched `__init__` change | Non-breaking addition. `mode=ConnectionMode.online` (the default) preserves prior behavior; `mode=ConnectionMode.offline` (or the string `"online"`/`"offline"`) stages writes locally. Subclasses overriding `__init__` may forward `mode` through to `super().__init__(...)` to expose offline mode. |
+
 Version 1.39.0
 
 **Breaking-API change shipped as a minor bump.** The four ways to upload execution outputs (`Execution.upload_execution_outputs`, `Execution.upload_outputs`, `ExecutionSnapshot.upload_outputs`, `DerivaML.upload_pending`) collapse into one per-execution method and one batch method. Callers of the removed methods must migrate at upgrade — there are no deprecation shims. Major-version (`v2.0.0`) is deferred until the unified surface has more bake time. See ADR-0009 for the rationale and the two latent bugs fixed.

--- a/src/deriva_ml/core/mixins/path_builder.py
+++ b/src/deriva_ml/core/mixins/path_builder.py
@@ -46,6 +46,7 @@ class PathBuilderMixin:
         _table_path: Internal filesystem path for table CSV files
         get_table_as_dataframe: Get table contents as pandas DataFrame
         get_table_as_dict: Get table contents as dictionaries
+        user_list: Get catalog users from public.ERMrest_Client
     """
 
     # Type hints for IDE support - actual attributes from host class
@@ -162,3 +163,30 @@ class PathBuilderMixin:
         table_obj = self.model.name_to_table(table)
         pb = self.pathBuilder()
         yield from pb.schemas[table_obj.schema.name].tables[table_obj.name].entities().fetch()
+
+    def user_list(self) -> list[dict[str, str]]:
+        """Returns the catalog user list.
+
+        Retrieves basic information about all users who have access to the
+        catalog, from the ``public.ERMrest_Client`` table.
+
+        Note:
+            The user table lives in the ``public`` schema, which is *outside*
+            the domain/ML schema search path used by
+            :meth:`get_table_as_dict` (``name_to_table`` searches
+            ``domain_schemas → ml_schema → WWW``). This method is the
+            supported accessor for catalog users; ``get_table_as_dict``
+            cannot reach ``ERMrest_Client``.
+
+        Returns:
+            A list of user dictionaries, each with:
+                - ``'ID'``: the user's globus identifier
+                - ``'Full_Name'``: the user's full name
+
+        Example:
+            >>> users = ml.user_list()  # doctest: +SKIP
+            >>> for user in users:  # doctest: +SKIP
+            ...     print(f"{user['Full_Name']} ({user['ID']})")
+        """
+        user_path = self.pathBuilder().schemas["public"].tables["ERMrest_Client"]
+        return [{"ID": u["ID"], "Full_Name": u["Full_Name"]} for u in user_path.entities().fetch()]

--- a/src/deriva_ml/interfaces.py
+++ b/src/deriva_ml/interfaces.py
@@ -765,6 +765,14 @@ class DerivaMLCatalogReader(Protocol):
         """
         ...
 
+    def user_list(self) -> list[dict[str, str]]:
+        """Get the catalog user list from public.ERMrest_Client.
+
+        Returns:
+            List of user dicts, each with 'ID' and 'Full_Name'.
+        """
+        ...
+
     def list_dataset_element_types(self) -> Iterable[Table]:
         """List the types of elements that can be contained in datasets.
 

--- a/tests/core/test_user_list.py
+++ b/tests/core/test_user_list.py
@@ -1,0 +1,35 @@
+"""Regression test for ``DerivaML.user_list()``.
+
+``user_list()`` was once deleted as "dead code" (zero callers *inside*
+deriva-ml) even though external subclasses (e.g. EyeAI) depend on it. This
+test pins the public method's existence and contract so the deletion cannot
+silently recur.
+
+The user table (``public.ERMrest_Client``) lives outside the domain/ML schema
+search path, so ``get_table_as_dict("ERMrest_Client")`` cannot reach it —
+``user_list()`` is the supported accessor. See
+``core/mixins/path_builder.py``.
+"""
+
+
+class TestUserList:
+    def test_user_list_contract(self, test_ml):
+        """user_list() returns a list of {'ID', 'Full_Name'} dicts.
+
+        Asserts the shape/contract rather than specific user content, since
+        the rows in public.ERMrest_Client vary by environment. ERMrest
+        auto-populates this table with at least the catalog's creator, so the
+        list is expected to be non-empty against a real catalog.
+        """
+        users = test_ml.user_list()
+
+        assert isinstance(users, list)
+        # ERMrest_Client always holds at least the creating client.
+        assert len(users) >= 1
+        for user in users:
+            assert set(user.keys()) == {"ID", "Full_Name"}
+
+    def test_user_list_method_exists(self, test_ml):
+        """Guard against re-deletion: the public method must be present."""
+        assert hasattr(test_ml, "user_list")
+        assert callable(test_ml.user_list)


### PR DESCRIPTION
## Summary

Restores `DerivaML.user_list()`, which was deleted as "dead code" (zero callers *inside* deriva-ml) but is depended on by external `DerivaML` subclasses — `EyeAI.image_tall()` (in eye-ai-ml) maps a grader's `RCB` user id to `Full_Name` via `user_list()`. The deletion silently broke that path.

## Changes

- **Restore `user_list()`** in `PathBuilderMixin` (`core/mixins/path_builder.py`) using the current subscript path-builder idiom, plus an interface stub in `interfaces.py`. Returns `[{"ID", "Full_Name"}, ...]` from `public.ERMrest_Client`.
  - Note: `public` is outside the domain/ML schema search path, so `get_table_as_dict("ERMrest_Client")` cannot reach it — `user_list()` is the supported accessor.
- **Regression test** (`tests/core/test_user_list.py`): pins the public method's existence and `{ID, Full_Name}` contract so the deletion cannot silently recur.
- **Release-notes backfill** (`docs/release-notes.md`): documents four previously under-documented public-API breakages that hit external callers — the `denormalize_as_dataframe` → `get_denormalized_as_dataframe` rename, the `domain_path` property → `_domain_path()` method change, the `check_auth` removal from the constructor (not just `DerivaMLConfig`), and the new `mode`/`ConnectionMode` `__init__` parameter.

## Context

Part of an eye-ai-ml migration to current deriva-ml. eye-ai-ml currently pins this branch; once merged it will move to a tag/default-branch pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)