### PR TITLE
chore(deps): advance deriva-py pin to include the O(n²) rid-set fetch fix

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -853,7 +853,7 @@ wheels = [
 [[package]]
 name = "deriva"
 version = "2.0.0.dev0"
-source = { git = "https://github.com/informatics-isi-edu/deriva-py?branch=deriva-ml#31784c87dca8df702d8e9c72f102aeb59b8558fe" }
+source = { git = "https://github.com/informatics-isi-edu/deriva-py?branch=deriva-ml#f3f988920cf127ae87e824316947c942b2030557" }
 dependencies = [
     { name = "bdbag" },
     { name = "fair-identifiers-client" },


### PR DESCRIPTION
Advances the locked deriva-py commit `31784c8` → `f3f9889` to include the merged O(n²) fix ([deriva-py#272](https://github.com/informatics-isi-edu/deriva-py/pull/272)).

Without this bump, a fresh `uv sync` installs deriva-py without the fix, so deriva-ml's Format-B bag generation would still be O(n²). With it, the live 2-277G `build_bag` drops from ~1120s to ~325s (3.4×), recovering the regression to ~the original deep-join baseline while keeping the one-clean-CSV-per-table portability win.

`uv.lock`-only change. Bag/reachability unit suites green (23 passed / 1 skipped).

Resolves the consumer side of [deriva-py#270](https://github.com/informatics-isi-edu/deriva-py/issues/270).

🤖 Generated with [Claude Code](https://claude.com/claude-code)