### PR TITLE
fix(storage): _dir_size survives PermissionError so cached-bag listing doesn't crash

### DIFF
--- a/src/deriva_ml/core/storage.py
+++ b/src/deriva_ml/core/storage.py
@@ -21,6 +21,7 @@ Example:
 from __future__ import annotations
 
 import logging
+import os
 import shutil
 import time
 from datetime import datetime, timezone
@@ -111,13 +112,25 @@ def _dir_size(path: Path) -> int:
     if not path.exists():
         return 0
     total = 0
-    for f in path.rglob("*"):
-        try:
-            if f.is_file():
-                total += f.stat().st_size
-        except FileNotFoundError:
-            # Entry vanished mid-walk (concurrent cleanup) — skip it.
-            continue
+    # Walk with ``os.walk`` (not ``Path.rglob``) so a single unreadable
+    # subdirectory is *skipped* and the walk *continues* across its siblings,
+    # rather than aborting. ``onerror`` swallows the per-directory
+    # PermissionError/OSError that traversal raises (e.g. a bag dir owned by
+    # another user, or a stricter filesystem); the per-file ``stat`` is also
+    # guarded for entries that vanish or are unreadable mid-walk. Without this,
+    # one denied bag crashes ``list_cached_bags`` instead of returning the
+    # readable ones.
+    for dirpath, _dirnames, filenames in os.walk(path, onerror=lambda _e: None):
+        base = Path(dirpath)
+        for name in filenames:
+            fp = base / name
+            try:
+                if fp.is_file():
+                    total += fp.stat().st_size
+            except (OSError, PermissionError):
+                # Entry vanished (FileNotFoundError) or is unreadable
+                # (PermissionError) — skip it, keep counting the rest.
+                continue
     return total
 
 

--- a/tests/core/test_storage_management.py
+++ b/tests/core/test_storage_management.py
@@ -299,3 +299,61 @@ def test_get_storage_summary_tallies_cache_and_executions(tmp_path):
     # working_dir and cache_dir are reported as strings.
     assert summary["working_dir"] == str(h.working_dir)
     assert summary["cache_dir"] == str(h.cache_dir)
+
+
+# ---------------------------------------------------------------------------
+# _dir_size resilience to PermissionError (regression: it caught only
+# FileNotFoundError, so a permission-denied subdir crashed list_cached_bags
+# instead of returning the readable bags).
+# ---------------------------------------------------------------------------
+
+
+def test_dir_size_skips_permission_denied_file(monkeypatch, tmp_path):
+    """A file whose size lookup raises PermissionError is skipped, not fatal."""
+    from deriva_ml.core import storage
+
+    (tmp_path / "ok.txt").write_text("hello")  # 5 bytes
+    (tmp_path / "locked.txt").write_text("secret")
+
+    real_stat = Path.stat
+
+    def fake_stat(self, *a, **k):
+        if self.name == "locked.txt":
+            raise PermissionError(13, "Permission denied", str(self))
+        return real_stat(self, *a, **k)
+
+    monkeypatch.setattr(Path, "stat", fake_stat)
+    # Must not raise; counts only the readable file.
+    assert storage._dir_size(tmp_path) == 5
+
+
+def test_dir_size_survives_permission_denied_subdir(monkeypatch, tmp_path):
+    """os.walk hitting a PermissionError traversing a subdir (perm-denied dir on
+    a non-owner process / stricter platform) is skipped, not fatal — and the
+    walk continues across readable siblings via os.walk's onerror callback."""
+    from deriva_ml.core import storage
+
+    # Two readable files plus a (would-be) denied subtree. os.walk's onerror
+    # makes a denied dir non-fatal; assert the readable bytes are still counted.
+    (tmp_path / "a.txt").write_text("hi")  # 2 bytes
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    (sub / "b.txt").write_text("yo")  # 2 bytes
+
+    real_walk = os.walk
+
+    def walk_with_denied_dir(top, **kw):
+        # Drive the real walk but inject an onerror trigger: simulate the
+        # scandir on `sub` raising PermissionError by skipping it and invoking
+        # the caller's onerror, exactly as os.walk does on a real denial.
+        onerror = kw.get("onerror")
+        for dirpath, dirnames, filenames in real_walk(top):
+            if Path(dirpath) == sub:
+                if onerror:
+                    onerror(PermissionError(13, "Permission denied", str(sub)))
+                continue  # denied dir contributes nothing, walk continues
+            yield dirpath, dirnames, filenames
+
+    monkeypatch.setattr(os, "walk", walk_with_denied_dir)
+    # Must not raise; counts the readable top-level file, skips the denied subdir.
+    assert storage._dir_size(tmp_path) == 2

--- a/tests/dataset/test_bag_cache.py
+++ b/tests/dataset/test_bag_cache.py
@@ -1,7 +1,7 @@
 """Tests for BagCache — cache status detection for downloaded dataset bags."""
 
-import pytest
 from pathlib import Path
+
 from deriva_ml.dataset.bag_cache import (
     BagCache,
     CacheStatus,
@@ -86,9 +86,7 @@ class TestCacheStatus:
         data_dir = bag_dir / "data"
         data_dir.mkdir(exist_ok=True)
         (bag_dir / "manifest-sha256.txt").write_text("")
-        (bag_dir / "fetch.txt").write_text(
-            "https://example.com/missing.dat\t100\tdata/missing.dat\n"
-        )
+        (bag_dir / "fetch.txt").write_text("https://example.com/missing.dat\t100\tdata/missing.dat\n")
 
         cache = BagCache(tmp_path)
         result = cache.cache_status("XXXX")
@@ -190,5 +188,41 @@ class TestBagCacheIndexIntegration:
             )
             assert info["cache_path"] is not None
             assert checksum in info["versions_cached"]
+        finally:
+            cache.dispose()
+
+
+class TestListBagsResilience:
+    """list_bags must survive an unreadable bag dir rather than crashing the
+    whole listing (regression: _dir_size caught only FileNotFoundError, so a
+    permission-denied subdir inside a cached bag raised straight through)."""
+
+    def test_list_bags_survives_permission_denied_bag(self, tmp_path, monkeypatch):
+        # Two recorded bags with no size_bytes in the index, so list_bags falls
+        # back to _dir_size(bag_dir) for each. Give each a real data file.
+        bag_a = _record_bag(tmp_path, dataset_rid="AAAA", checksum="aaa111")
+        bag_b = _record_bag(tmp_path, dataset_rid="BBBB", checksum="bbb222")
+        (bag_a / "data.txt").write_text("ok")
+        (bag_b / "data.txt").write_text("secret")
+
+        # Make the size lookup for the SECOND bag's data file raise
+        # PermissionError (a real unreadable file inside a cached bag). Pre-fix
+        # this propagated straight through list_bags and crashed the listing.
+        real_stat = Path.stat
+
+        def fake_stat(self, *a, **k):
+            if str(bag_b) in str(self) and self.name == "data.txt":
+                raise PermissionError(13, "Permission denied", str(self))
+            return real_stat(self, *a, **k)
+
+        monkeypatch.setattr(Path, "stat", fake_stat)
+
+        cache = BagCache(tmp_path)
+        try:
+            # Must NOT raise — returns both bags (the unreadable one included).
+            bags = cache.list_bags()
+            rids = {b.dataset_rid for b in bags}
+            assert "AAAA" in rids
+            assert "BBBB" in rids  # the unreadable bag is still listed
         finally:
             cache.dispose()


### PR DESCRIPTION
## What

`_dir_size` in `core/storage.py` — the per-bag size walk behind `list_cached_bags` / `BagCache.list_bags` — caught only `FileNotFoundError`, while **every other defensive function in the same file** catches `(OSError, PermissionError)` (e.g. `list_cached_assets`, `clear_cache`, `delete_cached_asset`). A permission-denied file or subdirectory inside a cached bag therefore raised straight up through the listing, crashing it with a traceback instead of returning the readable bags.

## The failure path (traced)

`BagCache.list_bags` ([`bag_cache.py:204`](../blob/main/src/deriva_ml/dataset/bag_cache.py#L204)) calls `_dir_size(bag_dir)` inline in the row-building loop with **no per-row try/except**. So a `PermissionError` from `_dir_size` propagates out of the loop → out of `list_bags` → crash, losing every readable bag.

## Fix

Two surfaces, both in `_dir_size`:
1. The per-file size lookup now catches `(OSError, PermissionError)`, not just `FileNotFoundError`.
2. Traversal uses `os.walk(onerror=...)` instead of `Path.rglob`, so a single unreadable subdirectory is **skipped and the walk continues** across its readable siblings, rather than aborting (`rglob`'s generator can't resume past a denied node). Per-file ops stay on `pathlib` (`Path.is_file`/`stat`) to satisfy the repo's PTH lint rules.

Result: a partially-unreadable bag contributes the bytes it *can* read (or 0) and is still listed; the listing never crashes.

## Tests

All three **fail pre-fix, pass post-fix** (verified by reverting `_dir_size` under stash):
- `test_dir_size_skips_permission_denied_file` — an unreadable file is skipped.
- `test_dir_size_survives_permission_denied_subdir` — a denied subdir is skipped via `os.walk`'s `onerror`, the walk continues across siblings, readable bytes still counted.
- `TestListBagsResilience::test_list_bags_survives_permission_denied_bag` — end-to-end: `list_bags` returns **both** bags when one is unreadable.

67 passed across `test_storage_management.py` + `test_bag_cache.py` + `test_cache_introspection.py` + the `storage.py` doctest. Lint clean (PTH-compliant).

Credit: the gap was spotted by tracing the actual failure path through the cache-listing code — most of the storage layer is correctly defensive; this was the one spot that wasn't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)