### PR TITLE
feat(execution): forward lineage + multirun status summary (closes #76)

### DIFF
--- a/docs/user-guide/executions.md
+++ b/docs/user-guide/executions.md
@@ -659,6 +659,53 @@ no recorded producer" is a valid answer to "how did this come to exist?".
 For the full method signature and the Pydantic model definitions, see
 [API Reference — Lineage](../api-reference/lineage.md).
 
+## How to check a sweep's progress (multirun status summary)
+
+One query answers "is the sweep done?" — status counts across all of a
+workflow's executions:
+
+```python
+summary = ml.multirun_status_summary(workflow_rid)
+summary.counts   # {'Uploaded': 18, 'Running': 2, 'Failed': 1}
+summary.total    # 21
+```
+
+Null catalog `Status` values are counted under `"Created"` (matching
+`lookup_execution`'s read contract). An unknown workflow RID raises
+rather than returning a misleading empty summary. For the full records
+behind a count (e.g. the two still-Running runs), follow up with
+`find_executions(workflow=workflow_rid, status=...)`.
+
+## How to find what consumed an artifact (forward lineage)
+
+`lookup_lineage` walks **backward** (what produced this?).
+`find_executions_consuming` walks **forward**: which executions took
+this Dataset or asset as an *input*?
+
+```python
+consumers = ml.find_executions_consuming(dataset_rid)
+[e.execution_rid for e in consumers]   # ['2-EXE9', ...]
+```
+
+The headline use case is **"is it safe to delete this dataset
+version?"**:
+
+```python
+if not ml.find_executions_consuming(old_dataset_rid):
+    # Nothing recorded ever consumed it -- no downstream run's
+    # provenance breaks if it goes.
+    ...
+```
+
+Two honesty notes: an empty result means no **recorded** consumption —
+runs that fetched data outside the execution machinery are invisible;
+and producers are not consumers (the execution that *created* a dataset
+is excluded). Dataset RIDs route through the input
+`Dataset_Execution` edge; asset RIDs route through the asset's
+`Execution` association with `Asset_Role="Input"`; any other RID kind
+raises (`Workflow` rows and plain domain rows have no consumption
+edges).
+
 ## See also
 
 - [Chapter 3 — Defining and using features](features.md): creating feature definitions, `FeatureRecord` classes, and asset-based features.

--- a/src/deriva_ml/core/mixins/execution.py
+++ b/src/deriva_ml/core/mixins/execution.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
     from deriva_ml.asset.aux_classes import AssetSpec
     from deriva_ml.dataset.aux_classes import DatasetSpec
     from deriva_ml.execution.execution import Execution
-    from deriva_ml.execution.execution_record import ExecutionRecord
+    from deriva_ml.execution.execution_record import ExecutionRecord, MultirunStatusSummary
     from deriva_ml.execution.lineage import (
         LineageNode,
         LineageResult,
@@ -730,6 +730,110 @@ class ExecutionMixin:
                 continue
             yield self.lookup_execution(exec_record["RID"])
 
+    def find_executions_consuming(self, rid: RID) -> list["ExecutionRecord"]:
+        """Forward lineage: the executions that CONSUMED the given artifact.
+
+        The forward complement of :meth:`lookup_lineage` (which walks
+        backward from an artifact to its producers). Given a Dataset or
+        asset RID, returns the executions that took it as an INPUT --
+        the "is it safe to delete this?" question: an empty result
+        means nothing recorded ever consumed it.
+
+        Dispatch is by resolved RID kind:
+
+        - **Dataset** -- executions with an input ``Dataset_Execution``
+          edge to it (same edge :meth:`find_executions` uses for
+          ``dataset_role="input"``).
+        - **Asset** (any asset-table row) -- executions linked through
+          the asset's ``<Asset>_Execution`` association with
+          ``Asset_Role="Input"``.
+
+        Other RID kinds are not consumption-shaped and raise.
+
+        Args:
+            rid: RID of a Dataset or an asset-table row.
+
+        Returns:
+            List of :class:`ExecutionRecord` for the consuming
+            executions (empty when nothing consumed the artifact --
+            note this means "no RECORDED consumption"; producers are
+            not consumers and are excluded).
+
+        Raises:
+            DerivaMLException: If ``rid`` does not exist, or resolves
+                to a table kind that has no consumption edges (e.g. a
+                Workflow or a plain domain row).
+
+        Example:
+            >>> consumers = ml.find_executions_consuming("1-DS01")  # doctest: +SKIP
+            >>> [e.execution_rid for e in consumers]  # doctest: +SKIP
+            ['2-EXE9']
+            >>> ml.find_executions_consuming("1-LEAF")  # doctest: +SKIP
+            []
+        """
+        if not rid:
+            raise DerivaMLException("find_executions_consuming requires a non-empty RID")
+        resolved = self.resolve_rid(rid)
+        table = resolved.table
+        if table.schema.name == self.ml_schema and table.name == "Dataset":
+            return list(self.find_executions(dataset=rid, dataset_role="input"))
+        if self.model.is_asset(table):
+            return self.list_asset_executions(rid, asset_role="Input")
+        raise DerivaMLException(
+            f"RID {rid} resolves to {table.schema.name}:{table.name}, which has no "
+            "consumption edges -- forward lineage is defined for Dataset and "
+            "asset-table RIDs."
+        )
+
+    def multirun_status_summary(self, workflow_rid: RID) -> "MultirunStatusSummary":
+        """Status counts across all executions of one workflow, in one query.
+
+        The "is the sweep done?" question: instead of listing every
+        execution record and counting client-side, fetch only the
+        ``Status`` column for the workflow's executions and aggregate.
+
+        Null ``Status`` values are counted under ``"Created"``,
+        matching :meth:`lookup_execution`'s read contract
+        (``Status or "Created"``).
+
+        Args:
+            workflow_rid: RID of the workflow to summarize.
+
+        Returns:
+            :class:`MultirunStatusSummary` with ``workflow_rid``,
+            ``counts`` (status name -> execution count), and ``total``.
+
+        Raises:
+            DerivaMLException: If ``workflow_rid`` is not a workflow
+                (propagated from :meth:`lookup_workflow`).
+
+        Example:
+            >>> summary = ml.multirun_status_summary("1-WF01")  # doctest: +SKIP
+            >>> summary.counts  # doctest: +SKIP
+            {'Uploaded': 18, 'Running': 2, 'Failed': 1}
+            >>> summary.total  # doctest: +SKIP
+            21
+        """
+        # Import here to avoid a circular import at module load
+        # (execution_record imports from this package's neighbors).
+        from deriva_ml.execution.execution_record import MultirunStatusSummary
+
+        # Validate the RID names a real workflow so a typo'd RID fails
+        # loudly instead of returning an empty (and misleading) summary.
+        self.lookup_workflow(workflow_rid)
+
+        pb = self.pathBuilder()
+        epath = pb.schemas[self.ml_schema].Execution
+        counts: dict[str, int] = {}
+        for row in epath.filter(epath.Workflow == workflow_rid).attributes(epath.Status).fetch():
+            status = row["Status"] or "Created"
+            counts[status] = counts.get(status, 0) + 1
+        return MultirunStatusSummary(
+            workflow_rid=workflow_rid,
+            counts=counts,
+            total=sum(counts.values()),
+        )
+
     def lookup_experiment(self, execution_rid: RID) -> "Experiment":
         """Look up an experiment by execution RID.
 
@@ -1039,6 +1143,8 @@ class ExecutionMixin:
         """
         from deriva_ml.execution.lineage import RootDescriptor
 
+        if not rid:
+            raise DerivaMLException("find_executions_consuming requires a non-empty RID")
         resolved = self.resolve_rid(rid)
         table = resolved.table
         table_name = table.name

--- a/src/deriva_ml/execution/execution_record.py
+++ b/src/deriva_ml/execution/execution_record.py
@@ -31,7 +31,7 @@ import logging
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Iterable
 
-from pydantic import BaseModel, PrivateAttr
+from pydantic import BaseModel, ConfigDict, PrivateAttr
 
 from deriva_ml.core.definitions import RID
 from deriva_ml.core.exceptions import DerivaMLException
@@ -641,3 +641,26 @@ class ExecutionRecord(BaseModel):
     def __repr__(self) -> str:
         """Return repr of the execution record."""
         return f"ExecutionRecord(execution_rid={self.execution_rid!r}, status={self.status!r})"
+
+
+class MultirunStatusSummary(BaseModel):
+    """Status counts across all executions of one workflow.
+
+    Produced by :meth:`DerivaML.multirun_status_summary` -- the
+    one-query answer to "is the sweep done?". Null catalog ``Status``
+    values are counted under ``"Created"``, matching
+    :meth:`lookup_execution`'s read contract.
+
+    Attributes:
+        workflow_rid: RID of the summarized workflow.
+        counts: Mapping of status name (e.g. ``"Uploaded"``,
+            ``"Running"``, ``"Failed"``) to execution count.
+        total: Total executions of the workflow (the sum of
+            ``counts`` values).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    workflow_rid: str
+    counts: dict[str, int]
+    total: int

--- a/tests/execution/test_forward_lineage.py
+++ b/tests/execution/test_forward_lineage.py
@@ -1,0 +1,114 @@
+"""Live-catalog tests for forward lineage + multirun status summary (issue #76).
+
+``find_executions_consuming`` is the forward complement of
+``lookup_lineage`` (which walks backward): given a Dataset or asset
+RID, which executions CONSUMED it? Needed for "is it safe to delete
+this?" questions. ``multirun_status_summary`` aggregates execution
+status counts for one workflow in a single query -- the "is the sweep
+done?" question.
+
+Builds the same two-execution chain as the lookup_lineage live smoke
+test: exe1 produces ds1; exe2 consumes ds1 and produces ds2.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from deriva_ml import DerivaMLException
+from deriva_ml import MLVocab as vc
+from deriva_ml.dataset.aux_classes import DatasetSpec, DatasetVersion
+from deriva_ml.execution.execution_configuration import ExecutionConfiguration
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("DERIVA_HOST"),
+    reason="forward-lineage live tests require DERIVA_HOST",
+)
+
+
+@pytest.fixture
+def chain(test_ml):
+    """exe1 -> ds1 -> exe2 -> ds2 under one workflow."""
+    test_ml.add_term(vc.dataset_type, "FwdLineageTest", description="Forward lineage smoke")
+    test_ml.add_term(vc.workflow_type, "Fwd Lineage Test", description="Forward lineage smoke")
+
+    wf = test_ml.create_workflow(
+        name="Forward lineage smoke workflow",
+        workflow_type="Fwd Lineage Test",
+        description="Forward lineage smoke test workflow",
+    )
+
+    exe1 = test_ml.create_execution(
+        ExecutionConfiguration(workflow=wf, description="fwd lineage exe1"),
+    )
+    ds1 = exe1.create_dataset(
+        dataset_types="FwdLineageTest",
+        description="fwd lineage smoke ds1",
+        version=DatasetVersion(1, 0, 0),
+    )
+
+    exe2 = test_ml.create_execution(
+        ExecutionConfiguration(
+            workflow=wf,
+            description="fwd lineage exe2",
+            datasets=[DatasetSpec(rid=ds1.dataset_rid, version=ds1.current_version)],
+        ),
+    )
+    ds2 = exe2.create_dataset(
+        dataset_types="FwdLineageTest",
+        description="fwd lineage smoke ds2",
+        version=DatasetVersion(1, 0, 0),
+    )
+    # create_workflow returns a LOCAL spec object (no RID -- the catalog
+    # row is registered lazily when an execution uses it). Read the
+    # registered Workflow RID off the execution row.
+    wf_rid = test_ml._retrieve_rid(exe1.execution_rid)["Workflow"]
+    return test_ml, wf_rid, exe1, ds1, exe2, ds2
+
+
+class TestFindExecutionsConsuming:
+    def test_consumer_found_producer_excluded(self, chain):
+        """exe2 consumed ds1; exe1 (the producer) is not a consumer."""
+        ml, _wf_rid, exe1, ds1, exe2, _ds2 = chain
+        consuming = ml.find_executions_consuming(ds1.dataset_rid)
+        rids = {e.execution_rid for e in consuming}
+        assert exe2.execution_rid in rids
+        assert exe1.execution_rid not in rids
+
+    def test_unconsumed_dataset_is_safe_to_delete(self, chain):
+        """ds2 (leaf) has no consumers -- the 'safe to delete?' answer."""
+        ml, *_rest, ds2 = chain
+        assert ml.find_executions_consuming(ds2.dataset_rid) == []
+
+    def test_asset_rid_dispatches(self, chain):
+        """An asset RID routes through the asset Input-edge path."""
+        ml = chain[0]
+        images = ml.list_assets("Image")
+        if not images:
+            pytest.skip("demo catalog has no Image assets in this state")
+        result = ml.find_executions_consuming(images[0].asset_rid)
+        assert isinstance(result, list)  # may be empty; dispatch must not raise
+
+    def test_non_artifact_rid_raises(self, chain):
+        """A Workflow RID is not lineage-shaped -> clear DerivaMLException."""
+        ml, wf_rid, *_rest = chain
+        with pytest.raises(DerivaMLException):
+            ml.find_executions_consuming(wf_rid)
+
+
+class TestMultirunStatusSummary:
+    def test_counts_match_executions(self, chain):
+        """Summary totals agree with find_executions for the workflow."""
+        ml, wf_rid, *_rest = chain
+        summary = ml.multirun_status_summary(wf_rid)
+        assert summary.workflow_rid == wf_rid
+        assert summary.total == sum(summary.counts.values())
+        listed = list(ml.find_executions(workflow=wf_rid))
+        assert summary.total == len(listed) >= 2
+
+    def test_unknown_workflow_raises(self, chain):
+        ml = chain[0]
+        with pytest.raises(DerivaMLException):
+            ml.multirun_status_summary("9-NOPE")


### PR DESCRIPTION
Closes #76 (Round C).

## What

```python
# Forward lineage -- "is it safe to delete this?"
consumers = ml.find_executions_consuming(dataset_rid)   # executions that took it as INPUT
ml.find_executions_consuming(leaf_rid)                  # [] -> nothing recorded ever consumed it

# Multirun -- "is the sweep done?" in one query
summary = ml.multirun_status_summary(workflow_rid)
summary.counts   # {'Uploaded': 18, 'Running': 2, 'Failed': 1}
summary.total    # 21
```

- **`find_executions_consuming(rid)`** — dispatch by resolved RID kind: Dataset → input `Dataset_Execution` edge; asset row → `Asset_Role="Input"` association; other kinds raise clearly. Producers excluded; empty = no **recorded** consumption (documented). Guards empty RIDs.
- **`multirun_status_summary(workflow_rid)`** — single `Status`-column query + count; workflow validated first (typo'd RID fails loudly, not an empty summary); null statuses counted as `Created` per the read contract. New `MultirunStatusSummary` model (`extra="forbid"`).
- User guide: both workflows added to `executions.md` (sweep progress; safe-to-delete worked example + honesty notes).

## Verification

- Live two-execution chain tests (exe1 → ds1 → exe2 → ds2): consumer found / producer excluded; leaf safe-to-delete; asset dispatch; non-artifact raises; summary-vs-list agreement; unknown workflow raises — **5 passed + 1 conditional skip**.
- Regression: **514/515 execution-suite tests pass**; the 1 failure (`test_fresh_workflow_still_derives`) **reproduces on clean main** — pre-existing, filed as #295.
- ruff check + format clean.

## Pipeline

deriva-ml-mcp-plugin#26 adds the thin wrappers (`deriva_ml_find_executions_consuming`, `deriva_ml_multirun_status`) once this lands; skills follow-ups named in #76.

🤖 Generated with [Claude Code](https://claude.com/claude-code)