### PR TITLE
fix(bag): client-side bag staging moves off working_dir into a cache_dir TemporaryDirectory

### DIFF
--- a/docs/superpowers/plans/2026-06-15-client-bag-staging-tmpdir.md
+++ b/docs/superpowers/plans/2026-06-15-client-bag-staging-tmpdir.md
@@ -1,0 +1,535 @@
+# Client-side bag staging → cache_dir + TemporaryDirectory Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the client-side dataset-bag build stage into `cache_dir` inside a `TemporaryDirectory`, extract into the cache itself, and return the final cache path — eliminating the `working_dir/client_export` spill, the success-only cleanup, and the fragile cross-function `file://` hand-off.
+
+**Architecture:** Factor the extract→validate→atomic-move→`index.record` logic out of `download_dataset_minid` into a shared `_extract_archive_to_cache` helper. Rewrite `create_dataset_minid`'s `use_minid=False` arm to build into `TemporaryDirectory(dir=cache_dir)` and call that helper itself, returning the final cache path. Wrap the result as a `DatasetMinid` in `get_dataset_minid` Tier 3 so the downstream `download_dataset_minid` call becomes a cache-hit no-op. Delete the now-dead `file://`-archive and legacy `DerivaExport.retrieve_file` branches.
+
+**Tech Stack:** Python 3.12, `uv`, pytest, `tempfile.TemporaryDirectory`, deriva-py `bdb`/`BagCacheIndex`.
+
+**Spec:** `docs/superpowers/specs/2026-06-15-client-bag-staging-tmpdir-design.md`
+
+---
+
+### Task 1: Extract `_extract_archive_to_cache` helper (pure refactor, no behavior change)
+
+Factor the extract→validate→atomic-move→`index.record` body out of `download_dataset_minid` into a free function. `download_dataset_minid`'s S3 arm calls it. No behavior change yet — this is a safe, separately-verifiable refactor.
+
+**Files:**
+- Modify: `src/deriva_ml/dataset/bag_download.py`
+- Test: `tests/dataset/test_extract_archive_to_cache.py` (new)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+"""Unit tests for _extract_archive_to_cache (client-bag staging refactor).
+
+The helper owns the atomic cache-population dance: extract a bag archive
+into a staging dir, validate, atomically rename into the checksum-keyed
+cache location, and record in the BagCacheIndex. Both the S3 arm and the
+client arm of the download path call it.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from deriva_ml.dataset.bag_download import _extract_archive_to_cache
+
+
+def test_extract_archive_to_cache_atomic_move_and_record(tmp_path):
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+
+    # Fake index: bag_dir_for returns a checksum-keyed dir under cache_dir.
+    bag_root = cache_dir / "bags" / "deadbeef_2-SNAP"
+    index = MagicMock()
+    index.bag_dir_for.return_value = bag_root
+
+    # bdb.extract_bag creates the staging dir contents; we simulate it by
+    # making the directory it is handed and returning that path.
+    def fake_extract(archive, dest):
+        Path(dest).mkdir(parents=True, exist_ok=True)
+        (Path(dest) / "bag-info.txt").write_text("ok")
+        return dest
+
+    with (
+        patch("deriva_ml.dataset.bag_download.bdb.extract_bag", side_effect=fake_extract),
+        patch("deriva_ml.dataset.bag_download.bdb.validate_bag_structure"),
+    ):
+        result = _extract_archive_to_cache(
+            index=index,
+            archive_path="/tmp/whatever.zip",
+            checksum="deadbeef_2-SNAP",
+            dataset_rid="2-ABCD",
+            dataset_version="1.0.0",
+        )
+
+    # Returns the bag dir inside the cache root.
+    assert result == bag_root / "Dataset_2-ABCD"
+    # The checksum-keyed cache dir now exists (atomic move happened).
+    assert bag_root.exists()
+    # Index recorded the bag under the Dataset anchor + version summary.
+    index.record.assert_called_once()
+    _, kwargs = index.record.call_args
+    assert kwargs["checksum"] == "deadbeef_2-SNAP"
+    assert kwargs["anchors"] == [("Dataset", "2-ABCD")]
+    assert kwargs["anchor_summary"] == {"version": "1.0.0"}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/carl/GitHub/DerivaML/deriva-ml && DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/dataset/test_extract_archive_to_cache.py -q`
+Expected: FAIL with `ImportError: cannot import name '_extract_archive_to_cache'`.
+
+- [ ] **Step 3: Write the helper and route the S3 arm through it**
+
+Add the free function (near `download_dataset_minid`). Move the staging→validate→rename→record body verbatim into it. Note the helper takes the `BagCacheIndex` and **does not** dispose it (the caller owns the index lifecycle, matching the existing `try/finally index.dispose()` placement).
+
+```python
+def _extract_archive_to_cache(
+    index: "BagCacheIndex",
+    archive_path: str,
+    checksum: str,
+    dataset_rid: str,
+    dataset_version: str,
+) -> Path:
+    """Extract a bag archive into the checksum-keyed cache, atomically.
+
+    Extracts ``archive_path`` into a staging directory, validates the BDBag
+    structure, atomically renames the staging dir to its final cache location
+    (``{cache_root}/bags/{checksum}/Dataset_{rid}``), and records the bag in
+    ``index`` so the next Tier-1 lookup finds it. The atomic rename prevents
+    partial/corrupt cache entries if the process crashes mid-extract.
+
+    The caller owns ``index``'s lifecycle (this function does not dispose it).
+
+    Args:
+        index: Open BagCacheIndex rooted at the cache dir.
+        archive_path: Path to the bag zip archive to extract.
+        checksum: Deterministic cache key (``{spec_hash[:16]}_{snapshot}``)
+            or SHA-256 of the archive.
+        dataset_rid: Dataset RID, for the cache dir name and index anchor.
+        dataset_version: Dataset version string, for the index anchor summary.
+
+    Returns:
+        Path to the extracted bag directory inside the cache.
+
+    Example:
+        >>> # Illustrative — requires a live index + archive.
+        >>> path = _extract_archive_to_cache(idx, "/tmp/b.zip", "ab_S", "2-X", "1.0.0")  # doctest: +SKIP
+    """
+    bag_root = index.bag_dir_for(checksum)
+    bag_dir = bag_root / f"Dataset_{dataset_rid}"
+
+    staging_dir = bag_root.parent / f"{bag_root.name}_staging"
+    if staging_dir.exists():
+        shutil.rmtree(staging_dir)
+    staging_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        extracted_bag_path = bdb.extract_bag(archive_path, staging_dir.as_posix())
+        bdb.validate_bag_structure(extracted_bag_path)
+    except Exception:
+        shutil.rmtree(staging_dir, ignore_errors=True)
+        raise
+
+    bag_root.parent.mkdir(parents=True, exist_ok=True)
+    staging_dir.rename(bag_root)
+
+    index.record(
+        checksum=checksum,
+        anchors=[("Dataset", dataset_rid)],
+        anchor_summary={"version": str(dataset_version)},
+    )
+    return bag_dir
+```
+
+Then in `download_dataset_minid`, replace the inline staging/validate/rename/record block (current lines ~215–243) with a call to the helper. The S3 (`use_minid=True`) and the SHA-256-fallback (`not use_minid and not minid.checksum`) paths both still compute `archive_path` and `minid.checksum` as today; only the extraction body is replaced:
+
+```python
+        # (inside download_dataset_minid, after archive_path + minid.checksum resolved)
+        bag_dir = _extract_archive_to_cache(
+            index=index,
+            archive_path=archive_path,
+            checksum=minid.checksum,
+            dataset_rid=minid.dataset_rid,
+            dataset_version=str(minid.dataset_version),
+        )
+    finally:
+        index.dispose()
+    return bag_dir
+```
+
+Keep the `with TemporaryDirectory() as tmp_dir:` wrapping the archive download for the S3/legacy arms. (The `client_export` cleanup block and the `file://`/legacy branches are removed in Task 3, not here — Task 1 stays behavior-preserving for the S3 arm.)
+
+- [ ] **Step 4: Run the test + existing download tests**
+
+Run: `cd /Users/carl/GitHub/DerivaML/deriva-ml && DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/dataset/test_extract_archive_to_cache.py tests/dataset/test_get_dataset_minid_helpers.py tests/dataset/test_bag_materialize.py -q`
+Expected: PASS (new helper test green; existing dispatch/materialize tests unaffected).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml
+git add src/deriva_ml/dataset/bag_download.py tests/dataset/test_extract_archive_to_cache.py
+git commit -m "refactor(bag): extract _extract_archive_to_cache helper (no behavior change)"
+```
+
+---
+
+### Task 2: Client arm builds into TemporaryDirectory(dir=cache_dir) and extracts itself
+
+Rewrite `create_dataset_minid`'s `use_minid=False` branch so it builds the zip under `TemporaryDirectory(dir=cache_dir)`, extracts into the cache via the Task-1 helper, and returns the **final cache path** instead of a `file://` zip URI.
+
+**Files:**
+- Modify: `src/deriva_ml/dataset/bag_download.py` (the `else` arm of `create_dataset_minid`, ~lines 344–390)
+- Test: `tests/dataset/test_client_bag_staging.py` (new)
+
+- [ ] **Step 1: Write the failing tests (directory + cleanup-on-failure)**
+
+```python
+"""Client-arm bag staging lives under cache_dir, not working_dir, and is
+always cleaned up (TemporaryDirectory guarantee), even on extract failure.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from deriva_ml.dataset.bag_download import create_dataset_minid
+
+
+def _fake_dataset(tmp_path):
+    ds = MagicMock()
+    ds.dataset_rid = "2-ABCD"
+    ds._ml_instance.cache_dir = tmp_path / "cache"
+    ds._ml_instance.working_dir = tmp_path / "work"
+    ds._ml_instance.cache_dir.mkdir()
+    ds._ml_instance.working_dir.mkdir()
+    ds._ml_instance.s3_bucket = None
+    return ds
+
+
+def test_client_arm_stages_under_cache_dir_not_working_dir(tmp_path):
+    ds = _fake_dataset(tmp_path)
+    captured = {}
+
+    def fake_build_bag(self, dataset, output_dir, timeout=None):
+        captured["output_dir"] = Path(output_dir)
+        zip_path = Path(output_dir) / "Dataset_2-ABCD.zip"
+        zip_path.parent.mkdir(parents=True, exist_ok=True)
+        zip_path.write_text("zip")
+        return zip_path
+
+    with (
+        patch("deriva_ml.dataset.bag_download.DatasetBagBuilder.build_bag", new=fake_build_bag),
+        patch("deriva_ml.dataset.bag_download._extract_archive_to_cache",
+              return_value=ds._ml_instance.cache_dir / "bags" / "x" / "Dataset_2-ABCD"),
+        patch("deriva_ml.dataset.bag_download.BagCacheIndex"),
+    ):
+        result = create_dataset_minid(
+            ds, "1.0.0", use_minid=False, spec={"k": "v"}, spec_hash="deadbeefdeadbeef",
+        )
+
+    # Staging output_dir is under cache_dir, never working_dir.
+    assert ds._ml_instance.cache_dir in captured["output_dir"].parents
+    assert ds._ml_instance.working_dir not in captured["output_dir"].parents
+    # No client_export dir was created under working_dir.
+    assert not (ds._ml_instance.working_dir / "client_export").exists()
+    # Returns the final cache path (not a file:// URI string).
+    assert isinstance(result, Path)
+    assert "bags" in result.parts
+
+
+def test_client_arm_cleans_staging_on_extract_failure(tmp_path):
+    ds = _fake_dataset(tmp_path)
+    leaked = []
+
+    def fake_build_bag(self, dataset, output_dir, timeout=None):
+        leaked.append(Path(output_dir))
+        zip_path = Path(output_dir) / "Dataset_2-ABCD.zip"
+        zip_path.parent.mkdir(parents=True, exist_ok=True)
+        zip_path.write_text("zip")
+        return zip_path
+
+    with (
+        patch("deriva_ml.dataset.bag_download.DatasetBagBuilder.build_bag", new=fake_build_bag),
+        patch("deriva_ml.dataset.bag_download._extract_archive_to_cache",
+              side_effect=RuntimeError("extract boom")),
+        patch("deriva_ml.dataset.bag_download.BagCacheIndex"),
+    ):
+        with pytest.raises(RuntimeError, match="extract boom"):
+            create_dataset_minid(
+                ds, "1.0.0", use_minid=False, spec={"k": "v"}, spec_hash="deadbeefdeadbeef",
+            )
+
+    # The TemporaryDirectory(dir=cache_dir) staging is gone despite the failure.
+    for staging in leaked:
+        assert not staging.exists()
+    # Nothing orphaned under working_dir.
+    assert not (ds._ml_instance.working_dir / "client_export").exists()
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd /Users/carl/GitHub/DerivaML/deriva-ml && DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/dataset/test_client_bag_staging.py -q`
+Expected: FAIL — current code returns a `file://` string and stages under `working_dir/client_export`.
+
+- [ ] **Step 3: Rewrite the client arm**
+
+Replace the `else:` arm of `create_dataset_minid` (the `working_dir/client_export` build + `return zip_path.as_uri()`) with a self-contained build+extract under `TemporaryDirectory(dir=cache_dir)`. The function still returns `str` on the MINID arm (landing-page URL); on the client arm it now returns a `Path` (the cache dir). Update the return annotation to `str | Path` and the docstring.
+
+```python
+        else:
+            # Client-side bag construction: build into a TemporaryDirectory
+            # rooted at cache_dir, then extract straight into the cache. The
+            # staging zip never touches working_dir and is removed on every
+            # exit path (success or exception) by the context manager — no
+            # cross-function file:// hand-off, no manual cleanup.
+            from deriva.bag.cache_index import BagCacheIndex
+
+            version_snapshot_catalog = dataset._version_snapshot_catalog(version)
+            builder = DatasetBagBuilder(
+                ml_instance=version_snapshot_catalog,
+                s3_bucket=dataset._ml_instance.s3_bucket,
+                use_minid=False,
+                exclude_tables=exclude_tables,
+            )
+            cache_suffix = f"{spec_hash[:16]}_{snapshot}"  # see note below
+            cache_dir = Path(dataset._ml_instance.cache_dir)
+            with TemporaryDirectory(dir=cache_dir) as staging:
+                try:
+                    zip_path = builder.build_bag(dataset, output_dir=Path(staging), timeout=timeout)
+                except (
+                    DerivaDownloadError,
+                    DerivaDownloadConfigurationError,
+                    DerivaDownloadAuthenticationError,
+                    DerivaDownloadAuthorizationError,
+                    DerivaDownloadTimeoutError,
+                ) as e:
+                    raise DerivaMLException(
+                        f"Dataset bag export failed: {format_exception(e)}. "
+                        "This typically happens when deep multi-table joins "
+                        "exceed server query time limits. To fix this, add the "
+                        "desired records as direct dataset members using "
+                        "add_dataset_members() with the relevant table's RIDs."
+                    )
+                index = BagCacheIndex(cache_dir)
+                try:
+                    bag_dir = _extract_archive_to_cache(
+                        index=index,
+                        archive_path=str(zip_path),
+                        checksum=cache_suffix,
+                        dataset_rid=dataset.dataset_rid,
+                        dataset_version=str(version),
+                    )
+                finally:
+                    index.dispose()
+            return bag_dir
+```
+
+**Note on `snapshot`/`cache_suffix`:** `create_dataset_minid` currently does not
+have `snapshot` in scope on the client arm. Thread it in: the caller
+`get_dataset_minid` already computes `cache_suffix = f"{spec_hash[:16]}_{snapshot}"`
+(line ~711). Add a `cache_suffix: str | None = None` parameter to
+`create_dataset_minid` and pass `cache_suffix` from the Tier-3 call site (Task 3,
+Step 3). When `cache_suffix` is provided, use it directly instead of
+recomputing; this keeps the cache key identical to what Tier-1 looks up. If
+`cache_suffix is None` (defensive), fall back to deriving it from
+`spec_hash` + the version's snapshot via `_resolve_version_record(dataset, version).snapshot`.
+
+- [ ] **Step 4: Run the new tests**
+
+Run: `cd /Users/carl/GitHub/DerivaML/deriva-ml && DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/dataset/test_client_bag_staging.py -q`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml
+git add src/deriva_ml/dataset/bag_download.py tests/dataset/test_client_bag_staging.py
+git commit -m "feat(bag): client arm stages under cache_dir in a TemporaryDirectory, extracts in place"
+```
+
+---
+
+### Task 3: Wire Tier 3, delete dead branches, prune cleanup
+
+Make `get_dataset_minid` Tier 3 pass `cache_suffix` and wrap the returned cache path as a `DatasetMinid` whose `location` is the extracted dir (so downstream `download_dataset_minid` is a cache-hit no-op). Delete the now-dead `file://`-archive branch, the legacy `DerivaExport.retrieve_file` `else`, and the `client_export` string-matched cleanup in `download_dataset_minid`.
+
+**Files:**
+- Modify: `src/deriva_ml/dataset/bag_download.py` (`get_dataset_minid` Tier-3 call site ~line 610; `download_dataset_minid` branches ~lines 186–250)
+- Test: `tests/dataset/test_get_dataset_minid_helpers.py` (extend Tier-3 assertions)
+
+- [ ] **Step 1: Write/extend the failing test**
+
+```python
+def test_tier3_returns_minid_pointing_at_extracted_cache_dir(tmp_path):
+    """Tier 3 wraps the client arm's returned cache PATH as a DatasetMinid
+    whose location is the already-extracted bag dir, so the downstream
+    download_dataset_minid call is a no-op cache hit (no file:// zip)."""
+    from unittest.mock import MagicMock, patch
+    from deriva_ml.dataset.bag_download import _tier3_client_path
+
+    ds = MagicMock()
+    ds.dataset_rid = "2-ABCD"
+    cache_bag = tmp_path / "cache" / "bags" / "deadbeefdeadbeef_2-SNAP" / "Dataset_2-ABCD"
+    cache_bag.mkdir(parents=True)
+
+    with patch(
+        "deriva_ml.dataset.bag_download.create_dataset_minid",
+        return_value=cache_bag,  # now a Path, not a file:// str
+    ) as mk:
+        minid = _tier3_client_path(
+            ds, version="1.0.0", create=True, minid_url=None,
+            snapshot="2-SNAP", cache_suffix="deadbeefdeadbeef_2-SNAP",
+            spec={"k": "v"}, spec_hash="deadbeefdeadbeef", exclude_tables=None, timeout=None,
+        )
+
+    # create_dataset_minid was given the cache_suffix so its key matches Tier 1.
+    assert mk.call_args.kwargs["cache_suffix"] == "deadbeefdeadbeef_2-SNAP"
+    # The minid location is a file:// URI of the EXTRACTED dir's parent (cache root),
+    # matching the Tier-1 shape so download_dataset_minid hits bag_dir.exists().
+    assert minid.bag_url.startswith("file://")
+    assert "bags" in minid.bag_url
+```
+
+(Adjust `_tier3_client_path`'s real signature to taste — the assertion that matters is: `cache_suffix` is forwarded, and `location` points at the extracted cache dir, not a zip.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd /Users/carl/GitHub/DerivaML/deriva-ml && DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/dataset/test_get_dataset_minid_helpers.py -q`
+Expected: FAIL — Tier 3 currently forwards no `cache_suffix` and wraps a `file://` zip URI.
+
+- [ ] **Step 3: Wire Tier 3 + forward cache_suffix**
+
+In the Tier-3 client path (`_tier3_client_path` / the `create_dataset_minid` call at ~610), pass `cache_suffix=cache_suffix`, take the returned `Path`, and build the `DatasetMinid` with `location=bag_dir.parent.as_uri()` (the cache root for the checksum — same shape Tier-1 produces at line ~497, so `download_dataset_minid`'s top-of-function `bag_dir.exists()` guard returns it immediately).
+
+```python
+    bag_dir = create_dataset_minid(
+        dataset, version, use_minid=False, exclude_tables=exclude_tables,
+        spec=spec, spec_hash=spec_hash, cache_suffix=cache_suffix, timeout=timeout,
+    )
+    return DatasetMinid(
+        dataset_version=version,
+        RID=_build_version_rid(dataset.dataset_rid, snapshot),
+        location=bag_dir.parent.as_uri(),
+        checksums=[{"function": "sha256", "value": cache_suffix}],
+    )
+```
+
+- [ ] **Step 4: Delete dead branches in `download_dataset_minid`**
+
+Remove:
+- the `elif minid.bag_url.startswith("file://"):` archive branch (no producer now — the client arm extracts itself and the only `file://` minids are already-extracted Tier-1/Tier-3 dirs that hit the `bag_dir.exists()` guard at the top),
+- the legacy `else: exporter = DerivaExport(...).retrieve_file(...)` branch (no live producer),
+- the `client_export` string-matched cleanup block (lines ~245–250).
+
+Keep: the Tier-1 `bag_dir.exists()` early return, the S3 (`use_minid=True`) download arm, and the SHA-256-fallback. Remove the now-unused `DerivaExport`/`urlparse` imports if nothing else uses them (grep first).
+
+- [ ] **Step 5: Run full download/minid suite**
+
+Run: `cd /Users/carl/GitHub/DerivaML/deriva-ml && DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/dataset/test_get_dataset_minid_helpers.py tests/dataset/test_extract_archive_to_cache.py tests/dataset/test_client_bag_staging.py tests/dataset/test_bag_materialize.py tests/dataset/test_multi_anchor_bag_cache.py -q`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml
+git add src/deriva_ml/dataset/bag_download.py tests/dataset/test_get_dataset_minid_helpers.py
+git commit -m "refactor(bag): Tier-3 returns extracted cache path; drop dead file:// + legacy branches"
+```
+
+---
+
+### Task 4: Live round-trip + working_dir-clean assertion
+
+Confirm the end-to-end client download still produces a loadable bag in `cache_dir` and leaves `working_dir` free of `client_export`. Needs `DERIVA_HOST=localhost`.
+
+**Files:**
+- Test: `tests/dataset/test_client_bag_staging.py` (add a live test, marked to need a catalog)
+
+- [ ] **Step 1: Write the live test**
+
+```python
+def test_live_client_download_lands_in_cache_not_working_dir(catalog_with_datasets):
+    """End-to-end: cache(use_minid=False) builds a loadable bag under cache_dir
+    and never creates client_export under working_dir."""
+    ml, _ = catalog_with_datasets
+    datasets = list(ml.find_datasets())
+    if not datasets:
+        pytest.skip("Need a dataset.")
+    ds = ml.lookup_dataset(datasets[0].dataset_rid)
+    versions = list(ds.dataset_history())
+    version = str(versions[-1].dataset_version)
+
+    info = ds.cache(version=version, materialize=False)
+    assert info["cache_status"] in ("cached_holey", "cached_materialized")
+    assert info["cache_path"] is not None
+    assert Path(info["cache_path"]).exists()
+    # cache_path is under cache_dir, and working_dir has no client_export.
+    assert Path(ml.cache_dir) in Path(info["cache_path"]).parents
+    assert not (Path(ml.working_dir) / "client_export").exists()
+```
+
+- [ ] **Step 2: Run the live test**
+
+Run: `cd /Users/carl/GitHub/DerivaML/deriva-ml && DERIVA_ML_ALLOW_DIRTY=true DERIVA_HOST=localhost uv run pytest tests/dataset/test_client_bag_staging.py -q`
+Expected: PASS (the unit tests + the live round-trip).
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml
+git add tests/dataset/test_client_bag_staging.py
+git commit -m "test(bag): live client download lands in cache_dir, working_dir stays clean"
+```
+
+---
+
+### Task 5: cache_tui, lint, full sweep, PR
+
+Update the cache TUI's `working_dir` subdir list (it lists `client_export` — now obsolete under working_dir), lint/format, run the broader dataset suite, open the PR.
+
+**Files:**
+- Modify: `src/deriva_ml/cache_tui.py` (drop `client_export` from the working_dir subdir lists at ~276/288, since it no longer lands there)
+- Modify: `docs/superpowers/specs/2026-06-15-client-bag-staging-tmpdir-design.md` (status → Implemented) if desired
+
+- [ ] **Step 1: Update cache_tui**
+
+Remove `"client_export"` from the two `working_dir` subdir lists in `cache_tui.py` (it no longer appears under `working_dir`). Grep to confirm no other `working_dir`-rooted `client_export` reference remains:
+
+Run: `cd /Users/carl/GitHub/DerivaML/deriva-ml && grep -rn "client_export" src/`
+Expected: zero hits in `src/` after this (the staging is anonymous TemporaryDirectory names now).
+
+- [ ] **Step 2: Lint + format**
+
+Run: `cd /Users/carl/GitHub/DerivaML/deriva-ml && uv run ruff check --fix src/deriva_ml/dataset/bag_download.py src/deriva_ml/cache_tui.py tests/dataset/test_extract_archive_to_cache.py tests/dataset/test_client_bag_staging.py && uv run ruff format src/deriva_ml/dataset/bag_download.py src/deriva_ml/cache_tui.py tests/dataset/`
+Expected: clean.
+
+- [ ] **Step 3: Broader dataset suite**
+
+Run: `cd /Users/carl/GitHub/DerivaML/deriva-ml && DERIVA_ML_ALLOW_DIRTY=true DERIVA_HOST=localhost uv run pytest tests/dataset/test_download.py tests/dataset/test_format_b_bag.py tests/dataset/test_get_dataset_minid_helpers.py tests/dataset/test_extract_archive_to_cache.py tests/dataset/test_client_bag_staging.py tests/dataset/test_bag_materialize.py tests/dataset/test_multi_anchor_bag_cache.py -q`
+Expected: all PASS.
+
+- [ ] **Step 4: Branch, commit, PR**
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml
+git add -A
+git commit -m "chore(bag): drop obsolete client_export from cache_tui working_dir list"
+git push -u origin feat/client-bag-staging-cache-dir
+gh pr create --title "fix(bag): client-side bag staging moves off working_dir into a cache_dir TemporaryDirectory" --body "<summary + spec link + before/after + the two defects fixed>"
+```
+
+---
+
+## Self-Review notes
+
+- **Spec coverage:** Task 1 = shared helper; Task 2 = TemporaryDirectory(dir=cache_dir) + self-extract + return cache path; Task 3 = Tier-3 wiring + dead-branch deletion; Task 4 = live working_dir-clean; Task 5 = cache_tui + lint + PR. All spec sections covered.
+- **Type consistency:** `create_dataset_minid` return becomes `str | Path` (MINID arm → `str` landing URL; client arm → `Path` cache dir). `_extract_archive_to_cache` returns `Path`. Tier-3 builds `DatasetMinid(location=bag_dir.parent.as_uri())`.
+- **Cache-key invariant:** `cache_suffix` is threaded from `get_dataset_minid` into `create_dataset_minid` so the key the client arm writes equals the key Tier-1 reads — existing cached bags keep hitting.
+- **Deletion safety:** the `file://`-archive and legacy `DerivaExport` branches are removed only after confirming (in the audit) they have no live producer; if a hidden caller exists it surfaces as a Tier-3 dispatch test failure.

--- a/docs/superpowers/specs/2026-06-15-client-bag-staging-tmpdir-design.md
+++ b/docs/superpowers/specs/2026-06-15-client-bag-staging-tmpdir-design.md
@@ -1,0 +1,182 @@
+# Client-side bag staging: move off `working_dir`, wrap in a TemporaryDirectory
+
+**Date:** 2026-06-15
+**Status:** Design — approved approach (Option B, structural)
+**Issue origin:** Observed in an eye-ai run — the client-side bag build stages a
+multi-GB zip under `~/.deriva-ml/.../client_export/` (the `working_dir`),
+spilling onto a disk the user did not point `cache_dir` at, and the staging dir
+is only cleaned up on the success path.
+
+## Problem
+
+`create_dataset_minid`'s client arm (`use_minid=False`) builds the bag zip into:
+
+```
+{working_dir}/client_export/{spec_hash[:8]}/Dataset_{rid}/Dataset_{rid}.zip
+```
+
+([`bag_download.py` `create_dataset_minid`](../../../src/deriva_ml/dataset/bag_download.py)).
+It returns a `file://` URI pointing at that zip. A *separate* top-level call,
+`download_dataset_minid`, later opens that URI, extracts the bag into the
+checksum-keyed cache under `cache_dir`, and **then** removes the `client_export`
+dir by string-matching `"client_export"` in the archive's parent path.
+
+Two concrete defects plus one structural smell:
+
+1. **Wrong directory.** The staging zip is download-staging on the way to the
+   *cache*. It belongs under `cache_dir` (where the user controls disk), not
+   `working_dir`. Setting `cache_dir=/data` does not redirect it.
+2. **Cleanup only on the happy path.** The `rmtree` is a bare statement near the
+   end of `download_dataset_minid`, reached only if extract + validate succeed.
+   A crash/exception between build and cleanup orphans a multi-GB zip in
+   `working_dir`. No `try/finally` guarantees removal.
+3. **Fragile cross-function coupling.** The producer (`create_dataset_minid`)
+   and the cleanup (`download_dataset_minid`) are different functions coupled by
+   a magic substring (`"client_export"`). The zip must outlive the producer
+   *only because* extraction happens in the other function — which is exactly
+   why the existing `with TemporaryDirectory()` in `create_dataset_minid` could
+   not be used to wrap it.
+
+## Why a TemporaryDirectory is the clean fix
+
+`create_dataset_minid` is *already* wrapped in `with TemporaryDirectory() as
+tmp_dir:` — the MINID arm uses it for its spec file and export output. The
+client arm deliberately broke out of it (documented in a code comment) because
+the returned `file://` zip must survive the `with` block for the *other*
+function to extract it.
+
+Remove that reason and the TemporaryDirectory becomes usable: if the client arm
+**extracts into the cache itself**, inside one `with
+TemporaryDirectory(dir=cache_dir)`, then:
+
+- the OS/context-manager guarantees cleanup on **every** exit path (success,
+  exception, kill);
+- nothing lands in `working_dir`;
+- the `file://` Tier-3 branch in `download_dataset_minid` and its
+  string-matched cleanup both disappear;
+- staging sits on the same filesystem as the final cache, so the
+  staging→cache move is a cheap same-device `rename`, not a cross-device copy.
+
+## Reachability finding that simplifies the refactor
+
+Auditing every `location`/`bag_url` producer in current code:
+
+- **S3/MINID arm** sets `minid_page_url` and `return`s it directly from
+  `create_dataset_minid` — it never flows into `download_dataset_minid` as an
+  archive to extract (the S3 download path in `download_dataset_minid` fetches
+  from the S3 URL stored on the version record, a different route).
+- **Tier-1 hit** sets `location` to a `file://` URI of an *already-extracted*
+  cache directory — `download_dataset_minid` returns it immediately at the top
+  (`bag_dir.exists()` guard) without re-extracting.
+- **Client arm** sets `location` to a `file://` URI of the `client_export`
+  zip — the only `file://` *archive* that `download_dataset_minid` actually
+  extracts.
+- The **legacy `else` branch** in `download_dataset_minid`
+  (`DerivaExport.retrieve_file` for a non-`file://`, non-S3 URL) has **no live
+  producer** in current code. It is dead for the client/MINID flows.
+
+So the only consumer of the client arm's `file://`-zip-extraction is the
+Tier-3 path in `get_dataset_minid` (via `download_dataset_minid`). Collapsing
+extraction into the client arm touches exactly that one path.
+
+## Design (Option B)
+
+### New shape of the client arm
+
+`create_dataset_minid`'s `use_minid=False` branch becomes self-contained:
+
+```text
+with TemporaryDirectory(dir=cache_dir) as staging:
+    zip_path = builder.build_bag(dataset, output_dir=staging, timeout=timeout)
+    bag_dir  = _extract_and_cache(dataset, zip_path, cache_suffix)   # extract → validate → atomic move into cache → index.record
+return bag_dir            # the FINAL cache path, not a file:// URI
+```
+
+- The build + extract + cache-population all happen inside the one
+  `TemporaryDirectory(dir=cache_dir)`. On exit the staging zip and any unpacked
+  intermediate are gone, guaranteed.
+- The function returns the **final cache directory path**
+  (`{cache_root}/bags/{cache_suffix}/Dataset_{rid}`), not a `file://` URI.
+
+### Extraction helper
+
+The extract→validate→atomic-move→index.record logic currently living in
+`download_dataset_minid` (the staging-dir dance + `index.record`) is factored
+into a shared free function, e.g. `_extract_archive_to_cache(dataset, archive_path,
+checksum) -> Path`. Both the S3 arm (in `download_dataset_minid`) and the new
+client arm call it. This keeps the atomic-cache-population semantics identical
+and in one place.
+
+### `download_dataset_minid` after the change
+
+- **Tier-1 already-extracted** branch: unchanged (returns early).
+- **S3 (`use_minid=True`)** branch: unchanged behavior, but its inline
+  extract/validate/move/record body now calls `_extract_archive_to_cache`.
+- **`file://` archive branch**: removed — the client arm no longer returns a
+  `file://` zip to extract.
+- **Legacy `else` (`DerivaExport.retrieve_file`)**: removed (no live producer).
+  Per the workspace "no backwards-compat shims / delete unused" rule.
+- The `client_export` string-matched cleanup block: removed.
+
+### `get_dataset_minid` Tier-3 wiring
+
+Tier 3 currently calls `create_dataset_minid` → gets a `file://` `bag_url` →
+wraps it in a `DatasetMinid(location=bag_url)` → returns it → caller
+(`Dataset.download_dataset_bag`) calls `download_dataset_minid` to extract.
+
+After the change, the client arm already extracted into the cache. Tier 3 wraps
+the returned **cache path** as the `DatasetMinid.location` (a `file://` URI of
+the already-extracted dir, exactly like Tier-1 produces), so the downstream
+`download_dataset_minid(minid)` call hits its top-of-function `bag_dir.exists()`
+guard and returns immediately. **No downstream signature changes** —
+`Dataset.download_dataset_bag` keeps calling `download_dataset_minid`; it just
+becomes a cache-hit no-op for the freshly-built client bag.
+
+This preserves the public flow (`get_dataset_minid` → `materialize_dataset_bag`
+/ `download_dataset_minid`) while moving the extraction earlier.
+
+## What does NOT change
+
+- The cache layout: `{cache_root}/bags/{checksum}/Dataset_{rid}/`.
+- The checksum / `cache_suffix` (`{spec_hash[:16]}_{snapshot}`) — same key, so
+  existing cached bags still hit Tier-1.
+- `BagCacheIndex.record(...)` call — same anchors/summary.
+- `materialize_dataset_bag` — still materializes the cache bag in place.
+- The MINID/S3 arm's externally-visible behavior.
+- Public method signatures (`download_dataset_bag`, `get_dataset_minid`,
+  `materialize_dataset_bag`).
+
+## Testing
+
+Existing tests to keep green (mock-level, no catalog):
+`tests/dataset/test_get_dataset_minid_helpers.py` (Tier-2/Tier-3 dispatch),
+`tests/dataset/test_bag_materialize.py`, `tests/dataset/test_multi_anchor_bag_cache.py`.
+
+New coverage:
+
+1. **Staging lives under `cache_dir`, never `working_dir`** — patch
+   `build_bag` to assert its `output_dir` is under `cache_dir` and not under
+   `working_dir`; assert no `client_export` dir is created under `working_dir`.
+2. **Cleanup on success** — after a client-arm build, the
+   `TemporaryDirectory(dir=cache_dir)` staging is gone; only the final cache
+   dir remains.
+3. **Cleanup on failure** — make extract/validate raise after a successful
+   `build_bag`; assert the staging dir is removed anyway (the
+   TemporaryDirectory guarantee) and nothing is orphaned under `cache_dir` or
+   `working_dir`.
+4. **Return contract** — client arm returns the final cache path; the
+   `DatasetMinid` built from it resolves to an existing extracted bag so the
+   downstream `download_dataset_minid` is a no-op cache hit.
+5. **Live round-trip** (catalog) — `cache(..., use_minid=False)` on a demo
+   dataset still produces a fully-formed, loadable bag in `cache_dir`; assert
+   `working_dir` gains no `client_export`.
+
+## Risks
+
+- **Merging build + extract responsibilities.** Mitigated by factoring the
+  extraction into a shared `_extract_archive_to_cache` so the atomic-move +
+  index-record semantics are identical to today and exercised by both arms.
+- **Dead-branch removal.** The legacy `DerivaExport.retrieve_file` branch is
+  removed; confirmed no live producer. If a hidden caller exists, it would
+  surface as a test failure in the dispatch tests — acceptable, and correct per
+  the delete-unused rule.

--- a/src/deriva_ml/cache_tui.py
+++ b/src/deriva_ml/cache_tui.py
@@ -272,8 +272,7 @@ def discover_entries() -> list[DirectoryEntry]:
 
             # Check if this looks like a catalog working dir
             is_workdir = any(
-                (catalog_dir / sub).exists()
-                for sub in ["cache", "databases", "deriva-ml", "hydra", "hydra-sweep", "client_export"]
+                (catalog_dir / sub).exists() for sub in ["cache", "databases", "deriva-ml", "hydra", "hydra-sweep"]
             )
 
             if is_workdir:
@@ -284,8 +283,7 @@ def discover_entries() -> list[DirectoryEntry]:
         # Also check if host_dir itself is a working dir (e.g., ~/.deriva-ml/eye-ai/)
         if not has_catalog_subdirs:
             is_workdir = any(
-                (host_dir / sub).exists()
-                for sub in ["cache", "databases", "deriva-ml", "hydra", "hydra-sweep", "client_export"]
+                (host_dir / sub).exists() for sub in ["cache", "databases", "deriva-ml", "hydra", "hydra-sweep"]
             ) or any(
                 "_" in child.name and child.is_dir() and len(child.name) > 40
                 for child in host_dir.iterdir()

--- a/src/deriva_ml/dataset/bag_download.py
+++ b/src/deriva_ml/dataset/bag_download.py
@@ -58,7 +58,6 @@ from tempfile import TemporaryDirectory
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
 
-import deriva.core.utils.hash_utils as hash_utils
 import requests
 from bdbag import bdbag_api as bdb
 from bdbag.fetch.fetcher import fetch_single_file
@@ -198,48 +197,36 @@ def _extract_archive_to_cache(
 
 
 def download_dataset_minid(dataset: "Dataset", minid: DatasetMinid, use_minid: bool) -> Path:
-    """Download and extract a dataset bag archive into the local cache.
+    """Resolve a dataset bag into the local cache, returning its directory.
 
-    Handles three source types based on how the bag was obtained:
+    Two source types:
 
-    1. **Local cache hit** (``minid.checksum`` set by Tier 1 in
-       :func:`get_dataset_minid`):
-       The index already records this checksum and the bag directory
+    1. **Local cache hit** (the common case):
+       The index already records ``minid.checksum`` and the bag directory
        exists at ``{cache_root}/bags/{checksum}/Dataset_{rid}`` → return
-       immediately.
+       immediately. This also covers the client arm (Tier 3 of
+       :func:`get_dataset_minid`), which extracts into the cache itself and
+       hands back an already-extracted dir.
 
-    2. **S3 download** (``use_minid=True``):
-       Download the bag archive from S3 via ``minid.bag_url``.
+    2. **S3 download** (``use_minid=True``, MINID arm):
+       Download the bag archive from S3 via ``minid.bag_url``, then extract +
+       validate + atomic-move into the cache and record in the index (via
+       :func:`_extract_archive_to_cache`).
 
-    3. **Client-side bag** (``use_minid=False``):
-       The bag was already generated locally by
-       :func:`create_dataset_minid` driving
-       :meth:`DatasetBagBuilder.build_bag` and is referenced via a
-       ``file://`` URI.
-
-    After obtaining the archive, this function:
-
-    - Extracts it under a staging directory (atomic — prevents corrupt caches).
-    - Validates the BDBag structure.
-    - Moves the staging directory to its final cache location under
-      ``{cache_root}/bags/{checksum}/Dataset_{rid}/``.
-    - Records the bag in :class:`~deriva.bag.cache_index.BagCacheIndex`
-      so Tier-1 lookups can find it on the next call.
-    - Cleans up temporary files (including any ``client_export``
-      intermediate produced by the non-MINID path).
-
-    Cache layout (post-Phase-2 cutover):
+    Cache layout:
         ``{cache_root}/bags/{checksum}/Dataset_{rid}/``
 
         ``checksum`` is the deterministic ``{spec_hash[:16]}_{snapshot}``
-        string for non-MINID downloads (set by Tier 1/3) or the SHA-256
-        of the S3 archive (set by Tier 2).
+        string (set by Tier 1/3) for non-MINID bags, or the value recorded on
+        the MINID for the S3 arm.
 
     Args:
         dataset: The dataset being downloaded (for catalog access and
             logging).
         minid: DatasetMinid with bag URL and cache key (in checksum field).
-        use_minid: If True, source is S3. If False, source is local file://.
+        use_minid: If True, the bag is downloaded from S3. If False, the bag
+            was already extracted into the cache by the client arm and this is
+            a cache-hit no-op.
 
     Returns:
         Path to the extracted bag directory:
@@ -255,34 +242,13 @@ def download_dataset_minid(dataset: "Dataset", minid: DatasetMinid, use_minid: b
             dataset._logger.info(f"Using cached bag for {minid.dataset_rid} Version:{minid.dataset_version}")
             return bag_dir
 
-        # ----- Download the archive ---------------------------------------
+        # ----- Tier 2: download the bag archive from S3 -------------------
+        # The client arm (use_minid=False, Tier 3) extracts into the cache
+        # itself and returns an already-extracted dir, which the Tier-1 guard
+        # above catches — so the only archive that reaches here is the S3 one.
         with TemporaryDirectory() as tmp_dir:
-            if use_minid:
-                # Tier 2: Download bag archive from S3
-                bag_path = Path(tmp_dir) / Path(urlparse(minid.bag_url).path).name
-                archive_path = fetch_single_file(minid.bag_url, output_path=bag_path)
-            elif minid.bag_url.startswith("file://"):
-                # Tier 3: Client-side bag — already on local filesystem
-                archive_path = urlparse(minid.bag_url).path
-            else:
-                # Legacy: Download from catalog export endpoint
-                exporter = DerivaExport(host=dataset._ml_instance.catalog.deriva_server.server, output_dir=tmp_dir)
-                archive_path = exporter.retrieve_file(minid.bag_url)
-
-            # For non-MINID downloads without a pre-computed cache key (legacy
-            # code path), fall back to SHA-256 of the archive as cache key.
-            if not use_minid and not minid.checksum:
-                hashes = hash_utils.compute_file_hashes(archive_path, hashes=["md5", "sha256"])
-                checksum = hashes["sha256"][0]
-                bag_root = index.bag_dir_for(checksum)
-                bag_dir = bag_root / f"Dataset_{minid.dataset_rid}"
-                if bag_dir.exists():
-                    dataset._logger.info(f"Using cached bag for {minid.dataset_rid} Version:{minid.dataset_version}")
-                    return bag_dir
-                # Rebind minid.checksum so the index record uses the SHA-256
-                # cache key. ``DatasetMinid`` is immutable; rebuild it with
-                # the derived checksum.
-                minid = minid.model_copy(update={"checksums": [{"function": "sha256", "value": checksum}]})
+            bag_path = Path(tmp_dir) / Path(urlparse(minid.bag_url).path).name
+            archive_path = fetch_single_file(minid.bag_url, output_path=bag_path)
 
             # Extract + validate + atomic-move into the cache, then record in
             # the index. Shared with the client arm of create_dataset_minid.
@@ -293,13 +259,6 @@ def download_dataset_minid(dataset: "Dataset", minid: DatasetMinid, use_minid: b
                 dataset_rid=minid.dataset_rid,
                 dataset_version=str(minid.dataset_version),
             )
-
-            # Clean up the client_export temp directory for local file:// bags.
-            # After extraction to cache, the original archive is no longer needed.
-            if not use_minid and minid.bag_url.startswith("file://"):
-                export_dir = Path(archive_path).parent
-                if "client_export" in export_dir.parts:
-                    shutil.rmtree(export_dir, ignore_errors=True)
     finally:
         index.dispose()
 
@@ -684,19 +643,25 @@ def _tier3_client_path(
         dataset.dataset_rid,
         version,
     )
-    bag_url = create_dataset_minid(
+    # The client arm extracts the bag into the cache itself and returns the
+    # final cache PATH. Wrap its PARENT (the checksum cache root) as the
+    # location — same shape Tier 1 produces — so the downstream
+    # download_dataset_minid call hits its bag_dir.exists() guard and returns
+    # immediately (no re-extraction).
+    bag_dir = create_dataset_minid(
         dataset,
         version,
         use_minid=False,
         exclude_tables=exclude_tables,
         spec=spec,
         spec_hash=spec_hash,
+        cache_suffix=cache_suffix,
         timeout=timeout,
     )
     return DatasetMinid(
         dataset_version=version,
         RID=_build_version_rid(dataset.dataset_rid, snapshot),
-        location=bag_url,
+        location=bag_dir.parent.as_uri(),
         checksums=[{"function": "sha256", "value": cache_suffix}],
     )
 

--- a/src/deriva_ml/dataset/bag_download.py
+++ b/src/deriva_ml/dataset/bag_download.py
@@ -80,6 +80,8 @@ from deriva_ml.dataset.bag_builder import DatasetBagBuilder
 _module_logger = get_logger(__name__)
 
 if TYPE_CHECKING:
+    from deriva.bag.cache_index import BagCacheIndex
+
     from deriva_ml.dataset.dataset import Dataset
 
 
@@ -121,6 +123,79 @@ def fetch_minid_metadata(dataset: "Dataset", version: DatasetVersion, url: str) 
     r = requests.get(url, headers={"accept": "application/json"})
     r.raise_for_status()
     return DatasetMinid(dataset_version=version, **r.json())
+
+
+def _extract_archive_to_cache(
+    index: "BagCacheIndex",
+    archive_path: str,
+    checksum: str,
+    dataset_rid: str,
+    dataset_version: str,
+) -> Path:
+    """Extract a bag archive into the checksum-keyed cache, atomically.
+
+    Extracts ``archive_path`` into a staging directory, validates the BDBag
+    structure, atomically renames the staging dir to its final cache location
+    (``{cache_root}/bags/{checksum}/Dataset_{rid}``), and records the bag in
+    ``index`` so the next Tier-1 lookup finds it. The atomic rename prevents
+    partial/corrupt cache entries if the process crashes mid-extract.
+
+    The caller owns ``index``'s lifecycle (this function does not dispose it).
+    Shared by the S3 arm of :func:`download_dataset_minid` and the client arm
+    of :func:`create_dataset_minid`.
+
+    Args:
+        index: Open :class:`~deriva.bag.cache_index.BagCacheIndex` rooted at
+            the cache dir.
+        archive_path: Path to the bag zip archive to extract.
+        checksum: Deterministic cache key (``{spec_hash[:16]}_{snapshot}``)
+            or SHA-256 of the archive — used as the cache-dir name.
+        dataset_rid: Dataset RID, for the cache dir name and index anchor.
+        dataset_version: Dataset version string, for the index anchor summary.
+
+    Returns:
+        Path to the extracted bag directory inside the cache
+        (``{cache_root}/bags/{checksum}/Dataset_{rid}``).
+
+    Raises:
+        Exception: Propagates any error from ``bdb.extract_bag`` /
+            ``bdb.validate_bag_structure`` after cleaning up the staging dir
+            (so no partial cache entry is left behind).
+
+    Example:
+        >>> # Illustrative — requires a live index + archive.
+        >>> path = _extract_archive_to_cache(idx, "/tmp/b.zip", "ab_S", "2-X", "1.0.0")  # doctest: +SKIP
+    """
+    bag_root = index.bag_dir_for(checksum)
+    bag_dir = bag_root / f"Dataset_{dataset_rid}"
+
+    # ----- Extract to staging directory (atomic cache population) ------
+    # Write to a temporary staging directory first. Only rename to the
+    # final cache location after successful extraction and validation.
+    # This prevents partial/corrupt cache entries if the process crashes.
+    staging_dir = bag_root.parent / f"{bag_root.name}_staging"
+    if staging_dir.exists():
+        shutil.rmtree(staging_dir)
+    staging_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        extracted_bag_path = bdb.extract_bag(archive_path, staging_dir.as_posix())
+        bdb.validate_bag_structure(extracted_bag_path)
+    except Exception:
+        shutil.rmtree(staging_dir, ignore_errors=True)
+        raise
+
+    # Atomic move: staging → final cache location. The bag directory's
+    # parent (``cache_root/bags/{checksum}``) is created by the rename.
+    bag_root.parent.mkdir(parents=True, exist_ok=True)
+    staging_dir.rename(bag_root)
+
+    # Record the bag in the index so the next Tier-1 lookup finds it.
+    index.record(
+        checksum=checksum,
+        anchors=[("Dataset", dataset_rid)],
+        anchor_summary={"version": str(dataset_version)},
+    )
+    return bag_dir
 
 
 def download_dataset_minid(dataset: "Dataset", minid: DatasetMinid, use_minid: bool) -> Path:
@@ -174,80 +249,62 @@ def download_dataset_minid(dataset: "Dataset", minid: DatasetMinid, use_minid: b
     from deriva.bag.cache_index import BagCacheIndex
 
     index = BagCacheIndex(dataset._ml_instance.cache_dir)
-
-    # Tier-1 hit: the index lookup in get_dataset_minid set minid.checksum;
-    # the bag may already exist on disk from a prior download.
-    bag_root = index.bag_dir_for(minid.checksum)
-    bag_dir = bag_root / f"Dataset_{minid.dataset_rid}"
-    if bag_dir.exists():
-        dataset._logger.info(f"Using cached bag for {minid.dataset_rid} Version:{minid.dataset_version}")
-        return bag_dir
-
-    # ----- Download the archive -------------------------------------------
-    with TemporaryDirectory() as tmp_dir:
-        if use_minid:
-            # Tier 2: Download bag archive from S3
-            bag_path = Path(tmp_dir) / Path(urlparse(minid.bag_url).path).name
-            archive_path = fetch_single_file(minid.bag_url, output_path=bag_path)
-        elif minid.bag_url.startswith("file://"):
-            # Tier 3: Client-side bag — already on local filesystem
-            archive_path = urlparse(minid.bag_url).path
-        else:
-            # Legacy: Download from catalog export endpoint
-            exporter = DerivaExport(host=dataset._ml_instance.catalog.deriva_server.server, output_dir=tmp_dir)
-            archive_path = exporter.retrieve_file(minid.bag_url)
-
-        # For non-MINID downloads without a pre-computed cache key (legacy
-        # code path), fall back to SHA-256 of the archive as cache key.
-        if not use_minid and not minid.checksum:
-            hashes = hash_utils.compute_file_hashes(archive_path, hashes=["md5", "sha256"])
-            checksum = hashes["sha256"][0]
-            bag_root = index.bag_dir_for(checksum)
-            bag_dir = bag_root / f"Dataset_{minid.dataset_rid}"
-            if bag_dir.exists():
-                dataset._logger.info(f"Using cached bag for {minid.dataset_rid} Version:{minid.dataset_version}")
-                return bag_dir
-            # Rebind minid.checksum so the index record at the end of this
-            # function uses the SHA-256 cache key. ``DatasetMinid`` is
-            # immutable; rebuild it with the derived checksum.
-            minid = minid.model_copy(update={"checksums": [{"function": "sha256", "value": checksum}]})
-
-        # ----- Extract to staging directory (atomic cache population) ------
-        # Write to a temporary staging directory first. Only rename to the
-        # final cache location after successful extraction and validation.
-        # This prevents partial/corrupt cache entries if the process crashes.
-        staging_dir = bag_root.parent / f"{bag_root.name}_staging"
-        if staging_dir.exists():
-            shutil.rmtree(staging_dir)
-        staging_dir.mkdir(parents=True, exist_ok=True)
-        try:
-            extracted_bag_path = bdb.extract_bag(archive_path, staging_dir.as_posix())
-            bdb.validate_bag_structure(extracted_bag_path)
-        except Exception:
-            shutil.rmtree(staging_dir, ignore_errors=True)
-            raise
-
-    # Atomic move: staging → final cache location. The bag directory's
-    # parent (``cache_root/bags/{checksum}``) is created by the rename.
-    bag_root.parent.mkdir(parents=True, exist_ok=True)
-    staging_dir.rename(bag_root)
-
-    # Record the bag in the index so the next Tier-1 lookup finds it.
     try:
-        index.record(
-            checksum=minid.checksum,
-            anchors=[("Dataset", minid.dataset_rid)],
-            anchor_summary={"version": str(minid.dataset_version)},
-        )
+        # Tier-1 hit: the index lookup in get_dataset_minid set minid.checksum;
+        # the bag may already exist on disk from a prior download.
+        bag_root = index.bag_dir_for(minid.checksum)
+        bag_dir = bag_root / f"Dataset_{minid.dataset_rid}"
+        if bag_dir.exists():
+            dataset._logger.info(f"Using cached bag for {minid.dataset_rid} Version:{minid.dataset_version}")
+            return bag_dir
+
+        # ----- Download the archive ---------------------------------------
+        with TemporaryDirectory() as tmp_dir:
+            if use_minid:
+                # Tier 2: Download bag archive from S3
+                bag_path = Path(tmp_dir) / Path(urlparse(minid.bag_url).path).name
+                archive_path = fetch_single_file(minid.bag_url, output_path=bag_path)
+            elif minid.bag_url.startswith("file://"):
+                # Tier 3: Client-side bag — already on local filesystem
+                archive_path = urlparse(minid.bag_url).path
+            else:
+                # Legacy: Download from catalog export endpoint
+                exporter = DerivaExport(host=dataset._ml_instance.catalog.deriva_server.server, output_dir=tmp_dir)
+                archive_path = exporter.retrieve_file(minid.bag_url)
+
+            # For non-MINID downloads without a pre-computed cache key (legacy
+            # code path), fall back to SHA-256 of the archive as cache key.
+            if not use_minid and not minid.checksum:
+                hashes = hash_utils.compute_file_hashes(archive_path, hashes=["md5", "sha256"])
+                checksum = hashes["sha256"][0]
+                bag_root = index.bag_dir_for(checksum)
+                bag_dir = bag_root / f"Dataset_{minid.dataset_rid}"
+                if bag_dir.exists():
+                    dataset._logger.info(f"Using cached bag for {minid.dataset_rid} Version:{minid.dataset_version}")
+                    return bag_dir
+                # Rebind minid.checksum so the index record uses the SHA-256
+                # cache key. ``DatasetMinid`` is immutable; rebuild it with
+                # the derived checksum.
+                minid = minid.model_copy(update={"checksums": [{"function": "sha256", "value": checksum}]})
+
+            # Extract + validate + atomic-move into the cache, then record in
+            # the index. Shared with the client arm of create_dataset_minid.
+            bag_dir = _extract_archive_to_cache(
+                index=index,
+                archive_path=archive_path,
+                checksum=minid.checksum,
+                dataset_rid=minid.dataset_rid,
+                dataset_version=str(minid.dataset_version),
+            )
+
+            # Clean up the client_export temp directory for local file:// bags.
+            # After extraction to cache, the original archive is no longer needed.
+            if not use_minid and minid.bag_url.startswith("file://"):
+                export_dir = Path(archive_path).parent
+                if "client_export" in export_dir.parts:
+                    shutil.rmtree(export_dir, ignore_errors=True)
     finally:
         index.dispose()
-
-    # Clean up the client_export temp directory for local file:// bags.
-    # After extraction to cache, the original archive is no longer needed.
-    if not use_minid and minid.bag_url.startswith("file://"):
-        export_dir = Path(archive_path).parent
-        if "client_export" in export_dir.parts:
-            shutil.rmtree(export_dir, ignore_errors=True)
 
     return bag_dir
 

--- a/src/deriva_ml/dataset/bag_download.py
+++ b/src/deriva_ml/dataset/bag_download.py
@@ -62,6 +62,7 @@ import deriva.core.utils.hash_utils as hash_utils
 import requests
 from bdbag import bdbag_api as bdb
 from bdbag.fetch.fetcher import fetch_single_file
+from deriva.bag.cache_index import BagCacheIndex
 from deriva.core.utils.core_utils import format_exception
 from deriva.transfer.download import (
     DerivaDownloadAuthenticationError,
@@ -80,8 +81,6 @@ from deriva_ml.dataset.bag_builder import DatasetBagBuilder
 _module_logger = get_logger(__name__)
 
 if TYPE_CHECKING:
-    from deriva.bag.cache_index import BagCacheIndex
-
     from deriva_ml.dataset.dataset import Dataset
 
 
@@ -246,8 +245,6 @@ def download_dataset_minid(dataset: "Dataset", minid: DatasetMinid, use_minid: b
         Path to the extracted bag directory:
         ``{cache_root}/bags/{checksum}/Dataset_{rid}``.
     """
-    from deriva.bag.cache_index import BagCacheIndex
-
     index = BagCacheIndex(dataset._ml_instance.cache_dir)
     try:
         # Tier-1 hit: the index lookup in get_dataset_minid set minid.checksum;
@@ -316,8 +313,9 @@ def create_dataset_minid(
     exclude_tables: set[str] | None = None,
     spec: dict | None = None,
     spec_hash: str | None = None,
+    cache_suffix: str | None = None,
     timeout: tuple[int, int] | None = None,
-) -> str:
+) -> str | Path:
     """Create a new MINID (Minimal Viable Identifier) for the dataset.
 
     This function generates a BDBag export of the dataset and optionally
@@ -334,12 +332,19 @@ def create_dataset_minid(
             generated from the snapshot catalog.
         spec_hash: Optional pre-computed SHA-256 hash of the spec. If None and
             spec is provided, it is computed from the spec.
+        cache_suffix: Deterministic cache key (``{spec_hash[:16]}_{snapshot}``)
+            for the client arm (``use_minid=False``). When provided, the
+            client-side bag is extracted into the cache under this key — kept
+            identical to the key Tier 1 looks up so existing cached bags hit.
+            If None on the client arm, it is derived from ``spec_hash`` + the
+            version's snapshot. Ignored on the MINID arm.
         timeout: Optional (connect_timeout, read_timeout) in seconds for network
             requests. Defaults to (10, 610).
 
     Returns:
-        URL to the MINID landing page (if ``use_minid=True``) or
-        the direct bag download URL (``file://`` URI).
+        On the MINID arm (``use_minid=True``): the MINID landing-page URL
+        (``str``). On the client arm (``use_minid=False``): the :class:`Path`
+        to the extracted bag directory in the local cache.
     """
     with TemporaryDirectory() as tmp_dir:
         # Generate spec if not supplied (allows callers to reuse a spec they already computed).
@@ -406,13 +411,19 @@ def create_dataset_minid(
             # anchors/policy); we keep the parameter on the function
             # signature because the MINID arm above still consumes it.
             #
-            # The bag is built into a working subdirectory under
-            # ``working_dir/client_export/`` (NOT ``tmp_dir``) so the zip
-            # survives the ``TemporaryDirectory`` cleanup at the end of
-            # this function — the caller (:func:`download_dataset_minid`)
-            # consumes the file:// URI returned here. The cleanup path in
-            # :func:`download_dataset_minid` recognizes ``client_export`` in
-            # the archive's parent and removes it after extraction.
+            # The bag is built into a ``TemporaryDirectory`` rooted at
+            # ``cache_dir`` and extracted straight into the cache. The staging
+            # zip never touches ``working_dir`` and is removed on every exit
+            # path (success or exception) by the context manager — no
+            # cross-function ``file://`` hand-off, no manual cleanup. Staging
+            # on the cache filesystem also makes the staging→cache move a cheap
+            # same-device rename.
+            if cache_suffix is None:
+                # Defensive: derive the cache key the way Tier 1 does, so the
+                # extracted bag is found on the next lookup.
+                snapshot = _resolve_version_record(dataset, version).snapshot
+                cache_suffix = f"{spec_hash[:16]}_{snapshot}"
+
             version_snapshot_catalog = dataset._version_snapshot_catalog(version)
             builder = DatasetBagBuilder(
                 ml_instance=version_snapshot_catalog,
@@ -420,31 +431,42 @@ def create_dataset_minid(
                 use_minid=False,
                 exclude_tables=exclude_tables,
             )
-            client_export_dir = Path(dataset._ml_instance.working_dir) / "client_export" / spec_hash[:8]
-            client_export_dir.mkdir(parents=True, exist_ok=True)
-            try:
-                zip_path = builder.build_bag(dataset, output_dir=client_export_dir, timeout=timeout)
-            except (
-                DerivaDownloadError,
-                DerivaDownloadConfigurationError,
-                DerivaDownloadAuthenticationError,
-                DerivaDownloadAuthorizationError,
-                DerivaDownloadTimeoutError,
-            ) as e:
-                # Preserve the actionable-message contract callers relied on
-                # from the legacy _create_dataset_bag_client. The original
-                # advice (add direct dataset members for tables whose deep
-                # FK joins timed out) still applies — surface it alongside
-                # the deriva-py error so users have a fix to try.
-                raise DerivaMLException(
-                    f"Dataset bag export failed: {format_exception(e)}. "
-                    "This typically happens when deep multi-table joins "
-                    "exceed server query time limits. To fix this, add the "
-                    "desired records as direct dataset members using "
-                    "add_dataset_members() with the relevant table's RIDs."
-                )
+            cache_dir = Path(dataset._ml_instance.cache_dir)
+            with TemporaryDirectory(dir=cache_dir) as staging:
+                try:
+                    zip_path = builder.build_bag(dataset, output_dir=Path(staging), timeout=timeout)
+                except (
+                    DerivaDownloadError,
+                    DerivaDownloadConfigurationError,
+                    DerivaDownloadAuthenticationError,
+                    DerivaDownloadAuthorizationError,
+                    DerivaDownloadTimeoutError,
+                ) as e:
+                    # Preserve the actionable-message contract callers relied
+                    # on from the legacy _create_dataset_bag_client. The
+                    # original advice (add direct dataset members for tables
+                    # whose deep FK joins timed out) still applies — surface it
+                    # alongside the deriva-py error so users have a fix to try.
+                    raise DerivaMLException(
+                        f"Dataset bag export failed: {format_exception(e)}. "
+                        "This typically happens when deep multi-table joins "
+                        "exceed server query time limits. To fix this, add the "
+                        "desired records as direct dataset members using "
+                        "add_dataset_members() with the relevant table's RIDs."
+                    )
 
-            return zip_path.as_uri()
+                index = BagCacheIndex(cache_dir)
+                try:
+                    bag_dir = _extract_archive_to_cache(
+                        index=index,
+                        archive_path=str(zip_path),
+                        checksum=cache_suffix,
+                        dataset_rid=dataset.dataset_rid,
+                        dataset_version=str(version),
+                    )
+                finally:
+                    index.dispose()
+            return bag_dir
 
 
 def _resolve_version_record(dataset: "Dataset", version: DatasetVersion) -> Any:
@@ -524,8 +546,6 @@ def _tier1_local_cache_lookup(
         :class:`DatasetMinid` pointing at the cached bag, or
         ``None`` when no matching bag is on disk.
     """
-    from deriva.bag.cache_index import BagCacheIndex
-
     index = BagCacheIndex(dataset._ml_instance.cache_dir)
     try:
         cached_checksums = index.find_bags_for_rid(table="Dataset", rid=dataset.dataset_rid)

--- a/tests/dataset/test_client_bag_staging.py
+++ b/tests/dataset/test_client_bag_staging.py
@@ -1,0 +1,105 @@
+"""Client-arm bag staging lives under cache_dir, not working_dir, and is
+always cleaned up (TemporaryDirectory guarantee), even on extract failure.
+
+Regression coverage for the staging-spill fix: the client-side bag build
+(``use_minid=False``) used to stage a multi-GB zip under
+``working_dir/client_export/`` and clean it up only on the success path. It
+now builds into a ``TemporaryDirectory(dir=cache_dir)`` and extracts in place,
+so nothing lands in ``working_dir`` and the context manager guarantees cleanup.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from deriva_ml.dataset.bag_download import create_dataset_minid
+
+
+def _fake_dataset(tmp_path):
+    ds = MagicMock()
+    ds.dataset_rid = "2-ABCD"
+    ds._ml_instance.cache_dir = tmp_path / "cache"
+    ds._ml_instance.working_dir = tmp_path / "work"
+    ds._ml_instance.cache_dir.mkdir()
+    ds._ml_instance.working_dir.mkdir()
+    ds._ml_instance.s3_bucket = None
+    return ds
+
+
+def test_client_arm_stages_under_cache_dir_not_working_dir(tmp_path):
+    ds = _fake_dataset(tmp_path)
+    captured = {}
+
+    def fake_build_bag(self, dataset, output_dir, timeout=None):
+        captured["output_dir"] = Path(output_dir)
+        zip_path = Path(output_dir) / "Dataset_2-ABCD.zip"
+        zip_path.parent.mkdir(parents=True, exist_ok=True)
+        zip_path.write_text("zip")
+        return zip_path
+
+    cache_bag = ds._ml_instance.cache_dir / "bags" / "x" / "Dataset_2-ABCD"
+
+    with (
+        patch("deriva_ml.dataset.bag_download.DatasetBagBuilder.build_bag", new=fake_build_bag),
+        patch(
+            "deriva_ml.dataset.bag_download._extract_archive_to_cache",
+            return_value=cache_bag,
+        ),
+        patch("deriva_ml.dataset.bag_download.BagCacheIndex"),
+    ):
+        result = create_dataset_minid(
+            ds,
+            "1.0.0",
+            use_minid=False,
+            spec={"k": "v"},
+            spec_hash="deadbeefdeadbeef",
+            cache_suffix="deadbeefdeadbeef_2-SNAP",
+        )
+
+    # Staging output_dir is under cache_dir, never working_dir.
+    assert ds._ml_instance.cache_dir in captured["output_dir"].parents
+    assert ds._ml_instance.working_dir not in captured["output_dir"].parents
+    # No client_export dir was created under working_dir.
+    assert not (ds._ml_instance.working_dir / "client_export").exists()
+    # Returns the final cache path (a Path, not a file:// URI string).
+    assert isinstance(result, Path)
+    assert "bags" in result.parts
+
+
+def test_client_arm_cleans_staging_on_extract_failure(tmp_path):
+    ds = _fake_dataset(tmp_path)
+    seen_staging = []
+
+    def fake_build_bag(self, dataset, output_dir, timeout=None):
+        seen_staging.append(Path(output_dir))
+        zip_path = Path(output_dir) / "Dataset_2-ABCD.zip"
+        zip_path.parent.mkdir(parents=True, exist_ok=True)
+        zip_path.write_text("zip")
+        return zip_path
+
+    with (
+        patch("deriva_ml.dataset.bag_download.DatasetBagBuilder.build_bag", new=fake_build_bag),
+        patch(
+            "deriva_ml.dataset.bag_download._extract_archive_to_cache",
+            side_effect=RuntimeError("extract boom"),
+        ),
+        patch("deriva_ml.dataset.bag_download.BagCacheIndex"),
+    ):
+        with pytest.raises(RuntimeError, match="extract boom"):
+            create_dataset_minid(
+                ds,
+                "1.0.0",
+                use_minid=False,
+                spec={"k": "v"},
+                spec_hash="deadbeefdeadbeef",
+                cache_suffix="deadbeefdeadbeef_2-SNAP",
+            )
+
+    # The TemporaryDirectory(dir=cache_dir) staging is gone despite the failure.
+    for staging in seen_staging:
+        assert not staging.exists()
+    # Nothing orphaned under working_dir.
+    assert not (ds._ml_instance.working_dir / "client_export").exists()

--- a/tests/dataset/test_client_bag_staging.py
+++ b/tests/dataset/test_client_bag_staging.py
@@ -103,3 +103,38 @@ def test_client_arm_cleans_staging_on_extract_failure(tmp_path):
         assert not staging.exists()
     # Nothing orphaned under working_dir.
     assert not (ds._ml_instance.working_dir / "client_export").exists()
+
+
+def test_live_client_download_lands_in_cache_not_working_dir(catalog_with_datasets):
+    """End-to-end: cache(use_minid=False) builds a loadable bag under cache_dir
+    and never creates a client_export dir under working_dir.
+
+    Exercises the full client arm through the public ``Dataset.cache`` entry
+    point: build into a TemporaryDirectory(dir=cache_dir), extract in place,
+    Tier-3 returns the cache path, downstream download is a no-op cache hit.
+    """
+    ml, _ = catalog_with_datasets
+    datasets = list(ml.find_datasets())
+    if not datasets:
+        pytest.skip("Need a dataset.")
+    ds = ml.lookup_dataset(datasets[0].dataset_rid)
+    versions = list(ds.dataset_history())
+    version = str(versions[-1].dataset_version)
+
+    info = ds.cache(version=version, materialize=False)
+
+    # ``cache()`` returns bag_info, which merges in BagCache.cache_status:
+    # the ``status`` key carries a CacheStatus value; metadata-only downloads
+    # land as cached_metadata_only / cached_holey.
+    assert info["status"] in (
+        "cached_metadata_only",
+        "cached_holey",
+        "cached_materialized",
+    )
+    assert info["cache_path"] is not None
+    cache_path = Path(info["cache_path"])
+    assert cache_path.exists()
+    # The cached bag lives under cache_dir, and working_dir gained no
+    # client_export staging dir.
+    assert Path(ml.cache_dir) in cache_path.parents
+    assert not (Path(ml.working_dir) / "client_export").exists()

--- a/tests/dataset/test_extract_archive_to_cache.py
+++ b/tests/dataset/test_extract_archive_to_cache.py
@@ -1,0 +1,92 @@
+"""Unit tests for _extract_archive_to_cache (client-bag staging refactor).
+
+The helper owns the atomic cache-population dance: extract a bag archive
+into a staging dir, validate, atomically rename into the checksum-keyed
+cache location, and record in the BagCacheIndex. Both the S3 arm and the
+client arm of the download path call it.
+
+Pure-Python; no live catalog required.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from deriva_ml.dataset.bag_download import _extract_archive_to_cache
+
+
+def test_extract_archive_to_cache_atomic_move_and_record(tmp_path):
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+
+    # Fake index: bag_dir_for returns a checksum-keyed dir under cache_dir.
+    bag_root = cache_dir / "bags" / "deadbeef_2-SNAP"
+    index = MagicMock()
+    index.bag_dir_for.return_value = bag_root
+
+    # bdb.extract_bag creates the staging dir contents; simulate it by
+    # populating the directory it is handed and returning that path.
+    def fake_extract(archive, dest):
+        Path(dest).mkdir(parents=True, exist_ok=True)
+        (Path(dest) / "bag-info.txt").write_text("ok")
+        return dest
+
+    with (
+        patch("deriva_ml.dataset.bag_download.bdb.extract_bag", side_effect=fake_extract),
+        patch("deriva_ml.dataset.bag_download.bdb.validate_bag_structure"),
+    ):
+        result = _extract_archive_to_cache(
+            index=index,
+            archive_path="/tmp/whatever.zip",
+            checksum="deadbeef_2-SNAP",
+            dataset_rid="2-ABCD",
+            dataset_version="1.0.0",
+        )
+
+    # Returns the bag dir inside the cache root.
+    assert result == bag_root / "Dataset_2-ABCD"
+    # The checksum-keyed cache dir now exists (atomic move happened).
+    assert bag_root.exists()
+    # Index recorded the bag under the Dataset anchor + version summary.
+    index.record.assert_called_once()
+    _, kwargs = index.record.call_args
+    assert kwargs["checksum"] == "deadbeef_2-SNAP"
+    assert kwargs["anchors"] == [("Dataset", "2-ABCD")]
+    assert kwargs["anchor_summary"] == {"version": "1.0.0"}
+
+
+def test_extract_archive_to_cache_cleans_staging_on_failure(tmp_path):
+    """If validation raises, the staging dir is removed and the error propagates."""
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    bag_root = cache_dir / "bags" / "beef_2-SNAP"
+    index = MagicMock()
+    index.bag_dir_for.return_value = bag_root
+
+    def fake_extract(archive, dest):
+        Path(dest).mkdir(parents=True, exist_ok=True)
+        return dest
+
+    import pytest
+
+    with (
+        patch("deriva_ml.dataset.bag_download.bdb.extract_bag", side_effect=fake_extract),
+        patch(
+            "deriva_ml.dataset.bag_download.bdb.validate_bag_structure",
+            side_effect=RuntimeError("bad bag"),
+        ),
+    ):
+        with pytest.raises(RuntimeError, match="bad bag"):
+            _extract_archive_to_cache(
+                index=index,
+                archive_path="/tmp/whatever.zip",
+                checksum="beef_2-SNAP",
+                dataset_rid="2-ABCD",
+                dataset_version="1.0.0",
+            )
+
+    # Staging dir cleaned up; no partial cache entry left behind.
+    assert not (bag_root.parent / f"{bag_root.name}_staging").exists()
+    assert not bag_root.exists()
+    index.record.assert_not_called()

--- a/tests/dataset/test_get_dataset_minid_helpers.py
+++ b/tests/dataset/test_get_dataset_minid_helpers.py
@@ -24,6 +24,7 @@ Pure-Python tests; no live catalog required.
 
 from __future__ import annotations
 
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -103,9 +104,7 @@ class TestTier2MinidPath:
         """When the stored ``spec_hash`` matches, the MINID is fetched."""
         dataset = MagicMock()
         version_record = MagicMock(spec_hash="abc123")
-        with patch(
-            "deriva_ml.dataset.bag_download.fetch_minid_metadata"
-        ) as fetch:
+        with patch("deriva_ml.dataset.bag_download.fetch_minid_metadata") as fetch:
             fetch.return_value = "FETCHED"
             result = _tier2_minid_path(
                 dataset,
@@ -142,9 +141,10 @@ class TestTier2MinidPath:
         """Stored spec_hash mismatch → regenerate; ``create=False`` would raise."""
         dataset = MagicMock()
         version_record = MagicMock(spec_hash="OLD")
-        with patch("deriva_ml.dataset.bag_download.fetch_minid_metadata") as fetch, patch(
-            "deriva_ml.dataset.bag_download.create_dataset_minid"
-        ) as create_fn:
+        with (
+            patch("deriva_ml.dataset.bag_download.fetch_minid_metadata") as fetch,
+            patch("deriva_ml.dataset.bag_download.create_dataset_minid") as create_fn,
+        ):
             fetch.return_value = "REFRESHED"
             create_fn.return_value = "ark://new"
             result = _tier2_minid_path(
@@ -161,9 +161,7 @@ class TestTier2MinidPath:
         assert result == "REFRESHED"
         create_fn.assert_called_once()
         # The regenerated URL flows into the metadata fetch.
-        fetch.assert_called_once_with(
-            dataset, DatasetVersion.parse("1.0.0"), "ark://new"
-        )
+        fetch.assert_called_once_with(dataset, DatasetVersion.parse("1.0.0"), "ark://new")
 
     def test_spec_drift_create_false_raises(self):
         dataset = MagicMock()
@@ -191,15 +189,19 @@ class TestTier2MinidPath:
 class TestTier3ClientPath:
     """``_tier3_client_path`` generates bags locally under the cache suffix."""
 
-    def test_generates_bag_and_returns_dataset_minid(self):
+    def test_generates_bag_and_returns_dataset_minid(self, tmp_path):
         dataset = MagicMock()
         dataset.dataset_rid = "3WX"
+        # The client arm now extracts into the cache itself and returns the
+        # final cache PATH; Tier 3 wraps its PARENT (the checksum cache root)
+        # as the DatasetMinid location, matching the Tier-1 shape so the
+        # downstream download_dataset_minid call is a no-op cache hit.
+        cache_bag = tmp_path / "cache" / "bags" / "abcdef1234567890_2-7XYZ" / "Dataset_3WX"
+        cache_bag.mkdir(parents=True)
         # Snapshot must be RID-shaped to satisfy the
         # ``DatasetMinid.RID`` pattern.
-        with patch(
-            "deriva_ml.dataset.bag_download.create_dataset_minid"
-        ) as create_fn:
-            create_fn.return_value = "file:///tmp/bag.zip"
+        with patch("deriva_ml.dataset.bag_download.create_dataset_minid") as create_fn:
+            create_fn.return_value = cache_bag
             result = _tier3_client_path(
                 dataset,
                 version=DatasetVersion.parse("1.0.0"),
@@ -212,10 +214,12 @@ class TestTier3ClientPath:
                 exclude_tables=None,
                 timeout=None,
             )
-        # ``DatasetMinid`` aliases ``location`` → ``bag_url`` and
-        # collapses the ``checksums`` list into the SHA256 value
-        # via a validator.
-        assert result.bag_url == "file:///tmp/bag.zip"
+        # cache_suffix is forwarded to the client arm so its write key matches
+        # what Tier 1 reads.
+        assert create_fn.call_args.kwargs["cache_suffix"] == "abcdef1234567890_2-7XYZ"
+        # ``DatasetMinid`` aliases ``location`` → ``bag_url``. The location is
+        # the file:// URI of the cache root (parent of the extracted bag dir).
+        assert result.bag_url == cache_bag.parent.as_uri()
         assert result.version_rid == "3WX@2-7XYZ"
         assert result.checksum == "abcdef1234567890_2-7XYZ"
 
@@ -245,10 +249,8 @@ class TestTier3ClientPath:
         """
         dataset = MagicMock()
         dataset.dataset_rid = "3WX"
-        with patch(
-            "deriva_ml.dataset.bag_download.create_dataset_minid"
-        ) as create_fn:
-            create_fn.return_value = "file:///tmp/bag.zip"
+        with patch("deriva_ml.dataset.bag_download.create_dataset_minid") as create_fn:
+            create_fn.return_value = Path("/tmp/cache/bags/abc_None/Dataset_3WX")
             result = _tier3_client_path(
                 dataset,
                 version=DatasetVersion.parse("1.0.0"),
@@ -267,10 +269,8 @@ class TestTier3ClientPath:
     def test_passes_through_exclude_tables_and_timeout(self):
         dataset = MagicMock()
         dataset.dataset_rid = "3WX"
-        with patch(
-            "deriva_ml.dataset.bag_download.create_dataset_minid"
-        ) as create_fn:
-            create_fn.return_value = "file:///tmp/bag.zip"
+        with patch("deriva_ml.dataset.bag_download.create_dataset_minid") as create_fn:
+            create_fn.return_value = Path("/tmp/cache/bags/abc_None/Dataset_3WX")
             _tier3_client_path(
                 dataset,
                 version=DatasetVersion.parse("1.0.0"),
@@ -287,3 +287,5 @@ class TestTier3ClientPath:
         assert kwargs["exclude_tables"] == {"Skip"}
         assert kwargs["timeout"] == (7, 42)
         assert kwargs["use_minid"] is False
+        # cache_suffix is forwarded so the client arm's write key matches Tier 1.
+        assert kwargs["cache_suffix"] == "abc_None"


### PR DESCRIPTION
## What

The client-side dataset-bag build (`use_minid=False`) used to stage its zip under `{working_dir}/client_export/{spec_hash[:8]}/` and clean it up only on the success path, via a magic-substring match in a *different* function. This moves staging into a `TemporaryDirectory(dir=cache_dir)`, extracts the bag into the cache **in place**, and returns the final cache path — eliminating the spill, the crash-leak, and the cross-function hand-off.

## Why this was a problem

1. **Wrong directory.** Download staging belongs under `cache_dir` (where the user controls disk via `cache_dir=`), not `working_dir`. Setting `cache_dir=/data` did not redirect it — a multi-GB zip spilled onto `~/.deriva-ml` regardless. (Observed on an eye-ai run: `~/.deriva-ml` near-full while `/data` had room.)
2. **Cleanup only on success.** The `rmtree` was a bare statement reached only if extract+validate succeeded; a crash/exception orphaned the zip in `working_dir`. No `try/finally`.
3. **Fragile coupling.** Producer (`create_dataset_minid`) and cleanup (`download_dataset_minid`) were coupled by the magic substring `"client_export"`.

## How

- **`_extract_archive_to_cache` helper** (new): factors the extract→validate→atomic-move→`index.record` dance out of `download_dataset_minid`. Shared by the S3 arm and the client arm so cache-population semantics are identical and live in one place.
- **Client arm** builds into `TemporaryDirectory(dir=cache_dir)` and extracts itself, returning the final cache `Path`. The context manager guarantees cleanup on **every** exit path (success, exception, kill); nothing touches `working_dir`; staging on the cache filesystem makes the staging→cache move a cheap same-device rename. `cache_suffix` is threaded from `get_dataset_minid` so the write key equals the Tier-1 read key (existing cached bags still hit).
- **Tier 3** wraps the returned cache path as a `DatasetMinid` whose `location` is the extracted dir's parent — same shape Tier 1 produces — so the downstream `download_dataset_minid` call is a cache-hit no-op. No public signatures change.
- **Dead code removed** (delete-unused rule): the `file://`-archive extraction branch, the legacy `DerivaExport.retrieve_file` `else` (no live producer — audited), the `client_export` string-matched cleanup, and the now-unused SHA-256 fallback + `hash_utils` import. `cache_tui` no longer lists `client_export` as a working-dir subdir (`grep -rn client_export src/` → zero hits).

## What does NOT change

Cache layout (`{cache_root}/bags/{checksum}/Dataset_{rid}/`), the `{spec_hash[:16]}_{snapshot}` cache key, `BagCacheIndex.record`, `materialize_dataset_bag` (still materializes in place in the cache), the MINID/S3 arm's external behavior, and all public method signatures.

## Tests

New: `tests/dataset/test_extract_archive_to_cache.py` (helper: atomic move + record, staging cleanup on failure); `tests/dataset/test_client_bag_staging.py` (staging under cache_dir not working_dir, cleanup on extract failure, **live** round-trip asserting the bag lands under `cache_dir` and `working_dir` stays free of `client_export`). Updated `test_get_dataset_minid_helpers.py` Tier-3 tests for the Path-return + `cache_suffix` forwarding.

Green locally against `DERIVA_HOST=localhost`:
- 54 passed across `test_download.py`, `test_format_b_bag.py`, `test_get_dataset_minid_helpers.py`, `test_extract_archive_to_cache.py`, `test_client_bag_staging.py`, `test_bag_materialize.py`, `test_multi_anchor_bag_cache.py`, `test_bag_builder.py` — including the full live client download/materialize/load pipeline (nested, recursive, versioned).

Spec + plan: `docs/superpowers/specs/2026-06-15-client-bag-staging-tmpdir-design.md`, `docs/superpowers/plans/2026-06-15-client-bag-staging-tmpdir.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)