### PR TITLE
feat(core): DerivaML.create_asset_table — canonical asset shape in one call (closes #74)

### DIFF
--- a/docs/user-guide/assets.md
+++ b/docs/user-guide/assets.md
@@ -145,6 +145,39 @@ models = [a for a in ml.list_assets("Model") if a.asset_types == ["Model_File"]]
   diffs against the current tags). Do not use raw `update_entities` on asset
   rows; it bypasses the tag-diff and provenance handling.
 
+## How to create a new asset table
+
+Use `ml.create_asset_table(...)` — never hand-build asset tables with the
+generic `create_table`. One call creates the full canonical shape, so the
+result always satisfies `model.is_asset` (validation-by-construction):
+
+- the five standard hatrac columns (`URL`, `Filename`, `Length`, `MD5`,
+  `Description`) with the standard constraints and the `asset` annotation;
+- the `<name>_Asset_Type` association (an asset can carry multiple type
+  tags, e.g. `Model_File` + `Output_File`);
+- the `<name>_Execution` association with the `Asset_Role` FK
+  (`Input` / `Output`) that the execution upload machinery writes;
+- the standard Chaise display annotations.
+
+```python
+from deriva_ml import ColumnDefinition, BuiltinTypes
+
+table = ml.create_asset_table(
+    "Scan_File",
+    additional_columns=[
+        ColumnDefinition(name="Scanner_Model", type=BuiltinTypes.text),
+    ],
+    comment="Raw scanner output files.",
+)
+assert ml.model.is_asset("Scan_File")
+```
+
+`additional_columns` appends domain-specific metadata columns to the
+standard shape. Pass `use_hatrac=False` for assets whose bytes live outside
+Hatrac (the `URL` column becomes a plain string and no upload UI is wired).
+When creating several tables in a batch, pass `update_navbar=False` and call
+`ml.apply_catalog_annotations()` once at the end.
+
 ## Summary
 
 | Task | Use | Provenance edge? |

--- a/src/deriva_ml/core/base.py
+++ b/src/deriva_ml/core/base.py
@@ -15,6 +15,7 @@ from __future__ import annotations  # noqa: I001
 
 # Standard library imports
 import logging
+from collections.abc import Sequence
 from datetime import datetime
 from pathlib import Path
 from typing import Dict, cast, TYPE_CHECKING, Any
@@ -42,7 +43,14 @@ DEFAULT_LOGGER_OVERRIDES = _core_utils.DEFAULT_LOGGER_OVERRIDES
 from deriva_ml.core.catalog_stub import CatalogStub
 from deriva_ml.core.config import DerivaMLConfig
 from deriva_ml.core.connection_mode import ConnectionMode
-from deriva_ml.core.definitions import DRY_RUN_RID, ML_SCHEMA, RID, TableDefinition, VocabularyTableDef
+from deriva_ml.core.definitions import (
+    DRY_RUN_RID,
+    ML_SCHEMA,
+    RID,
+    ColumnDefinition,
+    TableDefinition,
+    VocabularyTableDef,
+)
 from deriva_ml.core.exceptions import (
     DerivaMLConfigurationError,
     DerivaMLException,
@@ -1230,6 +1238,100 @@ class DerivaML(
             self.apply_catalog_annotations()
 
         return vocab_table
+
+    def create_asset_table(
+        self,
+        asset_name: str,
+        additional_columns: Sequence[ColumnDefinition] = (),
+        comment: str | None = None,
+        schema: str | None = None,
+        use_hatrac: bool = True,
+        update_navbar: bool = True,
+    ) -> Table:
+        """Creates an asset table with the canonical DerivaML asset shape.
+
+        One call builds everything an asset table needs, so the shape can
+        never drift from the canonical form (validation-by-construction --
+        the result always satisfies ``model.is_asset``):
+
+        - The five standard hatrac columns: ``URL``, ``Filename``,
+          ``Length``, ``MD5``, ``Description`` (with the standard NOT NULL
+          constraints and the ``asset`` annotation on ``URL``).
+        - The ``<asset_name>_Asset_Type`` association to the deriva-ml
+          ``Asset_Type`` vocabulary (an asset can carry multiple type tags,
+          e.g. ``Model_File`` + ``Output_File``).
+        - The ``<asset_name>_Execution`` association to ``Execution``,
+          carrying the ``Asset_Role`` FK (``Input`` / ``Output``) that the
+          execution upload machinery writes.
+        - The standard Chaise display annotations for asset tables.
+
+        This replaces the manual recipe (generic ``create_table`` with
+        hand-written hatrac columns) that was verbose and easy to get
+        subtly wrong (issue #74).
+
+        Args:
+            asset_name: Name for the new asset table. Must be a valid SQL
+                identifier.
+            additional_columns: Optional domain-specific columns appended to
+                the standard hatrac shape (e.g. a ``Scanner_Model`` text
+                column on a ``Scan_File`` table). Use ``ColumnDefinition``
+                with ``BuiltinTypes`` from ``deriva_ml``.
+            comment: Description of the asset table's purpose.
+            schema: Schema name to create the table in. If None, uses the
+                domain schema.
+            use_hatrac: When True (default) the ``URL`` column is wired with
+                the Hatrac upload template so Chaise's file-upload UI
+                deposits bytes into Hatrac. When False the ``URL`` column is
+                a plain string (for assets whose bytes live elsewhere).
+            update_navbar: If True (default), refresh the navigation bar to
+                include the new table. Set to False during batch creation,
+                then call ``apply_catalog_annotations()`` once at the end.
+
+        Returns:
+            Table: ERMrest table object for the newly created asset table.
+
+        Raises:
+            DerivaMLException: If ``asset_name`` already exists.
+
+        Examples:
+            Create an asset table for raw scanner output:
+
+                >>> from deriva_ml import ColumnDefinition, BuiltinTypes
+                >>> table = ml.create_asset_table(  # doctest: +SKIP
+                ...     "Scan_File",
+                ...     additional_columns=[
+                ...         ColumnDefinition(name="Scanner_Model", type=BuiltinTypes.text),
+                ...     ],
+                ...     comment="Raw scanner output files.",
+                ... )
+                >>> ml.model.is_asset("Scan_File")  # doctest: +SKIP
+                True
+        """
+        # Lazy import: schema.create_schema owns the canonical wiring (it
+        # builds the same shape at catalog bootstrap); importing it at
+        # module load would cycle through the schema package.
+        from deriva_ml.core.definitions import MLTable, MLVocab
+        from deriva_ml.schema.create_schema import create_asset_table as _create_asset_table
+
+        schema = schema or self.model._require_default_schema()
+        try:
+            asset_table = _create_asset_table(
+                self.model.schemas[schema],
+                asset_name,
+                execution_table=self.model.name_to_table(MLTable.execution),
+                asset_type_table=self.model.name_to_table(MLVocab.asset_type),
+                asset_role_table=self.model.name_to_table(MLVocab.asset_role),
+                use_hatrac=use_hatrac,
+                comment=comment,
+                additional_columns=additional_columns,
+            )
+        except ValueError:
+            raise DerivaMLException(f"Table {asset_name} already exist")
+
+        if update_navbar:
+            self.apply_catalog_annotations()
+
+        return asset_table
 
     def create_table(self, table: TableDefinition, schema: str | None = None, update_navbar: bool = True) -> Table:
         """Creates a new table in the domain schema.

--- a/src/deriva_ml/schema/create_schema.py
+++ b/src/deriva_ml/schema/create_schema.py
@@ -13,6 +13,7 @@ ERMrest catalog. The main entry points are:
 
 import subprocess
 import sys
+from collections.abc import Sequence
 from importlib.resources import files
 from typing import Any, Optional
 
@@ -183,9 +184,7 @@ def create_dataset_table(
     # step — mirrors `dataset_table.create_reference(("Version", True, ...))`
     # above. NULL means the consumed version is unknown (e.g. legacy rows).
     dv_cols, _ = dataset_execution.create_reference(("Dataset_Version", True, dataset_version))
-    dv_cols[0].alter(
-        comment="RID of the Dataset_Version consumed by this input edge (NULL if unknown)."
-    )
+    dv_cols[0].alter(comment="RID of the Dataset_Version consumed by this input edge (NULL if unknown).")
     return dataset_table
 
 
@@ -434,6 +433,7 @@ def create_asset_table(
     asset_role_table: Table,
     use_hatrac: bool = True,
     comment: Optional[str] = None,
+    additional_columns: Sequence[ColumnDef] = (),
 ) -> Table:
     """Create an asset table with associated type and execution associations.
 
@@ -458,6 +458,11 @@ def create_asset_table(
             distinguish the three asset tables (Execution_Asset,
             Execution_Metadata, File) which otherwise share the
             same generic shape.
+        additional_columns: Optional domain-specific columns appended
+            to the standard hatrac shape (``URL`` / ``Filename`` /
+            ``Length`` / ``MD5`` / ``Description``). Used by the
+            public ``DerivaML.create_asset_table`` wrapper; the
+            bootstrap call sites leave it empty.
 
     Returns:
         The created asset Table object.
@@ -471,6 +476,7 @@ def create_asset_table(
         AssetTableDef(
             schema_name=schema.name,
             name=asset_name,
+            columns=list(additional_columns),
             hatrac_template=hatrac_template,
             comment=comment,
         )

--- a/tests/core/test_asset_table.py
+++ b/tests/core/test_asset_table.py
@@ -1,0 +1,78 @@
+"""Tests for DerivaML.create_asset_table (issue #74).
+
+The public method promotes the canonical asset-table wiring (the
+internal ``schema.create_schema.create_asset_table`` used at catalog
+bootstrap) to a user-facing ``DerivaML`` method: the five standard
+hatrac columns, the ``<Asset>_Asset_Type`` tag association, the
+``<Asset>_Execution`` association carrying the ``Asset_Role`` FK, and
+the standard Chaise asset annotations -- plus ``additional_columns``
+for domain extensions. Validation-by-construction: a table created
+this way always satisfies ``model.is_asset``.
+
+Unit shape test (no catalog) lives alongside the integration tests so
+the deriva-py ``AssetTableDef`` contract this method relies on is
+pinned where the method is tested.
+"""
+
+import pytest
+
+from deriva_ml import DerivaMLException
+from deriva_ml.core.definitions import AssetTableDef, BuiltinTypes, ColumnDefinition
+
+
+class TestAssetTableDefShape:
+    """Unit: the AssetTableDef contract create_asset_table relies on."""
+
+    def test_hatrac_columns_auto_generated(self):
+        """AssetTableDef.to_dict() carries the 5 standard hatrac columns."""
+        d = AssetTableDef(schema_name="s", name="Widget_File").to_dict()
+        names = [c["name"] for c in d["column_definitions"]]
+        for required in ("URL", "Filename", "Length", "MD5", "Description"):
+            assert required in names, f"missing standard column {required}"
+
+    def test_additional_columns_extend_shape(self):
+        """columns= extends, not replaces, the standard hatrac shape."""
+        extra = ColumnDefinition(name="Frame_Count", type=BuiltinTypes.int4)
+        d = AssetTableDef(schema_name="s", name="Widget_File", columns=[extra]).to_dict()
+        names = [c["name"] for c in d["column_definitions"]]
+        assert "Frame_Count" in names
+        for required in ("URL", "Filename", "Length", "MD5", "Description"):
+            assert required in names
+
+
+class TestCreateAssetTable:
+    """Integration: DerivaML.create_asset_table against the test catalog."""
+
+    def test_create_asset_table_full_shape(self, test_ml):
+        ml = test_ml
+        table = ml.create_asset_table(
+            "Scan_File",
+            additional_columns=[
+                ColumnDefinition(name="Scanner_Model", type=BuiltinTypes.text),
+            ],
+            comment="Raw scanner output files.",
+        )
+        # The created table satisfies the asset contract (hatrac columns,
+        # NOT NULL constraints, URL asset annotation).
+        assert ml.model.is_asset("Scan_File")
+        # Domain extension column present.
+        assert "Scanner_Model" in [c.name for c in table.columns]
+        # Asset_Type tag association exists.
+        assoc_type = ml.model.name_to_table("Scan_File_Asset_Type")
+        assert ml.model.is_association(assoc_type)
+        # Execution association exists and carries the Asset_Role FK.
+        assoc_exec = ml.model.name_to_table("Scan_File_Execution")
+        assert ml.model.is_association(assoc_exec, max_arity=3, pure=False)
+        assert "Asset_Role" in [c.name for c in assoc_exec.columns]
+
+    def test_create_asset_table_duplicate_raises(self, test_ml):
+        ml = test_ml
+        ml.create_asset_table("Dup_File", update_navbar=False)
+        with pytest.raises(DerivaMLException):
+            ml.create_asset_table("Dup_File", update_navbar=False)
+
+    def test_create_asset_table_no_hatrac(self, test_ml):
+        """use_hatrac=False still yields a valid asset table (plain URL column)."""
+        ml = test_ml
+        ml.create_asset_table("Plain_File", use_hatrac=False, update_navbar=False)
+        assert ml.model.is_asset("Plain_File")


### PR DESCRIPTION
Closes #74 (Round A).

## What

Promotes the bootstrap-internal asset-table wiring (`schema.create_schema.create_asset_table`) to a public `DerivaML.create_asset_table(...)`. One call builds the full canonical shape — **validation-by-construction**: the result always satisfies `model.is_asset`:

- the five standard hatrac columns (`URL`, `Filename`, `Length`, `MD5`, `Description`) with standard constraints + the `asset` annotation;
- the `<name>_Asset_Type` tag association (multi-tag);
- the `<name>_Execution` association carrying the `Asset_Role` FK the upload machinery writes;
- the standard Chaise display annotations.

```python
table = ml.create_asset_table(
    "Scan_File",
    additional_columns=[ColumnDefinition(name="Scanner_Model", type=BuiltinTypes.text)],
    comment="Raw scanner output files.",
)
```

`additional_columns` appends domain metadata to the standard shape (threaded through `AssetTableDef.columns`); `use_hatrac=False` gives a plain-string URL column; `update_navbar` mirrors `create_vocabulary`'s batching contract. The internal bootstrap function gains only the `additional_columns` pass-through; its three bootstrap call sites are unchanged.

## Acceptance (from #74)

- [x] `DerivaML.create_asset_table()` with Google-style docstring + Example
- [x] Unit tests: AssetTableDef shape contract (hatrac columns auto-generated; `columns=` extends not replaces)
- [x] Integration tests vs the test catalog: `is_asset`, both associations, `Asset_Role` column, additional columns, duplicate → `DerivaMLException`, `use_hatrac=False`
- [x] User-guide section (`docs/user-guide/assets.md`)
- [ ] RAG ingest after merge (operational)
- [x] PR per repo convention

## Verification

- New tests: 5/5 pass against the localhost catalog.
- Regression: 555 local tests (local_db/asset/model) + 38 schema integration tests pass — the modified bootstrap path is exercised end-to-end.
- ruff: my files clean/formatted; the 12 pre-existing repo lint findings (PTH123/F821 in unrelated code) untouched.

## Pipeline

After merge + minor bump: deriva-ml-mcp-plugin#15 (thin MCP wrapper), then the `work-with-assets` skill update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)