### PR TITLE
fix(bag): scope asset byte download to reachable assets (bump deriva-py #275 + fetch.txt test)

### DIFF
--- a/tests/dataset/test_format_b_bag.py
+++ b/tests/dataset/test_format_b_bag.py
@@ -178,3 +178,94 @@ def test_format_b_bag_one_csv_per_table_matches_estimate(catalog_with_datasets, 
         asserted += 1
 
     assert asserted, "no non-vocab table count was asserted -- the count gate did nothing"
+
+
+@pytest.mark.skipif(
+    os.environ.get("DERIVA_HOST") in (None, ""),
+    reason="needs a live catalog",
+)
+def test_format_b_bag_fetch_txt_scoped_to_reachable_assets(catalog_with_datasets, tmp_path):
+    """The bag's fetch.txt (asset byte manifest) is scoped to the dataset's
+    reachable assets -- one entry per reachable asset RID, not the whole asset
+    table.
+
+    Consumer-side coverage for the asset-fetch over-fetch bug (deriva-py
+    PR #275). Previously the csv processor was rid_set-scoped but the *fetch*
+    processor queried the whole asset table, so fetch.txt -- and therefore the
+    actual byte download -- pulled every asset in the table regardless of
+    dataset membership (a ~6x over-download on eye-ai 2-277G). The estimate
+    correctly counts only reachable assets; this asserts the bag's fetch
+    manifest agrees with it.
+
+    Validated as a true regression guard: against pre-#275 deriva-py this
+    fails on the demo catalog (BoundingBox: fetch.txt 10 vs reachable 4); with
+    the fix the fetch manifest is scoped to the 4 reachable rows.
+
+    The existing one-CSV-per-table test only inspects ``data/**/*.csv`` -- the
+    correctly-scoped half. This test inspects ``fetch.txt``, the half that was
+    broken.
+    """
+    from deriva_ml.dataset.bag_builder import DatasetBagBuilder
+
+    ml, _desc = catalog_with_datasets
+
+    datasets = list(ml.find_datasets())
+    nested = next((d for d in datasets if d.list_dataset_children()), None)
+    if nested is None:
+        pytest.skip("fixture has no nested dataset")
+    version = nested.current_version
+
+    # Estimate is the oracle: per-asset-table reachable row counts.
+    est = nested.estimate_bag_size(version)
+    asset_est = {t: d["row_count"] for t, d in est["tables"].items() if d.get("is_asset") and d["row_count"] > 0}
+    if not asset_est:
+        pytest.skip("fixture's reachable slice has no asset rows to scope")
+
+    snap = nested._version_snapshot_catalog(version)
+    builder = DatasetBagBuilder(ml_instance=snap)
+    zip_path = builder.build_bag(nested, output_dir=tmp_path)
+
+    extract = tmp_path / "extracted"
+    with zipfile.ZipFile(zip_path) as zf:
+        zf.extractall(extract)
+
+    fetch_files = list(extract.rglob("fetch.txt"))
+    assert fetch_files, "bag has no fetch.txt"
+
+    # Bucket fetch entries by asset table. Entry filenames are templated
+    # ``data/asset/{asset_rid}/{table_name}/...`` (the fetch processor's
+    # output_path), so the path segment after ``asset/<rid>/`` is the table.
+    per_table_fetched: dict[str, set[str]] = {}
+    for fetch_txt in fetch_files:
+        for line in fetch_txt.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            # fetch.txt is TSV: <url>\t<length>\t<filename>
+            parts = line.split("\t")
+            if len(parts) < 3:
+                continue
+            filename = parts[2]
+            segs = filename.split("/")
+            if "asset" not in segs:
+                continue
+            i = segs.index("asset")
+            # segs[i+1] = asset_rid, segs[i+2] = table_name
+            if i + 2 >= len(segs):
+                continue
+            asset_rid, table_name = segs[i + 1], segs[i + 2]
+            per_table_fetched.setdefault(table_name, set()).add(asset_rid)
+
+    # For every asset table the estimate reached, the bag's fetch.txt must
+    # contain exactly the reachable asset count -- not the full-table count.
+    # (Pre-#275 the fetch manifest held every row in the table, so this count
+    # would exceed the estimate.)
+    asserted = 0
+    for table, reachable in asset_est.items():
+        fetched = len(per_table_fetched.get(table, set()))
+        assert fetched == reachable, (
+            f"{table}: fetch.txt has {fetched} asset entries but the dataset "
+            f"reaches {reachable} -- fetch processor not scoped to the rid set"
+        )
+        asserted += 1
+    assert asserted, "no asset table fetch-count was asserted"

--- a/uv.lock
+++ b/uv.lock
@@ -853,7 +853,7 @@ wheels = [
 [[package]]
 name = "deriva"
 version = "2.0.0.dev0"
-source = { git = "https://github.com/informatics-isi-edu/deriva-py?branch=deriva-ml#f3f988920cf127ae87e824316947c942b2030557" }
+source = { git = "https://github.com/informatics-isi-edu/deriva-py?branch=deriva-ml#93add8069d03a8411c7239ca576145f1ac1d9507" }
 dependencies = [
     { name = "bdbag" },
     { name = "fair-identifiers-client" },


### PR DESCRIPTION
## What

Bumps the deriva-py pin to include [deriva-py#275](https://github.com/informatics-isi-edu/deriva-py/pull/275) (merged) and adds the consumer-side regression test.

deriva-py #275 fixes a real over-fetch bug: `CatalogBagBuilder.get_export_spec` emitted a `rid_set`-scoped **csv** processor for each reachable asset table but an **unscoped fetch** processor. Since the fetch processor drives `fetch.txt` (the asset byte manifest), a dataset bag downloaded the bytes of **every row in the asset table**, not just the dataset-reachable rows. On eye-ai `2-277G` the bag's fetch.txt had 225,345 image entries (the whole catalog) vs ~29,734 reachable → ~6-8x over-download. The deriva-ml **estimate** was correct (it scopes asset bytes to reachable RIDs); the **bag** over-fetched — they disagreed.

## Changes

- **`uv.lock`**: deriva pin `f3f9889` → `93add80` (the merged #275). Verified the installed `catalog_builder.py` now emits a chunked `RID=any(...)`-scoped asset fetch.
- **`tests/dataset/test_format_b_bag.py`**: new `test_format_b_bag_fetch_txt_scoped_to_reachable_assets`. Builds a Format-B bag, parses `fetch.txt`, buckets asset entries by table, and asserts the per-table fetch-entry count equals the estimate's reachable asset count.

## Why this test (the gap that let the bug ship)

The existing `test_format_b_bag_one_csv_per_table_matches_estimate` only inspects `data/**/*.csv` — the correctly-scoped half. It never looked at `fetch.txt`, the half that was broken. This new test inspects exactly that.

**Validated as a true regression guard, not a tautology:** with the pre-#275 deriva-py installed, it *fails* on the demo catalog — `BoundingBox: fetch.txt has 10 asset entries but the dataset reaches 4` (the demo fixture already has reachable < total for the BoundingBox asset table, so no fixture change was needed). With #275 it passes (scoped to 4).

## Verification

- `tests/dataset/test_format_b_bag.py`: **9 passed** (incl. the new test) against `DERIVA_HOST=localhost`.
- Demonstrated red→green by swapping the installed deriva-py: pre-fix fails (10≠4), post-fix passes.

Per the cross-repo rule (CLAUDE.md), the contract test for the emission lives upstream in deriva-py #275 (`test_rid_set_scopes_asset_fetch_processor`, `test_rid_set_chunks_large_asset_fetch`); this downstream test is consumer-integration coverage of the real `build_bag` → `fetch.txt` flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)