### PR TITLE
chore(deps): advance deriva-py pin to include rid-set Accept-header fix

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -853,7 +853,7 @@ wheels = [
 [[package]]
 name = "deriva"
 version = "2.0.0.dev0"
-source = { git = "https://github.com/informatics-isi-edu/deriva-py?branch=deriva-ml#e27ecc6ae58f101de355c24110293f64dbff1187" }
+source = { git = "https://github.com/informatics-isi-edu/deriva-py?branch=deriva-ml#31784c87dca8df702d8e9c72f102aeb59b8558fe" }
 dependencies = [
     { name = "bdbag" },
     { name = "fair-identifiers-client" },


### PR DESCRIPTION
## Summary

Advances the locked deriva-py commit from `e27ecc6` → `31784c8` to include the merged Accept-header fix ([deriva-py#271](https://github.com/informatics-isi-edu/deriva-py/pull/271)).

That fix defaults `Accept: text/csv` in `get_as_file`'s `rid_set` path — without it, a direct `get_as_file(rid_set=...)` caller with no explicit accept silently gets JSON and writes 0 rows. deriva-ml `main` was pinned one commit behind it, so a fresh `uv sync` would install deriva-py without the fix.

## Impact

- deriva-ml's own Format-B bag path is **unaffected** — `CSVQueryProcessor` always passes `accept=text/csv` — so nothing was broken in practice.
- But the lock should reflect the merged upstream state, and any future direct rid-set caller needs the fix. This is the natural completion of #271 landing.

`uv.lock`-only change. Bag/reachability/estimate-helper unit suites pass against the bumped pin (29 passed / 1 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)