### PR TITLE
feat(bag): DatasetBag.materialize() for in-place materialization

### DIFF
--- a/docs/superpowers/plans/2026-06-13-datasetbag-materialize.md
+++ b/docs/superpowers/plans/2026-06-13-datasetbag-materialize.md
@@ -1,0 +1,573 @@
+# DatasetBag.materialize() Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `DatasetBag.materialize()` method that fetches any not-yet-downloaded `fetch.txt` entries for an already-extracted bag, in place, with no catalog connection.
+
+**Architecture:** Extract the path-only fetch tail of `materialize_dataset_bag` into a shared free function `materialize_bag_dir(bag_path, *, fetch_concurrency, logger)` in `bag_download.py`. Both the existing download path (`materialize_dataset_bag`, after its `download_dataset_minid` step) and the new offline method (`DatasetBag.materialize`) call it. The `DatasetBag` is a deliberately offline object — it imports only the path-only helper, never the `Dataset`-oriented function.
+
+**Tech Stack:** Python ≥3.12, `bdbag` (`bdb.materialize`), pytest, `uv`, ruff.
+
+---
+
+## File Structure
+
+- `src/deriva_ml/dataset/bag_download.py` — add `materialize_bag_dir` free function; refactor `materialize_dataset_bag` to delegate its fetch tail to it; export the new function in `__all__`.
+- `src/deriva_ml/dataset/dataset_bag.py` — add `DatasetBag.materialize(self, *, fetch_concurrency=1) -> Self`.
+- `tests/dataset/test_bag_materialize.py` — new unit tests (no catalog) for `materialize_bag_dir` and `DatasetBag.materialize`.
+- `tests/dataset/test_bag_api_coverage.py` — add one integration test (live catalog) for the metadata-only → materialized flip.
+
+---
+
+## Task 1: Extract `materialize_bag_dir` free function (path-only fetch tail)
+
+**Files:**
+- Modify: `src/deriva_ml/dataset/bag_download.py` (imports near top; `materialize_dataset_bag` at 744–815; `__all__` at 818–824)
+
+- [ ] **Step 1: Add a module logger import at the top of `bag_download.py`**
+
+`bag_download.py` has no module logger today. Add the import alongside the other stdlib imports (after line 57, `from typing import ...`) and a module-level logger after the imports block. Add:
+
+```python
+import logging
+```
+
+and, immediately after the import block (before the first function/`TYPE_CHECKING` block), add:
+
+```python
+logger = logging.getLogger("deriva_ml.dataset.bag_download")
+```
+
+(Place the `logger = ...` line at module top level, near where other module constants would live — directly after the final `import`/`from` line group. If a `TYPE_CHECKING` block is the first thing after imports, put `logger = ...` just before it.)
+
+- [ ] **Step 2: Add the `materialize_bag_dir` free function**
+
+Insert this function **immediately before** `def materialize_dataset_bag(` (i.e., before line 744):
+
+```python
+def materialize_bag_dir(
+    bag_path: Path,
+    *,
+    fetch_concurrency: int = 1,
+    logger: "logging.Logger | None" = None,
+) -> Path:
+    """Fetch every ``fetch.txt`` entry for an already-extracted bag dir.
+
+    Path-only — needs no catalog connection. ``fetch.txt`` carries
+    absolute (Hatrac/S3) URLs, so materialization is a pure local
+    operation over a bag that is already on disk. Idempotent: if the
+    bag is already fully materialized, returns immediately without
+    fetching.
+
+    This is the shared fetch tail used by both
+    :func:`materialize_dataset_bag` (after it has downloaded/extracted
+    the bag) and :meth:`~deriva_ml.dataset.dataset_bag.DatasetBag.materialize`
+    (which operates on a bag already on disk).
+
+    Args:
+        bag_path: Path to the extracted BDBag directory (parent of
+            ``data/``).
+        fetch_concurrency: Maximum number of concurrent file downloads.
+        logger: Logger for progress messages. Defaults to this module's
+            logger.
+
+    Returns:
+        ``Path`` to the bag directory (unchanged; only its contents grow).
+
+    Raises:
+        Exception: Propagates any error raised by ``bdb.materialize`` —
+            e.g. a ``fetch.txt`` URL that is unreachable. The bag is
+            left partially materialized in that case.
+    """
+    from deriva_ml.dataset.bag_cache import BagCache
+
+    log = logger if logger is not None else globals()["logger"]
+    bag_path = Path(bag_path)
+
+    def fetch_progress_callback(current, total):
+        log.info(f"Materializing bag: {current} of {total} file(s) downloaded.")
+        return True
+
+    def validation_progress_callback(current, total):
+        log.info(f"Validating bag: {current} of {total} file(s) validated.")
+        return True
+
+    # If the bag already has every fetch.txt entry resolved, skip the
+    # materialize call — there's nothing to download.
+    if BagCache._is_fully_materialized(bag_path):
+        log.info(f"Bag at {bag_path} already materialized.")
+        return bag_path
+
+    log.info(f"Materializing bag at {bag_path}")
+    # Ensure parent directories exist for all fetch entries.
+    fetch_file = bag_path / "fetch.txt"
+    if fetch_file.exists():
+        with fetch_file.open("r", encoding="utf-8") as f:
+            for line in f:
+                parts = line.strip().split("\t")
+                if len(parts) >= 3:
+                    rel_path = parts[2]
+                    (bag_path / rel_path).parent.mkdir(parents=True, exist_ok=True)
+    bdb.materialize(
+        bag_path.as_posix(),
+        fetch_callback=fetch_progress_callback,
+        validation_callback=validation_progress_callback,
+        fetch_concurrency=fetch_concurrency,
+    )
+    return bag_path
+```
+
+- [ ] **Step 3: Refactor `materialize_dataset_bag` to delegate its fetch tail**
+
+Replace the body of `materialize_dataset_bag` from line 776 (the first `def fetch_progress_callback`) through line 815 (`return Path(bag_path)`) with a thin body that downloads then delegates. The new body (keeping the existing signature and docstring at 744–775):
+
+```python
+    bag_path = download_dataset_minid(dataset, minid, use_minid)
+    return materialize_bag_dir(
+        bag_path,
+        fetch_concurrency=fetch_concurrency,
+        logger=dataset._logger,
+    )
+```
+
+This removes the now-duplicated inline callbacks, the `_is_fully_materialized` short-circuit, and the parent-dir/`bdb.materialize` block (all moved into `materialize_bag_dir`). The "already materialized" log message text changes slightly (now keyed on path, not RID/version) — that is an internal log line, not asserted anywhere.
+
+- [ ] **Step 4: Export `materialize_bag_dir` in `__all__`**
+
+In the `__all__` list (was 818–824), add `"materialize_bag_dir",` in alphabetical position (between `"get_dataset_minid",` and `"materialize_dataset_bag",`):
+
+```python
+__all__ = [
+    "create_dataset_minid",
+    "download_dataset_minid",
+    "fetch_minid_metadata",
+    "get_dataset_minid",
+    "materialize_bag_dir",
+    "materialize_dataset_bag",
+]
+```
+
+- [ ] **Step 5: Lint and confirm import works**
+
+Run:
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml && uv run ruff check src/deriva_ml/dataset/bag_download.py && uv run python -c "from deriva_ml.dataset.bag_download import materialize_bag_dir, materialize_dataset_bag; print('ok')"
+```
+Expected: ruff passes (no errors), prints `ok`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml && git add src/deriva_ml/dataset/bag_download.py && git commit -m "$(cat <<'EOF'
+refactor(bag): extract path-only materialize_bag_dir from materialize_dataset_bag
+
+Pulls the fetch.txt → bdb.materialize tail into a standalone free
+function that needs no catalog connection, so it can be shared by both
+the download path and the upcoming DatasetBag.materialize() method.
+Behavior of materialize_dataset_bag is unchanged.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Unit test `materialize_bag_dir` (no catalog)
+
+**Files:**
+- Create: `tests/dataset/test_bag_materialize.py`
+
+These tests build a minimal BDBag on disk with a `file://` fetch entry, so they need no catalog and no network beyond the local filesystem.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/dataset/test_bag_materialize.py`:
+
+```python
+"""Unit tests for in-place bag materialization (no catalog required).
+
+Builds a minimal BDBag on disk whose fetch.txt points at a local
+``file://`` source, then exercises ``materialize_bag_dir`` and
+``DatasetBag.materialize`` without any catalog connection.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import pytest
+from bdbag import bdbag_api as bdb
+
+from deriva_ml.dataset.bag_cache import BagCache
+from deriva_ml.dataset.bag_download import materialize_bag_dir
+
+
+def _make_holey_bag(tmp_path: Path) -> tuple[Path, Path]:
+    """Create a valid BDBag with one un-fetched fetch.txt entry.
+
+    Returns (bag_dir, expected_target_file). The referenced payload
+    lives at a local ``file://`` URL so materialization needs no network.
+    """
+    # The remote payload the bag will fetch.
+    payload = b"hello-materialize"
+    src = tmp_path / "remote" / "payload.txt"
+    src.parent.mkdir(parents=True)
+    src.write_bytes(payload)
+
+    # Build a bag around an (initially) empty data dir.
+    bag_dir = tmp_path / "bag"
+    (bag_dir / "data").mkdir(parents=True)
+    bdb.make_bag(bag_dir.as_posix())
+
+    # Add a remote entry via fetch.txt: <url>\t<length>\t<relpath>.
+    rel = "data/assets/payload.txt"
+    fetch_txt = bag_dir / "fetch.txt"
+    fetch_txt.write_text(f"{src.as_uri()}\t{len(payload)}\t{rel}\n", encoding="utf-8")
+
+    # Record the entry in the tag manifest so bag structure stays valid.
+    md5 = hashlib.md5(payload).hexdigest()
+    (bag_dir / "manifest-md5.txt").write_text(f"{md5}  {rel}\n", encoding="utf-8")
+
+    return bag_dir, bag_dir / rel
+
+
+def test_materialize_bag_dir_fetches_missing_entry(tmp_path: Path):
+    """materialize_bag_dir downloads an un-fetched fetch.txt entry."""
+    bag_dir, target = _make_holey_bag(tmp_path)
+    assert not target.exists()
+    assert not BagCache._is_fully_materialized(bag_dir)
+
+    result = materialize_bag_dir(bag_dir)
+
+    assert result == bag_dir
+    assert target.exists()
+    assert target.read_bytes() == b"hello-materialize"
+    assert BagCache._is_fully_materialized(bag_dir)
+
+
+def test_materialize_bag_dir_idempotent_noop(tmp_path: Path, monkeypatch):
+    """On an already-complete bag, materialize_bag_dir does not fetch."""
+    bag_dir, _ = _make_holey_bag(tmp_path)
+    materialize_bag_dir(bag_dir)  # first call completes it
+    assert BagCache._is_fully_materialized(bag_dir)
+
+    # Second call must short-circuit before touching bdb.materialize.
+    def _boom(*args, **kwargs):
+        raise AssertionError("bdb.materialize should not be called on a complete bag")
+
+    monkeypatch.setattr("deriva_ml.dataset.bag_download.bdb.materialize", _boom)
+    result = materialize_bag_dir(bag_dir)
+    assert result == bag_dir
+```
+
+- [ ] **Step 2: Run tests to verify they fail / behave**
+
+Run:
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml && DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/dataset/test_bag_materialize.py -q
+```
+Expected: both tests PASS (the implementation from Task 1 already exists). If `_make_holey_bag` doesn't produce a structure that `_is_fully_materialized` rejects (e.g. `validate_bag_structure` fails for an unrelated reason), the first test will surface it — fix the fixture, not the implementation.
+
+> Note: this is a refactor-then-test ordering (the function exists from Task 1). The "failing first" discipline is preserved at the *feature* level by Task 3 (the `DatasetBag.materialize` method does not exist yet).
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml && git add tests/dataset/test_bag_materialize.py && git commit -m "$(cat <<'EOF'
+test(bag): unit-test materialize_bag_dir with a local file:// fetch bag
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Add `DatasetBag.materialize()` method
+
+**Files:**
+- Modify: `src/deriva_ml/dataset/dataset_bag.py` (add method after the `path` property, which ends at line 225)
+- Modify: `tests/dataset/test_bag_materialize.py` (add a method-level unit test)
+
+- [ ] **Step 1: Write the failing test for the method**
+
+Append to `tests/dataset/test_bag_materialize.py`:
+
+```python
+class _StubModel:
+    """Minimal stand-in for DatabaseModel exposing only ``bag_path``."""
+
+    def __init__(self, bag_path: Path):
+        self.bag_path = bag_path
+
+
+def test_datasetbag_materialize_fetches_in_place(tmp_path: Path, monkeypatch):
+    """DatasetBag.materialize() fetches missing files and returns self."""
+    from deriva_ml.dataset.dataset_bag import DatasetBag
+
+    bag_dir, target = _make_holey_bag(tmp_path)
+
+    # Build a DatasetBag without running its catalog-touching __init__.
+    bag = DatasetBag.__new__(DatasetBag)
+    bag.model = _StubModel(bag_dir)
+
+    assert not target.exists()
+    result = bag.materialize()
+
+    assert result is bag
+    assert target.exists()
+    assert target.read_bytes() == b"hello-materialize"
+    assert BagCache._is_fully_materialized(bag_dir)
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run:
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml && DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/dataset/test_bag_materialize.py::test_datasetbag_materialize_fetches_in_place -q
+```
+Expected: FAIL with `AttributeError: 'DatasetBag' object has no attribute 'materialize'`.
+
+- [ ] **Step 3: Implement `DatasetBag.materialize`**
+
+In `src/deriva_ml/dataset/dataset_bag.py`, insert this method immediately after the `path` property (after line 225, before `def list_tables`):
+
+```python
+    def materialize(self, *, fetch_concurrency: int = 1) -> Self:
+        """Fetch any not-yet-downloaded files for this bag, in place.
+
+        A :class:`DatasetBag` may be downloaded metadata-only (via
+        ``download_dataset_bag(..., materialize=False)``) or be left
+        partially materialized (``cached_holey``) after an interrupted
+        fetch. This method completes it: it reads the bag's ``fetch.txt``
+        (which carries absolute Hatrac/S3 URLs) and downloads every
+        referenced file into the bag directory. No catalog connection is
+        used — materialization is a pure local operation over the bag
+        already on disk.
+
+        The bag's :attr:`path` is unchanged; only the directory contents
+        grow. The SQLite mirror is unaffected (it is built from the CSV
+        tables already present in a metadata-only bag).
+
+        The call is idempotent: a fully-materialized bag returns
+        immediately without fetching.
+
+        Args:
+            fetch_concurrency: Maximum number of concurrent file
+                downloads.
+
+        Returns:
+            Self: this same bag (its assets are now present on disk),
+            so the call can be chained, e.g.
+            ``bag = ml.download_dataset_bag(spec).materialize()``.
+
+        Raises:
+            Exception: Propagates any error raised by the underlying
+                ``bdbag`` fetch — e.g. a ``fetch.txt`` URL that is
+                unreachable (source store down, or asset bytes never
+                uploaded to a reachable store). The bag is left
+                partially materialized in that case.
+
+        Example:
+            >>> spec = DatasetSpec(rid="1-abc123", materialize=False)  # doctest: +SKIP
+            >>> bag = ml.download_dataset_bag(spec)  # metadata only      # doctest: +SKIP
+            >>> bag.materialize()  # fetch the asset bytes in place       # doctest: +SKIP
+            <deriva_ml.DatasetBag object ...>
+        """
+        from deriva_ml.core.logging_config import get_logger
+        from deriva_ml.dataset.bag_download import materialize_bag_dir
+
+        materialize_bag_dir(
+            self.path,
+            fetch_concurrency=fetch_concurrency,
+            logger=get_logger(__name__),
+        )
+        return self
+```
+
+- [ ] **Step 4: Run the method test to verify it passes**
+
+Run:
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml && DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/dataset/test_bag_materialize.py -q
+```
+Expected: all three tests PASS.
+
+- [ ] **Step 5: Lint**
+
+Run:
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml && uv run ruff check src/deriva_ml/dataset/dataset_bag.py tests/dataset/test_bag_materialize.py
+```
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml && git add src/deriva_ml/dataset/dataset_bag.py tests/dataset/test_bag_materialize.py && git commit -m "$(cat <<'EOF'
+feat(bag): add DatasetBag.materialize() for in-place materialization
+
+Lets a metadata-only or partially-materialized DatasetBag fetch its
+remaining fetch.txt entries in place, with no catalog connection,
+complementing download_dataset_bag(materialize=True). Returns self so
+the call chains.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Integration test — metadata-only → materialized flip (live catalog)
+
+**Files:**
+- Modify: `tests/dataset/test_bag_api_coverage.py` (add a test class at end of file, after line 413)
+
+This mirrors the existing `TestNonMaterializedBagAccess` fixture pattern. The demo catalog may produce a bag with an empty `fetch.txt` (no remote assets); in that case `materialize=False` already yields a complete bag, so the test skips rather than asserting a flip that can't occur.
+
+- [ ] **Step 1: Write the integration test**
+
+Append to `tests/dataset/test_bag_api_coverage.py`:
+
+```python
+class TestBagMaterializeInPlace:
+    """Tests for DatasetBag.materialize() against a live catalog."""
+
+    def test_materialize_flips_metadata_only_to_materialized(
+        self, catalog_manager: CatalogManager, tmp_path: Path
+    ):
+        """A metadata-only bag becomes fully materialized in place."""
+        catalog_manager.reset()
+        ml, dataset_desc = catalog_manager.ensure_datasets(tmp_path / "source")
+        dataset = dataset_desc.dataset
+        version = dataset.current_version
+
+        # Download metadata-only.
+        bag = dataset.download_dataset_bag(version=version, use_minid=False, materialize=False)
+
+        if BagCache._is_fully_materialized(bag.path):
+            pytest.skip("Demo bag has no remote fetch.txt entries; nothing to materialize.")
+
+        # Materialize in place; must return the same object.
+        result = bag.materialize()
+        assert result is bag
+        assert BagCache._is_fully_materialized(bag.path)
+
+        # Cache status flips to materialized.
+        info = dataset.bag_info(version=version)
+        assert info["status"] == CacheStatus.cached_materialized.value
+
+    def test_materialize_idempotent_on_materialized_bag(
+        self, catalog_manager: CatalogManager, tmp_path: Path
+    ):
+        """materialize() on an already-materialized bag is a safe no-op."""
+        catalog_manager.reset()
+        ml, dataset_desc = catalog_manager.ensure_datasets(tmp_path / "source")
+        dataset = dataset_desc.dataset
+        version = dataset.current_version
+
+        bag = dataset.download_dataset_bag(version=version, use_minid=False)  # materialize=True default
+        assert BagCache._is_fully_materialized(bag.path)
+
+        result = bag.materialize()
+        assert result is bag
+        assert BagCache._is_fully_materialized(bag.path)
+```
+
+- [ ] **Step 2: Run the integration test**
+
+Run (needs `DERIVA_HOST`):
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml && DERIVA_ML_ALLOW_DIRTY=true DERIVA_HOST=localhost uv run pytest tests/dataset/test_bag_api_coverage.py::TestBagMaterializeInPlace -q --timeout=600
+```
+Expected: PASS (or SKIP on the first test if the demo bag has no remote assets; the second test always runs).
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml && git add tests/dataset/test_bag_api_coverage.py && git commit -m "$(cat <<'EOF'
+test(bag): integration test for DatasetBag.materialize() in-place flip
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Full unit-suite sanity, PR
+
+**Files:** none (verification + PR)
+
+- [ ] **Step 1: Run the fast unit suites to confirm no regression**
+
+Run:
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml && DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/dataset/test_bag_materialize.py tests/local_db/ tests/asset/ tests/model/ -q
+```
+Expected: all pass.
+
+- [ ] **Step 2: Lint + format the whole change set**
+
+Run:
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml && uv run ruff format src/deriva_ml/dataset/bag_download.py src/deriva_ml/dataset/dataset_bag.py tests/dataset/test_bag_materialize.py tests/dataset/test_bag_api_coverage.py && uv run ruff check src tests
+```
+Expected: format makes no/minimal changes; check passes. Commit any format-only changes:
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml && git diff --quiet || (git add -A && git commit -m "style: ruff format")
+```
+
+- [ ] **Step 3: Push and open the PR**
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml && git push -u origin feature/datasetbag-materialize && gh pr create --title "feat(bag): DatasetBag.materialize() for in-place materialization" --body "$(cat <<'EOF'
+## Summary
+Adds `DatasetBag.materialize(*, fetch_concurrency=1)` — fetches any
+not-yet-downloaded `fetch.txt` entries for an already-extracted bag, in
+place, with no catalog connection. Complements the existing cache-aware
+`download_dataset_bag(materialize=True)` path by giving an affordance
+directly on a `DatasetBag` object (a metadata-only or `cached_holey`
+bag you already hold).
+
+## Design
+- The fetch tail of `materialize_dataset_bag` (parent-dir prep +
+  `bdb.materialize`, gated by `_is_fully_materialized`) is extracted into
+  a shared, catalog-free free function `materialize_bag_dir(bag_path, *,
+  fetch_concurrency, logger)`. Both the download path and the new method
+  call it — one implementation, two callers.
+- `DatasetBag` stays offline-only: it imports only the path-only helper,
+  never the `Dataset`-oriented `materialize_dataset_bag`.
+- Errors from `bdbag` fetch propagate (no new exception layer), matching
+  the existing download path.
+
+## Tests
+- Unit (no catalog): `tests/dataset/test_bag_materialize.py` builds a
+  minimal BDBag with a local `file://` fetch entry and verifies the fetch,
+  idempotent no-op, and the method returning `self`.
+- Integration (live catalog): `TestBagMaterializeInPlace` verifies the
+  metadata-only → `cached_materialized` flip and idempotency (skips the
+  flip assertion if the demo bag carries no remote assets).
+
+Spec: `docs/superpowers/specs/2026-06-13-datasetbag-materialize-design.md`
+Plan: `docs/superpowers/plans/2026-06-13-datasetbag-materialize.md`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 4: Report the PR URL to the user**
+
+Paste the PR URL. Note the patch version bump happens **after** merge, on clean `main` (repo rule), not in this branch.
+
+---
+
+## Self-Review notes
+
+- **Spec coverage:** §3.1 method → Task 3; §3.2 propagate error → docstring `Raises` + no try/except anywhere; §3.3 shared helper → Task 1; §3.4 logger arg → Task 1 Step 2 (`logger` param) + Task 3 (`get_logger(__name__)`); §4 `__all__` export → Task 1 Step 4; §5.1 unit → Tasks 2 & 3; §5.2 integration → Task 4.
+- **Type consistency:** `materialize_bag_dir(bag_path, *, fetch_concurrency, logger)` signature is identical at definition (Task 1), free-function callers (`materialize_dataset_bag` Task 1 Step 3), and method caller (Task 3 Step 3). `DatasetBag.materialize(self, *, fetch_concurrency=1) -> Self` consistent between test (Task 3 Step 1) and impl (Task 3 Step 3).
+- **No placeholders:** every code step shows full code; every run step shows the command and expected result.

--- a/docs/superpowers/specs/2026-06-13-datasetbag-materialize-design.md
+++ b/docs/superpowers/specs/2026-06-13-datasetbag-materialize-design.md
@@ -1,0 +1,187 @@
+# `DatasetBag.materialize()` — in-place bag materialization — Design
+
+**Date:** 2026-06-13
+**Status:** Approved in brainstorming; spec for implementation.
+**Subproject:** `deriva-ml`
+
+## 1. Problem statement
+
+There is a user-accessible path to materialize an *unmaterialized*
+(metadata-only) bag today, but it is keyed off the **dataset spec +
+cache**, not off a `DatasetBag` instance:
+
+```python
+bag = ml.download_dataset_bag(DatasetSpec(rid=..., version=..., materialize=True))
+```
+
+`download_dataset_bag(materialize=True)` is cache-aware — it skips the
+export/metadata work already on disk and fetches only the missing asset
+bytes (via `materialize_dataset_bag` → `bdb.materialize()`). What is
+**missing** is a convenience affordance directly on a `DatasetBag`
+object: given a `DatasetBag` you already hold (downloaded with
+`materialize=False`, or a `cached_holey` bag), there is no
+`bag.materialize()` to fill it in place. The grep for public
+materialize/fetch methods on `dataset_bag.py` returns nothing.
+
+This spec adds that method.
+
+## 2. Key constraint (what makes this clean)
+
+A `DatasetBag` is a deliberately **offline** object. It holds **no**
+`DerivaML` instance and **no** catalog connection — only the on-disk
+bag path (`bag.path`, via `self.model.bag_path`) and the SQLite mirror.
+`DerivaMLBagView` and `DatabaseModel` likewise carry no back-reference
+to a live catalog.
+
+Verified that in-place materialization needs no catalog:
+
+- `bdb.materialize(bag_path)` reads `fetch.txt` (which holds **absolute**
+  Hatrac/S3 URLs) and fetches the referenced files into the bag dir.
+  Path-only; no catalog.
+- `BagCache._is_fully_materialized(bag_path)` is a pure path check
+  (validate bag structure + every `fetch.txt` entry resolves locally).
+- The SQLite mirror is built from the CSV tables, which are already
+  present in a metadata-only bag, so materialization does not touch it.
+
+Both of these already run as the **tail** of
+`materialize_dataset_bag` (`bag_download.py:744`), *after* its download
+step. Because a `DatasetBag` can only exist if its bag is already
+extracted on disk, materializing it in place is exactly that tail —
+no download, no catalog, no re-export, no snapshot re-pin.
+
+## 3. Design
+
+### 3.1 New method on `DatasetBag`
+
+```python
+def materialize(self, *, fetch_concurrency: int = 1) -> Self:
+    """Fetch any not-yet-downloaded files for this bag, in place."""
+```
+
+Behavior:
+
+1. If `_is_fully_materialized(self.path)` → log "already materialized"
+   and return `self` (idempotent; no work, no network).
+2. Otherwise: ensure parent dirs exist for every `fetch.txt` entry,
+   then call `bdb.materialize(self.path, fetch_concurrency=...)` with
+   the same fetch/validation progress callbacks the existing free
+   function uses, then return `self`.
+3. Returns `self` so the call chains
+   (`bag = ml.download_dataset_bag(spec).materialize()`) and the
+   *same* object's assets are now present on disk (its `path` is
+   unchanged; only the directory contents grew).
+
+`Self` is already imported in `dataset_bag.py`.
+
+### 3.2 Failure mode
+
+**Propagate the `bdb` fetch error.** If a `fetch.txt` URL is
+unreachable (source Hatrac down, or asset bytes never uploaded to a
+reachable store), `bdb.materialize` raises and the bag is left in the
+partially-materialized (`cached_holey`) state it was already in. This
+matches `materialize_dataset_bag`'s current behavior exactly — no new
+error-translation layer, consistent with the existing download path.
+
+### 3.3 Avoiding duplication
+
+The "ensure parent dirs + `bdb.materialize`" block is currently inline
+in `materialize_dataset_bag`. Extract that tail into a small free
+function in `bag_download.py`:
+
+```python
+def materialize_bag_dir(
+    bag_path: Path,
+    *,
+    fetch_concurrency: int = 1,
+    logger: logging.Logger,
+) -> Path:
+    """Fetch every fetch.txt entry for an already-extracted bag dir.
+
+    Path-only; no catalog. Idempotent: returns immediately if the bag
+    is already fully materialized.
+    """
+```
+
+Both call sites use it:
+
+- `materialize_dataset_bag` — after `download_dataset_minid` returns the
+  on-disk path, delegate the fetch tail to `materialize_bag_dir`
+  (passing `dataset._logger`). The early
+  `_is_fully_materialized` short-circuit moves into the helper.
+- `DatasetBag.materialize()` — call `materialize_bag_dir(self.path,
+  fetch_concurrency=..., logger=get_logger(__name__))`.
+
+One implementation, two callers. `DatasetBag` does **not** import the
+`Dataset`-oriented `materialize_dataset_bag` (which needs a live
+catalog); it imports only the path-only helper.
+
+### 3.4 Logging
+
+`materialize_dataset_bag` logs via `dataset._logger`. The extracted
+helper takes a `logger` argument so both callers supply their own:
+the free function passes `dataset._logger`; `DatasetBag.materialize`
+passes `get_logger(__name__)` (the standard
+`deriva_ml.core.logging_config` pattern).
+
+## 4. Deliverables
+
+- `src/deriva_ml/dataset/bag_download.py`:
+  - new free function `materialize_bag_dir(...)`;
+  - `materialize_dataset_bag` refactored to delegate its fetch tail to
+    it (behavior unchanged);
+  - `materialize_bag_dir` added to `__all__`.
+- `src/deriva_ml/dataset/dataset_bag.py`:
+  - new `DatasetBag.materialize(self, *, fetch_concurrency=1) -> Self`
+    with a Google-style docstring + runnable-where-possible `Example:`.
+- Tests (below).
+- Patch version bump after the PR merges to `main`.
+
+## 5. Testing
+
+### 5.1 Unit (no catalog)
+
+In a new `tests/dataset/test_bag_materialize.py` (or alongside existing
+bag tests):
+
+- **Fetches a missing entry:** build a minimal bag dir with a valid
+  BDBag structure and a `fetch.txt` whose single entry points at a
+  local `file://` source and a not-yet-present target; call
+  `bag.materialize()` (or `materialize_bag_dir` directly for the
+  pure-path unit); assert the target file now exists and
+  `_is_fully_materialized` is `True`.
+- **Idempotent no-op:** on an already-complete bag, `materialize()`
+  returns immediately (assert no fetch attempted — e.g. monkeypatch
+  `bdb.materialize` to raise, prove it is not called) and returns the
+  same object.
+
+RIDs in any fixture come from a fixture-produced row, never a literal
+(repo rule).
+
+### 5.2 Integration (live catalog)
+
+Guarded like the other catalog-dependent dataset tests:
+
+- Download a small demo dataset with `materialize=False`; assert cache
+  status is `cached_metadata_only`/`cached_holey`.
+- Call `bag.materialize()`; assert `_is_fully_materialized(bag.path)`
+  and that the cache status flips to `cached_materialized`.
+- Assert the call returns the same `DatasetBag` object (`is`).
+
+## 6. Non-goals
+
+- No change to `download_dataset_bag` signatures or the `materialize=`
+  flag — purely additive.
+- No catalog re-export, snapshot re-pin, or version change — the method
+  fetches exactly the URLs the bag's `fetch.txt` already carries.
+- No new error-translation layer (§3.2).
+- Not a `de-materialize` / prune-assets operation (cache deletion is the
+  `manage-deriva-storage` surface).
+
+## 7. Verification
+
+- `uv run ruff check` / `format` clean.
+- Unit tests pass with no catalog
+  (`DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/dataset/test_bag_materialize.py -q`).
+- Integration test passes against `DERIVA_HOST=localhost`.
+- All changes via a feature-branch PR (repo rule); `bump-version patch`
+  on clean `main` after merge.

--- a/src/deriva_ml/dataset/bag_download.py
+++ b/src/deriva_ml/dataset/bag_download.py
@@ -52,6 +52,7 @@ from __future__ import annotations
 import hashlib
 import json
 import shutil
+from logging import Logger
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import TYPE_CHECKING, Any
@@ -72,8 +73,11 @@ from deriva.transfer.download import (
 from deriva.transfer.download.deriva_export import DerivaExport
 
 from deriva_ml.core.exceptions import DerivaMLException
+from deriva_ml.core.logging_config import get_logger
 from deriva_ml.dataset.aux_classes import DatasetMinid, DatasetVersion
 from deriva_ml.dataset.bag_builder import DatasetBagBuilder
+
+_module_logger = get_logger(__name__)
 
 if TYPE_CHECKING:
     from deriva_ml.dataset.dataset import Dataset
@@ -741,6 +745,78 @@ def get_dataset_minid(
     )
 
 
+def materialize_bag_dir(
+    bag_path: Path,
+    *,
+    fetch_concurrency: int = 1,
+    logger: "Logger | None" = None,
+) -> Path:
+    """Fetch every ``fetch.txt`` entry for an already-extracted bag dir.
+
+    Path-only — needs no catalog connection. ``fetch.txt`` carries
+    absolute (Hatrac/S3) URLs, so materialization is a pure local
+    operation over a bag that is already on disk. Idempotent: if the
+    bag is already fully materialized, returns immediately without
+    fetching.
+
+    This is the shared fetch tail used by both
+    :func:`materialize_dataset_bag` (after it has downloaded/extracted
+    the bag) and :meth:`~deriva_ml.dataset.dataset_bag.DatasetBag.materialize`
+    (which operates on a bag already on disk).
+
+    Args:
+        bag_path: Path to the extracted BDBag directory (parent of
+            ``data/``).
+        fetch_concurrency: Maximum number of concurrent file downloads.
+        logger: Logger for progress messages. Defaults to this module's
+            logger.
+
+    Returns:
+        ``Path`` to the bag directory (unchanged; only its contents grow).
+
+    Raises:
+        Exception: Propagates any error raised by ``bdb.materialize`` —
+            e.g. a ``fetch.txt`` URL that is unreachable. The bag is
+            left partially materialized in that case.
+    """
+    from deriva_ml.dataset.bag_cache import BagCache
+
+    log = logger if logger is not None else _module_logger
+    bag_path = Path(bag_path)
+
+    def fetch_progress_callback(current, total):
+        log.info(f"Materializing bag: {current} of {total} file(s) downloaded.")
+        return True
+
+    def validation_progress_callback(current, total):
+        log.info(f"Validating bag: {current} of {total} file(s) validated.")
+        return True
+
+    # If the bag already has every fetch.txt entry resolved, skip the
+    # materialize call — there's nothing to download.
+    if BagCache._is_fully_materialized(bag_path):
+        log.info(f"Bag at {bag_path} already materialized.")
+        return bag_path
+
+    log.info(f"Materializing bag at {bag_path}")
+    # Ensure parent directories exist for all fetch entries.
+    fetch_file = bag_path / "fetch.txt"
+    if fetch_file.exists():
+        with fetch_file.open("r", encoding="utf-8") as f:
+            for line in f:
+                parts = line.strip().split("\t")
+                if len(parts) >= 3:
+                    rel_path = parts[2]
+                    (bag_path / rel_path).parent.mkdir(parents=True, exist_ok=True)
+    bdb.materialize(
+        bag_path.as_posix(),
+        fetch_callback=fetch_progress_callback,
+        validation_callback=validation_progress_callback,
+        fetch_concurrency=fetch_concurrency,
+    )
+    return bag_path
+
+
 def materialize_dataset_bag(
     dataset: "Dataset",
     minid: DatasetMinid,
@@ -773,46 +849,12 @@ def materialize_dataset_bag(
     Returns:
         Path to the fully materialized bag directory.
     """
-
-    def fetch_progress_callback(current, total):
-        msg = f"Materializing bag: {current} of {total} file(s) downloaded."
-        dataset._logger.info(msg)
-        return True
-
-    def validation_progress_callback(current, total):
-        msg = f"Validating bag: {current} of {total} file(s) validated."
-        dataset._logger.info(msg)
-        return True
-
     bag_path = download_dataset_minid(dataset, minid, use_minid)
-
-    # If the bag already has every fetch.txt entry resolved, skip the
-    # materialize call — there's nothing to download.
-    from deriva_ml.dataset.bag_cache import BagCache
-
-    if BagCache._is_fully_materialized(bag_path):
-        dataset._logger.info(
-            f"Cached bag {minid.dataset_rid} Version:{minid.dataset_version} already materialized."
-        )
-        return Path(bag_path)
-
-    dataset._logger.info(f"Materializing bag {minid.dataset_rid} Version:{minid.dataset_version}")
-    # Ensure parent directories exist for all fetch entries
-    fetch_file = bag_path / "fetch.txt"
-    if fetch_file.exists():
-        with fetch_file.open("r", encoding="utf-8") as f:
-            for line in f:
-                parts = line.strip().split("\t")
-                if len(parts) >= 3:
-                    rel_path = parts[2]
-                    (bag_path / rel_path).parent.mkdir(parents=True, exist_ok=True)
-    bdb.materialize(
-        bag_path.as_posix(),
-        fetch_callback=fetch_progress_callback,
-        validation_callback=validation_progress_callback,
+    return materialize_bag_dir(
+        bag_path,
         fetch_concurrency=fetch_concurrency,
+        logger=dataset._logger,
     )
-    return Path(bag_path)
 
 
 __all__ = [
@@ -820,5 +862,6 @@ __all__ = [
     "download_dataset_minid",
     "fetch_minid_metadata",
     "get_dataset_minid",
+    "materialize_bag_dir",
     "materialize_dataset_bag",
 ]

--- a/src/deriva_ml/dataset/bag_download.py
+++ b/src/deriva_ml/dataset/bag_download.py
@@ -408,9 +408,7 @@ def _resolve_version_record(dataset: "Dataset", version: DatasetVersion) -> Any:
     try:
         return next(v for v in dataset.dataset_history() if str(v.dataset_version) == version_str)
     except StopIteration:
-        raise DerivaMLException(
-            f"Version {version_str} does not exist for RID {dataset.dataset_rid}"
-        ) from None
+        raise DerivaMLException(f"Version {version_str} does not exist for RID {dataset.dataset_rid}") from None
 
 
 def _build_version_rid(dataset_rid: str, snapshot: str | None) -> str:
@@ -482,8 +480,7 @@ def _tier1_local_cache_lookup(
 
     # Re-open the index in a short scope to compute the bag path.
     cached_bag_path = (
-        BagCacheIndex(dataset._ml_instance.cache_dir).bag_dir_for(cache_suffix)
-        / f"Dataset_{dataset.dataset_rid}"
+        BagCacheIndex(dataset._ml_instance.cache_dir).bag_dir_for(cache_suffix) / f"Dataset_{dataset.dataset_rid}"
     )
     if not cached_bag_path.exists():
         return None

--- a/src/deriva_ml/dataset/dataset_bag.py
+++ b/src/deriva_ml/dataset/dataset_bag.py
@@ -224,6 +224,57 @@ class DatasetBag:
         """
         return self.model.bag_path
 
+    def materialize(self, *, fetch_concurrency: int = 1) -> Self:
+        """Fetch any not-yet-downloaded files for this bag, in place.
+
+        A :class:`DatasetBag` may be downloaded metadata-only (via
+        ``download_dataset_bag(..., materialize=False)``) or be left
+        partially materialized (``cached_holey``) after an interrupted
+        fetch. This method completes it: it reads the bag's ``fetch.txt``
+        (which carries absolute Hatrac/S3 URLs) and downloads every
+        referenced file into the bag directory. No catalog connection is
+        used — materialization is a pure local operation over the bag
+        already on disk.
+
+        The bag's :attr:`path` is unchanged; only the directory contents
+        grow. The SQLite mirror is unaffected (it is built from the CSV
+        tables already present in a metadata-only bag).
+
+        The call is idempotent: a fully-materialized bag returns
+        immediately without fetching.
+
+        Args:
+            fetch_concurrency: Maximum number of concurrent file
+                downloads.
+
+        Returns:
+            Self: this same bag (its assets are now present on disk),
+            so the call can be chained, e.g.
+            ``bag = ml.download_dataset_bag(spec).materialize()``.
+
+        Raises:
+            Exception: Propagates any error raised by the underlying
+                ``bdbag`` fetch — e.g. a ``fetch.txt`` URL that is
+                unreachable (source store down, or asset bytes never
+                uploaded to a reachable store). The bag is left
+                partially materialized in that case.
+
+        Example:
+            >>> spec = DatasetSpec(rid="1-abc123", materialize=False)  # doctest: +SKIP
+            >>> bag = ml.download_dataset_bag(spec)  # metadata only      # doctest: +SKIP
+            >>> bag.materialize()  # fetch the asset bytes in place       # doctest: +SKIP
+            <deriva_ml.DatasetBag object ...>
+        """
+        from deriva_ml.core.logging_config import get_logger
+        from deriva_ml.dataset.bag_download import materialize_bag_dir
+
+        materialize_bag_dir(
+            self.path,
+            fetch_concurrency=fetch_concurrency,
+            logger=get_logger(__name__),
+        )
+        return self
+
     def list_tables(self) -> list[str]:
         """List all tables available in the bag's SQLite database.
 

--- a/tests/dataset/test_bag_api_coverage.py
+++ b/tests/dataset/test_bag_api_coverage.py
@@ -410,3 +410,47 @@ class TestNonMaterializedBagAccess:
         # Use single table to avoid FK path ambiguity
         df = bag.get_denormalized_as_dataframe(include_tables=["Image"])
         assert isinstance(df, pd.DataFrame)
+
+
+class TestBagMaterializeInPlace:
+    """Tests for DatasetBag.materialize() against a live catalog."""
+
+    def test_materialize_flips_metadata_only_to_materialized(
+        self, catalog_manager: CatalogManager, tmp_path: Path
+    ):
+        """A metadata-only bag becomes fully materialized in place."""
+        catalog_manager.reset()
+        ml, dataset_desc = catalog_manager.ensure_datasets(tmp_path / "source")
+        dataset = dataset_desc.dataset
+        version = dataset.current_version
+
+        # Download metadata-only.
+        bag = dataset.download_dataset_bag(version=version, use_minid=False, materialize=False)
+
+        if BagCache._is_fully_materialized(bag.path):
+            pytest.skip("Demo bag has no remote fetch.txt entries; nothing to materialize.")
+
+        # Materialize in place; must return the same object.
+        result = bag.materialize()
+        assert result is bag
+        assert BagCache._is_fully_materialized(bag.path)
+
+        # Cache status flips to materialized.
+        info = dataset.bag_info(version=version)
+        assert info["status"] == CacheStatus.cached_materialized.value
+
+    def test_materialize_idempotent_on_materialized_bag(
+        self, catalog_manager: CatalogManager, tmp_path: Path
+    ):
+        """materialize() on an already-materialized bag is a safe no-op."""
+        catalog_manager.reset()
+        ml, dataset_desc = catalog_manager.ensure_datasets(tmp_path / "source")
+        dataset = dataset_desc.dataset
+        version = dataset.current_version
+
+        bag = dataset.download_dataset_bag(version=version, use_minid=False)  # materialize=True default
+        assert BagCache._is_fully_materialized(bag.path)
+
+        result = bag.materialize()
+        assert result is bag
+        assert BagCache._is_fully_materialized(bag.path)

--- a/tests/dataset/test_bag_api_coverage.py
+++ b/tests/dataset/test_bag_api_coverage.py
@@ -20,8 +20,7 @@ from pathlib import Path
 import pandas as pd
 import pytest
 
-from deriva_ml import DerivaML
-from deriva_ml.dataset.aux_classes import DatasetVersion, VersionPart
+from deriva_ml.dataset.aux_classes import DatasetVersion
 from deriva_ml.dataset.bag_cache import BagCache, CacheStatus
 from tests.catalog_manager import CatalogManager
 
@@ -348,7 +347,7 @@ class TestCacheDeletionAndRedownload:
         version = dataset.current_version
 
         # Download to populate cache
-        bag1 = dataset.download_dataset_bag(version=version, use_minid=False)
+        dataset.download_dataset_bag(version=version, use_minid=False)
         info1 = dataset.bag_info(version=version)
         assert info1["status"] == CacheStatus.cached_materialized.value
 
@@ -415,9 +414,7 @@ class TestNonMaterializedBagAccess:
 class TestBagMaterializeInPlace:
     """Tests for DatasetBag.materialize() against a live catalog."""
 
-    def test_materialize_flips_metadata_only_to_materialized(
-        self, catalog_manager: CatalogManager, tmp_path: Path
-    ):
+    def test_materialize_flips_metadata_only_to_materialized(self, catalog_manager: CatalogManager, tmp_path: Path):
         """A metadata-only bag becomes fully materialized in place."""
         catalog_manager.reset()
         ml, dataset_desc = catalog_manager.ensure_datasets(tmp_path / "source")
@@ -439,9 +436,7 @@ class TestBagMaterializeInPlace:
         info = dataset.bag_info(version=version)
         assert info["status"] == CacheStatus.cached_materialized.value
 
-    def test_materialize_idempotent_on_materialized_bag(
-        self, catalog_manager: CatalogManager, tmp_path: Path
-    ):
+    def test_materialize_idempotent_on_materialized_bag(self, catalog_manager: CatalogManager, tmp_path: Path):
         """materialize() on an already-materialized bag is a safe no-op."""
         catalog_manager.reset()
         ml, dataset_desc = catalog_manager.ensure_datasets(tmp_path / "source")

--- a/tests/dataset/test_bag_materialize.py
+++ b/tests/dataset/test_bag_materialize.py
@@ -1,0 +1,124 @@
+"""Unit tests for in-place bag materialization (no catalog required).
+
+Builds a minimal BDBag on disk whose fetch.txt points at a local
+HTTP server, then exercises ``materialize_bag_dir`` and
+``DatasetBag.materialize`` without any catalog connection.
+
+Note on ``file://`` vs ``http://``: bdbag's fetch engine does not
+support the ``file://`` protocol (its default fetchers only cover
+``http``, ``https``, ``s3``, and ``gs``).  The fixture therefore
+spins up a ``socketserver.TCPServer`` on 127.0.0.1 using a random
+ephemeral port for the duration of each test.  This keeps the tests
+network-free in the external sense while still exercising the real
+bdbag materialization path.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import http.server
+import json
+import socketserver
+import threading
+from pathlib import Path
+
+from bdbag import bdbag_api as bdb
+
+from deriva_ml.dataset.bag_cache import BagCache
+from deriva_ml.dataset.bag_download import materialize_bag_dir
+
+
+class _SilentHandler(http.server.SimpleHTTPRequestHandler):
+    """SimpleHTTPRequestHandler that suppresses access log output."""
+
+    def __init__(self, *args, directory: str, **kwargs):
+        super().__init__(*args, directory=directory, **kwargs)
+
+    def log_message(self, *args):  # noqa: D102
+        pass
+
+
+def _make_holey_bag(tmp_path: Path) -> tuple[Path, Path, socketserver.TCPServer]:
+    """Create a valid BDBag with one un-fetched fetch.txt entry.
+
+    Spins up a local HTTP server on a random port to serve the payload
+    (bdbag does not support ``file://`` URLs natively).
+
+    Returns ``(bag_dir, expected_target_file, httpd)`` where ``httpd``
+    must be shut down by the caller once the test is complete.
+    """
+    # The remote payload the bag will fetch.
+    payload = b"hello-materialize"
+    src_dir = tmp_path / "remote"
+    src_dir.mkdir(parents=True)
+    (src_dir / "payload.txt").write_bytes(payload)
+
+    # Start a local HTTP server serving src_dir.
+    httpd = socketserver.TCPServer(
+        ("127.0.0.1", 0),
+        lambda *a, **kw: _SilentHandler(*a, directory=str(src_dir), **kw),
+    )
+    port = httpd.server_address[1]
+    thread = threading.Thread(target=httpd.serve_forever)
+    thread.daemon = True
+    thread.start()
+
+    # Build the remote file manifest that bdb.make_bag will turn into
+    # a properly-structured fetch.txt + manifest-md5.txt.
+    md5 = hashlib.md5(payload).hexdigest()
+    url = f"http://127.0.0.1:{port}/payload.txt"
+    manifest = [
+        {
+            "url": url,
+            "length": len(payload),
+            "filename": "assets/payload.txt",  # relative to data/; bdbag prepends data/
+            "md5": md5,
+        }
+    ]
+    manifest_file = tmp_path / "remote_manifest.json"
+    manifest_file.write_text(json.dumps(manifest), encoding="utf-8")
+
+    # Create the bag directory and build the bag using the remote manifest.
+    # make_bag writes fetch.txt and manifest-md5.txt automatically so the
+    # resulting bag passes validate_bag_structure before materialization.
+    bag_dir = tmp_path / "bag"
+    bag_dir.mkdir()
+    bdb.make_bag(bag_dir.as_posix(), remote_file_manifest=manifest_file.as_posix())
+
+    target = bag_dir / "data" / "assets" / "payload.txt"
+    return bag_dir, target, httpd
+
+
+def test_materialize_bag_dir_fetches_missing_entry(tmp_path: Path):
+    """materialize_bag_dir downloads an un-fetched fetch.txt entry."""
+    bag_dir, target, httpd = _make_holey_bag(tmp_path)
+    try:
+        assert not target.exists()
+        assert not BagCache._is_fully_materialized(bag_dir)
+
+        result = materialize_bag_dir(bag_dir)
+
+        assert result == bag_dir
+        assert target.exists()
+        assert target.read_bytes() == b"hello-materialize"
+        assert BagCache._is_fully_materialized(bag_dir)
+    finally:
+        httpd.shutdown()
+
+
+def test_materialize_bag_dir_idempotent_noop(tmp_path: Path, monkeypatch):
+    """On an already-complete bag, materialize_bag_dir does not fetch."""
+    bag_dir, _target, httpd = _make_holey_bag(tmp_path)
+    try:
+        materialize_bag_dir(bag_dir)  # first call completes it
+        assert BagCache._is_fully_materialized(bag_dir)
+
+        # Second call must short-circuit before touching bdb.materialize.
+        def _boom(*args, **kwargs):
+            raise AssertionError("bdb.materialize should not be called on a complete bag")
+
+        monkeypatch.setattr("deriva_ml.dataset.bag_download.bdb.materialize", _boom)
+        result = materialize_bag_dir(bag_dir)
+        assert result == bag_dir
+    finally:
+        httpd.shutdown()

--- a/tests/dataset/test_bag_materialize.py
+++ b/tests/dataset/test_bag_materialize.py
@@ -122,3 +122,31 @@ def test_materialize_bag_dir_idempotent_noop(tmp_path: Path, monkeypatch):
         assert result == bag_dir
     finally:
         httpd.shutdown()
+
+
+class _StubModel:
+    """Minimal stand-in for DatabaseModel exposing only ``bag_path``."""
+
+    def __init__(self, bag_path: Path):
+        self.bag_path = bag_path
+
+
+def test_datasetbag_materialize_fetches_in_place(tmp_path: Path):
+    """DatasetBag.materialize() fetches missing files and returns self."""
+    from deriva_ml.dataset.dataset_bag import DatasetBag
+
+    bag_dir, target, httpd = _make_holey_bag(tmp_path)
+    try:
+        # Build a DatasetBag without running its catalog-touching __init__.
+        bag = DatasetBag.__new__(DatasetBag)
+        bag.model = _StubModel(bag_dir)
+
+        assert not target.exists()
+        result = bag.materialize()
+
+        assert result is bag
+        assert target.exists()
+        assert target.read_bytes() == b"hello-materialize"
+        assert BagCache._is_fully_materialized(bag_dir)
+    finally:
+        httpd.shutdown()


### PR DESCRIPTION
## Summary
Adds `DatasetBag.materialize(*, fetch_concurrency=1) -> Self` — fetches any
not-yet-downloaded `fetch.txt` entries for an already-extracted bag, **in
place**, with **no catalog connection**. This complements the existing
cache-aware `download_dataset_bag(materialize=True)` path by giving an
affordance directly on a `DatasetBag` object you already hold (a
metadata-only bag from `download_dataset_bag(..., materialize=False)`, or a
`cached_holey` bag left by an interrupted fetch). Returns `self` so the call
chains: `bag = ml.download_dataset_bag(spec).materialize()`.

## Design
- `DatasetBag` is a deliberately **offline** object (no `DerivaML`/catalog
  back-reference). Materialization needs none: `fetch.txt` carries absolute
  Hatrac/S3 URLs, and both `bdb.materialize(bag_path)` and the
  fully-materialized check are pure path operations over the on-disk bag.
- The fetch tail of `materialize_dataset_bag` (parent-dir prep +
  `bdb.materialize`, gated by `_is_fully_materialized`) is extracted into a
  shared, catalog-free free function `materialize_bag_dir(bag_path, *,
  fetch_concurrency, logger)`. Both the download path and the new method call
  it — one implementation, two callers. `DatasetBag` imports only the
  path-only helper, never the `Dataset`-oriented `materialize_dataset_bag`.
- Errors from the `bdbag` fetch **propagate** (no new exception layer),
  matching the existing download path; a failed fetch leaves the bag in the
  partially-materialized state it was already in.
- `bag_download.py` now uses the project `get_logger(__name__)` convention
  (was previously logger-less).

## Tests
- **Unit (no catalog)** — `tests/dataset/test_bag_materialize.py`: builds a
  structurally-valid BDBag via `make_bag(remote_file_manifest=...)` served by
  a loopback HTTP server (bdbag's fetcher doesn't support `file://`), and
  verifies a real fetch, an idempotent no-op (proven by monkeypatching
  `bdb.materialize` to raise), and the method returning `self`.
- **Integration (live catalog)** — `TestBagMaterializeInPlace` in
  `tests/dataset/test_bag_api_coverage.py`: downloads a demo dataset
  metadata-only, calls `bag.materialize()`, and asserts the
  `_is_fully_materialized` flip + `bag_info` status → `cached_materialized`,
  plus idempotency. **Both ran and passed against the localhost demo catalog**
  (the skip-guard for a no-remote-asset bag was not triggered — the flip path
  was exercised end-to-end).

## Verification
- Full fast unit suite: **558 passed, 8 skipped**.
- `ruff check` clean on all touched files; `ruff format` applied. (The
  repo-wide ~220 ruff errors are pre-existing tech debt on `main`, untouched
  here.)

Spec: `docs/superpowers/specs/2026-06-13-datasetbag-materialize-design.md`
Plan: `docs/superpowers/plans/2026-06-13-datasetbag-materialize.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)