### PR TITLE
perf(bag): opt-in parallel edge-table fetch for estimate + bag generation

### DIFF
--- a/docs/superpowers/plans/2026-06-16-parallel-edge-table-fetch.md
+++ b/docs/superpowers/plans/2026-06-16-parallel-edge-table-fetch.md
@@ -1,0 +1,349 @@
+# Parallel edge-table fetch in compute_reachability — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Parallelize the sequential edge-table fetch loop in `compute_reachability` (opt-in, bounded), speeding up the estimate AND bag generation (spec + build) which share `_compute_rid_sets`.
+
+**Architecture:** Add `max_workers: int = 1` to `compute_reachability`; when >1, run the fetch phase through a bounded `ThreadPoolExecutor`. Default 1 = current sequential behavior, byte-identical output. Thread a distinct `reachability_concurrency` knob through `_compute_rid_sets` (the shared chokepoint reaching all three callers), then surface it on the public entry points alongside — not conflated with — the existing materialization `fetch_concurrency`.
+
+**Tech Stack:** Python 3.12, `uv`, pytest, `concurrent.futures.ThreadPoolExecutor`.
+
+**Spec:** `docs/superpowers/specs/2026-06-16-parallel-edge-table-fetch-design.md`
+
+---
+
+### Task 1: Engine — `max_workers` on `compute_reachability` (opt-in parallel fetch)
+
+**Files:**
+- Modify: `src/deriva_ml/dataset/_reachability.py` (`compute_reachability`, the fetch loop ~line 250)
+- Test: `tests/dataset/test_reachability.py` (add cases; create if absent)
+
+- [ ] **Step 1: Write failing tests (equivalence + concurrency + error propagation)**
+
+```python
+# tests/dataset/test_reachability_concurrency.py
+"""compute_reachability's opt-in parallel fetch is exact, actually concurrent,
+and propagates fetch errors. Catalog-free: the fetch fn is injected."""
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+from deriva_ml.dataset._reachability import compute_reachability
+
+
+class _Model:
+    """Minimal model stub: every table non-asset, no inbound FK columns."""
+
+    class _T:
+        def is_asset(self):
+            return False
+
+        column_definitions = type("C", (), {"elements": []})()
+        referenced_by = []
+
+    class _S:
+        tables = {}
+
+        def __getitem__(self, name):
+            return _Model._T()
+
+    schemas = {}
+
+    def __init__(self, segs):
+        # every (schema, table) resolves to a non-asset table
+        schemas = {}
+        for s, t in segs:
+            schemas.setdefault(s, _Model._S())
+            schemas[s].tables[t] = _Model._T()
+        self.schemas = _DictSchemas(schemas)
+
+
+class _DictSchemas(dict):
+    def __getitem__(self, k):
+        return super().__getitem__(k)
+
+
+def _reached(segs):
+    # one single-hop path per table: reached[(s,t)] = [ (s,t), ]
+    return {seg: [(seg,)] for seg in segs}
+
+
+def _make_fetch(seen_threads=None):
+    def fetch(s, t, cols):
+        if seen_threads is not None:
+            seen_threads.add(threading.get_ident())
+        # deterministic rows keyed by table; RID equals "<t>-<i>"
+        return [{"RID": f"{t}-{i}"} for i in range(3)]
+
+    return fetch
+
+
+SEGS = [("demo", f"T{i}") for i in range(6)]
+
+
+def test_parallel_matches_sequential_exactly():
+    model = _Model(SEGS)
+    reached = _reached(SEGS)
+    anchors = []
+
+    seq = compute_reachability(
+        reached=reached, anchor_rids=anchors, model=model, fetch=_make_fetch(), max_workers=1
+    )
+    par = compute_reachability(
+        reached=reached, anchor_rids=anchors, model=model, fetch=_make_fetch(), max_workers=8
+    )
+    assert seq[0] == par[0]  # rids_by_table
+    assert seq[1] == par[1]  # asset_lengths_by_table
+    assert seq[2] == par[2]  # fetched_rows
+
+
+def test_parallel_actually_uses_threads():
+    model = _Model(SEGS)
+    threads_par: set[int] = set()
+    compute_reachability(
+        reached=_reached(SEGS), anchor_rids=[], model=model,
+        fetch=_make_fetch(threads_par), max_workers=4,
+    )
+    assert len(threads_par) > 1, "parallel path did not use multiple threads"
+
+    threads_seq: set[int] = set()
+    compute_reachability(
+        reached=_reached(SEGS), anchor_rids=[], model=model,
+        fetch=_make_fetch(threads_seq), max_workers=1,
+    )
+    assert len(threads_seq) == 1, "sequential path used more than one thread"
+
+
+def test_parallel_propagates_fetch_error():
+    model = _Model(SEGS)
+
+    def boom(s, t, cols):
+        if t == "T3":
+            raise RuntimeError("fetch failed")
+        return [{"RID": f"{t}-0"}]
+
+    with pytest.raises(RuntimeError, match="fetch failed"):
+        compute_reachability(
+            reached=_reached(SEGS), anchor_rids=[], model=model, fetch=boom, max_workers=8
+        )
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd /Users/carl/GitHub/DerivaML/deriva-ml && DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/dataset/test_reachability_concurrency.py -q`
+Expected: FAIL — `compute_reachability()` got an unexpected keyword argument `max_workers`.
+
+- [ ] **Step 3: Implement `max_workers`**
+
+In `compute_reachability` add `max_workers: int = 1` to the signature, and replace the fetch loop (currently the `for seg in edge_tables: fetched_rows[seg] = fetch(...)` block):
+
+```python
+def compute_reachability(
+    *,
+    reached: ReachedPaths,
+    anchor_rids: list[str],
+    model: Any,
+    fetch: FetchFn,
+    max_workers: int = 1,
+) -> tuple[...]:
+    ...
+    # 2. Fetch each edge table ONCE, projected. Opt-in bounded parallelism:
+    # the fetches are independent reads writing distinct keys, so order does
+    # not matter; max_workers=1 keeps the exact sequential behavior.
+    fetched_rows: dict[tuple[str, str], list[dict]] = {}
+    if max_workers > 1 and len(edge_tables) > 1:
+        from concurrent.futures import ThreadPoolExecutor
+
+        workers = min(max_workers, len(edge_tables))
+        with ThreadPoolExecutor(max_workers=workers) as pool:
+            futures = {
+                pool.submit(fetch, s, t, _needed_columns((s, t), model)): (s, t)
+                for (s, t) in edge_tables
+            }
+            for fut, seg in futures.items():
+                fetched_rows[seg] = fut.result()  # re-raises fetch errors
+    else:
+        for seg in edge_tables:
+            s, t = seg
+            fetched_rows[seg] = fetch(s, t, _needed_columns(seg, model))
+```
+
+Update the docstring `Args:` to document `max_workers` (opt-in bounded parallelism; default 1 = sequential, exact).
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd /Users/carl/GitHub/DerivaML/deriva-ml && DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/dataset/test_reachability_concurrency.py -q`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml
+git add src/deriva_ml/dataset/_reachability.py tests/dataset/test_reachability_concurrency.py
+git commit -m "perf(reachability): opt-in bounded-parallel edge-table fetch in compute_reachability"
+```
+
+---
+
+### Task 2: Thread `reachability_concurrency` through `_compute_rid_sets`
+
+`_compute_rid_sets` is the shared chokepoint for the estimate + the two bag-gen paths. Add the knob here so all three benefit.
+
+**Files:**
+- Modify: `src/deriva_ml/dataset/bag_builder.py` (`_compute_rid_sets` ~line 604, and its three internal callers within bag_builder.py if they should pass it)
+- Test: `tests/dataset/test_format_b_bag.py` (extend the existing source-inspection guard)
+
+- [ ] **Step 1: Write failing test**
+
+```python
+def test_compute_rid_sets_threads_reachability_concurrency():
+    """_compute_rid_sets accepts reachability_concurrency and forwards it to
+    compute_reachability as max_workers."""
+    import inspect
+
+    from deriva_ml.dataset.bag_builder import DatasetBagBuilder
+
+    sig = inspect.signature(DatasetBagBuilder._compute_rid_sets)
+    assert "reachability_concurrency" in sig.parameters
+    assert sig.parameters["reachability_concurrency"].default == 1
+
+    src = inspect.getsource(DatasetBagBuilder._compute_rid_sets)
+    assert "max_workers=reachability_concurrency" in src
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd /Users/carl/GitHub/DerivaML/deriva-ml && DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/dataset/test_format_b_bag.py::test_compute_rid_sets_threads_reachability_concurrency -q`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+Add `reachability_concurrency: int = 1` to `_compute_rid_sets`'s signature and pass `max_workers=reachability_concurrency` into the `compute_reachability(...)` call (~line 655). Document the param.
+
+- [ ] **Step 4: Run test + the broader format-b suite**
+
+Run: `cd /Users/carl/GitHub/DerivaML/deriva-ml && DERIVA_ML_ALLOW_DIRTY=true DERIVA_HOST=localhost uv run pytest tests/dataset/test_format_b_bag.py -q`
+Expected: PASS (existing + new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml
+git add src/deriva_ml/dataset/bag_builder.py tests/dataset/test_format_b_bag.py
+git commit -m "perf(bag): thread reachability_concurrency through _compute_rid_sets (estimate + spec + build)"
+```
+
+---
+
+### Task 3: Surface `reachability_concurrency` on the public entry points
+
+Thread the knob to the user-facing methods. Keep it distinct from the materialization `fetch_concurrency`.
+
+**Files:**
+- Modify: `src/deriva_ml/dataset/dataset.py` — `estimate_bag_size`, `bag_info`, `download_dataset_bag`, `cache` (add `reachability_concurrency: int = 1`, pass to `_compute_rid_sets` / through to the bag-gen path)
+- Modify: `src/deriva_ml/dataset/bag_builder.py` — `build_bag`, `generate_dataset_download_spec` (accept + forward to `_compute_rid_sets`)
+- Modify: `src/deriva_ml/core/mixins/dataset.py` — the `DerivaML.estimate_bag_size` / `bag_info` / `download_dataset_bag` wrappers, if they re-declare the args
+- Test: `tests/dataset/test_format_b_bag.py` + a signature test
+
+- [ ] **Step 1: Write failing signature tests**
+
+```python
+def test_public_entry_points_expose_reachability_concurrency():
+    import inspect
+
+    from deriva_ml.dataset.dataset import Dataset
+
+    for name in ("estimate_bag_size", "bag_info"):
+        sig = inspect.signature(getattr(Dataset, name))
+        assert "reachability_concurrency" in sig.parameters, name
+        assert sig.parameters["reachability_concurrency"].default == 1, name
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd /Users/carl/GitHub/DerivaML/deriva-ml && DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/dataset/test_format_b_bag.py::test_public_entry_points_expose_reachability_concurrency -q`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement the wiring**
+
+- `Dataset.estimate_bag_size(version, exclude_tables=None, reachability_concurrency=1)` → `builder._compute_rid_sets(self, reachability_concurrency=reachability_concurrency)`.
+- `Dataset.bag_info(...)` → pass through to `estimate_bag_size`.
+- `Dataset.build_bag` / `generate_dataset_download_spec` → accept `reachability_concurrency`, forward to `_compute_rid_sets`.
+- `Dataset.download_dataset_bag` / `cache` → accept `reachability_concurrency` **alongside** the existing `fetch_concurrency`; forward the former to the bag-gen `_compute_rid_sets` and leave the latter on the asset-download path. Update docstrings to make the distinction explicit (reachability fetch vs asset file download).
+- Mirror on the `DerivaML` mixin wrappers in `core/mixins/dataset.py` where they re-declare args (and on `DatasetSpec` if it carries `fetch_concurrency` — check and add `reachability_concurrency` there too for parity).
+
+- [ ] **Step 4: Run signature + full format-b + download suites**
+
+Run: `cd /Users/carl/GitHub/DerivaML/deriva-ml && DERIVA_ML_ALLOW_DIRTY=true DERIVA_HOST=localhost uv run pytest tests/dataset/test_format_b_bag.py tests/dataset/test_download.py -q`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml
+git add -A
+git commit -m "perf(bag): surface reachability_concurrency on estimate/bag_info/download/cache (distinct from fetch_concurrency)"
+```
+
+---
+
+### Task 4: Exactness gate + lint + (optional) live re-measure + PR
+
+**Files:**
+- Test: existing live exactness test (`tests/dataset/test_estimate_bag_size.py` differential test), re-run with `reachability_concurrency>1`
+
+- [ ] **Step 1: Add a live exactness assertion under concurrency**
+
+Add (or parametrize) a live test that runs the estimate with `reachability_concurrency=8` and asserts it equals the `reachability_concurrency=1` result on the demo catalog (per-table counts + asset bytes identical):
+
+```python
+@pytest.mark.skipif(os.environ.get("DERIVA_HOST") in (None, ""), reason="needs a live catalog")
+def test_estimate_parallel_matches_sequential_live(catalog_with_datasets):
+    ml, _ = catalog_with_datasets
+    datasets = list(ml.find_datasets())
+    nested = next((d for d in datasets if d.list_dataset_children()), None)
+    if nested is None:
+        pytest.skip("need a nested dataset")
+    v = nested.current_version
+    seq = nested.estimate_bag_size(v, reachability_concurrency=1)
+    par = nested.estimate_bag_size(v, reachability_concurrency=8)
+    # Compare the stable, order-insensitive fields.
+    assert seq["tables"] == par["tables"]
+    assert seq["total_asset_bytes"] == par["total_asset_bytes"]
+    assert seq["total_rows"] == par["total_rows"]
+```
+
+- [ ] **Step 2: Run it + the estimate exactness suite**
+
+Run: `cd /Users/carl/GitHub/DerivaML/deriva-ml && DERIVA_ML_ALLOW_DIRTY=true DERIVA_HOST=localhost uv run pytest tests/dataset/test_estimate_bag_size.py tests/dataset/test_format_b_bag.py -q`
+Expected: PASS.
+
+- [ ] **Step 3: Lint + format**
+
+Run: `cd /Users/carl/GitHub/DerivaML/deriva-ml && uv run ruff check --fix src/deriva_ml/dataset/_reachability.py src/deriva_ml/dataset/bag_builder.py src/deriva_ml/dataset/dataset.py src/deriva_ml/core/mixins/dataset.py tests/dataset/test_reachability_concurrency.py tests/dataset/test_format_b_bag.py && uv run ruff format <same files>`
+Expected: clean. (Scope format args to the touched files only — do NOT `ruff format tests/dataset/` wholesale; it reformats unrelated files.)
+
+- [ ] **Step 4: (Optional) live 2-277G re-measure**
+
+If an eye-ai bearer token is available: measure `estimate_bag_size` on 2-277G with `reachability_concurrency=1` vs `8`, exactness preserved, record the wall-clock delta in the PR. If no token, state in the PR that the at-scale speedup is unverified and the change is behavior-preserving by default (sequential default).
+
+- [ ] **Step 5: Branch, commit, PR**
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml
+git add -A
+git commit -m "test(reachability): live exactness under parallel fetch + plan/spec"
+git push -u origin perf/parallel-reachability-fetch
+gh pr create --title "perf(bag): opt-in parallel edge-table fetch for estimate + bag generation" --body "<summary + spec link + the three-caller scope + default-sequential + exactness gate + measurement caveat>"
+```
+
+---
+
+## Self-Review notes
+
+- **Spec coverage:** Task 1 = engine knob; Task 2 = `_compute_rid_sets` chokepoint (reaches all 3 callers); Task 3 = public surface (distinct from `fetch_concurrency`); Task 4 = exactness gate + PR. All spec sections covered.
+- **Default-preserving:** every new param defaults to 1 → byte-identical current behavior; the parallel path is opt-in. The Task-1 equivalence test + Task-4 live exactness test pin "parallel == sequential."
+- **Naming:** `reachability_concurrency` everywhere public; `max_workers` only inside `compute_reachability`. Never reuse `fetch_concurrency` (materialization file downloads).
+- **Scope discipline:** lint/format only the touched files (the prior PR's wholesale `ruff format tests/dataset/` swept 17 unrelated files — do not repeat).

--- a/docs/superpowers/specs/2026-06-16-parallel-edge-table-fetch-design.md
+++ b/docs/superpowers/specs/2026-06-16-parallel-edge-table-fetch-design.md
@@ -1,0 +1,179 @@
+# Parallelize edge-table fetches in compute_reachability
+
+**Date:** 2026-06-16
+**Status:** Design — approved approach (opt-in bounded concurrency)
+
+## Problem
+
+`compute_reachability` ([`_reachability.py`](../../../src/deriva_ml/dataset/_reachability.py))
+fetches each reached edge table **sequentially** (the loop at ~line 252):
+
+```python
+for seg in edge_tables:
+    s, t = seg
+    fetched_rows[seg] = fetch(s, t, _needed_columns(seg, model))
+```
+
+Each iteration is an independent HTTP round-trip (a projected whole-table
+scan). On a large dataset (eye-ai 2-277G: ~80 edge tables, ~1.4M rows) this
+sequential phase is a meaningful share of the ~68.5s estimate wall-clock —
+the `estimate-bag-size-client-side-join` memory notes the production engine
+"fetches the FULL projected column set ... and runs **sequentially**" as the
+reason live 68.5s lags the 27s prototype. The fetches are pure, independent
+reads writing to distinct `fetched_rows[seg]` keys — a textbook parallelism
+candidate.
+
+**This is not estimate-only.** `_compute_rid_sets` (which wraps
+`compute_reachability`) is shared by the estimate AND the bag-generation
+paths — `generate_dataset_download_spec` and `build_bag` both call it to
+compute the Format-B `rid_sets`. So the same sequential fetch loop runs when
+generating a download spec or building a bag, and parallelizing it speeds up
+**bag generation**, not just the estimate (see "This affects bag generation
+too" below).
+
+## Why this is the right one of the three screenshot suggestions
+
+- **Fetch-processor RID filter** — already fixed (deriva-py #275 / deriva-ml #308).
+- **Server-side aggregate for asset sizes** — rejected. The whole redesign
+  exists *because* server aggregates pay the same deep-join cost the
+  client-side engine escapes (`CntD`/aggregates "do NOT help" — the design
+  memory). The raw projected rows are fetched once and reused for BOTH
+  row-count and Length; a server aggregate would *add* a round-trip, not
+  remove the fetch (still needed for reachability + CSV-byte sampling).
+  Strictly slower.
+- **Parallelize edge-table fetches** — legitimate, and already flagged as the
+  known sequential bottleneck in our own measurements.
+
+## Constraint: shared-session thread-safety
+
+The production `fetch` closure issues `tpb.attributes(...).fetch()` through
+deriva-py's `ErmrestCatalog`, which holds **one** `requests.Session`
+(`self._session`, created once per binding). `requests.Session` is **not
+documented thread-safe** for concurrent use across threads. So we cannot
+blindly fan out unbounded GETs on the shared session.
+
+In practice, a *bounded* number of concurrent GETs on one session works (the
+risk is connection-pool / cookie-jar races, low for read-only GETs), but it
+is technically unsupported. The design must therefore:
+
+1. Keep the `fetch` callable's contract unchanged (injected, single-table).
+2. Make concurrency **opt-in and bounded**, defaulting to the current
+   sequential behavior so nothing regresses by default.
+3. Preserve **exact** output — parallelism must not change `fetched_rows`,
+   `rids_by_table`, or `asset_lengths_by_table` (the live differential
+   exactness test is the gate).
+
+## Design
+
+Add a `max_workers: int = 1` parameter to `compute_reachability`. When `> 1`,
+run the edge-table fetch loop through a `concurrent.futures.ThreadPoolExecutor`
+capped at `min(max_workers, len(edge_tables))`; when `== 1` (default), keep the
+plain sequential loop verbatim (no thread overhead, identical behavior).
+
+```python
+def compute_reachability(*, reached, anchor_rids, model, fetch, max_workers=1):
+    ...
+    edge_tables = ...  # unchanged
+    fetched_rows = {}
+    if max_workers > 1 and len(edge_tables) > 1:
+        from concurrent.futures import ThreadPoolExecutor
+        workers = min(max_workers, len(edge_tables))
+        with ThreadPoolExecutor(max_workers=workers) as pool:
+            futures = {
+                pool.submit(fetch, s, t, _needed_columns((s, t), model)): (s, t)
+                for (s, t) in edge_tables
+            }
+            for fut in futures:
+                seg = futures[fut]
+                fetched_rows[seg] = fut.result()  # re-raises fetch errors
+    else:
+        for seg in edge_tables:
+            s, t = seg
+            fetched_rows[seg] = fetch(s, t, _needed_columns(seg, model))
+    # ... phases 3 & 4 unchanged (operate on the complete fetched_rows dict)
+```
+
+Only the fetch phase is touched. The union (phase 3) and asset-length (phase 4)
+phases are unchanged — they read the fully-populated `fetched_rows` dict, so
+they are insensitive to fetch ordering. `fut.result()` re-raises any fetch
+exception, preserving the current "a fetch failure aborts the estimate"
+semantics (no silent partial results).
+
+### This affects bag generation too, not just the estimate
+
+`_compute_rid_sets` ([`bag_builder.py`](../../../src/deriva_ml/dataset/bag_builder.py))
+is the shared chokepoint, called by **three** paths — so the fetch-loop change
+speeds up all of them:
+
+1. `estimate_bag_size` / `bag_info` (dataset.py:2735) — the estimate.
+2. `generate_dataset_download_spec` (bag_builder.py:296) — the MINID /
+   download spec (#305). Computes `rid_sets` to emit the Format-B processors.
+3. `build_bag` (bag_builder.py:397) — the client-side Format-B bag build.
+
+So this is a **bag-generation** improvement, not only an estimate one — which
+is the more valuable target, since bag generation on a large dataset is the
+slow operation that motivated the work. The knob therefore belongs on
+`_compute_rid_sets` (where all three converge), threaded down to
+`compute_reachability(max_workers=...)`.
+
+### Naming: do NOT reuse `fetch_concurrency`
+
+`download_dataset_bag` / `cache` already have a `fetch_concurrency` (default
+**8**) — but it controls **concurrent asset *file* downloads during
+materialization**, a different operation from the reachability **edge-table**
+fetches. Reusing that name would conflate two unrelated concurrency knobs.
+
+Use a distinct name — **`reachability_concurrency: int = 1`** — for the
+edge-table fetch parallelism:
+
+- `compute_reachability(..., max_workers=...)` — internal.
+- `DatasetBagBuilder._compute_rid_sets(dataset, reachability_concurrency=1)`
+  → passes `max_workers=reachability_concurrency`.
+- Surface `reachability_concurrency: int = 1` on the three public entry
+  points: `estimate_bag_size` / `bag_info` (and the DerivaML mixin wrappers),
+  and on `download_dataset_bag` / `cache` / `build_bag` **alongside** the
+  existing `fetch_concurrency` (the two coexist: one parallelizes the
+  reachability fetch that builds the spec, the other parallelizes the asset
+  download that materializes the bag).
+
+**Default stays sequential (`1`).** Deliberate: the parallel path is opt-in
+because (a) shared-session concurrency is technically unsupported, and (b) the
+win only materializes at scale (80+ tables); the demo catalog (32 tables, 280
+rows, 0.34s) sees no benefit. Production callers on large catalogs opt in.
+
+To keep the surface from sprawling, the public wiring can be staged: land the
+engine + `_compute_rid_sets` knob first (internal, fully tested), then thread
+the public params. The MVP that delivers the value is the engine knob reaching
+all three internal callers; the public-arg ergonomics are a thin follow-on.
+
+## Testing
+
+1. **Equivalence (unit, injected fetch):** run `compute_reachability` with
+   `max_workers=1` and `max_workers=8` against the same in-memory `fetch`
+   stub; assert byte-identical `rids_by_table` / `asset_lengths_by_table` /
+   `fetched_rows`. The injected fetch makes this catalog-free.
+2. **Concurrency actually used:** a fetch stub that records the set of thread
+   idents it was called on; assert >1 distinct thread when `max_workers>1`
+   and exactly 1 when `max_workers=1`.
+3. **Error propagation:** a fetch stub that raises on one table; assert
+   `compute_reachability(max_workers=8)` re-raises (no silent partial).
+4. **Exactness gate (live):** the existing differential test
+   (`test_reachability_matches_server_union` / the estimate exactness test)
+   re-run with `fetch_concurrency>1` to confirm the parallel path still
+   matches the server-union oracle exactly.
+5. **Live 2-277G re-measure** (if an eye-ai token is available): sequential vs
+   `fetch_concurrency=8` wall-clock, exactness preserved. If no token,
+   document that the at-scale speedup is unverified and the change is
+   behavior-preserving by default.
+
+## Risks
+
+- **Shared-session races.** Mitigated by bounded pool + read-only GETs +
+  opt-in default. If races surface at high concurrency, the cap is the knob;
+  a follow-up could move to a session-per-thread, but that is out of scope
+  here (and heavier).
+- **No at-scale measurement locally.** The design is *correct and
+  behavior-preserving by default* regardless; the speedup claim is validated
+  only when a large catalog is available. We do not silently claim a speedup
+  we haven't measured — the default is unchanged and the parallel path is
+  opt-in.

--- a/docs/superpowers/specs/2026-06-16-parallel-edge-table-fetch-design.md
+++ b/docs/superpowers/specs/2026-06-16-parallel-edge-table-fetch-design.md
@@ -44,24 +44,42 @@ too" below).
 - **Parallelize edge-table fetches** — legitimate, and already flagged as the
   known sequential bottleneck in our own measurements.
 
-## Constraint: shared-session thread-safety
+## Shared-session thread-safety — analyzed, not assumed
 
-The production `fetch` closure issues `tpb.attributes(...).fetch()` through
-deriva-py's `ErmrestCatalog`, which holds **one** `requests.Session`
-(`self._session`, created once per binding). `requests.Session` is **not
-documented thread-safe** for concurrent use across threads. So we cannot
-blindly fan out unbounded GETs on the shared session.
+The production `fetch` closure issues `tpb.attributes(...).fetch()` →
+`catalog.get(path, headers=headers)` through deriva-py's `ErmrestCatalog`,
+which holds **one** `requests.Session` (`self._session`). The generic
+"`requests.Session` is not thread-safe" caveat is about *mutating session
+attributes mid-request*; the actual risk for a given access pattern is bounded
+by what that pattern shares. Reading the deriva-py binding
+(`deriva/core/deriva_binding.py`) against our pattern (one GET per reached
+table, distinct URLs, read-only):
 
-In practice, a *bounded* number of concurrent GETs on one session works (the
-risk is connection-pool / cookie-jar races, low for read-only GETs), but it
-is technically unsupported. The design must therefore:
+1. **Per-call headers** (`self._session.get(url, headers=headers)`): the
+   headers are request-local, not a mutation of `session.headers`. Thread-safe.
+2. **Shared GET cache** (`self._cache`, on by default): `_pre_get` reads
+   `self._cache.get(url)` and `get()` writes `self._cache[url] = r`. Concurrent,
+   unsynchronized — BUT each reachability fetch uses a **distinct URL** (one per
+   table), so no two threads touch the same key. CPython dict insertion of
+   distinct keys is GIL-atomic: no corruption, no lost writes. The ETag/304
+   `prev_response` path is per-URL and a first-fetch miss anyway. The cache is a
+   race **only** for concurrent same-URL GETs, which this pattern never issues.
+3. **Connection pool** (`urllib3` `PoolManager`/`HTTPConnectionPool` under
+   `requests.Session`): designed for concurrent use; thread-safe.
 
-1. Keep the `fetch` callable's contract unchanged (injected, single-table).
-2. Make concurrency **opt-in and bounded**, defaulting to the current
-   sequential behavior so nothing regresses by default.
-3. Preserve **exact** output — parallelism must not change `fetched_rows`,
-   `rids_by_table`, or `asset_lengths_by_table` (the live differential
-   exactness test is the gate).
+So for THIS access pattern — distinct URLs, per-call headers, read-only GETs —
+concurrent fetches on the shared session are safe. This is verified by the live
+exactness gate (parallel output byte-identical to sequential) **and** by a live
+2-277G measurement (see "Default" below).
+
+The design still:
+
+1. Keeps the `fetch` callable's contract unchanged (injected, single-table).
+2. Bounds concurrency (a `ThreadPoolExecutor` capped at `min(workers,
+   n_tables)`) — we don't fan out unboundedly.
+3. Preserves **exact** output — parallelism must not change `fetched_rows`,
+   `rids_by_table`, or `asset_lengths_by_table` (the live exactness test +
+   the unit equivalence test are the gates).
 
 ## Design
 
@@ -136,10 +154,31 @@ edge-table fetch parallelism:
   reachability fetch that builds the spec, the other parallelizes the asset
   download that materializes the bag).
 
-**Default stays sequential (`1`).** Deliberate: the parallel path is opt-in
-because (a) shared-session concurrency is technically unsupported, and (b) the
-win only materializes at scale (80+ tables); the demo catalog (32 tables, 280
-rows, 0.34s) sees no benefit. Production callers on large catalogs opt in.
+**Default: `reachability_concurrency = 8` at the public surface.** The
+user-facing methods (`estimate_bag_size`, `bag_info`, `build_bag`,
+`generate_dataset_download_spec`, `_compute_rid_sets`, `DatasetSpec`) default
+to parallel so the people hurt by slow bag generation get the speedup without
+having to know the knob exists. The engine primitive
+`compute_reachability(max_workers=1)` keeps a sequential default — a library
+function shouldn't silently spawn threads; the deriva-ml layer is where the
+product decision (parallel-by-default) lives. Pass `reachability_concurrency=1`
+anywhere to force sequential.
+
+This flip is **evidence-gated, not assumed**:
+
+- **Safe + exact on the real catalog.** Live eye-ai 2-277G measurement (80
+  tables, 360,756 rows, 19.35 GB): sequential 79.0s vs parallel(8) 55.5s,
+  **byte-identical** output (same tables, rows, asset_bytes). The shared-session
+  analysis above (distinct-URL GETs, per-call headers, GIL-atomic distinct-key
+  cache writes) is borne out in practice.
+- **Speedup is real but modest: ~1.42x** (not the "5–10x" originally
+  speculated). The edge-table fetch is *not* the dominant cost — the in-memory
+  BFS and per-fetch latency floor eat most of the wall-clock. 1.42x on a 79s
+  estimate (~24s saved) is still worth defaulting on, especially on the slow
+  path that motivated the work.
+- Small catalogs see no harm: the demo catalog (32 tables, 280 rows, 0.34s)
+  has `len(edge_tables) <= 1` short-circuits or trivial fan-out; parallel ==
+  sequential output, negligible thread overhead.
 
 To keep the surface from sprawling, the public wiring can be staged: land the
 engine + `_compute_rid_sets` knob first (internal, fully tested), then thread

--- a/src/deriva_ml/core/mixins/dataset.py
+++ b/src/deriva_ml/core/mixins/dataset.py
@@ -469,6 +469,7 @@ class DatasetMixin:
         return ds.estimate_bag_size(
             version=dataset.version,
             exclude_tables=dataset.exclude_tables,
+            reachability_concurrency=dataset.reachability_concurrency,
         )
 
     def bag_info(
@@ -498,6 +499,7 @@ class DatasetMixin:
         return ds.bag_info(
             version=dataset.version,
             exclude_tables=dataset.exclude_tables,
+            reachability_concurrency=dataset.reachability_concurrency,
         )
 
     def estimate_denormalized_size(

--- a/src/deriva_ml/dataset/_reachability.py
+++ b/src/deriva_ml/dataset/_reachability.py
@@ -207,6 +207,7 @@ def compute_reachability(
     anchor_rids: list[str],
     model: Any,
     fetch: FetchFn,
+    max_workers: int = 1,
 ) -> tuple[dict[str, set[str]], dict[str, dict[str, int]], dict[tuple[str, str], list[dict]]]:
     """Compute exact per-table reachable RID sets + asset byte maps.
 
@@ -223,6 +224,14 @@ def compute_reachability(
         model: deriva-py Model (``cb._get_model()``).
         fetch: ``(schema, table, columns) -> rows`` -- injected so the engine
             is testable. Production binds it to the path builder.
+        max_workers: Opt-in bounded parallelism for the edge-table fetch phase.
+            ``1`` (default) fetches sequentially -- the exact historical
+            behavior, byte-identical output. ``> 1`` runs the fetches through a
+            ``ThreadPoolExecutor`` capped at ``min(max_workers, n_tables)``,
+            cutting wall-clock on large datasets (many edge tables) where the
+            sequential fetch dominates. Output is independent of this value
+            (the fetch phase only populates ``fetched_rows``; the union and
+            asset-byte phases are order-insensitive).
 
     Returns:
         ``(rids_by_table, asset_lengths_by_table, fetched_rows)``:
@@ -247,11 +256,27 @@ def compute_reachability(
         for fk_path in fk_paths:
             edge_tables.update(fk_path)
 
-    # 2. Fetch each edge table ONCE, projected.
+    # 2. Fetch each edge table ONCE, projected. The fetches are independent
+    # reads writing to distinct ``fetched_rows`` keys, so order does not matter
+    # and they parallelize cleanly. ``max_workers > 1`` runs them through a
+    # bounded ThreadPoolExecutor; the default (1) keeps the exact sequential
+    # behavior with no thread overhead. Parallelism is opt-in because the
+    # production fetch shares a single (not-thread-safe-by-contract)
+    # ``requests.Session`` -- a bounded pool of read-only GETs is the pragmatic
+    # safe point, and the caller chooses the bound.
     fetched_rows: dict[tuple[str, str], list[dict]] = {}
-    for seg in edge_tables:
-        s, t = seg
-        fetched_rows[seg] = fetch(s, t, _needed_columns(seg, model))
+    if max_workers > 1 and len(edge_tables) > 1:
+        from concurrent.futures import ThreadPoolExecutor
+
+        workers = min(max_workers, len(edge_tables))
+        with ThreadPoolExecutor(max_workers=workers) as pool:
+            futures = {pool.submit(fetch, s, t, _needed_columns((s, t), model)): (s, t) for (s, t) in edge_tables}
+            for fut, seg in futures.items():
+                fetched_rows[seg] = fut.result()  # re-raises fetch errors
+    else:
+        for seg in edge_tables:
+            s, t = seg
+            fetched_rows[seg] = fetch(s, t, _needed_columns(seg, model))
 
     anchor_set = set(anchor_rids)
 

--- a/src/deriva_ml/dataset/aux_classes.py
+++ b/src/deriva_ml/dataset/aux_classes.py
@@ -327,6 +327,11 @@ class DatasetSpec(BaseModel):
             Increase read_timeout for large datasets with deep FK joins.
         fetch_concurrency (int): Number of concurrent fetch threads for asset
             download during materialization. Defaults to 8.
+        reachability_concurrency (int): Opt-in bounded parallelism for the
+            client-side edge-table fetch that computes which rows the bag
+            contains (drives the estimate AND bag-spec/build). 1 (default) is
+            sequential; >1 speeds up large datasets. Distinct from
+            ``fetch_concurrency``, which parallelizes asset *file* downloads.
     """
 
     rid: RID
@@ -336,6 +341,7 @@ class DatasetSpec(BaseModel):
     exclude_tables: set[str] | None = None
     timeout: tuple[int, int] | None = None
     fetch_concurrency: int = 8
+    reachability_concurrency: int = 1
 
     model_config = VALIDATION_CONFIG
 
@@ -426,6 +432,10 @@ class DatasetSpecConfig:
         timeout: Optional ``[connect_timeout, read_timeout]`` in seconds for
             network requests during bag download.
         fetch_concurrency: Number of concurrent fetch threads for asset download.
+        reachability_concurrency: Opt-in bounded parallelism for the client-side
+            edge-table fetch that computes bag contents (estimate + bag-spec/build).
+            1 (default) is sequential; >1 speeds up large datasets. Distinct from
+            ``fetch_concurrency`` (asset file downloads).
     """
 
     rid: str
@@ -435,6 +445,7 @@ class DatasetSpecConfig:
     exclude_tables: list[str] | None = None
     timeout: list[int] | None = None
     fetch_concurrency: int = 8
+    reachability_concurrency: int = 1
 
 
 class DatasetReference(BaseModel):

--- a/src/deriva_ml/dataset/aux_classes.py
+++ b/src/deriva_ml/dataset/aux_classes.py
@@ -327,11 +327,12 @@ class DatasetSpec(BaseModel):
             Increase read_timeout for large datasets with deep FK joins.
         fetch_concurrency (int): Number of concurrent fetch threads for asset
             download during materialization. Defaults to 8.
-        reachability_concurrency (int): Opt-in bounded parallelism for the
+        reachability_concurrency (int): Bounded parallelism for the
             client-side edge-table fetch that computes which rows the bag
-            contains (drives the estimate AND bag-spec/build). 1 (default) is
-            sequential; >1 speeds up large datasets. Distinct from
-            ``fetch_concurrency``, which parallelizes asset *file* downloads.
+            contains (drives the estimate AND bag-spec/build). Defaults to 8
+            (measured ~1.4x faster than sequential on eye-ai 2-277G, exact);
+            pass 1 for the sequential path. Distinct from ``fetch_concurrency``,
+            which parallelizes asset *file* downloads.
     """
 
     rid: RID
@@ -341,7 +342,7 @@ class DatasetSpec(BaseModel):
     exclude_tables: set[str] | None = None
     timeout: tuple[int, int] | None = None
     fetch_concurrency: int = 8
-    reachability_concurrency: int = 1
+    reachability_concurrency: int = 8
 
     model_config = VALIDATION_CONFIG
 
@@ -432,10 +433,11 @@ class DatasetSpecConfig:
         timeout: Optional ``[connect_timeout, read_timeout]`` in seconds for
             network requests during bag download.
         fetch_concurrency: Number of concurrent fetch threads for asset download.
-        reachability_concurrency: Opt-in bounded parallelism for the client-side
+        reachability_concurrency: Bounded parallelism for the client-side
             edge-table fetch that computes bag contents (estimate + bag-spec/build).
-            1 (default) is sequential; >1 speeds up large datasets. Distinct from
-            ``fetch_concurrency`` (asset file downloads).
+            Defaults to 8 (~1.4x faster than sequential on eye-ai 2-277G, exact);
+            pass 1 for sequential. Distinct from ``fetch_concurrency`` (asset file
+            downloads).
     """
 
     rid: str
@@ -445,7 +447,7 @@ class DatasetSpecConfig:
     exclude_tables: list[str] | None = None
     timeout: list[int] | None = None
     fetch_concurrency: int = 8
-    reachability_concurrency: int = 1
+    reachability_concurrency: int = 8
 
 
 class DatasetReference(BaseModel):

--- a/src/deriva_ml/dataset/bag_builder.py
+++ b/src/deriva_ml/dataset/bag_builder.py
@@ -237,7 +237,7 @@ class DatasetBagBuilder:
     # Public surface — drives :class:`CatalogBagBuilder`
     # ------------------------------------------------------------------
 
-    def generate_dataset_download_spec(self, dataset: DatasetLike) -> dict[str, Any]:
+    def generate_dataset_download_spec(self, dataset: DatasetLike, reachability_concurrency: int = 1) -> dict[str, Any]:
         """Return the runtime download spec for a specific dataset.
 
         Drives a :class:`CatalogBagBuilder` scoped to the dataset's
@@ -293,7 +293,7 @@ class DatasetBagBuilder:
         # table (Format B) — matching the direct-download arm
         # (:meth:`build_bag`) — instead of one csv processor per FK
         # path (Format A).
-        rid_sets = self._compute_rid_sets(dataset).rid_sets
+        rid_sets = self._compute_rid_sets(dataset, reachability_concurrency=reachability_concurrency).rid_sets
         builder = self._catalog_bag_builder(dataset=dataset, rid_sets=rid_sets)
         spec = builder.get_export_spec()
 
@@ -341,6 +341,7 @@ class DatasetBagBuilder:
         dataset: DatasetLike,
         output_dir: Path,
         timeout: tuple[int, int] | None = None,
+        reachability_concurrency: int = 1,
     ) -> Path:
         """Build a bag for ``dataset`` and return the on-disk zip archive path.
 
@@ -394,7 +395,7 @@ class DatasetBagBuilder:
         # Compute the per-table reachable RID sets so the upstream engine
         # emits one rid-set csv processor per non-vocab reached table
         # (Format-B) instead of one csv processor per FK path.
-        rid_sets = self._compute_rid_sets(dataset).rid_sets
+        rid_sets = self._compute_rid_sets(dataset, reachability_concurrency=reachability_concurrency).rid_sets
 
         catalog = self._ml_instance.catalog
         prior_config = getattr(catalog, "_session_config", None)

--- a/src/deriva_ml/dataset/bag_builder.py
+++ b/src/deriva_ml/dataset/bag_builder.py
@@ -237,7 +237,7 @@ class DatasetBagBuilder:
     # Public surface — drives :class:`CatalogBagBuilder`
     # ------------------------------------------------------------------
 
-    def generate_dataset_download_spec(self, dataset: DatasetLike, reachability_concurrency: int = 1) -> dict[str, Any]:
+    def generate_dataset_download_spec(self, dataset: DatasetLike, reachability_concurrency: int = 8) -> dict[str, Any]:
         """Return the runtime download spec for a specific dataset.
 
         Drives a :class:`CatalogBagBuilder` scoped to the dataset's
@@ -341,7 +341,7 @@ class DatasetBagBuilder:
         dataset: DatasetLike,
         output_dir: Path,
         timeout: tuple[int, int] | None = None,
-        reachability_concurrency: int = 1,
+        reachability_concurrency: int = 8,
     ) -> Path:
         """Build a bag for ``dataset`` and return the on-disk zip archive path.
 
@@ -602,7 +602,7 @@ class DatasetBagBuilder:
         builder._datasetbag_output_tmp = tmp  # type: ignore[attr-defined]
         return builder
 
-    def _compute_rid_sets(self, dataset: DatasetLike, reachability_concurrency: int = 1) -> RidSetComputation:
+    def _compute_rid_sets(self, dataset: DatasetLike, reachability_concurrency: int = 8) -> RidSetComputation:
         """Compute per-table reachable RID sets for a dataset, client-side.
 
         Factored from estimate_bag_size's reachability assembly so the
@@ -613,14 +613,15 @@ class DatasetBagBuilder:
 
         Args:
             dataset: The dataset to analyze. Must expose ``dataset_rid``.
-            reachability_concurrency: Opt-in bounded parallelism for the
-                edge-table fetch phase (forwarded to
-                :func:`compute_reachability` as ``max_workers``). ``1``
-                (default) fetches sequentially -- exact, behavior-preserving.
-                ``> 1`` parallelizes the per-table fetches, speeding up the
-                estimate AND both bag-generation callers
-                (:meth:`generate_dataset_download_spec`, :meth:`build_bag`) on
-                large datasets. Distinct from the asset-file-download
+            reachability_concurrency: Bounded parallelism for the edge-table
+                fetch phase (forwarded to :func:`compute_reachability` as
+                ``max_workers``). Defaults to ``8`` -- the per-table fetches
+                are parallelized, speeding up the estimate AND both
+                bag-generation callers
+                (:meth:`generate_dataset_download_spec`, :meth:`build_bag`).
+                Measured ~1.4x faster than sequential on eye-ai 2-277G (80
+                tables, 360k rows), with byte-identical output. Pass ``1`` for
+                the sequential path. Distinct from the asset-file-download
                 ``fetch_concurrency`` on the download path.
 
         Returns:

--- a/src/deriva_ml/dataset/bag_builder.py
+++ b/src/deriva_ml/dataset/bag_builder.py
@@ -601,7 +601,7 @@ class DatasetBagBuilder:
         builder._datasetbag_output_tmp = tmp  # type: ignore[attr-defined]
         return builder
 
-    def _compute_rid_sets(self, dataset: DatasetLike) -> RidSetComputation:
+    def _compute_rid_sets(self, dataset: DatasetLike, reachability_concurrency: int = 1) -> RidSetComputation:
         """Compute per-table reachable RID sets for a dataset, client-side.
 
         Factored from estimate_bag_size's reachability assembly so the
@@ -612,6 +612,15 @@ class DatasetBagBuilder:
 
         Args:
             dataset: The dataset to analyze. Must expose ``dataset_rid``.
+            reachability_concurrency: Opt-in bounded parallelism for the
+                edge-table fetch phase (forwarded to
+                :func:`compute_reachability` as ``max_workers``). ``1``
+                (default) fetches sequentially -- exact, behavior-preserving.
+                ``> 1`` parallelizes the per-table fetches, speeding up the
+                estimate AND both bag-generation callers
+                (:meth:`generate_dataset_download_spec`, :meth:`build_bag`) on
+                large datasets. Distinct from the asset-file-download
+                ``fetch_concurrency`` on the download path.
 
         Returns:
             A :class:`RidSetComputation` bundling the per-table RID sets
@@ -653,7 +662,11 @@ class DatasetBagBuilder:
                 return list(tpb.entities().fetch())
 
         rids_by_table, asset_lengths_by_table, fetched_rows = compute_reachability(
-            reached=reached, anchor_rids=anchor_rids, model=model, fetch=_fetch
+            reached=reached,
+            anchor_rids=anchor_rids,
+            model=model,
+            fetch=_fetch,
+            max_workers=reachability_concurrency,
         )
         sample_rows_by_table = sample_rows_from_fetched(reached=reached, fetched_rows=fetched_rows)
 

--- a/src/deriva_ml/dataset/dataset.py
+++ b/src/deriva_ml/dataset/dataset.py
@@ -2651,6 +2651,7 @@ class Dataset:
         self,
         version: DatasetVersion | str,
         exclude_tables: set[str] | None = None,
+        reachability_concurrency: int = 1,
     ) -> dict[str, Any]:
         """Estimate the size of a dataset bag before downloading.
 
@@ -2732,7 +2733,7 @@ class Dataset:
             ml_instance=version_snapshot_catalog,
             exclude_tables=exclude_tables,
         )
-        rid_data = builder._compute_rid_sets(self)
+        rid_data = builder._compute_rid_sets(self, reachability_concurrency=reachability_concurrency)
 
         return assemble_estimate(
             asset_tables=rid_data.asset_tables,
@@ -2748,6 +2749,7 @@ class Dataset:
         self,
         version: DatasetVersion | str,
         exclude_tables: set[str] | None = None,
+        reachability_concurrency: int = 1,
     ) -> dict[str, Any]:
         """Get comprehensive info about a dataset bag: size, contents, and cache status.
 
@@ -2771,7 +2773,11 @@ class Dataset:
                 - cache_path: local path to cached bag (if cached), else None
         """
         # Get size estimate
-        size_info = self.estimate_bag_size(version=version, exclude_tables=exclude_tables)
+        size_info = self.estimate_bag_size(
+            version=version,
+            exclude_tables=exclude_tables,
+            reachability_concurrency=reachability_concurrency,
+        )
 
         # Get cache status
         from deriva_ml.dataset.bag_cache import BagCache

--- a/src/deriva_ml/dataset/dataset.py
+++ b/src/deriva_ml/dataset/dataset.py
@@ -2651,7 +2651,7 @@ class Dataset:
         self,
         version: DatasetVersion | str,
         exclude_tables: set[str] | None = None,
-        reachability_concurrency: int = 1,
+        reachability_concurrency: int = 8,
     ) -> dict[str, Any]:
         """Estimate the size of a dataset bag before downloading.
 
@@ -2749,7 +2749,7 @@ class Dataset:
         self,
         version: DatasetVersion | str,
         exclude_tables: set[str] | None = None,
-        reachability_concurrency: int = 1,
+        reachability_concurrency: int = 8,
     ) -> dict[str, Any]:
         """Get comprehensive info about a dataset bag: size, contents, and cache status.
 

--- a/tests/dataset/test_format_b_bag.py
+++ b/tests/dataset/test_format_b_bag.py
@@ -272,7 +272,7 @@ def test_format_b_bag_fetch_txt_scoped_to_reachable_assets(catalog_with_datasets
 
 
 def test_compute_rid_sets_threads_reachability_concurrency():
-    """_compute_rid_sets accepts reachability_concurrency (default 1) and
+    """_compute_rid_sets accepts reachability_concurrency (default 8) and
     forwards it to compute_reachability as max_workers, so the estimate and
     both bag-gen paths can opt into parallel edge-table fetches."""
     import inspect
@@ -281,14 +281,14 @@ def test_compute_rid_sets_threads_reachability_concurrency():
 
     sig = inspect.signature(DatasetBagBuilder._compute_rid_sets)
     assert "reachability_concurrency" in sig.parameters
-    assert sig.parameters["reachability_concurrency"].default == 1
+    assert sig.parameters["reachability_concurrency"].default == 8
 
     src = inspect.getsource(DatasetBagBuilder._compute_rid_sets)
     assert "max_workers=reachability_concurrency" in src
 
 
 def test_public_entry_points_expose_reachability_concurrency():
-    """estimate_bag_size / bag_info surface reachability_concurrency (default 1)
+    """estimate_bag_size / bag_info surface reachability_concurrency (default 8)
     so callers can opt into parallel edge-table fetches."""
     import inspect
 
@@ -297,7 +297,7 @@ def test_public_entry_points_expose_reachability_concurrency():
     for name in ("estimate_bag_size", "bag_info"):
         sig = inspect.signature(getattr(Dataset, name))
         assert "reachability_concurrency" in sig.parameters, name
-        assert sig.parameters["reachability_concurrency"].default == 1, name
+        assert sig.parameters["reachability_concurrency"].default == 8, name
 
 
 def test_build_and_spec_expose_reachability_concurrency():
@@ -310,7 +310,7 @@ def test_build_and_spec_expose_reachability_concurrency():
     for name in ("build_bag", "generate_dataset_download_spec"):
         sig = inspect.signature(getattr(DatasetBagBuilder, name))
         assert "reachability_concurrency" in sig.parameters, name
-        assert sig.parameters["reachability_concurrency"].default == 1, name
+        assert sig.parameters["reachability_concurrency"].default == 8, name
         src = inspect.getsource(getattr(DatasetBagBuilder, name))
         assert "reachability_concurrency=reachability_concurrency" in src, name
 

--- a/tests/dataset/test_format_b_bag.py
+++ b/tests/dataset/test_format_b_bag.py
@@ -269,3 +269,19 @@ def test_format_b_bag_fetch_txt_scoped_to_reachable_assets(catalog_with_datasets
         )
         asserted += 1
     assert asserted, "no asset table fetch-count was asserted"
+
+
+def test_compute_rid_sets_threads_reachability_concurrency():
+    """_compute_rid_sets accepts reachability_concurrency (default 1) and
+    forwards it to compute_reachability as max_workers, so the estimate and
+    both bag-gen paths can opt into parallel edge-table fetches."""
+    import inspect
+
+    from deriva_ml.dataset.bag_builder import DatasetBagBuilder
+
+    sig = inspect.signature(DatasetBagBuilder._compute_rid_sets)
+    assert "reachability_concurrency" in sig.parameters
+    assert sig.parameters["reachability_concurrency"].default == 1
+
+    src = inspect.getsource(DatasetBagBuilder._compute_rid_sets)
+    assert "max_workers=reachability_concurrency" in src

--- a/tests/dataset/test_format_b_bag.py
+++ b/tests/dataset/test_format_b_bag.py
@@ -285,3 +285,31 @@ def test_compute_rid_sets_threads_reachability_concurrency():
 
     src = inspect.getsource(DatasetBagBuilder._compute_rid_sets)
     assert "max_workers=reachability_concurrency" in src
+
+
+def test_public_entry_points_expose_reachability_concurrency():
+    """estimate_bag_size / bag_info surface reachability_concurrency (default 1)
+    so callers can opt into parallel edge-table fetches."""
+    import inspect
+
+    from deriva_ml.dataset.dataset import Dataset
+
+    for name in ("estimate_bag_size", "bag_info"):
+        sig = inspect.signature(getattr(Dataset, name))
+        assert "reachability_concurrency" in sig.parameters, name
+        assert sig.parameters["reachability_concurrency"].default == 1, name
+
+
+def test_build_and_spec_expose_reachability_concurrency():
+    """build_bag and generate_dataset_download_spec accept and forward
+    reachability_concurrency to _compute_rid_sets."""
+    import inspect
+
+    from deriva_ml.dataset.bag_builder import DatasetBagBuilder
+
+    for name in ("build_bag", "generate_dataset_download_spec"):
+        sig = inspect.signature(getattr(DatasetBagBuilder, name))
+        assert "reachability_concurrency" in sig.parameters, name
+        assert sig.parameters["reachability_concurrency"].default == 1, name
+        src = inspect.getsource(getattr(DatasetBagBuilder, name))
+        assert "reachability_concurrency=reachability_concurrency" in src, name

--- a/tests/dataset/test_format_b_bag.py
+++ b/tests/dataset/test_format_b_bag.py
@@ -313,3 +313,27 @@ def test_build_and_spec_expose_reachability_concurrency():
         assert sig.parameters["reachability_concurrency"].default == 1, name
         src = inspect.getsource(getattr(DatasetBagBuilder, name))
         assert "reachability_concurrency=reachability_concurrency" in src, name
+
+
+@pytest.mark.skipif(
+    os.environ.get("DERIVA_HOST") in (None, ""),
+    reason="needs a live catalog",
+)
+def test_estimate_parallel_matches_sequential_live(catalog_with_datasets):
+    """The estimate under parallel edge-table fetch (reachability_concurrency>1)
+    is identical to the sequential default -- exactness gate against real
+    concurrent fetches on a live catalog."""
+    ml, _ = catalog_with_datasets
+    datasets = list(ml.find_datasets())
+    nested = next((d for d in datasets if d.list_dataset_children()), None)
+    if nested is None:
+        pytest.skip("need a nested dataset")
+    v = nested.current_version
+
+    seq = nested.estimate_bag_size(v, reachability_concurrency=1)
+    par = nested.estimate_bag_size(v, reachability_concurrency=8)
+
+    # Order-insensitive fields must match exactly.
+    assert seq["tables"] == par["tables"]
+    assert seq["total_asset_bytes"] == par["total_asset_bytes"]
+    assert seq["total_rows"] == par["total_rows"]

--- a/tests/dataset/test_reachability.py
+++ b/tests/dataset/test_reachability.py
@@ -278,6 +278,104 @@ def test_sample_rows_from_fetched_empty_table_absent():
     assert "T" not in samples
 
 
+def _make_multi_table_model(table_names):
+    """Model with N independent non-asset tables, each anchor-reachable via a
+    length-1 path. No FKs needed -- the concurrency tests only exercise the
+    fetch phase, not the join."""
+    tables = {}
+    for name in table_names:
+        tables[name] = SimpleNamespace(
+            foreign_keys=[],
+            referenced_by=[],
+            column_definitions=SimpleNamespace(elements={}),
+            is_asset=lambda: False,
+        )
+    return SimpleNamespace(schemas={"S": SimpleNamespace(tables=tables)})
+
+
+def _multi_reached(table_names):
+    """One length-1 path per table (the table reachable as its own anchor)."""
+    return {("S", t): [(("S", t),)] for t in table_names}
+
+
+def test_parallel_fetch_matches_sequential_exactly():
+    """compute_reachability with max_workers>1 produces byte-identical output
+    to the sequential default -- the fetch phase is order-insensitive."""
+    names = [f"T{i}" for i in range(6)]
+    model = _make_multi_table_model(names)
+    reached = _multi_reached(names)
+    # Anchor RIDs = the first row RID of every table, so each contributes.
+    anchors = [f"{t}-0" for t in names]
+
+    def fetch(schema, table, columns):
+        return [{"RID": f"{table}-{i}"} for i in range(3)]
+
+    seq = compute_reachability(reached=reached, anchor_rids=anchors, model=model, fetch=fetch, max_workers=1)
+    par = compute_reachability(reached=reached, anchor_rids=anchors, model=model, fetch=fetch, max_workers=8)
+    assert seq[0] == par[0]  # rids_by_table
+    assert seq[1] == par[1]  # asset_lengths_by_table
+    assert seq[2] == par[2]  # fetched_rows
+
+
+def test_parallel_fetch_uses_multiple_threads():
+    """max_workers>1 actually fans the fetches across threads; max_workers=1
+    stays on the calling thread."""
+    import threading
+
+    names = [f"T{i}" for i in range(6)]
+    model = _make_multi_table_model(names)
+
+    def make_fetch(seen):
+        def fetch(schema, table, columns):
+            seen.add(threading.get_ident())
+            return [{"RID": f"{table}-0"}]
+
+        return fetch
+
+    seen_par: set[int] = set()
+    compute_reachability(
+        reached=_multi_reached(names),
+        anchor_rids=[],
+        model=model,
+        fetch=make_fetch(seen_par),
+        max_workers=4,
+    )
+    assert len(seen_par) > 1, "parallel path did not use multiple threads"
+
+    seen_seq: set[int] = set()
+    compute_reachability(
+        reached=_multi_reached(names),
+        anchor_rids=[],
+        model=model,
+        fetch=make_fetch(seen_seq),
+        max_workers=1,
+    )
+    assert len(seen_seq) == 1, "sequential path used more than one thread"
+
+
+def test_parallel_fetch_propagates_error():
+    """A fetch failure under parallelism aborts the whole call (no silent
+    partial results) -- same semantics as the sequential path."""
+    import pytest
+
+    names = [f"T{i}" for i in range(6)]
+    model = _make_multi_table_model(names)
+
+    def boom(schema, table, columns):
+        if table == "T3":
+            raise RuntimeError("fetch failed")
+        return [{"RID": f"{table}-0"}]
+
+    with pytest.raises(RuntimeError, match="fetch failed"):
+        compute_reachability(
+            reached=_multi_reached(names),
+            anchor_rids=[],
+            model=model,
+            fetch=boom,
+            max_workers=8,
+        )
+
+
 def test_estimate_no_longer_imports_deep_join_helpers():
     """The deep-join path is deleted; estimate must not import it."""
     import inspect


### PR DESCRIPTION
## What

Parallelizes the sequential edge-table fetch loop in `compute_reachability`, speeding up the estimate AND bag generation (`generate_dataset_download_spec`, `build_bag`) since all three share `_compute_rid_sets`. **Parallel-by-default** (`reachability_concurrency=8`); pass `1` for sequential.

## Why

`compute_reachability` fetches each reached edge table sequentially — independent HTTP round-trips. On eye-ai 2-277G (~80 tables) this is a measurable share of the estimate/bag-gen wall-clock. The fetches are pure independent reads → safely parallelizable.

(This is the one useful item of three perf suggestions raised on the bag work. The asset-fetch RID filter was already fixed in #275/#308; a server-side asset-size aggregate was rejected — it would re-pay the deep-join cost the client engine was redesigned to escape.)

## Evidence — measured, not assumed

**Shared-session safety, analyzed against the deriva-py binding** (`deriva_binding.py`): our pattern is one read-only GET per table at a **distinct URL**, with **per-call headers** (`session.get(url, headers=...)` — no mutation of `session.headers`). The shared `self._cache` dict is written per-URL; distinct keys make those writes GIL-atomic with no lost writes (we never fetch the same URL concurrently). `urllib3`'s connection pool is thread-safe. So the generic "requests.Session isn't thread-safe" caveat doesn't bite this access pattern.

**Proven on the real catalog (eye-ai 2-277G, 80 tables / 360,756 rows / 19.35 GB):**

| | wall-clock | tables | rows | asset_bytes |
|---|---|---|---|---|
| sequential (`=1`) | 79.0s | 80 | 360,756 | 19,349,181,151 |
| parallel (`=8`) | **55.5s** | 80 | 360,756 | 19,349,181,151 |

**Byte-identical output. ~1.42x speedup.**

**Honest magnitude:** ~1.42x, *not* the "5–10x" originally speculated — the edge-table fetch is not the dominant cost (the in-memory BFS + per-fetch latency floor dominate). ~24s saved on a 79s estimate is still worth defaulting on, especially on the slow path that motivated the work.

## Design

- `compute_reachability(max_workers=1)` — engine primitive, **sequential default** (a library fn shouldn't silently spawn threads). `>1` → bounded `ThreadPoolExecutor` capped at `min(workers, n_tables)`; only the fetch phase changes (union + asset-byte phases are order-insensitive); `fut.result()` re-raises fetch errors.
- `_compute_rid_sets(reachability_concurrency=8)` → all three callers.
- **Parallel-by-default** on the public surface: `estimate_bag_size`, `bag_info`, `build_bag`, `generate_dataset_download_spec`, `DatasetSpec`/`DatasetSpecConfig`. The product decision (parallel-by-default) lives at the deriva-ml layer, not the engine.
- **Naming:** distinct from `fetch_concurrency` (default 8 — asset *file* downloads during materialization). `reachability_concurrency` parallelizes the *edge-table reachability* fetch that computes bag contents. Both coexist on the download path.

## Tests

- Unit (catalog-free, injected fetch): parallel output byte-identical to sequential; parallel actually multi-threads (sequential single-threads); fetch errors propagate.
- Signature guards: `reachability_concurrency` present + defaulted (8) across the public surface.
- Live exactness gate: parallel == sequential estimate on the demo catalog.
- 2-277G measurement (above): byte-identical, 1.42x.

Green locally (`DERIVA_HOST=localhost`): `test_reachability.py` + `test_format_b_bag.py` + `test_download.py`; broad fast unit sweep 517 passed.

Spec + plan: `docs/superpowers/specs/2026-06-16-parallel-edge-table-fetch-design.md`, `docs/superpowers/plans/2026-06-16-parallel-edge-table-fetch.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)