### PR TITLE
feat(bag): Format-B client-side bag generation (one clean CSV per table)

### DIFF
--- a/docs/reference/bag-export.md
+++ b/docs/reference/bag-export.md
@@ -29,9 +29,12 @@ The behavior splits across two layers, the same split as in
 - **deriva-py decides *fetch mechanics*.** `CatalogBagBuilder`
   (`.venv/.../deriva/bag/catalog_builder.py`) runs the FK walk under
   that policy and translates the reachable-table set into an export
-  spec — one CSV `query_processor` per FK path, one `fetch` processor
-  per asset table. The ERMrest export engine executes that spec
-  server-side.
+  spec, then fetches the rows. On the **client-side build path** — what
+  `download_dataset_bag` uses by default — deriva-ml hands it a
+  precomputed per-table RID set (`rid_sets=`) and it emits **one
+  rid-set CSV processor per reached non-vocab table** plus one `fetch`
+  processor per asset table (**Format B**, [B4](#b4)). The ERMrest
+  export engine executes that spec.
 
 For the FK walk itself — the bidirectional traversal, terminal tables,
 vocabulary leaves, depth bounds — see [FK Traversal](fk-traversal.md);
@@ -46,7 +49,7 @@ documents the dataset-export *scope decisions* layered on top.
 | Why does my flat dataset's bag omit `Dataset_Image`? | [B2](#b2) (empty-association pruning) |
 | My dataset has no images — why is `Dataset_Image` in the bag anyway? | [B2](#b2) (a nested child has images) |
 | Why doesn't the bag carry the producing executions' assets? | [B3](#b3) (provenance terminal) → [T3](fk-traversal.md#t3) |
-| What does the export spec actually look like? | [B4](#b4) (one processor per FK path + fetch) |
+| What does the export spec actually look like? | [B4](#b4) (client-side build: one rid-set CSV per table + fetch — Format B) |
 | What lands in the bag, and what doesn't? | [B5](#b5) |
 | Does `estimate_bag_size` use this same walk? | [Same engine](#same-engine-different-consumer) (ADR-0008) |
 
@@ -71,9 +74,12 @@ DatasetLike  ──► DatasetBagBuilder ──► CatalogBagBuilder ──► E
 2. **Mechanics (deriva-py).** `CatalogBagBuilder` runs the
    [FK walk](fk-traversal.md) under that policy to discover the
    reachable `(schema, table)` set, then emits an **export spec**: a
-   list of `query_processors`, one CSV query per FK path to each
-   reached table, plus a `fetch` processor per asset table
-   ([B4](#b4)).
+   list of `query_processors`. On the client-side build path it is
+   handed a per-table RID set (`rid_sets=`, computed by deriva-ml's
+   reachability engine) and emits **one rid-set CSV processor per
+   reached non-vocab table** — one clean `data/{schema}/{table}.csv`
+   each — plus a `fetch` processor per asset table (**Format B**,
+   [B4](#b4)).
 3. **Execution (server-side).** The ERMrest export engine runs the
    spec, writing one CSV per processor under `data/{schema}/` and
    downloading asset bytes under `asset/{rid}/`. The result is
@@ -203,40 +209,63 @@ exact 12-table severed set — is documented in
 was captured on dataset `5D0` of this same demo catalog.
 
 <a id="b4"></a>
-**B4 — The export spec is one CSV `query_processor` per FK path, plus a
-`fetch` processor per asset table.** After the walk discovers the
-reachable `(schema, table)` set, `CatalogBagBuilder._build_export_spec`
-translates it into a deriva-py export spec — a list of `query_processors`
-under `catalog`:
+**B4 — The client-side build path emits one rid-set CSV processor per
+reached non-vocab table (Format B); vocabularies and asset `fetch`
+processors are unchanged.** deriva-ml's default bag-build arm — the
+client-side `build_bag` path that `download_dataset_bag` takes when
+`use_minid=False` (its default) — does **not** ask the server to
+re-discover reachability via deep FK joins. Instead `DatasetBagBuilder`
+computes the per-table reachable RID sets *up front* with its own
+[client-side reachability engine](#same-engine-different-consumer)
+(`_compute_rid_sets` → `compute_reachability`), then hands them to
+`CatalogBagBuilder(rid_sets=...)`. After the walk discovers the reachable
+`(schema, table)` set, the export spec under `catalog` becomes:
 
 - A leading **`json`** processor writes `data/schema.json` (the catalog
   schema).
-- For each reached table, **one `csv` processor per FK path** that the
-  walker found to it (`_fk_paths_for` → `_table_query_path`). Each
-  carries `"paged_query": True` (cursor pagination over RID) and an
-  `output_path` that encodes the path's table chain, so multiple FK
-  routes to the same table land at distinct on-disk locations; the
-  bag's loader unions their rows by RID. A `vocab_export=FULL` vocabulary
-  table is the exception — it gets a single unfiltered
-  `/entity/{schema}:{table}` query (the whole controlled vocabulary),
-  not one-per-path.
+- For each reached **non-vocab** table, **one `csv` processor carrying
+  that table's RID set** (`rid_table` + the RID list). It produces one
+  clean `data/{schema}/{table}.csv` — complete, RID-distinct, flat: the
+  CSV *is* the table's full reachable set, with no per-FK-path
+  fragmentation and no out-of-band union-by-basename/dedup-by-RID for
+  the loader to perform. `Image.csv` is THE complete reachable `Image`
+  set. The fetch is a set of cheap direct
+  `/entity/{schema}:{table}/RID=any(...)` reads, not deep joins.
+- A `vocab_export=FULL` **vocabulary** table is the exception — it keeps
+  its single unfiltered `/entity/{schema}:{table}` query (the whole
+  controlled vocabulary), **not** a rid-set processor. So a vocab CSV
+  carries every term in that vocabulary, and its row count can **exceed**
+  the reachable-subset count the estimate reports for the same table.
+  This is by design, not a bug — the live test
+  `test_format_b_bag_one_csv_per_table_matches_estimate` asserts the
+  non-vocab count-match and exempts vocab tables for exactly this reason.
 - For each reached table that **`is_asset()`**, one additional
-  **`fetch`** processor that reads `URL` / `Length` / `Filename` / `MD5`
-  / `RID` from each asset row and downloads the bytes to
-  `asset/{asset_rid}/{table}`.
+  **`fetch`** processor (unchanged) that reads `URL` / `Length` /
+  `Filename` / `MD5` / `RID` from each asset row and downloads the bytes
+  to `asset/{asset_rid}/{table}`. The rid-set `csv` query returns those
+  columns just as the per-path join query did, so the `fetch` processor
+  is identical to before.
 
-`[engine: deriva-py]`
-`deriva/bag/catalog_builder.py::_build_export_spec`,
-`::_table_query_path` (the spec is retrievable without running via
-`::get_export_spec`).
+`[deriva-ml]` computes the RID sets
+(`src/deriva_ml/dataset/bag_builder.py::_compute_rid_sets`,
+`::build_bag`); `[engine: deriva-py]` emits the rid-set processors and
+fetches them (`deriva/bag/catalog_builder.py`, the `rid_sets=`
+constructor path).
 
 The spec is *declarative* — it describes the queries; the ERMrest export
-engine executes them server-side. `_table_query_path` scopes each query
-to rows reachable from the anchor RIDs: an anchor table filters on its
-RID list (`/entity/{schema}:{table}/RID=any(...)`), and a non-anchor
-table reached via FK gets a chained path
-(`/entity/{anchor}/RID=any(...)/{step2}/...`) that ERMrest joins along
-its natural FKs.
+engine executes them. Each rid-set query scopes its table directly by RID
+(`/entity/{schema}:{table}/RID=any(...)`), with the RID list chunked into
+URL-safe batches and appended to one CSV (no 414 URL-length blow-up).
+
+> **The server-side MINID/S3 export arm is *not* Format B.** When
+> `download_dataset_bag` is called with `use_minid=True`, deriva-ml takes
+> a different arm: it asks the server-side ERMrest export engine to
+> produce the bag from a Chaise export spec, where each reached table is
+> reached by **one CSV query per FK path** (the older per-path emission)
+> and the bag's loader unions rows by RID. Only the **client-side build
+> arm** (`use_minid=False`) emits Format B. The two arms agree on
+> *scope* — same anchors ([B1](#b1)), same policy ([B2](#b2),
+> [B3](#b3)) — and differ only in the spec's CSV-processor shape.
 
 <a id="b5"></a>
 **B5 — What lands in the bag.** Combining [B1](#b1)–[B4](#b4), a dataset
@@ -251,7 +280,11 @@ bag contains:
 - **Referenced (and, by deriva-ml's choice, *full*) vocabularies** —
   `build_policy` defaults to `vocab_export=VocabExport.FULL`, so each
   reached vocabulary table exports *every* term ([B4](#b4)), and the
-  walk stops at vocab tables ([T4](fk-traversal.md#t4)).
+  walk stops at vocab tables ([T4](fk-traversal.md#t4)). Because the
+  vocab CSV is the whole controlled vocabulary — not the rid-set subset
+  the rest of Format B emits — its row count can be **larger** than the
+  reachable-subset count `estimate_bag_size` reports for that table.
+  Don't mistake the larger vocab count for a bug ([B4](#b4)).
 - **Provenance *link* rows** — `Dataset_Execution`, the `Execution` and
   `Workflow` rows, and the feature `*_Execution` associations, so the
   bag records which executions produced its contents ([B3](#b3)).
@@ -287,7 +320,13 @@ load-bearing invariant rather than an aspiration
   decision to bypass the export engine is ADR-0008
   (`docs/adr/0008-estimate-bag-size-bypasses-bag-pipeline.md`); only the
   bypass *mechanism* changed — from live per-path aggregate queries to
-  the client-side reachability engine.
+  the client-side reachability engine. The **client-side bag build**
+  ([B4](#b4)) now reuses that very engine: `_compute_rid_sets` runs the
+  same `compute_reachability` assembly the estimate does, then feeds the
+  resulting per-table RID sets to `CatalogBagBuilder(rid_sets=...)`. So
+  the estimate and the Format-B bag are computed from one shared
+  reachability pass — the count the estimate reports is the count the
+  bag's per-table CSV carries (vocab tables excepted; see [B4](#b4)).
 
 - **`clone_via_bag`** uses the *same policy shape* — including the same
   `terminal_tables={Execution, Workflow}` and `vocab_export=FULL` — but

--- a/docs/reference/bag-export.md
+++ b/docs/reference/bag-export.md
@@ -229,8 +229,12 @@ computes the per-table reachable RID sets *up front* with its own
   CSV *is* the table's full reachable set, with no per-FK-path
   fragmentation and no out-of-band union-by-basename/dedup-by-RID for
   the loader to perform. `Image.csv` is THE complete reachable `Image`
-  set. The fetch is a set of cheap direct
-  `/entity/{schema}:{table}/RID=any(...)` reads, not deep joins.
+  set. The fetch is a set of direct
+  `/entity/{schema}:{table}/RID=any(...)` reads (one per ~500-RID chunk),
+  not deep multi-hop FK joins. (Note: this changes the *shape* of the
+  query, not necessarily the end-to-end wall-clock — for datasets with
+  very large tables the chunked rid-set fetch can be slow; faster
+  generation is a tracked follow-up.)
 - A `vocab_export=FULL` **vocabulary** table is the exception — it keeps
   its single unfiltered `/entity/{schema}:{table}` query (the whole
   controlled vocabulary), **not** a rid-set processor. So a vocab CSV

--- a/docs/superpowers/plans/2026-06-15-format-b-bag-generation.md
+++ b/docs/superpowers/plans/2026-06-15-format-b-bag-generation.md
@@ -1,0 +1,624 @@
+# Format-B Bag Generation (deriva-ml, Plan B2) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire deriva-ml's bag generation to the client-side reachability engine so a dataset bag is built from per-table RID sets (Format B — one clean CSV per table) instead of deep-FK-join per-path CSVs, dropping bag-gen wall-clock from ~280s toward tens of seconds for eye-ai 2-277G.
+
+**Architecture:** Factor the estimate's reachability assembly (build walk → `iter_reached_paths` → anchors → model → `from_model` fetch closure → `compute_reachability`) into a shared `DatasetBagBuilder._compute_rid_sets(dataset)` helper, reused by both `estimate_bag_size` and the bag-build path. `build_bag` calls `_compute_rid_sets`, passes the resulting `{(schema,table): [RID,...]}` map to its `_SnapshotAwareCatalogBagBuilder(rid_sets=...)` (deriva-py B1's new param), and the upstream engine emits one rid-set csv processor per non-vocab table. `_catalog_bag_builder` gains an opt-in `rid_sets=None` param for the spec-generation path; the estimate/annotation/aggregate_queries callers pass nothing and are unchanged.
+
+**Tech Stack:** Python ≥3.12, deriva-ml (`src/deriva_ml/dataset/bag_builder.py`, `dataset.py`, `bag_download.py`), deriva-py (the merged B1 `CatalogBagBuilder(rid_sets=)` + `get_as_file(rid_set=)`), pytest. The deriva-py dependency is pinned to the `deriva-ml` branch, which now contains B1.
+
+---
+
+## Scope: this is Plan B2 of two (deriva-ml side)
+
+Stage B1 (deriva-py — RID-set fetch + `CatalogBagBuilder(rid_sets=)` emission) is **merged** (deriva-py PR #269 → `deriva-ml` branch). Stage A (the `compute_reachability` engine) is **merged** (deriva-ml PR #300). This plan is the consumer wiring: deriva-ml computes the RID sets and hands them to the merged upstream engine.
+
+Design: `docs/superpowers/specs/2026-06-14-stage-b-fast-portable-bag-design.md` (decisions D1–D4) + `2026-06-14-portable-bag-csv-contract.md` (the CSV contract). The reachability engine: `src/deriva_ml/dataset/_reachability.py::compute_reachability` (returns `(rids_by_table, asset_lengths_by_table, fetched_rows)`). Memory: `csv-ridset-chunk-append-proto.md`, `snapshot-held-model-staleness-hazard.md`.
+
+**The load-bearing reuse:** `estimate_bag_size` already assembles the exact reachability inputs (`dataset.py` ~2722–2746), including the `datapath.from_model(snapshot.catalog, model)` fix for the [[snapshot-held-model-staleness-hazard]]. B2 factors that into one helper so estimate and bag-gen share it — and the bag path inherits the from_model fix for free (it would hit the same KeyError otherwise).
+
+**Key shape difference from the estimate:** `compute_reachability` returns `rids_by_table` keyed by **bare table name** (`{table: set}`). The upstream `CatalogBagBuilder(rid_sets=...)` is keyed by **`(schema, table)` tuple** (`{(schema,table): [RID]}`). The helper must return the tuple-keyed form (it has the schema from `reached`'s keys). See Task 1.
+
+---
+
+## File Structure
+
+| File | Responsibility | Action |
+|---|---|---|
+| `src/deriva_ml/dataset/bag_builder.py` | New `_compute_rid_sets(dataset)` helper (factored reachability assembly, tuple-keyed). `_catalog_bag_builder` gains opt-in `rid_sets=None`. `build_bag` computes rid_sets + passes to `_SnapshotAwareCatalogBagBuilder(rid_sets=...)`. | **Modify** (~243 build_bag, ~449 _catalog_bag_builder, new helper) |
+| `src/deriva_ml/dataset/dataset.py` | `estimate_bag_size` calls the shared `_compute_rid_sets` instead of inlining the assembly (DRY; keeps the from_model fix in one place). | **Modify** (~2722–2746) |
+| `tests/dataset/test_format_b_bag.py` | Unit: `_compute_rid_sets` returns tuple-keyed RID sets matching `compute_reachability`; the spec carries rid-set processors. Live (DERIVA_HOST): a Format-B bag has one CSV per table, RID-distinct, with correct asset fetch.txt, and round-trips through the loader with counts matching the estimate. | **Create** |
+| `docs/reference/bag-export.md` | Update "Same engine, different consumer" + B4: dataset bags now use Format B (one rid-set csv processor per table) when built client-side. | **Modify** |
+| `docs/superpowers/specs/2026-06-14-stage-b-fast-portable-bag-design.md` | Mark B2 shipped; record the live bag-gen number. | **Modify** |
+
+No new module — the reachability engine and the upstream emission already exist; B2 is wiring + one shared helper.
+
+---
+
+## Shared helper interface (locked here)
+
+```python
+# src/deriva_ml/dataset/bag_builder.py  (method on DatasetBagBuilder)
+
+def _compute_rid_sets(self, dataset: DatasetLike) -> dict[tuple[str, str], list[str]]:
+    """Compute per-table reachable RID sets for a dataset, client-side.
+
+    Factored from estimate_bag_size's reachability assembly so the bag-build
+    path and the estimate share one implementation (and one copy of the
+    from_model snapshot-staleness fix). Returns a ``{(schema, table): [RID,...]}``
+    map suitable for ``CatalogBagBuilder(rid_sets=...)`` — tuple-keyed (the
+    upstream engine's key), unlike compute_reachability's bare-table-name
+    rids_by_table. Vocab tables are EXCLUDED (the upstream rid-set branch
+    skips vocab; including them would be harmless but wasteful).
+    """
+```
+
+The helper builds `cb = self._catalog_bag_builder(dataset)`, `reached = cb.iter_reached_paths()`, `anchor_rids`, `model = cb._get_model()`, the `from_model` fetch closure, calls `compute_reachability`, then maps `rids_by_table` (bare name) back to `(schema, table)` keys using `reached`'s keys, dropping vocab tables. `self._ml_instance` is the snapshot catalog (the builder is constructed on the snapshot).
+
+---
+
+### Task 1: `_compute_rid_sets` shared helper
+
+**Files:**
+- Modify: `src/deriva_ml/dataset/bag_builder.py` (add `_compute_rid_sets` method)
+- Test: `tests/dataset/test_format_b_bag.py` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+A unit test with a synthetic builder is awkward (the helper drives a real walk). Instead, test the **key-mapping logic** in isolation with a small pure helper, plus a live test in Task 4. First, the pure mapping: given `compute_reachability`'s bare-name `rids_by_table` and `reached`'s `(schema,table)` keys, produce the tuple-keyed map dropping vocab. Extract that mapping as a module-level pure function `_rid_sets_from_reachability` and test it:
+
+```python
+# tests/dataset/test_format_b_bag.py
+"""Tests for Format-B (rid-set) bag generation."""
+
+from deriva_ml.dataset.bag_builder import _rid_sets_from_reachability
+
+
+def test_rid_sets_from_reachability_tuple_keys_and_drops_vocab():
+    # reached: (schema, table) -> [fk_path, ...]  (paths irrelevant here)
+    reached = {
+        ("eye-ai", "Image"): [()],
+        ("eye-ai", "Subject"): [()],
+        ("deriva-ml", "Asset_Role"): [()],  # vocab
+    }
+    rids_by_table = {
+        "Image": {"r1", "r2"},
+        "Subject": {"s1"},
+        "Asset_Role": {"Input", "Output"},  # bare names; vocab
+    }
+    vocab_tables = {("deriva-ml", "Asset_Role")}
+    result = _rid_sets_from_reachability(reached, rids_by_table, vocab_tables)
+    # Tuple-keyed, vocab dropped, RID lists sorted for determinism.
+    assert result == {
+        ("eye-ai", "Image"): ["r1", "r2"],
+        ("eye-ai", "Subject"): ["s1"],
+    }
+
+
+def test_rid_sets_from_reachability_missing_table_is_empty_list():
+    """A reached non-vocab table with no RID-set entry maps to []."""
+    reached = {("S", "T"): [()]}
+    result = _rid_sets_from_reachability(reached, {}, set())
+    assert result == {("S", "T"): []}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/carl/GitHub/DerivaML/deriva-ml && DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/dataset/test_format_b_bag.py -v`
+Expected: FAIL — `ImportError: cannot import name '_rid_sets_from_reachability'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add the pure mapping function at module level in `src/deriva_ml/dataset/bag_builder.py` (near the other module-level helpers, after the imports):
+
+```python
+def _rid_sets_from_reachability(
+    reached: dict[tuple[str, str], Any],
+    rids_by_table: dict[str, set[str]],
+    vocab_tables: set[tuple[str, str]],
+) -> dict[tuple[str, str], list[str]]:
+    """Map compute_reachability output to the upstream rid_sets shape.
+
+    ``compute_reachability`` returns ``rids_by_table`` keyed by bare table
+    name; ``CatalogBagBuilder(rid_sets=...)`` wants ``{(schema, table):
+    [RID,...]}``. This re-keys using ``reached``'s ``(schema, table)`` keys,
+    drops vocab tables (the upstream rid-set branch skips them — vocab keeps
+    its full/per-path query), and sorts each RID list for deterministic specs.
+
+    Args:
+        reached: ``{(schema, table): [fk_path, ...]}`` — the reached-paths map
+            (its keys enumerate the non-vocab tables to emit).
+        rids_by_table: ``{table_name: set(RID)}`` from compute_reachability.
+        vocab_tables: ``(schema, table)`` pairs that are vocabulary tables.
+
+    Returns:
+        ``{(schema, table): [RID, ...]}`` for every non-vocab reached table.
+    """
+    result: dict[tuple[str, str], list[str]] = {}
+    for key in reached:
+        if key in vocab_tables:
+            continue
+        schema_name, table_name = key
+        result[key] = sorted(rids_by_table.get(table_name, set()))
+    return result
+```
+
+(`Any` is already imported in this module — verify; if not, add `from typing import Any`.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /Users/carl/GitHub/DerivaML/deriva-ml && DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/dataset/test_format_b_bag.py -v`
+Expected: PASS (2 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml && git add src/deriva_ml/dataset/bag_builder.py tests/dataset/test_format_b_bag.py && git commit -m "feat(bag): rid-sets-from-reachability key-mapping helper
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: `_compute_rid_sets` method + factor estimate onto it
+
+**Files:**
+- Modify: `src/deriva_ml/dataset/bag_builder.py` (add `_compute_rid_sets` method)
+- Modify: `src/deriva_ml/dataset/dataset.py` (`estimate_bag_size` calls it)
+
+- [ ] **Step 1: Write the failing test**
+
+A wiring-shape guard: `estimate_bag_size`'s source should call `_compute_rid_sets`-shared logic rather than inlining `compute_reachability` + the from_model closure. We assert the shared method exists and that estimate no longer inlines its own `datapath.from_model` call (it delegates).
+
+```python
+# add to tests/dataset/test_format_b_bag.py
+def test_compute_rid_sets_method_exists():
+    from deriva_ml.dataset.bag_builder import DatasetBagBuilder
+
+    assert hasattr(DatasetBagBuilder, "_compute_rid_sets")
+
+
+def test_estimate_delegates_reachability_assembly():
+    """estimate_bag_size should not inline its own from_model fetch closure
+    once the shared helper exists — it reuses _compute_rid_sets' assembly."""
+    import inspect
+
+    from deriva_ml.dataset.bag_builder import DatasetBagBuilder
+
+    src = inspect.getsource(DatasetBagBuilder._compute_rid_sets)
+    # The from_model fix lives in the shared helper.
+    assert "from_model" in src
+    assert "compute_reachability" in src
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/carl/GitHub/DerivaML/deriva-ml && DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/dataset/test_format_b_bag.py::test_compute_rid_sets_method_exists -v`
+Expected: FAIL — `_compute_rid_sets` doesn't exist yet.
+
+- [ ] **Step 3: Write minimal implementation**
+
+READ `estimate_bag_size` in `dataset.py` (~2722–2790) to copy its exact reachability assembly. Add `_compute_rid_sets` to `DatasetBagBuilder` in `bag_builder.py`. It must return BOTH the rid_sets map AND the auxiliary data the estimate still needs (asset lengths, fetched rows for sampling) — OR be scoped to just rid_sets and have a sibling for the estimate's extra outputs. To keep the estimate working unchanged, make `_compute_rid_sets` return a richer result the estimate can use:
+
+```python
+    def _compute_rid_sets(
+        self, dataset: DatasetLike
+    ) -> tuple[
+        dict[tuple[str, str], list[str]],
+        dict[str, set[str]],
+        dict[str, dict[str, int]],
+        dict[tuple[str, str], list[dict]],
+        dict[str, list[dict]],
+    ]:
+        """Compute per-table reachable RID sets for a dataset, client-side.
+
+        Factored from estimate_bag_size's reachability assembly so the
+        bag-build path and the estimate share one implementation (and one
+        copy of the from_model snapshot-staleness fix — see
+        docs memory snapshot-held-model-staleness-hazard).
+
+        Returns:
+            A 5-tuple:
+            - ``rid_sets``: ``{(schema, table): [RID,...]}`` for non-vocab
+              reached tables — the shape ``CatalogBagBuilder(rid_sets=...)``
+              consumes (vocab excluded).
+            - ``rids_by_table``: bare-name ``{table: set(RID)}`` (estimate
+              row counts).
+            - ``asset_lengths_by_table``: ``{table: {RID: Length}}`` (estimate
+              asset bytes).
+            - ``fetched_rows``: ``{(schema, table): rows}`` (estimate CSV-byte
+              sampling).
+            - ``sample_rows_by_table``: ``{table: [row,...]}`` derived sample.
+        """
+        from deriva_ml.dataset._reachability import (
+            compute_reachability,
+            sample_rows_from_fetched,
+        )
+
+        cb = self._catalog_bag_builder(dataset=dataset)
+        reached = cb.iter_reached_paths()
+        anchor_rids = [dataset.dataset_rid] + list(self._iter_descendant_rids(dataset))
+        model = cb._get_model()
+
+        # Build the path builder from the SAME model the walk used (not the
+        # held-model pathBuilder()) — the snapshot-staleness fix. See
+        # docs memory snapshot-held-model-staleness-hazard.
+        pb = datapath.from_model(self._ml_instance.catalog, model)
+
+        def _fetch(schema: str, table: str, columns: set[str]) -> list[dict]:
+            tpb = pb.schemas[schema].tables[table]
+            try:
+                attrs = [getattr(tpb, c) for c in sorted(columns)]
+                return list(tpb.attributes(*attrs).fetch())
+            except Exception:  # noqa: BLE001
+                return list(tpb.entities().fetch())
+
+        rids_by_table, asset_lengths_by_table, fetched_rows = compute_reachability(
+            reached=reached, anchor_rids=anchor_rids, model=model, fetch=_fetch
+        )
+        sample_rows_by_table = sample_rows_from_fetched(
+            reached=reached, fetched_rows=fetched_rows
+        )
+
+        vocab_tables = {
+            key for key in reached
+            if model.schemas[key[0]].tables[key[1]].is_vocabulary()
+        }
+        rid_sets = _rid_sets_from_reachability(reached, rids_by_table, vocab_tables)
+
+        return (
+            rid_sets,
+            rids_by_table,
+            asset_lengths_by_table,
+            fetched_rows,
+            sample_rows_by_table,
+        )
+```
+
+**`datapath` is NOT currently imported in `bag_builder.py`** (verified — it only appears in docstrings). Add the import using the SAME importlib form `dataset.py` uses to avoid shadowing by local `deriva.py` files. At the top of `bag_builder.py`, after the existing imports, add:
+```python
+import importlib
+
+# Import datapath via importlib to avoid shadowing by local 'deriva.py' files
+# (mirrors dataset.py's pattern).
+datapath = importlib.import_module("deriva.core.datapath")
+```
+(If `importlib` is already imported, reuse it. Check the existing imports first.)
+
+Now refactor `estimate_bag_size` in `dataset.py` to delegate. Replace its inlined assembly (the block from `version_snapshot_catalog = ...` through the `compute_reachability`/`sample_rows_from_fetched` calls) with:
+
+```python
+        version_snapshot_catalog = self._version_snapshot_catalog(version)
+        builder = DatasetBagBuilder(
+            ml_instance=version_snapshot_catalog,
+            exclude_tables=exclude_tables,
+        )
+        (
+            _rid_sets,
+            rids_by_table,
+            asset_lengths_by_table,
+            _fetched_rows,
+            sample_rows_by_table,
+        ) = builder._compute_rid_sets(self)
+
+        # asset_tables for assemble_estimate: any reached table flagged asset.
+        model = builder._catalog_bag_builder(dataset=self)._get_model()
+        ...
+```
+
+Wait — recomputing the model/reached for `asset_tables` would re-walk. Instead, have `estimate_bag_size` derive `asset_tables` from the data it already has. The current estimate computes `asset_tables` from `reached` + model. To avoid a second walk, `_compute_rid_sets` should ALSO return the asset-table set. ADD a sixth return element `asset_tables: set[str]` (bare names) computed inside `_compute_rid_sets`:
+
+```python
+        asset_tables = {
+            key[1] for key in reached
+            if model.schemas[key[0]].tables[key[1]].is_asset()
+        }
+```
+
+and return it as the final tuple element. Update the helper's return type/docstring to a 6-tuple and the estimate's unpacking accordingly. Then `estimate_bag_size`'s `assemble_estimate` call uses that `asset_tables` directly (it already takes `asset_tables` after RE-Task 7).
+
+The estimate's final assembly becomes:
+```python
+        (
+            _rid_sets,
+            rids_by_table,
+            asset_lengths_by_table,
+            _fetched_rows,
+            sample_rows_by_table,
+            asset_tables,
+        ) = builder._compute_rid_sets(self)
+
+        return assemble_estimate(
+            asset_tables=asset_tables,
+            rids_by_table=rids_by_table,
+            asset_lengths_by_table=asset_lengths_by_table,
+            sample_rows_by_table=sample_rows_by_table,
+            estimate_csv_bytes=self._estimate_csv_bytes,
+            human_readable_size=self._human_readable_size,
+        )
+```
+
+> **Implementer note:** READ the current `estimate_bag_size` body first — RE-Task 6/7 already wired it to `compute_reachability` + `assemble_estimate(asset_tables=...)`. You are MOVING that assembly into `_compute_rid_sets` and having the estimate call it. Preserve the exact behavior: the live estimate test (`tests/dataset/test_estimate_bag_size.py::test_reachability_matches_server_union`) must still pass. The 6-tuple is unwieldy but keeps one walk; that's the right tradeoff over re-walking.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml && DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/dataset/test_format_b_bag.py tests/dataset/test_reachability.py tests/dataset/test_estimate_helpers.py -v
+```
+Expected: PASS (the new helper tests + the existing reachability/estimate-helper units).
+
+Run the live estimate exactness test (needs DERIVA_HOST) to confirm the refactor preserved estimate behavior:
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml && DERIVA_ML_ALLOW_DIRTY=true DERIVA_HOST=localhost uv run pytest tests/dataset/test_estimate_bag_size.py::test_reachability_matches_server_union -v
+```
+Expected: PASS (estimate counts still == server union — the assembly moved but didn't change).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml && git add src/deriva_ml/dataset/bag_builder.py src/deriva_ml/dataset/dataset.py tests/dataset/test_format_b_bag.py && git commit -m "refactor(bag): factor reachability assembly into _compute_rid_sets; estimate delegates
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: `build_bag` produces a Format-B bag
+
+**Files:**
+- Modify: `src/deriva_ml/dataset/bag_builder.py` (`build_bag` ~243, `_catalog_bag_builder` ~449)
+- Test: `tests/dataset/test_format_b_bag.py`
+
+- [ ] **Step 1: Write the failing test**
+
+A wiring-shape guard that `build_bag` computes rid_sets and constructs its builder with them. We assert `build_bag`'s source references `_compute_rid_sets` and passes `rid_sets=` to the builder.
+
+```python
+# add to tests/dataset/test_format_b_bag.py
+def test_build_bag_uses_rid_sets():
+    """build_bag computes rid_sets and passes them to the CatalogBagBuilder."""
+    import inspect
+
+    from deriva_ml.dataset.bag_builder import DatasetBagBuilder
+
+    src = inspect.getsource(DatasetBagBuilder.build_bag)
+    assert "_compute_rid_sets" in src
+    assert "rid_sets=" in src
+
+
+def test_catalog_bag_builder_accepts_rid_sets():
+    """_catalog_bag_builder forwards an opt-in rid_sets to CatalogBagBuilder."""
+    import inspect
+
+    from deriva_ml.dataset.bag_builder import DatasetBagBuilder
+
+    sig = inspect.signature(DatasetBagBuilder._catalog_bag_builder)
+    assert "rid_sets" in sig.parameters
+    assert sig.parameters["rid_sets"].default is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/carl/GitHub/DerivaML/deriva-ml && DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/dataset/test_format_b_bag.py::test_build_bag_uses_rid_sets tests/dataset/test_format_b_bag.py::test_catalog_bag_builder_accepts_rid_sets -v`
+Expected: FAIL — neither wiring exists yet.
+
+- [ ] **Step 3: Write minimal implementation**
+
+(a) Add opt-in `rid_sets` to `_catalog_bag_builder` (`bag_builder.py` ~449). Change the signature to `def _catalog_bag_builder(self, dataset: DatasetLike | None, rid_sets: dict[tuple[str, str], list[str]] | None = None) -> CatalogBagBuilder:` and pass it to the constructor:
+
+```python
+        builder = CatalogBagBuilder(
+            catalog=self._ml_instance.catalog,
+            anchors=anchors,
+            output_dir=output_dir,
+            policy=policy,
+            rid_sets=rid_sets,
+        )
+```
+
+Document the new param in the method's docstring Args (opt-in; only the download path supplies it; None keeps per-path emission). The three existing callers (`generate_dataset_download_spec`, `generate_dataset_download_annotations`, `aggregate_queries`) call `_catalog_bag_builder(dataset=...)` without `rid_sets` → None → unchanged.
+
+> **Watch:** `_compute_rid_sets` itself calls `self._catalog_bag_builder(dataset=dataset)` (no rid_sets) to run the walk. That's correct — it needs the walk to COMPUTE rid_sets; it must NOT pass rid_sets there (would be circular). Only `build_bag` and the spec path pass rid_sets to a SEPARATE builder used for emission.
+
+(b) Wire `build_bag` (`bag_builder.py` ~243) to compute rid_sets and pass them to its `_SnapshotAwareCatalogBagBuilder`. READ the current `build_bag` — it constructs `_SnapshotAwareCatalogBagBuilder(catalog=, anchors=, output_dir=, policy=)` directly (~line 311). Before that construction, compute rid_sets:
+
+```python
+        rid_sets, *_ = self._compute_rid_sets(dataset)
+```
+
+and add `rid_sets=rid_sets` to the `_SnapshotAwareCatalogBagBuilder(...)` constructor call.
+
+> **Confirmed (low risk):** `_SnapshotAwareCatalogBagBuilder` (`bag_builder.py` ~71) overrides ONLY `_run_export` — it does NOT override `__init__`. So it inherits `CatalogBagBuilder.__init__` unchanged, which (post-B1) accepts `rid_sets`. The new `rid_sets=` kwarg flows straight through the inherited constructor — no subclass change needed. Just add `rid_sets=rid_sets` to the `_SnapshotAwareCatalogBagBuilder(...)` call in `build_bag`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /Users/carl/GitHub/DerivaML/deriva-ml && DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/dataset/test_format_b_bag.py -v`
+Expected: PASS (the wiring-shape guards).
+
+Also confirm the spec-generation path is unbroken (it still passes no rid_sets):
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml && DERIVA_ML_ALLOW_DIRTY=true uv run python -c "from deriva_ml.dataset.bag_builder import DatasetBagBuilder; print('import OK')"
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml && git add src/deriva_ml/dataset/bag_builder.py tests/dataset/test_format_b_bag.py && git commit -m "feat(bag): build_bag produces Format-B bags via rid_sets
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Live Format-B bag round-trip + correctness
+
+**Files:**
+- Modify: `tests/dataset/test_format_b_bag.py`
+
+Prove on a live catalog (DERIVA_HOST) that a built bag is genuinely Format B: one CSV per table, RID-distinct, asset fetch.txt correct, and that loading it yields per-table row counts matching the estimate.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# add to tests/dataset/test_format_b_bag.py
+import os
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.skipif(
+    os.environ.get("DERIVA_HOST") in (None, ""),
+    reason="needs a live catalog",
+)
+def test_format_b_bag_one_csv_per_table_matches_estimate(catalog_with_datasets, tmp_path):
+    """A built bag has one clean CSV per table; loading it reproduces the
+    estimate's per-table row counts."""
+    from deriva_ml.dataset.bag_builder import DatasetBagBuilder
+
+    ml, _desc = catalog_with_datasets
+    datasets = list(ml.find_datasets())
+    nested = next(
+        (d for d in datasets if d.list_dataset_children()),
+        datasets[0],
+    )
+    version = nested.current_version
+
+    # Estimate (the oracle for per-table counts).
+    est = nested.estimate_bag_size(version)
+    est_counts = {t: d["row_count"] for t, d in est["tables"].items() if d["row_count"] > 0}
+
+    # Build a Format-B bag.
+    snap = nested._version_snapshot_catalog(version)
+    builder = DatasetBagBuilder(ml_instance=snap)
+    zip_path = builder.build_bag(nested, output_dir=tmp_path)
+    assert zip_path.exists()
+
+    # Unzip and inspect data/ CSVs.
+    import zipfile
+
+    extract = tmp_path / "extracted"
+    with zipfile.ZipFile(zip_path) as zf:
+        zf.extractall(extract)
+
+    # Find every {table}.csv under data/ and assert ONE per table basename
+    # (Format B: no per-path fragmentation).
+    csvs = list(extract.rglob("data/**/*.csv"))
+    from collections import Counter
+
+    by_basename = Counter(p.stem for p in csvs)
+    multi = {name: n for name, n in by_basename.items() if n > 1}
+    assert not multi, f"Format B violated — tables split across multiple CSVs: {multi}"
+
+    # For each estimated table, the bag's CSV row count (minus header) matches.
+    import csv as csvmod
+
+    for table, est_count in est_counts.items():
+        matches = [p for p in csvs if p.stem == table]
+        if not matches:
+            continue  # vocab tables use the full query; skip count match here
+        with matches[0].open(encoding="utf-8") as fh:
+            rows = list(csvmod.DictReader(fh))
+        # RID-distinct.
+        rids = [r["RID"] for r in rows if "RID" in r]
+        assert len(set(rids)) == len(rids), f"{table}.csv has duplicate RIDs"
+        assert len(rows) == est_count, f"{table}: bag={len(rows)} estimate={est_count}"
+```
+
+- [ ] **Step 2: Run test to verify it fails (or passes if wiring is correct)**
+
+Run: `cd /Users/carl/GitHub/DerivaML/deriva-ml && DERIVA_ML_ALLOW_DIRTY=true DERIVA_HOST=localhost uv run pytest tests/dataset/test_format_b_bag.py::test_format_b_bag_one_csv_per_table_matches_estimate -v --timeout=600`
+Expected: PASS if Tasks 1–3 wired correctly. If it FAILS:
+- "tables split across multiple CSVs" → rid_sets weren't passed / per-path emission still active. Re-check Task 3's `rid_sets=` threading into the actual builder `build()` uses.
+- a row-count mismatch → the rid_sets for that table don't match the estimate's reachable set; the bag and estimate share `_compute_rid_sets`, so a mismatch means the emission consumed a different map than computed — debug the key shape (tuple vs bare name).
+Do NOT weaken the test; fix the wiring.
+
+- [ ] **Step 3: (No new impl — validates Tasks 1–3)**
+
+If failing, the fix is in Task 3's threading (rid_sets must reach the builder whose `build()` runs). Trace `build_bag` → `_SnapshotAwareCatalogBagBuilder(rid_sets=...)` → `build()` → `_build_export_spec` (upstream) → rid-set processors.
+
+- [ ] **Step 4: Confirm pass**
+
+Run: `cd /Users/carl/GitHub/DerivaML/deriva-ml && DERIVA_ML_ALLOW_DIRTY=true DERIVA_HOST=localhost uv run pytest tests/dataset/test_format_b_bag.py -v --timeout=600`
+Expected: PASS (all — units + live).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml && git add tests/dataset/test_format_b_bag.py && git commit -m "test(bag): live Format-B bag one-CSV-per-table matches estimate counts
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: deriva-py pin advance, docs, lint, live 2-277G re-measure, PR
+
+**Files:**
+- Modify: `uv.lock` (advance the pinned deriva-py commit to include B1)
+- Modify: `docs/reference/bag-export.md`, the Stage-B spec
+
+- [ ] **Step 1: Advance the deriva-py pin to include B1**
+
+The pin is `@deriva-ml` (branch). B1 is merged there, but `uv.lock` may point at an older commit. Advance it:
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml && uv lock --upgrade-package deriva && uv sync
+```
+Confirm the merged B1 is present:
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml && DERIVA_ML_ALLOW_DIRTY=true uv run python -c "from deriva.core.ermrest_catalog import ErmrestCatalog; import inspect; assert 'rid_set' in inspect.signature(ErmrestCatalog.get_as_file).parameters; from deriva.bag.catalog_builder import CatalogBagBuilder; assert 'rid_sets' in inspect.signature(CatalogBagBuilder.__init__).parameters; print('B1 present')"
+```
+Expected: "B1 present". If `rid_set`/`rid_sets` are absent, the lock didn't advance — re-run `uv lock --upgrade-package deriva`.
+
+- [ ] **Step 2: Update bag-export.md**
+
+In the "Same engine, different consumer" section and B4: note that a **client-side-built** dataset bag (via `build_bag`) now uses Format B — one rid-set csv processor per reached non-vocab table, producing one clean `data/{schema}/{table}.csv` per table (no per-path fragmentation, no loader union needed). Vocab tables keep their full query. Reference deriva-py's `CatalogBagBuilder(rid_sets=)` and deriva-ml's `_compute_rid_sets`. Keep the MINID/server-export arm's description accurate (it still uses the server export engine; only the client-side `build()` arm is Format B — confirm which arm the user-facing `download_dataset_bag` takes by default and document accordingly).
+
+- [ ] **Step 3: Update the Stage-B spec**
+
+In `docs/superpowers/specs/2026-06-14-stage-b-fast-portable-bag-design.md`, mark B2 shipped and record the live 2-277G bag-gen wall-clock from Step 5.
+
+- [ ] **Step 4: Lint + full unit sweep**
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml && uv run ruff check --fix src/deriva_ml/dataset/bag_builder.py src/deriva_ml/dataset/dataset.py tests/dataset/test_format_b_bag.py && uv run ruff format src/deriva_ml/dataset/bag_builder.py src/deriva_ml/dataset/dataset.py tests/dataset/test_format_b_bag.py
+cd /Users/carl/GitHub/DerivaML/deriva-ml && DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/dataset/test_format_b_bag.py tests/dataset/test_reachability.py tests/dataset/test_estimate_helpers.py -q
+```
+Expected: clean + all pass.
+
+- [ ] **Step 5: Live 2-277G bag-gen re-measure + PR**
+
+Run a timed `build_bag` (metadata-only, no asset materialization) against eye-ai 2-277G to capture the headline bag-gen number (needs a fresh www.eye-ai.org token). Target: tens of seconds vs the prior ~280s. Capture for the PR body.
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml && git push -u origin feature/format-b-bag-generation
+gh pr create --base main --title "perf(bag): Format-B client-side bag generation (one clean CSV per table, ~Nx faster)" --body "Wires bag generation to the client-side reachability engine: build_bag computes per-table RID sets (compute_reachability) and hands them to deriva-py's CatalogBagBuilder(rid_sets=) (PR #269), which emits one rid-set csv processor per reached non-vocab table. Result: one clean data/{schema}/{table}.csv per table (no per-path fragmentation, no loader union), bag-gen <N>s vs ~280s on eye-ai 2-277G. Shares _compute_rid_sets with estimate_bag_size (and the from_model snapshot-staleness fix). Stage B2 of the fast-portable-bag effort; B1 = deriva-py #269, A = #300.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage** (against `2026-06-14-stage-b-fast-portable-bag-design.md` D1–D4):
+- D1 (`get_as_file` rid_set) — shipped in B1; B2 consumes it. ✓
+- D2 (Format B one-CSV-per-table) — Task 3 (build_bag passes rid_sets) + Task 4 (live one-CSV-per-table assertion). ✓
+- D3 (deriva-ml computes, passes rid_sets in) — Task 1 (mapping) + Task 2 (`_compute_rid_sets`) + Task 3 (build_bag wiring). The opt-in `_catalog_bag_builder(rid_sets=None)` keeps the other 3 callers unchanged. ✓
+- D4 (deriva-py first, then deriva-ml) — B1 merged; this is the deriva-ml PR (Task 5). ✓
+- The from_model snapshot-staleness fix carried into the shared helper — Task 2. ✓
+- Vocab exclusion (vocab keeps full query, not rid-set) — Task 1 (`_rid_sets_from_reachability` drops vocab) + matches B1's upstream `not is_vocabulary()` guard. ✓
+- Live bag-gen re-measure (the headline) — Task 5. ✓
+
+**2. Placeholder scan:** No "TBD"/"handle edge cases". Every code step shows complete code. Task 4 Step 3 has no new impl (validates prior tasks) and says so. The 6-tuple return in Task 2 is fully specified (each element named + typed). ✓
+
+**3. Type consistency:**
+- `_rid_sets_from_reachability(reached, rids_by_table, vocab_tables) -> {(schema,table): [RID]}` — Task 1, consumed by Task 2's `_compute_rid_sets`. ✓
+- `_compute_rid_sets(dataset) -> 6-tuple (rid_sets, rids_by_table, asset_lengths_by_table, fetched_rows, sample_rows_by_table, asset_tables)` — defined Task 2, unpacked by estimate (Task 2) and by `build_bag` (`rid_sets, *_`, Task 3). Consistent. ✓
+- `_catalog_bag_builder(dataset, rid_sets=None)` — Task 3; `_compute_rid_sets` calls it WITHOUT rid_sets (correct — avoids circularity, flagged). ✓
+- `assemble_estimate(asset_tables=...)` — matches the post-RE-Task-7 signature (Stage A). ✓
+- `build_bag` passes `rid_sets=` to `_SnapshotAwareCatalogBagBuilder`, which inherits/forwards to `CatalogBagBuilder(rid_sets=)` (B1). ✓
+
+**Risk flagged for the implementer:** Task 2's 6-tuple is unwieldy but deliberate — it keeps ONE walk shared between the estimate and the rid_sets computation. The alternative (separate methods) re-walks. If the implementer finds the estimate's `asset_tables` derivation differs from what `_compute_rid_sets` returns, reconcile by reading the post-RE-Task-7 `estimate_bag_size` — do not change `assemble_estimate`'s contract. Task 3's `_SnapshotAwareCatalogBagBuilder.__init__` is the integration risk: verify it forwards `rid_sets` (inherits or explicitly passes to super) — a dropped `rid_sets` there silently reverts to per-path emission and Task 4's live test catches it.

--- a/docs/superpowers/specs/2026-06-14-stage-b-fast-portable-bag-design.md
+++ b/docs/superpowers/specs/2026-06-14-stage-b-fast-portable-bag-design.md
@@ -1,0 +1,220 @@
+# Stage B — Fast Portable Bag Generation (Design)
+
+> **Status:** approved design, 2026-06-14. Stage B of the fast-estimate +
+> portable-bag effort. Stage A (the client-side FK-reachability engine +
+> fast estimate) shipped in deriva-ml PR #300. Stage B makes bag
+> *generation* fast and the bag portable, by reusing Stage A's
+> `compute_reachability`. Builds on the contract spec
+> `docs/superpowers/specs/2026-06-14-portable-bag-csv-contract.md` and the
+> proven prototype recorded in memory `csv-ridset-chunk-append-proto.md`.
+>
+> **Plan B2 SHIPPED, 2026-06-15.** The deriva-ml wiring is complete: the
+> client-side bag-build path now produces Format-B bags. `DatasetBagBuilder`
+> factors the shared reachability assembly into `_compute_rid_sets` (reused
+> by `estimate_bag_size`), and `build_bag` feeds the resulting per-table
+> RID sets to `CatalogBagBuilder(rid_sets=...)`, which emits one rid-set
+> `csv` processor per reached non-vocab table — one clean
+> `data/{schema}/{table}.csv` each. Vocabulary tables keep their full
+> unfiltered export (FULL, not a rid-set), so a vocab CSV's row count can
+> exceed the estimate's reachable-subset count by design. The live test
+> `tests/dataset/test_format_b_bag.py::test_format_b_bag_one_csv_per_table_matches_estimate`
+> pins one-CSV-per-table and the non-vocab count-match (vocab exempted),
+> and passes. The reference doc `docs/reference/bag-export.md` (rule B4)
+> documents the Format-B client-side build path. Plan B1 (the deriva-py
+> `get_as_file` rid-set chunk-append + `CatalogBagBuilder(rid_sets=)`
+> emission + loader simplification) shipped upstream first, per D4.
+> **Live 2-277G bag-gen wall-clock: <to be filled by the controller's
+> re-measure>** (target: tens of seconds vs ~280s deep-join).
+
+## Problem
+
+Bag generation pays the same deep server-side FK-join cost the estimate
+used to: ~280s for eye-ai 2-277G, because `CatalogBagBuilder` emits one
+deep-join `csv` query_processor **per FK path** to each reached table. The
+bag is also **not portable** to plain `bdbag`-CLI consumers: a table's
+rows are split across multiple path-encoded `data/**/{table}.csv` files,
+and the complete set requires an out-of-band union-by-basename +
+dedup-by-RID that only deriva-ml's SQLite loader implements.
+
+Stage A already computes, client-side and fast, the exact set of
+reachable RIDs per table (`compute_reachability` in
+`src/deriva_ml/dataset/_reachability.py`). Stage B feeds those RID sets to
+the bag exporter so generation becomes a set of cheap direct
+`/entity/{table}/RID=any(...)` fetches instead of deep joins, and emits
+**one clean CSV per table**.
+
+## Goals
+
+- Bag generation drops from ~280s toward tens of seconds (join
+  elimination, same as the estimate win).
+- One clean `data/{schema}/{table}.csv` per reached table — complete,
+  RID-distinct, flat. Trivially consumable by plain `bdbag` CLI (no
+  union/dedup contract to know).
+- The SQLite loader simplifies (one file → one table; no `ON CONFLICT`
+  union needed).
+- deriva-py stays domain-agnostic — it consumes RID sets, it does not
+  learn FK-reachability. The scope/mechanics split (ADR-0006/0008) holds.
+
+## Non-goals
+
+- Concurrency tuning of the RID-set fetch is a follow-up, not Stage B's
+  bar. Stage B's correctness + portability win stands at sequential speed
+  (the prototype's full-Image-table fetch was 55.6s sequential — already
+  faster than the 280s deep-join path; concurrency is the lever that
+  closes the rest, and is a known, proven technique from the estimate's
+  async path).
+- Chaise's annotation-driven export is untouched. The new behavior is
+  additive (a new optional `rid_set` param / processor mode); existing
+  `query_path` `csv` processors behave exactly as before.
+
+## The four locked decisions
+
+### D1 — Engine layer: extend `get_as_file` with `rid_set`
+
+Add an optional `rid_set` (list of RIDs) + `rid_table` to
+`ErmrestCatalog.get_as_file`
+(`deriva/core/ermrest_catalog.py`). When `rid_set` is present:
+
+- Chunk the RIDs into URL-safe batches (~500, matching
+  `rid_lease.py`'s `PENDING_ROWS_LEASE_CHUNK`).
+- For each chunk, fetch `/entity/{rid_table}/RID=any(q1,q2,...)` where
+  **each RID is individually URL-quoted** and joined with literal commas
+  (the load-bearing gotcha: `,` is `any()` syntax, not a value —
+  `quote(",".join(rids))` silently returns zero rows; the prototype
+  caught this).
+- **Append every chunk to one output CSV** by reusing the existing
+  per-page `first_page`-skips-header append logic already in the paged
+  loop: open `'w+b'` once (truncate), the first chunk writes
+  header+body, every later chunk skips its header line and appends body
+  only. The chunk loop and the page loop are the **same** append
+  mechanism — a chunk is just an outer iteration around the existing
+  paged fetch.
+
+This is the only genuinely new engine machinery, and it reuses the
+proven page-append. Solves the URL-length 414 (proven: a 225k-RID single
+URL = 1.9 MB → 414 Request-URI Too Long).
+
+### D2 — Bag format: one clean CSV per table (Format B)
+
+`CatalogBagBuilder` emits **one** `csv` query_processor per reached
+table (carrying that table's RID set), producing one flat
+`data/{schema}/{table}.csv`. Replaces the per-FK-path emission
+(`for fk_path in self._fk_paths_for(key)`). Vocabulary full-export keeps
+its single unfiltered `/entity/{schema}:{table}` query (unchanged). The
+asset `fetch` processor is **unchanged** — it reads
+`URL/Length/Filename/MD5` from the asset table, and the RID-set query
+returns those columns just as the join query did.
+
+The SQLite loader (`deriva/bag/database.py` / `loader.py`) simplifies:
+one CSV → one table, no `ON CONFLICT` union needed (the file is already
+RID-distinct). Clean break — the per-path emission is deleted, not kept
+behind a flag (no known consumer needs the path-encoded directory
+provenance; it was always "provenance, not semantics").
+
+### D3 — Integration seam: deriva-ml computes, passes RID sets in
+
+deriva-ml's `DatasetBagBuilder` calls `compute_reachability` to get
+`{table: rid_set}`, then builds the export spec with one rid-set `csv`
+processor per table (each `processor_params` carries `rid_table` + the
+RID list). `CatalogBagBuilder` gains a path that emits rid-set processors
+from a supplied `{table: rids}` map. deriva-py never learns
+FK-reachability — it consumes RID sets and fetches them. deriva-ml owns
+the "what's reachable" decision, consistent with the ADR-0006/0008
+scope/mechanics split.
+
+### D4 — PR sequencing: deriva-py first, then deriva-ml
+
+Two plans, two PRs, in dependency order:
+
+1. **Plan B1 (deriva-py):** `get_as_file` rid_set chunk-append +
+   `CSVQueryProcessor` passthrough of `rid_set`/`rid_table` from
+   `processor_params` + `CatalogBagBuilder` rid-set spec emission +
+   loader simplification + **upstream contract tests** (the contract
+   test belongs in deriva-py's CI, per the workspace cross-repo rule).
+   Ships as its own deriva-py PR on the `deriva-ml` branch.
+2. **Plan B2 (deriva-ml):** bump the deriva-py pin, wire
+   `DatasetBagBuilder` → `compute_reachability` → Format-B export spec,
+   rewire the bag download path, live 2-277G bag-gen re-measure. Ships as
+   its own deriva-ml PR after B1 merges.
+
+## Architecture
+
+```
+deriva-ml                                    deriva-py
+─────────                                    ─────────
+DatasetBagBuilder
+  compute_reachability(...)  ──► {table: rid_set}
+  build Format-B export spec ──────────────► CatalogBagBuilder
+    (one rid-set csv processor                 emit rid-set csv processors
+     per table)                                (one per table)
+                                                   │
+                                             export engine runs spec
+                                                   │
+                                             CSVQueryProcessor
+                                               passes rid_set/rid_table ──► ErmrestCatalog.get_as_file
+                                                                              chunk RIDs @500, quote
+                                                                              each, append to ONE CSV
+                                                   │
+                                             data/{schema}/{table}.csv  (one clean file per table)
+                                             + fetch.txt (assets, unchanged)
+                                                   │
+                                             BagDatabase loader: one CSV → one table (no union)
+```
+
+## CSV contract (Format B — the consumer-facing guarantee)
+
+Per the contract spec, the bag now satisfies:
+
+- **One CSV per table:** `data/{schema}/{table}.csv`. `Image.csv` is THE
+  complete reachable Image set.
+- **No union/dedup/glob:** the file IS the union, already RID-distinct.
+  `read_csv("data/eye-ai/Image.csv")` is correct and complete.
+- **`RID` is the PK** (in `data/schema.json`); asset bytes out-of-line
+  via `fetch.txt` (`sum(Length)` for size).
+
+## Testing
+
+**deriva-py (Plan B1) — contract tests upstream:**
+- `get_as_file` with `rid_set`: a RID set larger than the URL limit
+  produces one CSV, header once, RID-distinct, complete (against a
+  fixture catalog or the existing bag test harness). This is the pin for
+  the engine contract.
+- The per-RID-quoting correctness (commas are syntax): a test that a
+  multi-RID `rid_set` returns all rows (would fail under
+  `quote(",".join(...))`).
+- `CatalogBagBuilder` rid-set emission: the export spec has one csv
+  processor per table with the RID set, not one-per-FK-path.
+- Loader: one-CSV-per-table loads correctly.
+
+**deriva-ml (Plan B2) — integration + the headline:**
+- `DatasetBagBuilder` builds a Format-B spec from `compute_reachability`
+  output (the RID sets match the reachable sets).
+- A live bag-generation run produces one CSV per table, RID-distinct,
+  with correct asset `fetch.txt`.
+- **Live 2-277G bag-gen re-measure** — the headline number (target: tens
+  of seconds vs ~280s) for the PR.
+- A bag round-trips through the SQLite loader with correct per-table row
+  counts (matching the estimate).
+
+## Risks
+
+- **deriva-py is a shared library.** The `get_as_file` change is additive
+  (optional param), but `get_as_file` is widely used — the contract test
+  upstream is the guard. Chaise's existing exports use `query_path` and
+  are unaffected.
+- **Concurrency gap.** Sequential RID-set fetch is already faster than
+  the deep-join path but not as fast as the estimate's 27s prototype
+  (which fetched RID+FK cols only, concurrently). Stage B ships
+  sequential-correct; concurrency is a tracked follow-up, not a blocker.
+  `log()`/document the sequential nature so the speed expectation is
+  honest.
+
+## See also
+- `docs/superpowers/specs/2026-06-14-portable-bag-csv-contract.md` — the
+  CSV rules + export-spec shapes (Format A vs B) this design realizes.
+- Stage A: `docs/superpowers/plans/2026-06-14-reachability-engine-fast-estimate.md`
+  + deriva-ml PR #300 (the shipped `compute_reachability` engine B2 reuses).
+- Memory `csv-ridset-chunk-append-proto.md` — the proven prototype + the
+  per-RID-quoting gotcha.
+- ADR-0006 (bag-oriented data movement), ADR-0008 (estimate bypass) — the
+  scope/mechanics split this design preserves.

--- a/docs/superpowers/specs/2026-06-14-stage-b-fast-portable-bag-design.md
+++ b/docs/superpowers/specs/2026-06-14-stage-b-fast-portable-bag-design.md
@@ -23,8 +23,25 @@
 > documents the Format-B client-side build path. Plan B1 (the deriva-py
 > `get_as_file` rid-set chunk-append + `CatalogBagBuilder(rid_sets=)`
 > emission + loader simplification) shipped upstream first, per D4.
-> **Live 2-277G bag-gen wall-clock: <to be filled by the controller's
-> re-measure>** (target: tens of seconds vs ~280s deep-join).
+>
+> **Speed result (HONEST — B2 ships portability, NOT the speed win yet).**
+> Live 2-277G bag-gen measured **~1120s** over a WAN link — *slower* than the
+> prior ~280s per-path baseline. Phase-profiling (2026-06-15) shows the
+> rid-set fetch is **88%** of the build (987s), dominated by a few large
+> tables (Dataset_Image: 107k RIDs = 534s; rate collapses ~9× with table
+> size, 1,700 → 200 RIDs/s). The dominant cost is **not** concurrency-gap
+> alone: investigation refuted snapshot cost, `_read_last_csv_record`,
+> chunk-size (capped at 500 by a server URL-length 404 at 600), `@sort(RID)`
+> overhead, the download-engine session config, and a cursor bug — the
+> root of the rate-collapse is still **unconfirmed** (likely server-side
+> `RID=any(...)` query cost on large tables, partly WAN-latency-amplified —
+> ~84% of a small request is network RTT, so a local/fast network would
+> lower the absolute numbers substantially). The "Goals: tens of seconds"
+> target is therefore **deferred to a follow-up** with the perf data above
+> attached as a tracked deriva-py issue. **B2 ships the architectural win —
+> portable one-clean-CSV-per-table bags — not a bag-gen speedup.** See the
+> "Non-goals" note (concurrency was always deferred) and the memory record
+> `csv-ridset-chunk-append-proto.md` for the full measurement trail.
 
 ## Problem
 
@@ -45,15 +62,25 @@ the bag exporter so generation becomes a set of cheap direct
 
 ## Goals
 
-- Bag generation drops from ~280s toward tens of seconds (join
-  elimination, same as the estimate win).
-- One clean `data/{schema}/{table}.csv` per reached table — complete,
-  RID-distinct, flat. Trivially consumable by plain `bdbag` CLI (no
-  union/dedup contract to know).
-- The SQLite loader simplifies (one file → one table; no `ON CONFLICT`
-  union needed).
-- deriva-py stays domain-agnostic — it consumes RID sets, it does not
-  learn FK-reachability. The scope/mechanics split (ADR-0006/0008) holds.
+> **What B2 actually delivered:** the portability + architecture goals below
+> (one clean CSV per table, simplified loader, domain-agnostic deriva-py).
+> The *speed* goal was **not** achieved — see the honest speed result in the
+> Status header. Join elimination was real (no deep FK joins), but the
+> per-table `RID=any(...)` fetch is itself slow at scale on large tables, so
+> end-to-end bag-gen did not drop to "tens of seconds." Speed is deferred.
+
+- **(DEFERRED)** Bag generation drops from ~280s toward tens of seconds.
+  Join elimination landed, but the rid-set fetch is the new bottleneck at
+  scale (88% of build; one 107k-row table = 534s on WAN). Root cause
+  unconfirmed; tracked as a follow-up. See the Status header.
+- **(SHIPPED)** One clean `data/{schema}/{table}.csv` per reached table —
+  complete, RID-distinct, flat. Trivially consumable by plain `bdbag` CLI
+  (no union/dedup contract to know).
+- **(SHIPPED)** The SQLite loader simplifies (one file → one table; no
+  `ON CONFLICT` union needed).
+- **(SHIPPED)** deriva-py stays domain-agnostic — it consumes RID sets, it
+  does not learn FK-reachability. The scope/mechanics split (ADR-0006/0008)
+  holds.
 
 ## Non-goals
 

--- a/src/deriva_ml/dataset/bag_builder.py
+++ b/src/deriva_ml/dataset/bag_builder.py
@@ -68,6 +68,46 @@ from deriva_ml.interfaces import DatasetLike, DerivaMLCatalog
 logger = get_logger(__name__)
 
 
+def _rid_sets_from_reachability(
+    reached: dict[tuple[str, str], Any],
+    rids_by_table: dict[str, set[str]],
+    vocab_tables: set[tuple[str, str]],
+) -> dict[tuple[str, str], list[str]]:
+    """Map compute_reachability output to the upstream rid_sets shape.
+
+    ``compute_reachability`` returns ``rids_by_table`` keyed by bare table
+    name; ``CatalogBagBuilder(rid_sets=...)`` wants ``{(schema, table):
+    [RID,...]}``. This re-keys using ``reached``'s ``(schema, table)`` keys,
+    drops vocab tables (the upstream rid-set branch skips them -- vocab keeps
+    its full/per-path query), and sorts each RID list for deterministic specs
+    (sets are not JSON-serializable; the spec must be reproducible).
+
+    Args:
+        reached: ``{(schema, table): [fk_path, ...]}`` -- the reached-paths map
+            (its keys enumerate the tables to consider).
+        rids_by_table: ``{table_name: set(RID)}`` from compute_reachability.
+        vocab_tables: ``(schema, table)`` pairs that are vocabulary tables.
+
+    Returns:
+        ``{(schema, table): [RID, ...]}`` for every non-vocab reached table.
+
+    Example:
+        >>> _rid_sets_from_reachability(
+        ...     {("S", "T"): [()], ("S", "V"): [()]},
+        ...     {"T": {"b", "a"}},
+        ...     {("S", "V")},
+        ... )
+        {('S', 'T'): ['a', 'b']}
+    """
+    result: dict[tuple[str, str], list[str]] = {}
+    for key in reached:
+        if key in vocab_tables:
+            continue
+        table_name = key[1]
+        result[key] = sorted(rids_by_table.get(table_name, set()))
+    return result
+
+
 class _SnapshotAwareCatalogBagBuilder(CatalogBagBuilder):
     """``CatalogBagBuilder`` that honors the catalog's snapshot in exports.
 

--- a/src/deriva_ml/dataset/bag_builder.py
+++ b/src/deriva_ml/dataset/bag_builder.py
@@ -365,6 +365,10 @@ class DatasetBagBuilder:
 
         anchors = self.anchors_for(dataset)
         policy = self.build_policy(dataset)
+        # Compute the per-table reachable RID sets so the upstream engine
+        # emits one rid-set csv processor per non-vocab reached table
+        # (Format-B) instead of one csv processor per FK path.
+        rid_sets = self._compute_rid_sets(dataset).rid_sets
 
         catalog = self._ml_instance.catalog
         prior_config = getattr(catalog, "_session_config", None)
@@ -383,6 +387,7 @@ class DatasetBagBuilder:
                 anchors=anchors,
                 output_dir=cb_output_dir,
                 policy=policy,
+                rid_sets=rid_sets,
             )
             unpacked_path = builder.build()
         finally:
@@ -516,13 +521,17 @@ class DatasetBagBuilder:
     # Internal driver — constructs a :class:`CatalogBagBuilder`
     # ------------------------------------------------------------------
 
-    def _catalog_bag_builder(self, dataset: DatasetLike | None) -> CatalogBagBuilder:
+    def _catalog_bag_builder(
+        self,
+        dataset: DatasetLike | None,
+        rid_sets: dict[tuple[str, str], list[str]] | None = None,
+    ) -> CatalogBagBuilder:
         """Construct a :class:`CatalogBagBuilder` for this dataset.
 
-        Three callers (:meth:`generate_dataset_download_spec`,
+        Four callers (:meth:`generate_dataset_download_spec`,
         :meth:`generate_dataset_download_annotations`,
-        :meth:`aggregate_queries`) share this construction so all
-        three drive off the same walker.
+        :meth:`aggregate_queries`, :meth:`_compute_rid_sets`) share
+        this construction so they all drive off the same walker.
 
         Args:
             dataset: Per-dataset scoping. When non-``None``, the
@@ -532,6 +541,13 @@ class DatasetBagBuilder:
                 ``deriva-ml:Dataset`` table — the catalog-wide
                 view used by annotation generation and by
                 :meth:`aggregate_queries` with no dataset filter.
+            rid_sets: Opt-in per-table reachable RID sets. When
+                supplied, the upstream engine emits one rid-set csv
+                processor per non-vocab reached table (Format-B) instead
+                of one csv processor per FK path. ``None`` (the default,
+                used by every share-the-walker caller above) keeps
+                per-path emission unchanged; only the download/build
+                path supplies it (via a separately-constructed builder).
         """
         if dataset is not None:
             anchors = self.anchors_for(dataset)
@@ -549,6 +565,7 @@ class DatasetBagBuilder:
             anchors=anchors,
             output_dir=output_dir,
             policy=policy,
+            rid_sets=rid_sets,
         )
         # Stash the tmp on the builder so it lives until the
         # builder is garbage-collected. The annotation/aggregate

--- a/src/deriva_ml/dataset/bag_builder.py
+++ b/src/deriva_ml/dataset/bag_builder.py
@@ -50,10 +50,11 @@ CONTEXT.md is preserved by construction.
 
 from __future__ import annotations
 
+import importlib
 from collections import defaultdict
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Any, Iterable
+from typing import Any, Iterable, NamedTuple
 
 from deriva.bag.anchors import Anchor, RIDAnchor, TableAnchor
 from deriva.bag.catalog_builder import CatalogBagBuilder
@@ -65,7 +66,36 @@ from deriva_ml.core.constants import INTENTIONAL_FK_CYCLES, PROVENANCE_TERMINAL_
 from deriva_ml.core.logging_config import get_logger
 from deriva_ml.interfaces import DatasetLike, DerivaMLCatalog
 
+# Import datapath via importlib to avoid shadowing by local 'deriva.py' files
+# (mirrors dataset.py's pattern).
+datapath = importlib.import_module("deriva.core.datapath")
+
 logger = get_logger(__name__)
+
+
+class RidSetComputation(NamedTuple):
+    """Result of :meth:`DatasetBagBuilder._compute_rid_sets`.
+
+    Bundles the per-table RID sets (for Format-B bag generation) with the
+    auxiliary reachability data the estimate consumes — all from one walk.
+
+    Attributes:
+        rid_sets: ``{(schema, table): [RID,...]}`` for non-vocab reached
+            tables — the shape ``CatalogBagBuilder(rid_sets=...)`` consumes
+            (vocab excluded, lists sorted).
+        rids_by_table: bare-name ``{table: set(RID)}`` (row counts).
+        asset_lengths_by_table: ``{table: {RID: Length}}`` (asset bytes).
+        fetched_rows: ``{(schema, table): rows}`` (CSV-byte sampling source).
+        sample_rows_by_table: ``{table: [row,...]}`` derived sample.
+        asset_tables: bare table names that are asset tables.
+    """
+
+    rid_sets: dict[tuple[str, str], list[str]]
+    rids_by_table: dict[str, set[str]]
+    asset_lengths_by_table: dict[str, dict[str, int]]
+    fetched_rows: dict[tuple[str, str], list[dict]]
+    sample_rows_by_table: dict[str, list[dict]]
+    asset_tables: set[str]
 
 
 def _rid_sets_from_reachability(
@@ -527,6 +557,75 @@ class DatasetBagBuilder:
         # :meth:`CatalogBagBuilder.build`.
         builder._datasetbag_output_tmp = tmp  # type: ignore[attr-defined]
         return builder
+
+    def _compute_rid_sets(self, dataset: DatasetLike) -> RidSetComputation:
+        """Compute per-table reachable RID sets for a dataset, client-side.
+
+        Factored from estimate_bag_size's reachability assembly so the
+        bag-build path and the estimate share one implementation -- and one
+        copy of the ``from_model`` snapshot-staleness fix (the walk's fresh
+        model and the fetch's path builder must be the same model, or the
+        fetch raises KeyError on tables the held model lacks).
+
+        Args:
+            dataset: The dataset to analyze. Must expose ``dataset_rid``.
+
+        Returns:
+            A :class:`RidSetComputation` bundling the per-table RID sets
+            (for Format-B bag generation) with the auxiliary reachability
+            data the estimate consumes; see that NamedTuple's attribute docs
+            for the per-field shapes.
+        """
+        from deriva_ml.dataset._reachability import (
+            compute_reachability,
+            sample_rows_from_fetched,
+        )
+
+        cb = self._catalog_bag_builder(dataset=dataset)
+        reached = cb.iter_reached_paths()
+        anchor_rids = [dataset.dataset_rid] + list(self._iter_descendant_rids(dataset))
+        model = cb._get_model()
+
+        # Build the path builder from the SAME model the walk used -- not the
+        # held-model pathBuilder(). The walk reaches tables in deriva-py's
+        # freshly-fetched snapshot model; the instance's held model can lag
+        # (reused schema_json) and would be missing them, raising KeyError.
+        # Sharing one model keeps walk and fetch in lockstep, no /schema fetch.
+        pb = datapath.from_model(self._ml_instance.catalog, model)
+
+        def _fetch(schema: str, table: str, columns: set[str]) -> list[dict]:
+            tpb = pb.schemas[schema].tables[table]
+            try:
+                attrs = [getattr(tpb, c) for c in sorted(columns)]
+                return list(tpb.attributes(*attrs).fetch())
+            except Exception as exc:  # noqa: BLE001
+                # Defensive fallback: a projection naming a column the table
+                # lacks (model/data skew) degrades to a full-entity fetch.
+                logger.debug(
+                    "rid-set projected fetch for %s:%s fell back to full-entity scan: %s",
+                    schema,
+                    table,
+                    exc,
+                )
+                return list(tpb.entities().fetch())
+
+        rids_by_table, asset_lengths_by_table, fetched_rows = compute_reachability(
+            reached=reached, anchor_rids=anchor_rids, model=model, fetch=_fetch
+        )
+        sample_rows_by_table = sample_rows_from_fetched(reached=reached, fetched_rows=fetched_rows)
+
+        vocab_tables = {key for key in reached if model.schemas[key[0]].tables[key[1]].is_vocabulary()}
+        rid_sets = _rid_sets_from_reachability(reached, rids_by_table, vocab_tables)
+        asset_tables = {key[1] for key in reached if model.schemas[key[0]].tables[key[1]].is_asset()}
+
+        return RidSetComputation(
+            rid_sets,
+            rids_by_table,
+            asset_lengths_by_table,
+            fetched_rows,
+            sample_rows_by_table,
+            asset_tables,
+        )
 
     @property
     def _ml_schema(self) -> str:

--- a/src/deriva_ml/dataset/dataset.py
+++ b/src/deriva_ml/dataset/dataset.py
@@ -28,7 +28,6 @@ Typical usage example:
 
 from __future__ import annotations
 
-import importlib
 from collections import defaultdict
 
 # Standard library imports
@@ -43,11 +42,6 @@ if TYPE_CHECKING:
 # Third-party imports
 import pandas as pd
 from deriva.core.ermrest_model import Table
-
-# Import datapath via importlib to avoid shadowing by local 'deriva.py' files
-# (same convention as core/mixins/path_builder.py). Used to build a path
-# builder from an explicit model in estimate_bag_size.
-datapath = importlib.import_module("deriva.core.datapath")
 from pydantic import validate_call
 
 from deriva_ml.core.constants import RID
@@ -2723,67 +2717,28 @@ class Dataset:
                   (no per-table query failures can occur).
         """
         from deriva_ml.dataset._estimate import assemble_estimate
-        from deriva_ml.dataset._reachability import (
-            compute_reachability,
-            sample_rows_from_fetched,
-        )
 
         if isinstance(version, str):
             version = DatasetVersion.parse(version)
 
         # Build a DatasetBagBuilder on the version snapshot. The walk (which
         # tables are reachable, via which FK paths) is shared with the bag
-        # export; only the *execution* differs -- see docs/adr/0008.
+        # export; only the *execution* differs -- see docs/adr/0008. The
+        # reachability assembly (walk -> from_model fetch -> compute_reachability)
+        # lives in DatasetBagBuilder._compute_rid_sets so the bag-build path and
+        # this estimate share one implementation and one from_model fix.
         version_snapshot_catalog = self._version_snapshot_catalog(version)
         builder = DatasetBagBuilder(
             ml_instance=version_snapshot_catalog,
             exclude_tables=exclude_tables,
         )
-        cb = builder._catalog_bag_builder(dataset=self)
-        reached = cb.iter_reached_paths()
-        anchor_rids = [self.dataset_rid] + list(builder._iter_descendant_rids(self))
-        model = cb._get_model()
-
-        # Fetch closure: whole-table projected scan. Cheap relative to deep FK
-        # joins (a 240k-row scan is ~0.3s; the join through it was 16-60s).
-        #
-        # Build the path builder from the SAME model the walk used
-        # (``cb._get_model()``), not ``version_snapshot_catalog.pathBuilder()``.
-        # The walk reaches tables named in deriva-py's freshly-fetched snapshot
-        # model; the deriva-ml instance's held model can legitimately differ
-        # (e.g. a snapshot reusing the live instance's schema_json, or any
-        # held-model staleness) and would be missing tables the walk reached,
-        # raising KeyError here. Sharing one model keeps walk and fetch in
-        # lockstep and adds no /schema fetch -- the walk already fetched it.
-        pb = datapath.from_model(version_snapshot_catalog.catalog, model)
-
-        def _fetch(schema: str, table: str, columns: set[str]) -> list[dict]:
-            tpb = pb.schemas[schema].tables[table]
-            try:
-                attrs = [getattr(tpb, c) for c in sorted(columns)]
-                return list(tpb.attributes(*attrs).fetch())
-            except Exception as exc:  # noqa: BLE001
-                # Defensive fallback: a projection naming a column the table
-                # lacks (model/data skew) degrades to a full-entity fetch
-                # rather than dropping the table from the estimate.
-                self._logger.debug(
-                    "estimate projected fetch for %s:%s fell back to full-entity scan: %s",
-                    schema,
-                    table,
-                    exc,
-                )
-                return list(tpb.entities().fetch())
-
-        rids_by_table, asset_lengths_by_table, fetched_rows = compute_reachability(
-            reached=reached, anchor_rids=anchor_rids, model=model, fetch=_fetch
-        )
-        sample_rows_by_table = sample_rows_from_fetched(reached=reached, fetched_rows=fetched_rows)
+        rid_data = builder._compute_rid_sets(self)
 
         return assemble_estimate(
-            asset_tables={key[1] for key in reached if model.schemas[key[0]].tables[key[1]].is_asset()},
-            rids_by_table=rids_by_table,
-            asset_lengths_by_table=asset_lengths_by_table,
-            sample_rows_by_table=sample_rows_by_table,
+            asset_tables=rid_data.asset_tables,
+            rids_by_table=rid_data.rids_by_table,
+            asset_lengths_by_table=rid_data.asset_lengths_by_table,
+            sample_rows_by_table=rid_data.sample_rows_by_table,
             estimate_csv_bytes=self._estimate_csv_bytes,
             human_readable_size=self._human_readable_size,
         )

--- a/tests/dataset/test_format_b_bag.py
+++ b/tests/dataset/test_format_b_bag.py
@@ -29,3 +29,34 @@ def test_rid_sets_from_reachability_missing_table_is_empty_list():
     reached = {("S", "T"): [()]}
     result = _rid_sets_from_reachability(reached, {}, set())
     assert result == {("S", "T"): []}
+
+
+def test_compute_rid_sets_method_exists():
+    from deriva_ml.dataset.bag_builder import DatasetBagBuilder
+
+    assert hasattr(DatasetBagBuilder, "_compute_rid_sets")
+
+
+def test_compute_rid_sets_carries_from_model_and_reachability():
+    """The shared helper owns the from_model fix and the reachability call."""
+    import inspect
+
+    from deriva_ml.dataset.bag_builder import DatasetBagBuilder
+
+    src = inspect.getsource(DatasetBagBuilder._compute_rid_sets)
+    assert "from_model" in src
+    assert "compute_reachability" in src
+    assert "_rid_sets_from_reachability" in src
+
+
+def test_estimate_delegates_to_compute_rid_sets():
+    """estimate_bag_size delegates the reachability assembly (no longer inlines
+    its own from_model fetch closure)."""
+    import inspect
+
+    from deriva_ml.dataset.dataset import Dataset
+
+    src = inspect.getsource(Dataset.estimate_bag_size)
+    assert "_compute_rid_sets" in src
+    # The from_model closure now lives in the shared helper, not the estimate.
+    assert "datapath.from_model" not in src

--- a/tests/dataset/test_format_b_bag.py
+++ b/tests/dataset/test_format_b_bag.py
@@ -60,3 +60,25 @@ def test_estimate_delegates_to_compute_rid_sets():
     assert "_compute_rid_sets" in src
     # The from_model closure now lives in the shared helper, not the estimate.
     assert "datapath.from_model" not in src
+
+
+def test_catalog_bag_builder_accepts_rid_sets():
+    """_catalog_bag_builder forwards an opt-in rid_sets to CatalogBagBuilder."""
+    import inspect
+
+    from deriva_ml.dataset.bag_builder import DatasetBagBuilder
+
+    sig = inspect.signature(DatasetBagBuilder._catalog_bag_builder)
+    assert "rid_sets" in sig.parameters
+    assert sig.parameters["rid_sets"].default is None
+
+
+def test_build_bag_uses_rid_sets():
+    """build_bag computes rid_sets and passes them to the CatalogBagBuilder."""
+    import inspect
+
+    from deriva_ml.dataset.bag_builder import DatasetBagBuilder
+
+    src = inspect.getsource(DatasetBagBuilder.build_bag)
+    assert "_compute_rid_sets" in src
+    assert "rid_sets=" in src

--- a/tests/dataset/test_format_b_bag.py
+++ b/tests/dataset/test_format_b_bag.py
@@ -1,5 +1,11 @@
 """Tests for Format-B (rid-set) bag generation."""
 
+import os
+import zipfile
+from collections import Counter
+
+import pytest
+
 from deriva_ml.dataset.bag_builder import _rid_sets_from_reachability
 
 
@@ -82,3 +88,93 @@ def test_build_bag_uses_rid_sets():
     src = inspect.getsource(DatasetBagBuilder.build_bag)
     assert "_compute_rid_sets" in src
     assert "rid_sets=" in src
+
+
+@pytest.mark.skipif(
+    os.environ.get("DERIVA_HOST") in (None, ""),
+    reason="needs a live catalog",
+)
+def test_format_b_bag_one_csv_per_table_matches_estimate(catalog_with_datasets, tmp_path):
+    """A built bag has one clean CSV per table (Format B); loading it
+    reproduces the estimate's per-table row counts, RID-distinct."""
+    import csv as csvmod
+
+    from deriva_ml.dataset.bag_builder import DatasetBagBuilder
+
+    ml, _desc = catalog_with_datasets
+
+    # Pick a nested dataset (multi-path tables -- the interesting case).
+    datasets = list(ml.find_datasets())
+    nested = next((d for d in datasets if d.list_dataset_children()), None)
+    if nested is None:
+        pytest.skip("fixture has no nested dataset to exercise multi-path union")
+    version = nested.current_version
+
+    # Estimate = the oracle for per-table counts.
+    est = nested.estimate_bag_size(version)
+    est_counts = {t: d["row_count"] for t, d in est["tables"].items() if d["row_count"] > 0}
+
+    # Build a Format-B bag.
+    snap = nested._version_snapshot_catalog(version)
+    builder = DatasetBagBuilder(ml_instance=snap)
+
+    # The rid-set keys are exactly the NON-vocab reached tables: vocab tables
+    # are deliberately dropped from rid_sets and exported FULL via the full
+    # query (per the FKTraversalPolicy vocab_export=FULL rule). So a table's
+    # bag CSV equals its reachable-subset estimate ONLY for non-vocab tables;
+    # vocab CSVs hold the whole vocabulary (e.g. Asset_Role = Input + Output)
+    # and legitimately exceed the reachable-subset count. Use the production
+    # code's own vocab determination -- the rid_sets keys -- so this exemption
+    # tracks the implementation rather than re-deriving it.
+    rid_set_tables = {key[1] for key in builder._compute_rid_sets(nested).rid_sets}
+
+    zip_path = builder.build_bag(nested, output_dir=tmp_path)
+    assert zip_path.exists()
+
+    # Extract and inspect data/ CSVs.
+    extract = tmp_path / "extracted"
+    with zipfile.ZipFile(zip_path) as zf:
+        zf.extractall(extract)
+
+    csvs = list(extract.rglob("data/**/*.csv"))
+    assert csvs, "bag contains no data CSVs"
+
+    # Format B: exactly ONE CSV per table (no per-path fragmentation). The bag
+    # tree is data/<schema>/<table>.csv, so key by (schema, table) -- a table is
+    # "split across multiple CSVs" only if the SAME (schema, table) recurs. Keying
+    # by bare p.stem would false-positive if two schemas held a same-named table.
+    by_schema_table = Counter((p.parent.name, p.stem) for p in csvs)
+    multi = {key: n for key, n in by_schema_table.items() if n > 1}
+    assert not multi, f"Format B violated -- tables split across multiple CSVs: {multi}"
+
+    # Every data CSV in the bag must be RID-distinct (Format B emits sorted,
+    # de-duplicated rid-set rows; a duplicate RID signals a regression in the
+    # rid-set emission). This applies to vocab CSVs too. Key by (schema, table) =
+    # (p.parent.name, p.stem) so two same-named tables in different schemas stay
+    # distinct rather than overwriting each other.
+    rows_by_csv = {}
+    for p in csvs:
+        with p.open(encoding="utf-8") as fh:
+            rows = list(csvmod.DictReader(fh))
+        rids = [r["RID"] for r in rows if "RID" in r]
+        assert len(set(rids)) == len(rids), f"{p.parent.name}/{p.stem}.csv has duplicate RIDs"
+        rows_by_csv[(p.parent.name, p.stem)] = rows
+
+    # For each NON-vocab data CSV, the bag's rid-set row count must match the
+    # estimate exactly (the correctness gate: a dropped rid_sets would revert to
+    # per-path multi-CSV emission caught above, or a count drift here). We iterate
+    # over the real (schema, table) CSV files but compare to the estimate's count,
+    # which is keyed by BARE table name -- that bare-name keying is the estimate's
+    # contract. The two align on the demo catalog because table names are unique
+    # across schemas; if a same-named table ever appeared in two schemas the
+    # ambiguity would live in the estimate's keying, not in this check.
+    asserted = 0
+    for (_schema, table), rows in rows_by_csv.items():
+        if table not in rid_set_tables:
+            continue  # vocab table: exported FULL, not by reachable-subset rid-set
+        if table not in est_counts:
+            continue  # not estimated (e.g. zero-row table omitted from est_counts)
+        assert len(rows) == est_counts[table], f"{table}: bag={len(rows)} estimate={est_counts[table]}"
+        asserted += 1
+
+    assert asserted, "no non-vocab table count was asserted -- the count gate did nothing"

--- a/tests/dataset/test_format_b_bag.py
+++ b/tests/dataset/test_format_b_bag.py
@@ -1,0 +1,31 @@
+"""Tests for Format-B (rid-set) bag generation."""
+
+from deriva_ml.dataset.bag_builder import _rid_sets_from_reachability
+
+
+def test_rid_sets_from_reachability_tuple_keys_and_drops_vocab():
+    # reached: (schema, table) -> [fk_path, ...]  (paths irrelevant here)
+    reached = {
+        ("eye-ai", "Image"): [()],
+        ("eye-ai", "Subject"): [()],
+        ("deriva-ml", "Asset_Role"): [()],  # vocab
+    }
+    rids_by_table = {
+        "Image": {"r1", "r2"},
+        "Subject": {"s1"},
+        "Asset_Role": {"Input", "Output"},  # bare names; vocab
+    }
+    vocab_tables = {("deriva-ml", "Asset_Role")}
+    result = _rid_sets_from_reachability(reached, rids_by_table, vocab_tables)
+    # Tuple-keyed, vocab dropped, RID lists sorted for determinism.
+    assert result == {
+        ("eye-ai", "Image"): ["r1", "r2"],
+        ("eye-ai", "Subject"): ["s1"],
+    }
+
+
+def test_rid_sets_from_reachability_missing_table_is_empty_list():
+    """A reached non-vocab table with no RID-set entry maps to []."""
+    reached = {("S", "T"): [()]}
+    result = _rid_sets_from_reachability(reached, {}, set())
+    assert result == {("S", "T"): []}

--- a/uv.lock
+++ b/uv.lock
@@ -853,7 +853,7 @@ wheels = [
 [[package]]
 name = "deriva"
 version = "2.0.0.dev0"
-source = { git = "https://github.com/informatics-isi-edu/deriva-py?branch=deriva-ml#f897051534db94217f3ca584e1d04f18b59e5939" }
+source = { git = "https://github.com/informatics-isi-edu/deriva-py?branch=deriva-ml#e27ecc6ae58f101de355c24110293f64dbff1187" }
 dependencies = [
     { name = "bdbag" },
     { name = "fair-identifiers-client" },


### PR DESCRIPTION
## Summary

Wires deriva-ml's client-side bag generation to the merged deriva-py RID-set engine ([deriva-py#269](https://github.com/informatics-isi-edu/deriva-py/pull/269)). `build_bag` now computes per-table reachable RID sets via `compute_reachability` (the Stage-A engine, [#300](https://github.com/informatics-isi-edu/deriva-ml/pull/300)) and feeds them to `CatalogBagBuilder(rid_sets=...)`, which emits **one rid-set csv processor per reached non-vocab table** — producing one clean `data/{schema}/{table}.csv` per table.

This is **Stage B2** of the fast-estimate + portable-bag effort. It ships the **portability / architecture win**, not a bag-gen speedup — see the honest note below.

## What changed
- **`DatasetBagBuilder._compute_rid_sets`** — factors the shared reachability assembly (also used by `estimate_bag_size`), carrying the `from_model` snapshot-staleness fix in one place. Returns a `RidSetComputation` NamedTuple.
- **`build_bag`** computes `_compute_rid_sets(dataset).rid_sets` and passes them to its `_SnapshotAwareCatalogBagBuilder(rid_sets=...)`.
- **`_catalog_bag_builder(rid_sets=None)`** — opt-in; the 3 existing callers (spec/annotation/aggregate) pass nothing → unchanged per-path behavior.
- **`_rid_sets_from_reachability`** — maps `compute_reachability`'s bare-name `{table: set}` to the upstream `{(schema,table): sorted-list}` (vocab dropped; sets → JSON-serializable deterministic lists).
- deriva-py pin advanced to include B1 (`uv.lock`).

## The Format-B bag (portability win)
- **One clean CSV per table**: `data/{schema}/{table}.csv`, complete + RID-distinct + flat. No per-FK-path fragmentation; no out-of-band union-by-basename/dedup-by-RID for a plain `bdbag` consumer to perform.
- **Loader simplifies** (one file → one table; no `ON CONFLICT` union).
- **Vocab tables** keep their FULL unfiltered export (not a rid-set), so a vocab CSV's count can exceed the estimate's reachable subset — by design.
- Applies to the **client-side build arm** (`download_dataset_bag`'s default `use_minid=False`); the server-side MINID/S3 arm is unchanged (still Format A).

## Tests
- New `tests/dataset/test_format_b_bag.py`: pure key-mapping unit tests + a **live round-trip** asserting one CSV per `(schema, table)`, RID-distinct, and 23 non-vocab table counts matching the estimate (vocab exempted via the production vocab classification; a hollow-pass guard ensures the count-match genuinely fires). Estimate exactness preserved after the refactor.
- Full unit + doctest suites green; lint clean.

## ⚠️ Honest speed result — speed is DEFERRED, not delivered
Live 2-277G bag-gen measured **~1120s over WAN — *slower* than the prior ~280s per-path baseline.** Phase-profiling: the rid-set fetch is **88%** of build (987s), dominated by a few large tables (Dataset_Image 107k RIDs = 534s; rate collapses ~9× with table size). Root cause of the rate-collapse is **unconfirmed** — investigation **refuted** snapshot cost, `_read_last_csv_record`, chunk-size (server URL-length 404 at 600 RIDs), `@sort(RID)` overhead, download-engine session config, and a cursor bug. ~84% of a small request is network RTT, so a local/fast network (the real use case) would lower the absolute numbers substantially, but the size-scaling is compute-side.

**This PR deliberately ships the architectural win (portable bags) without the speed win.** Faster generation is a tracked follow-up needing focused debugging of the at-scale rid-set fetch (full measurement trail in `docs/superpowers/specs/2026-06-14-stage-b-fast-portable-bag-design.md` Status header). Do not merge expecting a bag-gen speedup.

Stage A = [#300](https://github.com/informatics-isi-edu/deriva-ml/pull/300) · Stage B1 = [deriva-py#269](https://github.com/informatics-isi-edu/deriva-py/pull/269).

🤖 Generated with [Claude Code](https://claude.com/claude-code)