### PR TITLE
fix(snapshot): validate reused schema against catalog (fixes 409 on pre-migration snapshot bag download)

### DIFF
--- a/src/deriva_ml/core/base.py
+++ b/src/deriva_ml/core/base.py
@@ -473,12 +473,29 @@ class DerivaML(
         self.catalog = server.connect_ermrest(catalog_id)
 
         if reuse_schema_json is not None:
-            # Caller (catalog_snapshot) handed us a schema already parsed
-            # by the live instance — a snapshot's schema is structurally
-            # identical to live, so re-fetching /schema is pure waste.
-            # Skip the getCatalogSchema() round-trip and the offline-cache
-            # write (the live instance already wrote it).
-            schema_json = reuse_schema_json
+            # Caller (catalog_snapshot) handed us a schema parsed by the live
+            # instance. It is USUALLY identical to this catalog's schema, but
+            # NOT always: a snapshot pinned to a snaptime that predates a
+            # schema migration has a different schema than the live instance
+            # the reuse came from. Trusting the reused dict blindly would put
+            # tables in the model that this (snapshot) catalog does not have,
+            # and a later pathBuilder query against the snapshot would 409.
+            #
+            # So VALIDATE: fetch this catalog's own /schema. getCatalogSchema
+            # is ETag-revalidated (a cheap 304 when the snapshot schema equals
+            # live — the common case), and a real fetch only when they genuinely
+            # differ — exactly when reuse would be incorrect. Use the catalog's
+            # real schema so the model always matches the catalog it queries.
+            actual_schema = self.catalog.getCatalogSchema()
+            if actual_schema == reuse_schema_json:
+                schema_json = reuse_schema_json
+            else:
+                logger.info(
+                    "reuse_schema_json differs from the connected catalog's "
+                    "schema (likely a snapshot predating a schema change); "
+                    "using the catalog's own schema instead"
+                )
+                schema_json = actual_schema
         else:
             # Fetch the live schema. deriva-py caches the parsed dict on
             # the catalog instance and auto-invalidates on schema-mutating

--- a/tests/core/test_catalog_snapshot_schema_reuse.py
+++ b/tests/core/test_catalog_snapshot_schema_reuse.py
@@ -28,10 +28,18 @@ def test_live_instance_retains_schema_json(live_ml):
     assert "schemas" in live_ml._schema_json
 
 
-def test_init_online_skips_fetch_when_schema_supplied(live_ml, monkeypatch):
-    """When reuse_schema_json is supplied, _init_online does not call getCatalogSchema()."""
-    # Build a second instance against the same catalog, supplying the
-    # already-parsed schema; assert getCatalogSchema is never called.
+def test_init_online_validates_reused_schema_against_catalog(live_ml, monkeypatch):
+    """When reuse_schema_json is supplied, _init_online validates it against the
+    catalog's actual schema rather than trusting it blindly.
+
+    The reuse fast-path used to adopt reuse_schema_json unconditionally,
+    skipping getCatalogSchema() entirely. That is unsafe for a snapshot whose
+    schema differs from the live instance's (e.g. a snapshot taken before a
+    schema migration): the model would carry tables the snapshot catalog
+    doesn't have, and a pathBuilder query against the snapshot 409s. The fix
+    revalidates via getCatalogSchema (ETag-cheap) so the model matches the
+    catalog. So exactly one revalidation request is expected — not zero.
+    """
     from deriva.core.ermrest_catalog import ErmrestCatalog
 
     calls = {"n": 0}
@@ -51,16 +59,99 @@ def test_init_online_skips_fetch_when_schema_supplied(live_ml, monkeypatch):
         credential=live_ml.credential,
         reuse_schema_json=live_ml._schema_json,
     )
-    assert calls["n"] == 0, "getCatalogSchema must not be called when schema is reused"
+    # The model must come from the catalog's real schema (validated), not from
+    # blindly trusting the reused dict. One revalidation fetch is correct.
+    assert calls["n"] >= 1, (
+        "reused schema must be validated against the catalog (getCatalogSchema "
+        "called at least once), not adopted blindly"
+    )
+
+
+def test_init_online_model_matches_catalog_not_stale_reuse(live_ml, monkeypatch):
+    """REGRESSION: a reused schema that DIFFERS from the catalog must not win.
+
+    Reproduces the snapshot-predates-migration bug: the caller hands a reused
+    schema containing a table the connected catalog does NOT have. The built
+    model must reflect the CATALOG (table absent), not the stale reused dict
+    (table present) — otherwise a later pathBuilder query 409s on a table the
+    snapshot lacks.
+    """
+    import copy
+
+    from deriva.core.ermrest_catalog import ErmrestCatalog
+
+    real = ErmrestCatalog.getCatalogSchema
+    # The catalog's REAL schema (what the server returns).
+    catalog_schema = real(live_ml.catalog)
+    ml_schema_name = live_ml.ml_schema
+    assert "_PhantomTable_" not in catalog_schema["schemas"][ml_schema_name]["tables"]
+
+    # A STALE reused schema: same as live PLUS a phantom table the catalog
+    # does not have (simulating a table added after this snapshot's snaptime).
+    # Build a MINIMAL valid table definition (RID column only, no foreign
+    # keys) so it parses cleanly — copying an existing table would duplicate
+    # its FK constraint names and crash the parser before the assertion.
+    stale = copy.deepcopy(catalog_schema)
+    phantom = {
+        "schema_name": ml_schema_name,
+        "table_name": "_PhantomTable_",
+        "kind": "table",
+        "column_definitions": [
+            {"name": "RID", "type": {"typename": "ermrest_rid"}, "nullok": False},
+        ],
+        "keys": [{"unique_columns": ["RID"], "names": [[ml_schema_name, "_PhantomTable__RIDkey"]]}],
+        "foreign_keys": [],
+        "annotations": {},
+        "comment": None,
+    }
+    stale["schemas"][ml_schema_name]["tables"]["_PhantomTable_"] = phantom
+
+    monkeypatch.setattr(ErmrestCatalog, "getCatalogSchema", real)
+
+    instance = DerivaML(
+        live_ml.host_name,
+        live_ml.catalog_id,
+        working_dir=live_ml.working_dir,
+        ml_schema=live_ml.ml_schema,
+        credential=live_ml.credential,
+        reuse_schema_json=stale,
+    )
+    # The model must match the catalog (no phantom), proving the stale reuse
+    # was validated/discarded — not trusted.
+    model_tables = set(instance.model.model.schemas[ml_schema_name].tables)
+    assert "_PhantomTable_" not in model_tables, (
+        "stale reused schema's phantom table leaked into the model — reuse was "
+        "trusted blindly instead of validated against the catalog (the bug)"
+    )
 
 
 def _a_snapshot_id(live_ml):
-    """Resolve a real snapshot id from the live catalog's current snaptime."""
-    return live_ml.catalog.get("/").json()["snaptime"]
+    """Resolve a real snapshot id in the COMPOUND ``<catalog_id>@<snaptime>``
+    form that production (``_version_snapshot_catalog_id``) always uses.
+
+    A bare snaptime has no ``@``, so deriva-py would treat it as a *catalog
+    id* and connect to a non-existent catalog — which only appeared to work
+    before because the old code never queried ``/schema`` on that bogus
+    connection. The schema-validation fix does query it, so the id must be
+    the real compound form.
+    """
+    raw = live_ml.catalog.get("/").json()["snaptime"]
+    # catalog_id may already be compound (e.g. on a snapshot-derived
+    # instance); use only the bare catalog id portion to avoid a double "@".
+    bare_catalog_id = str(live_ml.catalog_id).split("@", 1)[0]
+    return f"{bare_catalog_id}@{raw}"
 
 
-def test_catalog_snapshot_does_no_schema_fetch(live_ml, monkeypatch):
-    """catalog_snapshot() builds the snapshot instance with zero getCatalogSchema calls."""
+def test_catalog_snapshot_validates_schema_against_snapshot(live_ml, monkeypatch):
+    """catalog_snapshot() validates the reused schema against the snapshot.
+
+    The reused schema is no longer trusted blindly — it is validated against
+    the snapshot catalog's own /schema (ETag-cheap: a 304 when the snapshot
+    schema equals live). So a single getCatalogSchema call is expected on the
+    snapshot, not zero. This is the correctness-over-zero-fetch tradeoff: a
+    snapshot predating a schema migration would otherwise get a model that
+    doesn't match its catalog.
+    """
     from deriva.core.ermrest_catalog import ErmrestCatalog
 
     calls = {"n": 0}
@@ -74,7 +165,7 @@ def test_catalog_snapshot_does_no_schema_fetch(live_ml, monkeypatch):
 
     snap = live_ml.catalog_snapshot(_a_snapshot_id(live_ml))
     assert snap is not None
-    assert calls["n"] == 0, "catalog_snapshot must not fetch /schema"
+    assert calls["n"] >= 1, "catalog_snapshot must validate the reused schema against the snapshot"
 
 
 def test_catalog_snapshot_memoized_per_id(live_ml):
@@ -110,11 +201,9 @@ def test_reused_schema_model_matches_fetched(live_ml):
     """The schema-reusing snapshot model is structurally identical to a fetched one."""
     from deriva.core.ermrest_catalog import ErmrestSnapshot
 
-    raw_snaptime = _a_snapshot_id(live_ml)
-    # catalog_snapshot expects the compound "<catalog_id>@<snaptime>" form
-    # (what _version_snapshot_catalog_id produces in production); a bare
-    # snaptime has no '@' and deriva-py would treat it as a catalog id.
-    compound_sid = f"{live_ml.catalog_id}@{raw_snaptime}"
+    # _a_snapshot_id already returns the compound "<catalog_id>@<snaptime>"
+    # form that catalog_snapshot / _version_snapshot_catalog_id expect.
+    compound_sid = _a_snapshot_id(live_ml)
 
     reused = live_ml.catalog_snapshot(compound_sid)
 
@@ -302,8 +391,8 @@ def test_model_built_wrapper_writes_reach_catalog(populated_catalog):
 
 def test_snapshot_pathbuilder_reads_are_snapshot_pinned(live_ml):
     """A snapshot instance's pathBuilder routes data reads to the @snaptime URI."""
-    raw = _a_snapshot_id(live_ml)
-    compound = f"{live_ml.catalog_id}@{raw}"
+    # _a_snapshot_id already returns the compound form.
+    compound = _a_snapshot_id(live_ml)
     snap = live_ml.catalog_snapshot(compound)
     pb = snap.pathBuilder()
     base = pb._wrapped_catalog._server_uri


### PR DESCRIPTION
## The bug

A dataset bag download fails with an ERMrest **409** when the dataset version's snapshot **predates a schema migration**. Reported symptom: `Dataset_Subject table not found` during `download_dataset_bag` against an eye-ai version snapshot.

## Root cause

`catalog_snapshot` builds the snapshot `DerivaML` instance by **reusing the live instance's parsed `schema_json`** (a perf optimization — avoids re-fetching `/schema`). `_init_online` adopted that reused schema **unconditionally**.

That's unsafe when the snapshot's snaptime predates a schema change: `Dataset_Subject` was added to the eye-ai schema *after* some dataset-version snapshots were taken. So the snapshot instance ends up with:
- a **model** (from the reused *live* schema) that **includes `Dataset_Subject`**, but
- a **catalog** pinned to a snaptime that **does not have `Dataset_Subject`**.

`_exclude_empty_associations` then enumerates `find_associations()` from the live model (sees `Dataset_Subject`) and queries the snapshot path for it → **409**, failing the whole download. This is a documented-but-unguarded precondition of `catalog_snapshot` ("do not use for a snapshot taken before a schema migration").

## The fix

Validate the reused schema against the catalog's own `/schema` in `_init_online`. `getCatalogSchema()` is **ETag-revalidated** — a cheap 304 when the snapshot schema equals live (the common case), and a real fetch only when they genuinely differ (exactly when reuse would be wrong). The model is built from the catalog's real schema, so it always matches the catalog it queries. This fixes the failing site **and every other consumer** that mixes the snapshot's model with its catalog (the walk, estimate, bag fetch).

Trades the absolute "zero `/schema` fetch on snapshot" guarantee — which was never safe for pre-migration snapshots — for correctness. The optimization's real benefit (cheap-when-matching) is preserved via ETag.

## Tests

- **`test_init_online_model_matches_catalog_not_stale_reuse`** (new): a reused schema carrying a phantom table absent from the catalog must NOT leak into the model. Fails on the old code (phantom leaks), passes after.
- **`test_init_online_validates_reused_schema_against_catalog`** / **`test_catalog_snapshot_validates_schema_against_snapshot`**: updated from "zero getCatalogSchema calls" to "≥1 validation" (the intended new behavior).
- `test_reused_schema_model_matches_fetched` still passes (matching case unaffected).
- Also fixed `_a_snapshot_id` + two call sites that double-wrapped the compound `<catalog_id>@<snaptime>` id — a latent test bug exposed once the fix actually queries the snapshot's `/schema`.

Full snapshot-reuse + estimate-schema-count + bag/reachability suites green (45 passed). The 4 ruff errors in base.py are pre-existing (`Workspace`/`pd` forward-refs on untouched lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)