### PR TITLE
feat(denormalize): opt-in system columns (RCB/RCT/RMT/RMB) in wide tables

### DIFF
--- a/src/deriva_ml/dataset/dataset_bag.py
+++ b/src/deriva_ml/dataset/dataset_bag.py
@@ -917,6 +917,7 @@ class DatasetBag:
         via: list[str] | None = None,
         ignore_unrelated_anchors: bool = False,
         selector: Callable[[list[FeatureRecord]], FeatureRecord | None] | None = None,
+        system_columns: list[str] | None = None,
     ) -> pd.DataFrame:
         """Return the dataset bag as a denormalized wide table (DataFrame).
 
@@ -940,6 +941,13 @@ class DatasetBag:
                 feature-association table; raises ``ValueError``
                 otherwise. Identical contract to
                 :meth:`feature_values`'s ``selector`` argument.
+            system_columns: Optional list of per-table system columns to
+                retain in the output (any of ``"RCT"``, ``"RMT"``,
+                ``"RCB"``, ``"RMB"``). These are dropped by default. Use
+                this when you need provenance — e.g. ``["RCB"]`` keeps each
+                row's creating-user id so it can be joined against the
+                catalog user list. Retained columns are labeled
+                ``Table.RCB`` like any other column.
 
         Returns:
             A :class:`pandas.DataFrame` with one row per ``row_per``
@@ -956,6 +964,11 @@ class DatasetBag:
                 ["Image", "Execution_Image_Image_Classification"],
                 selector=FeatureRecord.select_newest,
             )
+
+            # Keep the diagnosis row's creating-user id for a grader join:
+            df = bag.get_denormalized_as_dataframe(
+                ["Image", "Image_Diagnosis"], system_columns=["RCB"]
+            )
         """
         from deriva_ml.local_db.denormalizer import Denormalizer
 
@@ -965,6 +978,7 @@ class DatasetBag:
             via=via,
             ignore_unrelated_anchors=ignore_unrelated_anchors,
             selector=selector,
+            system_columns=system_columns,
         )
 
     def get_denormalized_as_dict(

--- a/src/deriva_ml/local_db/denormalize.py
+++ b/src/deriva_ml/local_db/denormalize.py
@@ -207,6 +207,7 @@ def _denormalize_impl(
     row_per: str | None = None,
     via: list[str] | None = None,
     selector: Callable[[list[Any]], Any] | None = None,
+    system_columns: list[str] | None = None,
 ) -> DenormalizeResult:
     """Unified denormalization: plan joins via ``_prepare_wide_table``, execute locally.
 
@@ -332,6 +333,7 @@ def _denormalize_impl(
         include_tables,
         row_per=row_per,
         via=via,
+        system_columns=system_columns,
     )
 
     # Build a quick lookup from table name to schema name so we can form

--- a/src/deriva_ml/local_db/denormalizer.py
+++ b/src/deriva_ml/local_db/denormalizer.py
@@ -434,6 +434,7 @@ class Denormalizer:
         via: list[str] | None = None,
         ignore_unrelated_anchors: bool = False,
         selector: Callable[[list["FeatureRecord"]], "FeatureRecord | None"] | None = None,
+        system_columns: list[str] | None = None,
     ) -> pd.DataFrame:
         """Materialize the denormalized table as a :class:`pandas.DataFrame`.
 
@@ -529,6 +530,7 @@ class Denormalizer:
             via=via,
             ignore_unrelated_anchors=ignore_unrelated_anchors,
             selector=selector,
+            system_columns=system_columns,
         )
         return result.to_dataframe()
 
@@ -1400,6 +1402,7 @@ class Denormalizer:
         via: list[str] | None,
         ignore_unrelated_anchors: bool,
         selector: Callable[[list["FeatureRecord"]], "FeatureRecord | None"] | None = None,
+        system_columns: list[str] | None = None,
     ) -> DenormalizeResult:
         """Execute the full 4-phase denormalization pipeline.
 
@@ -1546,6 +1549,7 @@ class Denormalizer:
             row_per=resolved_row_per,
             via=list(via or []) or None,
             selector=selector,
+            system_columns=system_columns,
         )
 
         # Step 4a: Augment orphans with scoping-upstream anchors whose specific

--- a/src/deriva_ml/model/denormalize_planner.py
+++ b/src/deriva_ml/model/denormalize_planner.py
@@ -1646,6 +1646,7 @@ class DenormalizePlanner:
         *,
         row_per: str | None = None,
         via: list[str] | None = None,
+        system_columns: list[str] | None = None,
     ) -> tuple[dict[str, Any], list[tuple], bool]:
         """Generate a join plan for denormalizing a dataset into a wide table.
 
@@ -1790,7 +1791,10 @@ class DenormalizePlanner:
         paths_by_element = {elem: paths for elem, paths in paths_by_element.items() if elem in include_tables_set}
 
         # ── Phase 2: build JoinTree per element ──────────────────────────────
-        skip_columns = {"RCT", "RMT", "RCB", "RMB"}
+        # System columns are dropped from the wide table by default. Callers
+        # that need provenance (e.g. RCB = the row's creating user) can opt
+        # specific ones back in via ``system_columns``.
+        skip_columns = {"RCT", "RMT", "RCB", "RMB"} - set(system_columns or [])
         element_tables: dict[str, tuple[list[str], dict[str, set], dict[str, str]]] = {}
 
         for element_name, paths in paths_by_element.items():

--- a/tests/local_db/test_denormalizer.py
+++ b/tests/local_db/test_denormalizer.py
@@ -44,6 +44,30 @@ class TestAsDataframe:
         assert any(c.startswith("Image.") for c in df.columns)
         assert any(c.startswith("Subject.") for c in df.columns)
 
+    def test_system_columns_excluded_by_default(self, populated_denorm) -> None:
+        """RCT/RMT/RCB/RMB are dropped from the wide table by default."""
+        ds = _FakeDataset(populated_denorm)
+        d = Denormalizer(ds)
+        df = d.as_dataframe(["Image", "Subject"])
+        for sys_col in ("RCT", "RMT", "RCB", "RMB"):
+            assert not any(c.endswith(f".{sys_col}") for c in df.columns), (
+                f"{sys_col} should be excluded by default"
+            )
+
+    def test_system_columns_opt_in_retains_rcb(self, populated_denorm) -> None:
+        """system_columns=['RCB'] retains the creating-user column per table."""
+        ds = _FakeDataset(populated_denorm)
+        d = Denormalizer(ds)
+        df = d.as_dataframe(["Image", "Subject"], system_columns=["RCB"])
+        # RCB now present, labeled Table.RCB, for each contributing table.
+        assert "Image.RCB" in df.columns
+        assert "Subject.RCB" in df.columns
+        # The other system columns remain excluded (opt-in is per-column).
+        for sys_col in ("RCT", "RMT", "RMB"):
+            assert not any(c.endswith(f".{sys_col}") for c in df.columns), (
+                f"{sys_col} should still be excluded"
+            )
+
     def test_empty_dataset(self, populated_denorm) -> None:
         """Nonexistent dataset RID returns empty DataFrame with correct columns."""
         ds = _FakeDataset(populated_denorm, dataset_rid="NO-SUCH-DS")


### PR DESCRIPTION
## Summary

The denormalizer drops the four system columns (`RCT`/`RMT`/`RCB`/`RMB`) from wide-table output. That makes provenance unrecoverable — notably `RCB` (the row's creating user), which a caller needs to map a row back to the user who created it. Concrete case: `EyeAI.image_tall` maps an `Image_Diagnosis` grader to a name via the catalog user list, and currently can't use `get_denormalized_as_dataframe` because it drops `RCB`.

## Change

Add a `system_columns: list[str] | None = None` parameter, threaded through:

```
DatasetBag.get_denormalized_as_dataframe
  -> Denormalizer.as_dataframe
    -> Denormalizer._run
      -> _denormalize_impl
        -> DenormalizePlanner._prepare_wide_table
```

In the planner, `skip_columns = {RCT, RMT, RCB, RMB} - set(system_columns)`, so opted-in columns flow through the existing `column_specs` -> SQL SELECT -> DataFrame path unchanged. Default (`None`) preserves current behavior exactly. Retained columns are labeled `Table.RCB` like any other column; opt-in is per-column.

## Verification

Empirically verified against a real eye-ai bag:
- default -> 0 RCB columns (55 cols)
- `system_columns=["RCB"]` -> `Image.RCB`, `Subject.RCB`, `Observation.RCB`, `Image_Diagnosis.RCB` (59 cols)

Adds two unit tests on the canned denorm fixture (default-excluded + opt-in-retained). Full local_db + denormalize logic suite passes (354 passed); the only failures/errors in the broader run are pre-existing live-`localhost`-catalog fixtures unrelated to this change.

## Downstream

Unblocks rewriting `EyeAI.image_tall` onto `get_denormalized_as_dataframe(..., system_columns=["RCB"])`, removing its manual join.

Generated with Claude Code