### PR TITLE
feat(core): schema-evolution impact analysis — find_datasets/features_referencing (closes #75)

### DIFF
--- a/docs/user-guide/schema-evolution.md
+++ b/docs/user-guide/schema-evolution.md
@@ -1,0 +1,54 @@
+# Schema-evolution impact analysis
+
+Before dropping a column, renaming a table, or restructuring a schema,
+ask the catalog what breaks. Two methods walk the DerivaML domain model
+and report the artifacts that reference the thing you are about to
+change:
+
+```python
+# About to change the Image table -- what breaks?
+ml.find_datasets_referencing("Image")
+# -> [DatasetReference(dataset_rid='1-AAAA', element_table='Image', member_count=550), ...]
+
+ml.find_features_referencing("Image")
+# -> [FeatureReference(feature_name='Quality', target_table='Image',
+#                      feature_table='Execution_Image_Quality',
+#                      referencing_columns=['Image']), ...]
+```
+
+## What each method checks
+
+**`find_datasets_referencing(table, column=None)`** — datasets reference
+tables through their member associations (`Dataset_<Table>`). Every
+dataset currently holding rows of the table is reported with its member
+count. Impact is **table-granular**: membership is row-level, so any
+column change affects every dataset holding rows of that table — the
+`column` argument is accepted for symmetry but does not narrow the
+result.
+
+**`find_features_referencing(table, column=None)`** — a feature's
+association table carries FKs to its target table (the self-FK), to
+vocabulary tables (term columns), and to asset tables (asset columns).
+Any feature whose FK lands on the table is reported, with the FK column
+names doing the referencing. `column=` narrows by the *referenced*
+column name (FKs reference key columns, almost always `RID`).
+
+This catches the non-obvious cases: dropping a **vocabulary** table
+breaks every feature with a term column into it; dropping an **asset**
+table breaks every feature that attaches files from it.
+
+## The workflow
+
+1. Run both methods for the table you plan to change.
+2. Empty results from both → the change is invisible to the DerivaML
+   domain layer (raw catalog consumers may still care — check FKs with
+   the schema tools).
+3. Non-empty `find_datasets_referencing` → those datasets' next bag
+   download changes shape; coordinate with their consumers and plan a
+   version bump.
+4. Non-empty `find_features_referencing` → those features break
+   structurally; migrate or delete them (`delete_feature`) before the
+   schema change.
+
+Both methods are read-only and cheap (one bulk query for datasets; a
+schema walk for features) — run them freely.

--- a/src/deriva_ml/__init__.py
+++ b/src/deriva_ml/__init__.py
@@ -74,6 +74,14 @@ def __getattr__(name: str) -> type:
         from deriva_ml.dataset.aux_classes import DatasetSpecConfig
 
         return DatasetSpecConfig
+    elif name == "DatasetReference":
+        from deriva_ml.dataset.aux_classes import DatasetReference
+
+        return DatasetReference
+    elif name == "FeatureReference":
+        from deriva_ml.dataset.aux_classes import FeatureReference
+
+        return FeatureReference
     elif name == "Asset":
         from deriva_ml.asset.asset import Asset
 
@@ -135,6 +143,7 @@ __all__ = [
     "Workflow",
     # Dataset classes (lazy-loaded)
     "Dataset",
+    "DatasetReference",
     "DatasetSpec",
     "DatasetSpecConfig",
     # Asset classes (lazy-loaded)

--- a/src/deriva_ml/core/mixins/dataset.py
+++ b/src/deriva_ml/core/mixins/dataset.py
@@ -37,10 +37,14 @@ from deriva_ml.config.validation import (
     ConfigValidationReport,
 )
 from deriva_ml.core.definitions import RID
-from deriva_ml.core.exceptions import DerivaMLException, DerivaMLTableTypeError
+from deriva_ml.core.exceptions import (
+    DerivaMLException,
+    DerivaMLTableTypeError,
+    NoAssociationException,
+)
 from deriva_ml.core.sort import SortSpec, resolve_sort
 from deriva_ml.core.validation import VALIDATION_CONFIG
-from deriva_ml.dataset.aux_classes import DatasetSpec
+from deriva_ml.dataset.aux_classes import DatasetReference, DatasetSpec
 from deriva_ml.dataset.validation import (
     AssetSpecResult,
     CrossSpecIssue,
@@ -262,6 +266,63 @@ class DatasetMixin:
             >>> print([t.name for t in types])  # doctest: +SKIP
         """
         return self.model.list_dataset_element_types()
+
+    def find_datasets_referencing(self, table: str | Table, column: str | None = None) -> list[DatasetReference]:
+        """Find the datasets impacted by a change to ``table`` (schema-evolution impact analysis).
+
+        Answers the catalog-evolver question "what breaks if I change
+        this table?": every dataset currently holding member rows of
+        ``table`` is reported, with its member count. Datasets reference
+        tables through their member associations (``Dataset_<Table>``),
+        so impact is **table-granular** -- membership is row-level, and
+        any column change on the member table affects every dataset
+        holding rows of that table. The ``column`` argument is accepted
+        for symmetry with :meth:`find_features_referencing` but does not
+        narrow the result; pair the two methods for a full impact
+        report.
+
+        One bulk query per call: the association table's dataset FK
+        column is fetched once and grouped in memory (same pattern as
+        the asset bulk reads).
+
+        Args:
+            table: Name of the table (str) or ``Table`` object to check.
+            column: Optional column name, accepted for API symmetry.
+                Dataset impact is table-granular, so this does not
+                narrow the result.
+
+        Returns:
+            One :class:`DatasetReference` per dataset with members in
+            ``table`` (``dataset_rid``, ``element_table``,
+            ``member_count``), sorted by dataset RID. Empty list when
+            the table is not a dataset element type anywhere.
+
+        Raises:
+            DerivaMLTableNotFound: If ``table`` does not exist.
+
+        Example:
+            >>> refs = ml.find_datasets_referencing("Image")  # doctest: +SKIP
+            >>> [(r.dataset_rid, r.member_count) for r in refs]  # doctest: +SKIP
+            [('1-AAAA', 550), ('1-BBBB', 110)]
+        """
+        target = self.model.name_to_table(table)
+        try:
+            _assoc, target_col, dataset_col = self.model.find_association(target, self._dataset_table)
+        except NoAssociationException:
+            # The table is not registered as a dataset element type
+            # anywhere -- no dataset can reference it.
+            return []
+        assoc_table = _assoc
+        pb = self.pathBuilder()
+        apath = pb.schemas[assoc_table.schema.name].tables[assoc_table.name]
+        counts: dict[str, int] = {}
+        for row in apath.attributes(apath.columns[dataset_col]).fetch():
+            rid = row[dataset_col]
+            counts[rid] = counts.get(rid, 0) + 1
+        return [
+            DatasetReference(dataset_rid=rid, element_table=target.name, member_count=n)
+            for rid, n in sorted(counts.items())
+        ]
 
     @validate_call(config=VALIDATION_CONFIG)
     def add_dataset_element_type(self, element: str | Table) -> Table:
@@ -631,7 +692,7 @@ class DatasetMixin:
         Example:
             Validate two specs, one good and one with a typo'd version::
 
-                >>> from deriva_ml.dataset.aux_classes import DatasetSpec  # doctest: +SKIP
+                >>> from deriva_ml.dataset.aux_classes import DatasetReference, DatasetSpec  # doctest: +SKIP
                 >>> report = ml.validate_dataset_specs(specs=[  # doctest: +SKIP
                 ...     DatasetSpec(rid="2-B4C8", version="0.4.0"),
                 ...     DatasetSpec(rid="2-B4C8", version="9.9.9"),
@@ -703,7 +764,7 @@ class DatasetMixin:
             Validate a config before invoking ``deriva-ml-run``::
 
                 >>> from deriva_ml.execution import ExecutionConfiguration  # doctest: +SKIP
-                >>> from deriva_ml.dataset.aux_classes import DatasetSpec  # doctest: +SKIP
+                >>> from deriva_ml.dataset.aux_classes import DatasetReference, DatasetSpec  # doctest: +SKIP
                 >>> from deriva_ml.asset.aux_classes import AssetSpec  # doctest: +SKIP
                 >>> config = ExecutionConfiguration(  # doctest: +SKIP
                 ...     workflow=workflow,
@@ -792,9 +853,7 @@ class DatasetMixin:
                 ...         print(r.entry.file, r.entry.line, r.reasons)
         """
         entries, parse_error = parse_config_file(path)
-        parse_errors: list[ConfigFileParseError] = (
-            [parse_error] if parse_error is not None else []
-        )
+        parse_errors: list[ConfigFileParseError] = [parse_error] if parse_error is not None else []
         results = self._validate_config_entries(entries)
         return ConfigValidationReport(
             file_count=1 if parse_error is None else 0,
@@ -949,12 +1008,16 @@ class DatasetMixin:
                 >>> for s in report.suggestions:  # doctest: +SKIP
                 ...     print(s.kind, s.config_name, s.spec_string)
         """
-        requested_kinds = set(kinds) if kinds is not None else {
-            "deriva_ml",
-            "datasets",
-            "assets",
-            "workflow",
-        }
+        requested_kinds = (
+            set(kinds)
+            if kinds is not None
+            else {
+                "deriva_ml",
+                "datasets",
+                "assets",
+                "workflow",
+            }
+        )
         if dataset_type_filter is None:
             type_filter = set(DEFAULT_DATASET_TYPE_FILTER)
         else:
@@ -974,8 +1037,7 @@ class DatasetMixin:
                         str(getattr(self, "catalog_id", "")),
                     ),
                     description=(
-                        f"Connection to {getattr(self, 'host_name', '?')} "
-                        f"catalog {getattr(self, 'catalog_id', '?')}"
+                        f"Connection to {getattr(self, 'host_name', '?')} catalog {getattr(self, 'catalog_id', '?')}"
                     ),
                     rationale="Connection group; pin this DerivaML instance.",
                 )
@@ -992,10 +1054,7 @@ class DatasetMixin:
                         BootstrapSkipped(
                             kind="datasets",
                             rid=ds_rid,
-                            reason=(
-                                f"dataset_types={ds_types} -- not in filter "
-                                f"{sorted(type_filter)}"
-                            ),
+                            reason=(f"dataset_types={ds_types} -- not in filter {sorted(type_filter)}"),
                         )
                     )
                     continue
@@ -1031,10 +1090,7 @@ class DatasetMixin:
                     if type_filter
                     else (ds_types[0] if ds_types else "Dataset")
                 )
-                rationale = (
-                    f"Dataset type {primary_type or '?'}; latest released "
-                    f"version {version_str}."
-                )
+                rationale = f"Dataset type {primary_type or '?'}; latest released version {version_str}."
                 suggestions.append(
                     BootstrapSuggestion(
                         kind="datasets",
@@ -1078,10 +1134,7 @@ class DatasetMixin:
                             rid=asset_rid,
                             spec_string=_format_asset_spec(asset_rid),
                             description=filename or None,
-                            rationale=(
-                                f"Asset in {table.name}"
-                                + (f" ({filename})" if filename else "")
-                            ),
+                            rationale=(f"Asset in {table.name}" + (f" ({filename})" if filename else "")),
                         )
                     )
 
@@ -1100,10 +1153,7 @@ class DatasetMixin:
                         rid=wf_rid,
                         spec_string=_format_workflow_spec(wf_rid),
                         description=wf_name or None,
-                        rationale=(
-                            "Existing Workflow row; pin by RID to reuse "
-                            "across executions."
-                        ),
+                        rationale=("Existing Workflow row; pin by RID to reuse across executions."),
                     )
                 )
 
@@ -1483,11 +1533,7 @@ class DatasetMixin:
                 entry=entry,
                 valid=not reasons,
                 reasons=reasons,
-                resolved_name=(
-                    f"{self_hostname or '?'}/{self_catalog_id or '?'}"
-                    if not reasons
-                    else None
-                ),
+                resolved_name=(f"{self_hostname or '?'}/{self_catalog_id or '?'}" if not reasons else None),
             )
 
         # Replace any leftover Nones with an internal-error result.

--- a/src/deriva_ml/core/mixins/feature.py
+++ b/src/deriva_ml/core/mixins/feature.py
@@ -18,6 +18,7 @@ from pydantic import validate_call
 from deriva_ml.core.definitions import ColumnDefinition, VocabularyTerm
 from deriva_ml.core.exceptions import DerivaMLException, DerivaMLMaterializeLimitExceeded
 from deriva_ml.core.validation import VALIDATION_CONFIG
+from deriva_ml.dataset.aux_classes import FeatureReference
 from deriva_ml.feature import Feature, FeatureRecord
 
 if TYPE_CHECKING:
@@ -352,6 +353,65 @@ class FeatureMixin:
                 >>> print([f.feature_name for f in image_features])  # doctest: +SKIP
         """
         return list(self.model.find_features(table))
+
+    def find_features_referencing(self, table: str | Table, column: str | None = None) -> list[FeatureReference]:
+        """Find the features impacted by a change to ``table`` (schema-evolution impact analysis).
+
+        Answers the catalog-evolver question "what breaks if I change
+        this table / column?" for the feature layer: a feature's
+        association table carries FKs to its target table (the
+        self-FK), to vocabulary tables (term columns), and to asset
+        tables (asset columns). Any feature whose association-table FK
+        lands on ``table`` (and, when ``column`` is given, on that
+        referenced column) is reported with the FK column names doing
+        the referencing.
+
+        Note that FKs reference key columns -- almost always ``RID`` --
+        so ``column=`` narrows by the *referenced* column name. Pair
+        with :meth:`find_datasets_referencing` for a full impact
+        report.
+
+        Args:
+            table: Name of the table (str) or ``Table`` object to check.
+            column: Optional referenced-column filter; only FKs whose
+                referenced columns include this name count.
+
+        Returns:
+            One :class:`FeatureReference` per impacted feature
+            (``feature_name``, ``target_table``, ``feature_table``,
+            ``referencing_columns``), sorted by (target_table,
+            feature_name). Empty list when nothing references the
+            table.
+
+        Raises:
+            DerivaMLTableNotFound: If ``table`` does not exist.
+
+        Example:
+            >>> refs = ml.find_features_referencing("Image")  # doctest: +SKIP
+            >>> [r.feature_name for r in refs]  # doctest: +SKIP
+            ['BoundingBox', 'Quality']
+        """
+        target = self.model.name_to_table(table)
+        target_key = (target.schema.name, target.name)
+        refs: list[FeatureReference] = []
+        for feature in self.model.find_features():
+            cols: set[str] = set()
+            for fk in feature.feature_table.foreign_keys:
+                if (fk.pk_table.schema.name, fk.pk_table.name) != target_key:
+                    continue
+                if column is not None and column not in {c.name for c in fk.referenced_columns}:
+                    continue
+                cols.update(c.name for c in fk.foreign_key_columns)
+            if cols:
+                refs.append(
+                    FeatureReference(
+                        feature_name=feature.feature_name,
+                        target_table=feature.target_table.name,
+                        feature_table=feature.feature_table.name,
+                        referencing_columns=sorted(cols),
+                    )
+                )
+        return sorted(refs, key=lambda r: (r.target_table, r.feature_name))
 
     def add_features(self, *args, **kwargs) -> int:
         """Retired — use ``exe.add_features(records)`` inside an execution context.

--- a/src/deriva_ml/dataset/aux_classes.py
+++ b/src/deriva_ml/dataset/aux_classes.py
@@ -13,6 +13,7 @@ from hydra_zen import hydrated_dataclass
 from packaging.version import Version
 from pydantic import (
     BaseModel,
+    ConfigDict,
     Field,
     computed_field,
     conlist,
@@ -434,3 +435,53 @@ class DatasetSpecConfig:
     exclude_tables: list[str] | None = None
     timeout: list[int] | None = None
     fetch_concurrency: int = 8
+
+
+class DatasetReference(BaseModel):
+    """One dataset that references a table through its member association.
+
+    Produced by :meth:`DerivaML.find_datasets_referencing` for
+    schema-evolution impact analysis ("what breaks if I change this
+    table?"). Dataset impact is table-granular: membership is row-level,
+    so any column change on the member table affects every dataset
+    holding rows of that table.
+
+    Attributes:
+        dataset_rid: RID of the referencing dataset.
+        element_table: Name of the referenced member table.
+        member_count: Number of rows of ``element_table`` currently in
+            the dataset (unversioned, current membership).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    dataset_rid: RID
+    element_table: str
+    member_count: int
+
+
+class FeatureReference(BaseModel):
+    """One feature that references a table via its association-table FKs.
+
+    Produced by :meth:`DerivaML.find_features_referencing`. A feature's
+    association table carries FKs to its target table (the self-FK),
+    to vocabulary tables (term columns), and to asset tables (asset
+    columns) -- dropping any referenced table or key column breaks the
+    feature.
+
+    Attributes:
+        feature_name: Name of the referencing feature.
+        target_table: Table the feature is defined ON.
+        feature_table: The feature's association table (where the FK
+            lives).
+        referencing_columns: FK column names on ``feature_table`` that
+            land on the queried table (filtered to FKs referencing the
+            queried column when ``column=`` was given).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    feature_name: str
+    target_table: str
+    feature_table: str
+    referencing_columns: list[str]

--- a/tests/dataset/test_impact.py
+++ b/tests/dataset/test_impact.py
@@ -1,0 +1,78 @@
+"""Tests for schema-evolution impact analysis (issue #75, Round B).
+
+``find_datasets_referencing`` and ``find_features_referencing`` answer
+the catalog-evolver's question "what breaks if I change this table /
+column?" by walking the deriva-ml domain model: datasets reference
+tables through their member associations (``Dataset_<Table>``);
+features reference tables through their association table's FKs
+(the self-FK to the target table plus any term / asset / value FKs).
+"""
+
+import pytest
+
+
+@pytest.fixture
+def impact_ml(catalog_manager, tmp_path):
+    """A DerivaML over the WITH_DATASETS catalog state.
+
+    ensure_datasets seeds datasets with Image + Subject members AND the
+    demo features (Execution_Image_BoundingBox / _Quality,
+    Execution_Subject_Health), giving a realistic reference graph.
+    """
+    ml, _desc = catalog_manager.ensure_datasets(tmp_path)
+    return ml
+
+
+class TestFindDatasetsReferencing:
+    def test_member_table_is_referenced(self, impact_ml):
+        """Datasets holding Image members are reported, with member counts."""
+        refs = impact_ml.find_datasets_referencing("Image")
+        assert refs, "demo datasets hold Image members; expected non-empty"
+        for ref in refs:
+            assert ref.element_table == "Image"
+            assert ref.member_count >= 1
+            assert ref.dataset_rid
+
+    def test_unreferenced_table_returns_empty(self, impact_ml):
+        """A table with no Dataset association yields no references."""
+        refs = impact_ml.find_datasets_referencing("Observation")
+        assert refs == []
+
+    def test_column_is_table_granular(self, impact_ml):
+        """Dataset impact is table-granular: column narrows nothing.
+
+        Dataset membership is row-level; any column drop on a member
+        table impacts every dataset holding rows of that table.
+        """
+        by_table = impact_ml.find_datasets_referencing("Image")
+        by_column = impact_ml.find_datasets_referencing("Image", column="URL")
+        assert {r.dataset_rid for r in by_column} == {r.dataset_rid for r in by_table}
+
+
+class TestFindFeaturesReferencing:
+    def test_features_on_target_table(self, impact_ml):
+        """Features defined ON Image reference it via the self-FK."""
+        refs = impact_ml.find_features_referencing("Image")
+        names = {r.feature_name for r in refs}
+        assert {"BoundingBox", "Quality"} <= names
+        for ref in refs:
+            assert ref.referencing_columns, "expected the FK column names"
+
+    def test_vocabulary_reference_via_term_column(self, impact_ml):
+        """A feature's term column makes it reference the vocabulary table."""
+        refs = impact_ml.find_features_referencing("ImageQuality")
+        names = {r.feature_name for r in refs}
+        assert "Quality" in names
+        quality = next(r for r in refs if r.feature_name == "Quality")
+        assert quality.target_table == "Image"
+
+    def test_column_narrows_to_referenced_column(self, impact_ml):
+        """column= matches the FK's REFERENCED column (usually RID)."""
+        by_rid = impact_ml.find_features_referencing("Image", column="RID")
+        assert {r.feature_name for r in by_rid} >= {"BoundingBox", "Quality"}
+        none = impact_ml.find_features_referencing("Image", column="No_Such_Column")
+        assert none == []
+
+    def test_unreferenced_table_returns_empty(self, impact_ml):
+        refs = impact_ml.find_features_referencing("ClinicalRecord")
+        assert refs == []


### PR DESCRIPTION
Closes #75 (Round B).

## What

The catalog-evolver about to drop a column or restructure a table can now ask the DerivaML domain model "what breaks?":

```python
ml.find_datasets_referencing("Image")
# -> [DatasetReference(dataset_rid='1-AAAA', element_table='Image', member_count=550), ...]
ml.find_features_referencing("ImageQuality")
# -> [FeatureReference(feature_name='Quality', target_table='Image',
#                      feature_table='Execution_Image_Quality', referencing_columns=['ImageQuality'])]
```

- **`find_datasets_referencing(table, column=None)`** — datasets holding member rows of the table, with counts. One bulk association-column fetch + in-memory groupby (the established asset bulk-read pattern). Table-granular by design (membership is row-level); `column=` accepted for symmetry, documented as non-narrowing. Non-element-type tables → `[]`.
- **`find_features_referencing(table, column=None)`** — features whose association-table FKs land on the table (self-FK, term columns, asset columns), with the referencing FK column names. `column=` narrows by the *referenced* column. Catches the non-obvious break: dropping a vocabulary breaks every feature with a term column into it.
- New `DatasetReference` / `FeatureReference` models (`extra="forbid"`) in `aux_classes.py`, exported from the package root.
- User guide: `docs/user-guide/schema-evolution.md` (the paired impact-analysis workflow).

## Verification

- 7 new integration tests vs the test catalog (member counts; unreferenced tables; table-granular semantics; self-FK + vocabulary-reference discovery; referenced-column narrowing) — all pass.
- Regression: **555 local + 101 feature-suite tests pass.** The one feature-suite failure (`test_download_feature`) **reproduces on clean main** — pre-existing, unrelated (stale bag vs accumulated feature values), filed as #293.
- ruff check + format clean.

## Pipeline

deriva-ml-mcp-plugin#25 adds the thin MCP wrappers once this lands; the skills follow-up is named in #75.

🤖 Generated with [Claude Code](https://claude.com/claude-code)