### PR TITLE
fix(storage): PR #286 review follow-ups (orphan sweep, summary sizing, ordering test)

### DIFF
--- a/src/deriva_ml/core/base.py
+++ b/src/deriva_ml/core/base.py
@@ -1706,8 +1706,14 @@ class DerivaML(
         bags = self.list_cached_bags()
         assets = self.list_cached_assets()
         # A multi-anchor bag appears once per dataset RID in the
-        # listing; size it once per checksum for the summary.
-        bag_bytes = sum({b.checksum: (b.size_bytes or 0) for b in bags}.values())
+        # listing (bag_count counts those entries); size it once per
+        # checksum, at the largest anchor's size — an anchor whose
+        # Dataset_{rid} directory doesn't exist reports 0/None and
+        # must not mask the real on-disk size.
+        sizes_by_checksum: dict[str, int] = {}
+        for b in bags:
+            sizes_by_checksum[b.checksum] = max(sizes_by_checksum.get(b.checksum, 0), b.size_bytes or 0)
+        bag_bytes = sum(sizes_by_checksum.values())
         asset_bytes = sum(a.size_bytes for a in assets)
 
         return {

--- a/src/deriva_ml/core/storage.py
+++ b/src/deriva_ml/core/storage.py
@@ -240,6 +240,10 @@ def clear_cache(
        :meth:`~deriva.bag.cache_index.BagCacheIndex.purge`, dropping
        the index row and the on-disk directory together. The index
        can never claim a bag whose directory this function removed.
+       A pass 1b then sweeps **orphan** ``bags/*`` entries (no index
+       row — e.g. debris from the pre-1.46 blind-walk cleaner) by
+       mtime; skipped entirely when the index is unusable, since
+       orphans can't be told apart from indexed bags.
     2. **Assets by mtime** — ``assets/*`` entries older than the
        cutoff are removed.
     3. **Stray top-level entries** (anything not in
@@ -270,6 +274,11 @@ def clear_cache(
     cutoff = time.time() - older_than_days * 86400 if older_than_days is not None else None
 
     # Pass 1: bags, through the index (never orphan the index).
+    # ``indexed_checksums`` doubles as the orphan-sweep allowlist for
+    # pass 1b: None means the index was unusable (can't tell orphans
+    # from indexed bags — leave bags/ alone); empty set means no index
+    # exists, so everything under bags/ is an orphan.
+    indexed_checksums: set[str] | None = set()
     if (cache_dir / "index.sqlite").exists():
         from deriva.bag.cache_index import BagCacheIndex
 
@@ -279,9 +288,11 @@ def clear_cache(
             log.warning("Bag index unusable, skipping bag pass: %s", e)
             stats["errors"] += 1
             index = None
+            indexed_checksums = None
         if index is not None:
             try:
                 for row in index.list_bags():
+                    indexed_checksums.add(row["checksum"])
                     if cutoff is not None:
                         built = datetime.fromisoformat(row["built_at"]).timestamp()
                         if built > cutoff:
@@ -300,6 +311,31 @@ def clear_cache(
                         stats["bytes_freed"] += freed
             finally:
                 index.dispose()
+
+    # Pass 1b: orphan bag directories — entries under bags/ with no
+    # index row (e.g. left behind by the pre-1.46 blind-rmtree
+    # clear_cache, which could delete index.sqlite while bags/
+    # survived an age filter). Purged bags' directories are already
+    # gone, so allowlisting every checksum seen in pass 1 is safe.
+    bags_dir = cache_dir / "bags"
+    if indexed_checksums is not None and bags_dir.exists():
+        for entry in bags_dir.iterdir():
+            if entry.name in indexed_checksums:
+                continue
+            try:
+                if cutoff is not None and entry.stat().st_mtime > cutoff:
+                    continue
+                freed = _dir_size(entry) if entry.is_dir() else entry.stat().st_size
+                if entry.is_dir():
+                    shutil.rmtree(entry)
+                    stats["dirs_removed"] += 1
+                else:
+                    entry.unlink()
+                    stats["files_removed"] += 1
+                stats["bytes_freed"] += freed
+            except (OSError, PermissionError) as e:
+                log.warning("Failed to remove orphan bag entry %s: %s", entry, e)
+                stats["errors"] += 1
 
     # Pass 2: assets, by mtime.
     assets_dir = cache_dir / "assets"

--- a/tests/core/test_cache_introspection.py
+++ b/tests/core/test_cache_introspection.py
@@ -282,7 +282,7 @@ class TestPurgeDataset:
         with BagCache(cache_dir) as cache:
             stats = cache.purge_dataset("RID-ERR")
 
-        assert stats["bags_removed"] == 1   # x2 succeeded despite x1 failing
+        assert stats["bags_removed"] == 1  # x2 succeeded despite x1 failing
 
 
 # ---------------------------------------------------------------------------
@@ -557,3 +557,103 @@ class TestDerivaMLSurface:
 class TestExports:
     def test_records_importable_from_top_level(self):
         from deriva_ml import CachedAsset, CachedBag  # noqa: F401
+
+
+# ---------------------------------------------------------------------------
+# PR #286 review follow-ups: orphan-dir sweep, summary denominators,
+# listing order
+# ---------------------------------------------------------------------------
+
+
+class TestClearCacheOrphanSweep:
+    def test_orphan_bag_dir_removed(self, tmp_path: Path):
+        """A bags/ directory with no index row (e.g. left by the old
+        blind-rmtree clear_cache) must be collected, not kept forever."""
+        from deriva.bag.cache_index import BagCacheIndex
+
+        from deriva_ml.core.storage import clear_cache
+
+        cache_dir = tmp_path / "cache"
+        indexed = _record_bag(cache_dir, checksum="ok1", dataset_rid="RID-OK")
+        orphan = cache_dir / "bags" / "orphan-cafe" / "Dataset_RID-GONE"
+        orphan.mkdir(parents=True)
+        (orphan / "stale.csv").write_text("x" * 64)
+
+        # A generous age filter keeps the fresh orphan (mtime-based,
+        # same semantics the dedicated age test pins):
+        clear_cache(cache_dir, older_than_days=3650)
+        assert (cache_dir / "bags" / "orphan-cafe").exists()
+
+        # With no age filter everything goes, orphan included:
+        stats = clear_cache(cache_dir)
+        assert not (cache_dir / "bags" / "orphan-cafe").exists()
+        assert not indexed.exists()
+        assert stats["errors"] == 0
+        index = BagCacheIndex(cache_dir)
+        try:
+            assert index.list_bags() == []
+        finally:
+            index.dispose()
+
+    def test_orphan_sweep_respects_age_filter(self, tmp_path: Path):
+        import os
+        import time as _time
+
+        from deriva_ml.core.storage import clear_cache
+
+        cache_dir = tmp_path / "cache"
+        old_orphan = cache_dir / "bags" / "old-orphan" / "data"
+        old_orphan.mkdir(parents=True)
+        (old_orphan / "f.bin").write_bytes(b"x" * 32)
+        fresh_orphan = cache_dir / "bags" / "fresh-orphan"
+        fresh_orphan.mkdir(parents=True)
+        (fresh_orphan / "f.bin").write_bytes(b"y" * 32)
+        old_ts = _time.time() - 40 * 86400
+        os.utime(cache_dir / "bags" / "old-orphan", (old_ts, old_ts))
+
+        stats = clear_cache(cache_dir, older_than_days=30)
+
+        assert not (cache_dir / "bags" / "old-orphan").exists()
+        assert fresh_orphan.exists()
+        assert stats["dirs_removed"] == 1
+
+
+class TestSummaryDenominators:
+    def test_multi_anchor_bag_sized_once_at_max(self, harness):
+        """A bag with two dataset anchors: counted per anchor in
+        bag_count, but sized once — and at the REAL size, not the
+        last anchor's (whose Dataset_{rid} dir may not exist)."""
+        from deriva.bag.cache_index import BagCacheIndex
+
+        from deriva_ml.core.base import DerivaML
+
+        harness.get_cache_size = lambda: DerivaML.get_cache_size(harness)
+        harness.list_execution_dirs = lambda: DerivaML.list_execution_dirs(harness)
+        harness.list_cached_bags = lambda: DerivaML.list_cached_bags(harness)
+        harness.list_cached_assets = lambda: DerivaML.list_cached_assets(harness)
+
+        _record_bag(harness.cache_dir, checksum="mm1", dataset_rid="RID-A")
+        index = BagCacheIndex(harness.cache_dir)
+        try:
+            index.record(checksum="mm1", anchors=[("Dataset", "RID-B")])  # no dir on disk
+        finally:
+            index.dispose()
+
+        summary = DerivaML.get_storage_summary(harness)
+        assert summary["bag_count"] == 2  # two dataset-anchored entries
+        assert summary["bag_size_mb"] > 0  # sized from the anchor that exists
+
+
+class TestListBagsOrdering:
+    def test_most_recently_built_first(self, tmp_path: Path):
+        from deriva_ml.dataset.bag_cache import BagCache
+
+        cache_dir = tmp_path / "cache"
+        older = datetime.now(timezone.utc) - timedelta(days=2)
+        _record_bag(cache_dir, checksum="ord1", dataset_rid="RID-OLDER", built_at=older)
+        _record_bag(cache_dir, checksum="ord2", dataset_rid="RID-NEWER")
+
+        with BagCache(cache_dir) as cache:
+            bags = cache.list_bags()
+
+        assert [b.dataset_rid for b in bags] == ["RID-NEWER", "RID-OLDER"]


### PR DESCRIPTION
Closes out the recorded review follow-ups from #286 (items 1–3 of the [follow-ups comment](https://github.com/informatics-isi-edu/deriva-ml/pull/286#issuecomment-4683377493)):

1. **Orphan-dir sweep** — `clear_cache` gains pass 1b: `bags/*` entries with no index row (debris the pre-1.46 blind-rmtree cleaner could leave) are now collected, age-filtered by mtime. Skipped when the index is unusable (orphans indistinguishable). Previously such directories were uncollectable forever.
2. **Summary sizing** — `get_storage_summary` sizes multi-anchor bags at the **max** size per checksum instead of last-write-wins (an anchor with no `Dataset_{rid}` dir reports 0 and could mask the bag's real size). `bag_count` still counts dataset-anchored entries; comment documents the denominators.
3. **Ordering pin** — test asserting `list_cached_bags()` returns most-recently-built first.

4 tests added; 46 pass across the introspection + legacy storage suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)