### PR TITLE
feat(bag): MINID download spec emits Format-B rid-set processors (#305)

### DIFF
--- a/src/deriva_ml/dataset/bag_builder.py
+++ b/src/deriva_ml/dataset/bag_builder.py
@@ -261,6 +261,26 @@ class DatasetBagBuilder:
         holds: any future change to the bag pipeline's walker is
         immediately reflected here.
 
+        **Format B (issue #305).** The spec is generated with the
+        per-table reachable RID sets, so its non-vocab CSV
+        processors are rid-set processors — one clean
+        ``data/{schema}/{table}.csv`` per reached table — identical
+        to what :meth:`build_bag` (the direct-download arm)
+        produces. This unifies the MINID / server-export bag format
+        with the directly-downloaded format: the two arms now drive
+        the same upstream emission with the same ``rid_sets`` map.
+
+        Server dependency: rid-set CSV processors are honored by the
+        deriva-py client (:meth:`get_as_file(rid_set=...)`) but
+        require the ERMrest export *service* to support rid-set
+        processors as well. Until the server gains that support,
+        live MINID downloads against the production export service
+        will fail; the directly-downloaded (``build_bag``) arm,
+        which runs the client engine locally, is unaffected. The
+        spec's content hash changes with this format, so any
+        cached MINID with the old (Format-A) hash regenerates
+        automatically — see ``get_dataset_minid``'s spec-hash gate.
+
         Args:
             dataset: The dataset to generate the spec for. Must
                 expose ``dataset_rid``.
@@ -268,7 +288,13 @@ class DatasetBagBuilder:
         Returns:
             The export-engine spec dict.
         """
-        builder = self._catalog_bag_builder(dataset=dataset)
+        # Compute the per-table reachable RID sets so the upstream
+        # engine emits one rid-set csv processor per non-vocab reached
+        # table (Format B) — matching the direct-download arm
+        # (:meth:`build_bag`) — instead of one csv processor per FK
+        # path (Format A).
+        rid_sets = self._compute_rid_sets(dataset).rid_sets
+        builder = self._catalog_bag_builder(dataset=dataset, rid_sets=rid_sets)
         spec = builder.get_export_spec()
 
         # Pull the bag-pipeline catalog block — we keep its

--- a/tests/dataset/test_bag_builder.py
+++ b/tests/dataset/test_bag_builder.py
@@ -25,11 +25,10 @@ the design and the verified-equivalence record.
 from __future__ import annotations
 
 import pytest
-
 from deriva.bag.anchors import RIDAnchor
 from deriva.bag.traversal import FKTraversalPolicy, VocabExport
-from deriva_ml.dataset.bag_builder import DatasetBagBuilder
 
+from deriva_ml.dataset.bag_builder import DatasetBagBuilder
 
 # ---------------------------------------------------------------------------
 # Spec smoke tests — confirm the new spec generator is callable
@@ -46,9 +45,7 @@ class TestSpecSmoke:
     failure.
     """
 
-    def test_spec_runs_without_error(
-        self, catalog_with_datasets
-    ) -> None:
+    def test_spec_runs_without_error(self, catalog_with_datasets) -> None:
         """``generate_dataset_download_spec`` produces a dict with the right keys."""
         ml, _ = catalog_with_datasets
         datasets = list(ml.find_datasets())
@@ -56,9 +53,7 @@ class TestSpecSmoke:
             pytest.skip("Need at least one dataset.")
         dataset = ml.lookup_dataset(datasets[0].dataset_rid)
 
-        spec = DatasetBagBuilder(
-            ml_instance=ml
-        ).generate_dataset_download_spec(dataset)
+        spec = DatasetBagBuilder(ml_instance=ml).generate_dataset_download_spec(dataset)
         assert "env" in spec
         assert "bag" in spec
         assert "catalog" in spec
@@ -66,23 +61,75 @@ class TestSpecSmoke:
         assert spec["env"]["RID"] == "{RID}"
         assert "query_processors" in spec["catalog"]
 
-    def test_annotations_run_without_error(
-        self, catalog_with_datasets
-    ) -> None:
+    def test_spec_emits_format_b_rid_set_processors(self, catalog_with_datasets) -> None:
+        """``generate_dataset_download_spec`` emits Format-B rid-set processors.
+
+        Issue #305: the MINID / server-export download spec must match
+        the directly-downloaded (``build_bag``) bag format — one clean
+        ``data/{schema}/{table}.csv`` per reached table, driven by a
+        rid-set csv processor (``processor_params`` carries
+        ``rid_table`` + ``rid_set``), not the legacy Format-A
+        per-FK-path emission (``processor_params`` carries a
+        join-chain ``query_path``).
+
+        Vocabulary tables are the one exception: under the default
+        ``VocabExport.FULL`` policy they keep a full-export
+        ``/entity/{schema}:{table}`` csv processor (vocabs are
+        referenced by Name, not RID, so a reachability map carries no
+        RID set for them). That is exactly what ``build_bag`` produces
+        too — both arms drive the same upstream emission with the same
+        ``rid_sets`` map.
+
+        So the contract pinned here is: at least one rid-set processor
+        exists, and **every non-vocab-full csv processor is a rid-set
+        processor** — no non-vocab FK-path ``query_path`` survives.
+        """
+        ml, _ = catalog_with_datasets
+        datasets = list(ml.find_datasets())
+        if not datasets:
+            pytest.skip("Need at least one dataset.")
+        dataset = ml.lookup_dataset(datasets[0].dataset_rid)
+
+        spec = DatasetBagBuilder(ml_instance=ml).generate_dataset_download_spec(dataset)
+
+        csv_processors = [qp for qp in spec["catalog"]["query_processors"] if qp.get("processor") == "csv"]
+        assert csv_processors, "Spec must contain at least one csv processor."
+
+        rid_set_processors = [qp for qp in csv_processors if "rid_set" in qp["processor_params"]]
+        assert rid_set_processors, (
+            "Format-B spec must contain at least one rid-set csv processor (one per non-vocab reached table)."
+        )
+
+        # The only csv processors allowed to keep a ``query_path`` are
+        # the full-vocab exports: a bare ``/entity/{schema}:{table}``
+        # with no FK-join chain. A ``query_path`` that contains a path
+        # join ("/" after the table segment) is a Format-A leftover.
+        for qp in csv_processors:
+            params = qp["processor_params"]
+            if "rid_set" in params:
+                assert "rid_table" in params, f"rid-set processor missing rid_table: {params!r}"
+                continue
+            query_path = params.get("query_path", "")
+            assert query_path.startswith("/entity/"), (
+                f"non-rid-set csv processor is not a vocab-full export: {params!r}"
+            )
+            # Full-vocab export is ``/entity/{schema}:{table}`` — a
+            # single segment after ``/entity/``. Anything longer is an
+            # FK-path join (Format A).
+            entity_tail = query_path[len("/entity/") :]
+            assert "/" not in entity_tail, f"csv processor carries a Format-A FK-path query_path: {params!r}"
+
+    def test_annotations_run_without_error(self, catalog_with_datasets) -> None:
         """``generate_dataset_download_annotations`` produces a dict with the right keys."""
         ml, _ = catalog_with_datasets
-        ann = DatasetBagBuilder(
-            ml_instance=ml
-        ).generate_dataset_download_annotations()
+        ann = DatasetBagBuilder(ml_instance=ml).generate_dataset_download_annotations()
         from deriva.core.utils.core_utils import tag as deriva_tags
 
         assert deriva_tags.export_fragment_definitions in ann
         assert deriva_tags.visible_foreign_keys in ann
         assert deriva_tags.export_2019 in ann
 
-    def test_aggregate_queries_runs_without_error(
-        self, catalog_with_datasets
-    ) -> None:
+    def test_aggregate_queries_runs_without_error(self, catalog_with_datasets) -> None:
         """``aggregate_queries`` produces a non-empty dict for a real dataset."""
         ml, _ = catalog_with_datasets
         datasets = list(ml.find_datasets())
@@ -113,15 +160,12 @@ class TestAnchorsAndPolicy:
     from here.
     """
 
-    def test_anchors_for_dataset_no_children(
-        self, catalog_with_datasets
-    ) -> None:
+    def test_anchors_for_dataset_no_children(self, catalog_with_datasets) -> None:
         """A dataset with no nested children yields a single anchor."""
         ml, _ = catalog_with_datasets
         datasets = list(ml.find_datasets())
         if not datasets:
             pytest.skip("Need at least one dataset.")
-        dataset = ml.lookup_dataset(datasets[0].dataset_rid)
         # Pick the first dataset that has no children; if all
         # datasets in the fixture have children, skip.
         candidate = None
@@ -132,8 +176,7 @@ class TestAnchorsAndPolicy:
                 break
         if candidate is None:
             pytest.skip(
-                "Need a dataset with no children to test the single-"
-                "anchor path; fixture has only nested datasets."
+                "Need a dataset with no children to test the single-anchor path; fixture has only nested datasets."
             )
 
         builder = DatasetBagBuilder(ml_instance=ml)
@@ -156,9 +199,7 @@ class TestAnchorsAndPolicy:
         assert isinstance(policy, FKTraversalPolicy)
         assert policy.vocab_export is VocabExport.FULL
 
-    def test_build_policy_respects_vocab_export_override(
-        self, catalog_with_datasets
-    ) -> None:
+    def test_build_policy_respects_vocab_export_override(self, catalog_with_datasets) -> None:
         """``vocab_export=REFERENCED_ONLY`` flows through to the policy."""
         ml, _ = catalog_with_datasets
         datasets = list(ml.find_datasets())
@@ -166,14 +207,10 @@ class TestAnchorsAndPolicy:
             pytest.skip("Need at least one dataset.")
         dataset = ml.lookup_dataset(datasets[0].dataset_rid)
         builder = DatasetBagBuilder(ml_instance=ml)
-        policy = builder.build_policy(
-            dataset, vocab_export=VocabExport.REFERENCED_ONLY
-        )
+        policy = builder.build_policy(dataset, vocab_export=VocabExport.REFERENCED_ONLY)
         assert policy.vocab_export is VocabExport.REFERENCED_ONLY
 
-    def test_build_policy_marks_execution_workflow_terminal(
-        self, catalog_with_datasets
-    ) -> None:
+    def test_build_policy_marks_execution_workflow_terminal(self, catalog_with_datasets) -> None:
         """Execution and Workflow are terminal so the walk doesn't fan
         out across the catalog provenance graph (the 2-277G 18-min hang)."""
         ml, _ = catalog_with_datasets
@@ -186,9 +223,7 @@ class TestAnchorsAndPolicy:
         assert ("deriva-ml", "Execution") in policy.terminal_tables
         assert ("deriva-ml", "Workflow") in policy.terminal_tables
 
-    def test_build_policy_includes_user_exclude_tables(
-        self, catalog_with_datasets
-    ) -> None:
+    def test_build_policy_includes_user_exclude_tables(self, catalog_with_datasets) -> None:
         """User-supplied ``exclude_tables`` make it into the policy."""
         ml, _ = catalog_with_datasets
         datasets = list(ml.find_datasets())
@@ -201,22 +236,15 @@ class TestAnchorsAndPolicy:
         # Dataset is always present; using it is harmless because
         # the user-exclude logic only flags it, not removes Dataset
         # from the walk (the anchor still pins it).
-        builder = DatasetBagBuilder(
-            ml_instance=ml, exclude_tables={"Dataset"}
-        )
+        builder = DatasetBagBuilder(ml_instance=ml, exclude_tables={"Dataset"})
         policy = builder.build_policy(dataset)
         # We don't assert the exact set — Dataset_Version etc. may
         # also land in policy.exclude_tables via the empty-
         # association filter. We just assert the user's input made
         # it in.
-        assert any(
-            table_name == "Dataset"
-            for _schema, table_name in policy.exclude_tables
-        )
+        assert any(table_name == "Dataset" for _schema, table_name in policy.exclude_tables)
 
-    def test_walk_excludes_execution_asset_closure(
-        self, catalog_with_datasets
-    ) -> None:
+    def test_walk_excludes_execution_asset_closure(self, catalog_with_datasets) -> None:
         """With Execution terminal, aggregate_queries reaches Execution
         (provenance link) and member/feature tables, but NOT the
         Execution_Asset closure the inbound fan-out used to pull in."""


### PR DESCRIPTION
Closes #305.

## What

Unifies the MINID / server-export bag format with the directly-downloaded (`build_bag`) bag format. `DatasetBagBuilder.generate_dataset_download_spec` now computes the per-table reachable RID sets (`_compute_rid_sets(dataset).rid_sets`) and threads them into `_catalog_bag_builder(dataset=dataset, rid_sets=rid_sets)`, so the download spec's non-vocab CSV processors are **rid-set processors** — one clean `data/{schema}/{table}.csv` per reached table (Format B) — exactly what `build_bag` already produces.

Before this change the MINID arm emitted **Format A** (one CSV per FK path, requiring union-by-basename + dedup-by-RID at load time); the directly-downloaded arm emitted **Format B**. The two formats are now the same single code path — both drive the same upstream `CatalogBagBuilder` emission with the same `rid_sets` map. The Format-A fork is gone.

## Scope decision

Per the issue, the change is **unconditional** — no gating flag. The two MINID call sites (`create_dataset_minid`, `get_dataset_minid` in `bag_download.py`) need **no change**: they call `generate_dataset_download_spec(dataset)` unchanged and pick up Format B automatically.

## Consequences

- **Server dependency.** rid-set CSV processors are honored by the deriva-py *client* (`get_as_file(rid_set=...)`, which chunks the RID set and appends to one CSV), but they require the ERMrest export *service* to support rid-set processors as well. Until the server lands that support, **live MINID downloads against the production export service will fail**. The directly-downloaded (`build_bag`) arm runs the client engine locally and is unaffected — this is the arm exercised by the green `test_download.py` suite below.
- **Auto-migration, no manual reset.** The spec's content hash (`Minid_Spec_Hash`) changes with the new format, so any cached MINID carrying the old (Format-A) hash regenerates automatically via `get_dataset_minid`'s spec-hash gate.

> ⚠️ Note for the server-side implementer (flagged on #305): the client's `get_as_file` chunks long `RID=any(...)` URLs (500 RIDs/chunk) to stay under URL-length limits. A server-side rid-set processor must implement the same URL-length handling — the client chunking does not run server-side.

## Tests

New pin: `tests/dataset/test_bag_builder.py::TestSpecSmoke::test_spec_emits_format_b_rid_set_processors` — asserts every non-vocab-full csv processor in the download spec is a rid-set processor (no FK-path `query_path` survives); vocab tables keep their full-export `/entity/{schema}:{table}` query_path, as `build_bag` does too. Written TDD-first (confirmed red against the old Format-A behavior, green after the fix).

Green locally against `DERIVA_HOST=localhost`:
- `tests/dataset/test_bag_builder.py` — 10 passed
- `tests/dataset/test_download.py` — 11 passed (full client-side download/materialize/load pipeline: nested, recursive, versioned, multi-schema)
- `tests/dataset/test_format_b_bag.py` + `tests/dataset/test_get_dataset_minid_helpers.py` — 22 passed (incl. the live one-CSV-per-table round-trip and the spec-hash regeneration helpers)

Also drive-by: removed a dead `dataset = ml.lookup_dataset(...)` local and fixed import ordering in the test file (both pre-existing ruff failures in the file being edited).

🤖 Generated with [Claude Code](https://claude.com/claude-code)