### PR TITLE
fix(asset): drop asset_role from AssetSpecConfig (context-determined)

### DIFF
--- a/src/deriva_ml/asset/aux_classes.py
+++ b/src/deriva_ml/asset/aux_classes.py
@@ -195,13 +195,21 @@ class AssetSpec(BaseModel):
 class AssetSpecConfig:
     """Hydra-zen configuration interface for ``AssetSpec``.
 
-    Field-for-field parity with :class:`AssetSpec`; configuring
-    an asset via hydra-zen must be able to express everything that
-    constructing an ``AssetSpec`` directly can. Drift would mean
-    some asset semantics are quietly unreachable from hydra-zen
-    configs — silent feature loss.
+    Exposes the asset attributes that are meaningful to *configure*: the
+    asset ``rid`` and whether to ``cache`` it. It deliberately does **not**
+    expose ``asset_role`` — an asset's role (``Input`` / ``Output``) is
+    determined by **context**, not by configuration: an asset referenced in
+    an execution's input configuration is an *input*, and assets written via
+    ``commit_output_assets`` are *outputs*. ``AssetSpec.asset_role`` therefore
+    keeps its ``"Input"`` default here and is set by the producing/consuming
+    operation, never by the config author.
 
-    Use in hydra-zen store definitions to specify assets with caching:
+    (Exposing ``asset_role`` as a configurable, ``Literal``-typed field also
+    broke structured-config registration under omegaconf < 2.4, which cannot
+    serialize ``Literal`` annotations — another reason it does not belong on
+    this interface.)
+
+    Use in hydra-zen store definitions to specify assets, optionally cached:
 
         >>> from hydra_zen import store  # doctest: +SKIP
         >>> asset_store = store(group="assets")  # doctest: +SKIP
@@ -210,18 +218,11 @@ class AssetSpecConfig:
         ...     name="cached_weights",
         ... )
 
-        >>> # Mark as an Output asset (e.g. for a workflow that
-        >>> # produces a model file):
-        >>> cfg = AssetSpecConfig(rid="6-EPNR", asset_role="Output")  # doctest: +SKIP
-
     Attributes:
         rid: Resource Identifier of the asset. Mirrors ``AssetSpec.rid``.
-        asset_role: Role of the asset (``"Input"`` or ``"Output"``).
-            Defaults to ``"Input"``. Mirrors ``AssetSpec.asset_role``.
         cache: If True, cache the downloaded asset by MD5 checksum in
             the DerivaML cache directory. Mirrors ``AssetSpec.cache``.
     """
 
     rid: str
-    asset_role: Literal["Input", "Output"] = "Input"
     cache: bool = False

--- a/tests/asset/test_asset_spec_parity.py
+++ b/tests/asset/test_asset_spec_parity.py
@@ -1,20 +1,22 @@
-"""Field-parity check for :class:`AssetSpec` and :class:`AssetSpecConfig`.
+"""Contract check for :class:`AssetSpec` and :class:`AssetSpecConfig`.
 
-``AssetSpec`` (regular Python) and ``AssetSpecConfig`` (hydra-zen
-dataclass interface) are documented as the two equivalent ways to
-declare an asset. They must stay field-for-field equivalent:
-anything expressible via ``AssetSpec`` must also be expressible via
-``AssetSpecConfig`` and vice versa.
+``AssetSpec`` (regular Python) is the canonical runtime model for an asset
+reference. ``AssetSpecConfig`` (hydra-zen dataclass interface) is its
+*configuration* surface — it exposes only the attributes that are meaningful
+to configure.
 
-Pre-fix, ``AssetSpecConfig`` was missing the ``asset_role`` field
-that ``AssetSpec`` already had. Users configuring assets through a
-hydra-zen store had no way to mark an asset as an ``Output`` —
-silent feature loss surfaced only when someone tried to express
-the role through the config interface and discovered it was
-ignored.
+The two are intentionally **not** field-for-field identical. ``AssetSpec``
+carries ``asset_role`` (``Input`` / ``Output``), but that role is determined
+by **context**, never configured:
 
-This test enforces the parity contract as a CI gate. Modelled on
-``tests/test_dataset_like_signature_parity.py`` (audit §3.C).
+- An asset referenced in an execution's input configuration is an *input*.
+- Assets written via ``commit_output_assets`` are *outputs*.
+
+So ``asset_role`` must NOT appear on ``AssetSpecConfig``: there is no scenario
+where a config author legitimately marks a config-declared asset as an Output,
+and exposing it as a configurable ``Literal``-typed field additionally broke
+structured-config registration under omegaconf < 2.4 (which cannot serialize
+``Literal`` annotations). This test pins that contract as a CI gate.
 """
 
 from __future__ import annotations
@@ -23,41 +25,40 @@ import dataclasses
 
 from deriva_ml.asset.aux_classes import AssetSpec, AssetSpecConfig
 
+# Fields that exist on AssetSpec but are intentionally NOT configurable.
+# asset_role is set by context (input config vs. commit_output_assets), so it
+# is excluded from the hydra-zen configuration surface by design.
+CONTEXT_DETERMINED_FIELDS = {"asset_role"}
 
-def test_assetspec_assetspecconfig_field_parity() -> None:
-    """Every ``AssetSpec`` field appears on ``AssetSpecConfig`` (same name & default).
 
-    Strict-direction parity: ``AssetSpec`` is the canonical model;
-    ``AssetSpecConfig`` is its hydra-zen surface and must mirror it.
-    Going the other way is technically allowed (the config can carry
-    purely-presentation hints like ``_target_``) but we don't see a
-    use case yet; flag it explicitly if it ever comes up.
+def test_config_exposes_configurable_fields_with_matching_defaults() -> None:
+    """Every *configurable* AssetSpec field appears on AssetSpecConfig.
+
+    Parity holds for all fields EXCEPT the context-determined ones
+    (``asset_role``). A configurable AssetSpec field missing from the config
+    would be silent feature loss; a context-determined field present on the
+    config would invite authors to set something the system ignores (and
+    reintroduce the omegaconf ``Literal`` break).
     """
     spec_fields = AssetSpec.model_fields
     config_fields = {f.name: f for f in dataclasses.fields(AssetSpecConfig)}
 
-    missing = sorted(set(spec_fields) - set(config_fields))
+    expected_configurable = set(spec_fields) - CONTEXT_DETERMINED_FIELDS
+
+    missing = sorted(expected_configurable - set(config_fields))
     assert not missing, (
-        f"AssetSpecConfig is missing fields that AssetSpec declares: "
-        f"{missing}. The hydra-zen interface must mirror the Python "
-        f"interface; otherwise hydra-zen users silently can't express "
-        f"those asset semantics. The pre-fix gap that prompted this "
-        f"test: ``asset_role`` lived on AssetSpec but not on "
-        f"AssetSpecConfig, so configs had no way to mark an asset "
-        f"as an Output."
+        f"AssetSpecConfig is missing configurable fields AssetSpec declares: "
+        f"{missing}. The hydra-zen interface must expose every field a config "
+        f"author can meaningfully set (e.g. ``rid``, ``cache``)."
     )
 
-    # Defaults must match. ``model_fields[name].default`` is
-    # PydanticUndefined for required fields; ``dataclasses.fields``
-    # uses ``dataclasses.MISSING`` — translate both to a sentinel
-    # so the comparison stays clean.
+    # Defaults must match for the shared configurable fields.
     REQUIRED = object()
 
     def _spec_default(name: str):
-        d = spec_fields[name].default
-        # Pydantic: ``PydanticUndefined`` means "required".
         from pydantic_core import PydanticUndefined
 
+        d = spec_fields[name].default
         return REQUIRED if d is PydanticUndefined else d
 
     def _config_default(name: str):
@@ -66,37 +67,43 @@ def test_assetspec_assetspecconfig_field_parity() -> None:
 
     mismatched = {
         name: (_spec_default(name), _config_default(name))
-        for name in spec_fields
+        for name in expected_configurable
         if _spec_default(name) != _config_default(name)
     }
     assert not mismatched, (
         f"Default-value mismatches between AssetSpec and AssetSpecConfig: "
-        f"{mismatched}. A drifted default means a hydra-zen-configured "
-        f"asset behaves differently from one declared in Python."
+        f"{mismatched}. A drifted default means a hydra-zen-configured asset "
+        f"behaves differently from one declared in Python."
     )
 
 
-def test_assetspecconfig_carries_asset_role() -> None:
-    """``AssetSpecConfig`` exposes ``asset_role`` with default ``'Input'``.
+def test_config_does_not_expose_asset_role() -> None:
+    """``AssetSpecConfig`` must NOT expose ``asset_role`` (context-determined).
 
-    Direct regression for the bug. Even with the parity test
-    above, an explicit positive assertion makes the failure mode
-    obvious in CI output: if the field disappears, this test names
-    it.
+    Direct regression guard: asset role is set by where the asset is used
+    (input config vs. ``commit_output_assets``), not by the config author.
+    Re-adding ``asset_role`` here would also reintroduce the omegaconf
+    ``Literal`` structured-config break.
     """
     config_field_names = {f.name for f in dataclasses.fields(AssetSpecConfig)}
-    assert "asset_role" in config_field_names, (
-        "AssetSpecConfig must declare ``asset_role`` for parity with "
-        "AssetSpec. Without it, hydra-zen configs can't express "
-        "Output assets."
+    assert "asset_role" not in config_field_names, (
+        "AssetSpecConfig must not declare ``asset_role`` — an asset's role is "
+        "determined by context (input configuration vs. commit_output_assets), "
+        "not configured. See AssetSpecConfig docstring."
     )
 
-    cfg = AssetSpecConfig(rid="3JSE")
-    assert cfg.asset_role == "Input", (
-        f"AssetSpecConfig.asset_role default should be 'Input' "
-        f"(matching AssetSpec); got {cfg.asset_role!r}."
-    )
 
-    # And it accepts a non-default value.
-    cfg_out = AssetSpecConfig(rid="3JSE", asset_role="Output")
-    assert cfg_out.asset_role == "Output"
+def test_config_instantiates_to_assetspec_with_input_default() -> None:
+    """A configured asset instantiates to an AssetSpec defaulting to Input.
+
+    ``rid`` + ``cache`` round-trip; the runtime ``asset_role`` takes its
+    ``"Input"`` default (the role is then set by the consuming/producing
+    operation).
+    """
+    from hydra_zen import instantiate
+
+    spec = instantiate(AssetSpecConfig(rid="3JSE", cache=True))
+    assert isinstance(spec, AssetSpec)
+    assert spec.rid == "3JSE"
+    assert spec.cache is True
+    assert spec.asset_role == "Input"


### PR DESCRIPTION
## Problem

`AssetSpecConfig` (the hydra-zen configuration interface for `AssetSpec`) exposed `asset_role` as a settable, `Literal["Input","Output"]`-typed field. This caused two issues:

1. **It's the wrong model.** An asset's role is determined by **context**, not configuration:
   - an asset referenced in an execution's *input configuration* is an **input** (deriva-ml stamps `asset_role="Input"`), and
   - assets written via `commit_output_assets` are **outputs** (stamped `Output`/`Output_File`).

   There is no scenario where a config author legitimately marks a config-declared asset as an `Output`. Exposing `asset_role` on the config invites setting something the system ignores. (`docs/audits/2026-05-22-engineer-audit-asset.md` already flagged "try to set `asset_role="Output"` on a hydra-zen asset" as a bug repro.)

2. **It crashes structured-config registration.** The `Literal` annotation cannot be registered by omegaconf < 2.4, and `hydra-core` 1.3.2 pins `omegaconf<2.4` (omegaconf 2.4 is dev-only). So **any** hydra-zen `store` containing an `AssetSpecConfig` fails at `store.add_to_hydra_store()` with:

   ```
   omegaconf.errors.ValidationError: Unexpected type annotation: Literal[Input, Output]
       (full_key: asset_role, object_type=AssetSpecConfig)
   ```

   This breaks `deriva-ml-run` (including `--info`) for any downstream project that uses `AssetSpecConfig(rid=..., cache=True)` — the pattern deriva-ml's own `config/bootstrap.py` generates and documents.

## Fix

Remove `asset_role` from the `AssetSpecConfig` hydra-zen interface (it now exposes only `rid` + `cache`). The runtime `AssetSpec` model is **unchanged** — it keeps `asset_role` with its `Literal` validation and `"Input"` default, which is set by the consuming/producing operation. When hydra-zen instantiates `AssetSpec` from the config, `asset_role` simply takes its default.

`config/bootstrap.py:_format_asset_spec` already only emits `rid` + `cache`, so it needs no change.

## Tests

Rewrote `tests/asset/test_asset_spec_parity.py` to pin the corrected contract:
- parity holds for *configurable* fields (`rid`, `cache`) with matching defaults;
- `asset_role` is explicitly **absent** from the config (regression guard);
- a configured asset instantiates to an `AssetSpec` defaulting to `Input`.

Verified: the parity tests and `tests/config/test_bootstrap.py` pass; a hydra-zen store with `AssetSpecConfig(rid=..., cache=True)` now registers under omegaconf 2.3 and instantiates to `AssetSpec(rid=..., cache=True, asset_role="Input")`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)