### PR TITLE
fix(bag): DatasetBag.materialize defaults fetch_concurrency to 8 (was 1)

### DIFF
--- a/src/deriva_ml/dataset/dataset_bag.py
+++ b/src/deriva_ml/dataset/dataset_bag.py
@@ -224,7 +224,7 @@ class DatasetBag:
         """
         return self.model.bag_path
 
-    def materialize(self, *, fetch_concurrency: int = 1) -> Self:
+    def materialize(self, *, fetch_concurrency: int = 8) -> Self:
         """Fetch any not-yet-downloaded files for this bag, in place.
 
         A :class:`DatasetBag` may be downloaded metadata-only (via
@@ -245,7 +245,8 @@ class DatasetBag:
 
         Args:
             fetch_concurrency: Maximum number of concurrent file
-                downloads.
+                downloads. Defaults to 8, matching ``download_dataset_bag`` /
+                ``cache``; pass 1 for sequential downloads.
 
         Returns:
             Self: this same bag (its assets are now present on disk),


### PR DESCRIPTION
## What

`DatasetBag.materialize()` defaulted `fetch_concurrency` to **1** while every other user-facing asset-fetch path defaults to **8**:

| entry point | `fetch_concurrency` default |
|---|---|
| `download_dataset_bag` | 8 |
| `cache` | 8 |
| `DatasetSpec` / `DatasetSpecConfig` | 8 |
| **`DatasetBag.materialize`** | **1** ← outlier |

`.materialize()` is the documented standalone path (`bag = ml.download_dataset_bag(spec).materialize()`), so calling it directly silently ran **sequential** asset downloads — inconsistent and slow. This aligns it to 8.

## Why this came up

Audit of all `fetch_concurrency` defaults (prompted by "confirm fetch_concurrency does not default to 1"). A prior writer-audit (`docs/audits/2026-05-22-writer-audit.md`) had already caught and fixed a P0 where `download_dataset_bag`'s signature was `= 1` but the docstring said "Defaults to 8" — that's resolved. This was the remaining `= 1` outlier on a user-facing method.

## Changes

- `DatasetBag.materialize(fetch_concurrency: int = 8)` (was `1`).
- Docstring now states the default and the rationale (matches `download_dataset_bag` / `cache`; pass 1 for sequential). Previously it documented the param without its default.

## Not changed (deliberate)

The internal free functions `materialize_bag_dir` / `materialize_dataset_bag` keep `= 1`. They are **not user-facing**, and every caller forwards an explicit value from an 8-default public method (verified), so their default never reaches a user. Leaving them avoids churn.

## Docs verified correct

All `fetch_concurrency` docstrings now match their signatures: `download_dataset_bag` / `cache` / `DatasetSpec` say "Defaults to 8" (✓), and `DatasetBag.materialize` now does too. No remaining signature/docstring contradictions.

15 tests pass (`test_bag_materialize.py` + `test_bag_cache.py`). Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)