### PR TITLE
feat(bag): expose reachability_concurrency on download_dataset_bag / cache (fix silent-no-op DatasetSpec field)

### DIFF
--- a/src/deriva_ml/core/mixins/dataset.py
+++ b/src/deriva_ml/core/mixins/dataset.py
@@ -440,6 +440,7 @@ class DatasetMixin:
             exclude_tables=dataset.exclude_tables,
             timeout=dataset.timeout,
             fetch_concurrency=dataset.fetch_concurrency,
+            reachability_concurrency=dataset.reachability_concurrency,
         )
 
     def estimate_bag_size(

--- a/src/deriva_ml/dataset/bag_download.py
+++ b/src/deriva_ml/dataset/bag_download.py
@@ -274,6 +274,7 @@ def create_dataset_minid(
     spec_hash: str | None = None,
     cache_suffix: str | None = None,
     timeout: tuple[int, int] | None = None,
+    reachability_concurrency: int = 8,
 ) -> str | Path:
     """Create a new MINID (Minimal Viable Identifier) for the dataset.
 
@@ -315,7 +316,7 @@ def create_dataset_minid(
                 use_minid=use_minid,
                 exclude_tables=exclude_tables,
             )
-            spec = downloader.generate_dataset_download_spec(dataset)
+            spec = downloader.generate_dataset_download_spec(dataset, reachability_concurrency=reachability_concurrency)
 
         if spec_hash is None:
             spec_hash = _hash_spec(spec)
@@ -393,7 +394,12 @@ def create_dataset_minid(
             cache_dir = Path(dataset._ml_instance.cache_dir)
             with TemporaryDirectory(dir=cache_dir) as staging:
                 try:
-                    zip_path = builder.build_bag(dataset, output_dir=Path(staging), timeout=timeout)
+                    zip_path = builder.build_bag(
+                        dataset,
+                        output_dir=Path(staging),
+                        timeout=timeout,
+                        reachability_concurrency=reachability_concurrency,
+                    )
                 except (
                     DerivaDownloadError,
                     DerivaDownloadConfigurationError,
@@ -545,6 +551,7 @@ def _tier2_minid_path(
     create: bool,
     exclude_tables: set[str] | None,
     timeout: tuple[int, int] | None,
+    reachability_concurrency: int = 8,
 ) -> DatasetMinid:
     """Tier 2 — fetch existing MINID or regenerate when spec drifted.
 
@@ -594,6 +601,7 @@ def _tier2_minid_path(
         spec=spec,
         spec_hash=spec_hash,
         timeout=timeout,
+        reachability_concurrency=reachability_concurrency,
     )
     return fetch_minid_metadata(dataset, version, new_minid_url)
 
@@ -609,6 +617,7 @@ def _tier3_client_path(
     cache_suffix: str,
     exclude_tables: set[str] | None,
     timeout: tuple[int, int] | None,
+    reachability_concurrency: int = 8,
 ) -> DatasetMinid:
     """Tier 3 — generate the bag client-side under the deterministic cache key.
 
@@ -657,6 +666,7 @@ def _tier3_client_path(
         spec_hash=spec_hash,
         cache_suffix=cache_suffix,
         timeout=timeout,
+        reachability_concurrency=reachability_concurrency,
     )
     return DatasetMinid(
         dataset_version=version,
@@ -673,6 +683,7 @@ def get_dataset_minid(
     use_minid: bool,
     exclude_tables: set[str] | None = None,
     timeout: tuple[int, int] | None = None,
+    reachability_concurrency: int = 8,
 ) -> DatasetMinid | None:
     """Locate or create a dataset bag, using a three-tier caching strategy.
 
@@ -748,7 +759,7 @@ def get_dataset_minid(
         use_minid=use_minid,
         exclude_tables=exclude_tables,
     )
-    spec = downloader.generate_dataset_download_spec(dataset)
+    spec = downloader.generate_dataset_download_spec(dataset, reachability_concurrency=reachability_concurrency)
     spec_hash = _hash_spec(spec)
     cache_suffix = f"{spec_hash[:16]}_{snapshot}"
 
@@ -769,6 +780,7 @@ def get_dataset_minid(
             create,
             exclude_tables,
             timeout,
+            reachability_concurrency,
         )
     return _tier3_client_path(
         dataset,
@@ -781,6 +793,7 @@ def get_dataset_minid(
         cache_suffix,
         exclude_tables,
         timeout,
+        reachability_concurrency,
     )
 
 

--- a/src/deriva_ml/dataset/dataset.py
+++ b/src/deriva_ml/dataset/dataset.py
@@ -2560,6 +2560,7 @@ class Dataset:
         exclude_tables: set[str] | None = None,
         timeout: tuple[int, int] | None = None,
         fetch_concurrency: int = 8,
+        reachability_concurrency: int = 8,
     ) -> DatasetBag:
         """Downloads a dataset to the local filesystem and optionally creates a MINID.
 
@@ -2586,6 +2587,10 @@ class Dataset:
                 with deep FK joins that need more time to complete.
             fetch_concurrency: Maximum number of concurrent file downloads during
                 materialization. Defaults to 8.
+            reachability_concurrency: Bounded parallelism for the client-side
+                edge-table reachability fetch that computes the bag's contents
+                (the download spec). Defaults to 8; pass 1 for sequential.
+                Distinct from ``fetch_concurrency`` (asset file downloads).
 
         Returns:
             DatasetBag: A ``DatasetBag`` instance wrapping the downloaded bag. Key attributes:
@@ -2633,7 +2638,13 @@ class Dataset:
         )
 
         minid = get_dataset_minid(
-            self, version, create=True, use_minid=use_minid, exclude_tables=exclude_tables, timeout=timeout
+            self,
+            version,
+            create=True,
+            use_minid=use_minid,
+            exclude_tables=exclude_tables,
+            timeout=timeout,
+            reachability_concurrency=reachability_concurrency,
         )
 
         bag_path = (
@@ -2794,6 +2805,7 @@ class Dataset:
         exclude_tables: set[str] | None = None,
         timeout: tuple[int, int] | None = None,
         fetch_concurrency: int = 8,
+        reachability_concurrency: int = 8,
     ) -> dict[str, Any]:
         """Download a dataset bag into the local cache without creating an execution.
 
@@ -2811,6 +2823,10 @@ class Dataset:
             timeout: Optional (connect_timeout, read_timeout) in seconds.
             fetch_concurrency: Maximum number of concurrent file downloads during
                 materialization. Defaults to 8.
+            reachability_concurrency: Bounded parallelism for the client-side
+                edge-table reachability fetch that computes the bag's contents
+                (the download spec). Defaults to 8; pass 1 for sequential.
+                Distinct from ``fetch_concurrency`` (asset file downloads).
 
         Returns:
             dict with bag_info results after caching (includes cache_status,
@@ -2823,8 +2839,13 @@ class Dataset:
             exclude_tables=exclude_tables,
             timeout=timeout,
             fetch_concurrency=fetch_concurrency,
+            reachability_concurrency=reachability_concurrency,
         )
-        return self.bag_info(version=version, exclude_tables=exclude_tables)
+        return self.bag_info(
+            version=version,
+            exclude_tables=exclude_tables,
+            reachability_concurrency=reachability_concurrency,
+        )
 
     @staticmethod
     def _estimate_csv_bytes(sample_rows: list[dict], total_row_count: int) -> int:

--- a/tests/dataset/test_format_b_bag.py
+++ b/tests/dataset/test_format_b_bag.py
@@ -288,16 +288,35 @@ def test_compute_rid_sets_threads_reachability_concurrency():
 
 
 def test_public_entry_points_expose_reachability_concurrency():
-    """estimate_bag_size / bag_info surface reachability_concurrency (default 8)
-    so callers can opt into parallel edge-table fetches."""
+    """The dataset-bag entry points surface reachability_concurrency (default 8)
+    so callers can tune the parallel edge-table fetch. download_dataset_bag /
+    cache run the same reachability work (via the download spec) as the
+    estimate, so they must expose the knob too."""
     import inspect
 
     from deriva_ml.dataset.dataset import Dataset
 
-    for name in ("estimate_bag_size", "bag_info"):
+    for name in ("estimate_bag_size", "bag_info", "download_dataset_bag", "cache"):
         sig = inspect.signature(getattr(Dataset, name))
         assert "reachability_concurrency" in sig.parameters, name
         assert sig.parameters["reachability_concurrency"].default == 8, name
+
+
+def test_get_and_create_minid_thread_reachability_concurrency():
+    """get_dataset_minid / create_dataset_minid accept reachability_concurrency
+    and forward it to generate_dataset_download_spec, so the download path runs
+    the reachability fetch at the caller's chosen concurrency."""
+    import inspect
+
+    from deriva_ml.dataset import bag_download
+
+    for fn_name in ("get_dataset_minid", "create_dataset_minid"):
+        fn = getattr(bag_download, fn_name)
+        sig = inspect.signature(fn)
+        assert "reachability_concurrency" in sig.parameters, fn_name
+        assert sig.parameters["reachability_concurrency"].default == 8, fn_name
+        src = inspect.getsource(fn)
+        assert "reachability_concurrency=reachability_concurrency" in src, fn_name
 
 
 def test_build_and_spec_expose_reachability_concurrency():
@@ -313,6 +332,18 @@ def test_build_and_spec_expose_reachability_concurrency():
         assert sig.parameters["reachability_concurrency"].default == 8, name
         src = inspect.getsource(getattr(DatasetBagBuilder, name))
         assert "reachability_concurrency=reachability_concurrency" in src, name
+
+
+def test_download_mixin_forwards_datasetspec_reachability_concurrency():
+    """The DerivaML.download_dataset_bag mixin must forward
+    DatasetSpec.reachability_concurrency to the Dataset method — otherwise the
+    DatasetSpec field is silently ignored on the download path."""
+    import inspect
+
+    from deriva_ml.core.mixins.dataset import DatasetMixin
+
+    src = inspect.getsource(DatasetMixin.download_dataset_bag)
+    assert "reachability_concurrency=dataset.reachability_concurrency" in src
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
## What

Threads the `reachability_concurrency` knob (#309 — parallel client-side edge-table fetch) through the **download path**, which previously didn't expose it even though it runs the same reachability work.

## Why

`reachability_concurrency` was surfaced on `estimate_bag_size` / `bag_info` / `build_bag` / `generate_dataset_download_spec`, but **not** on `download_dataset_bag` / `cache` — even though those run the same reachability fetch (via the download spec) to decide what the bag contains.

Worse: **`DatasetSpec` already carried `reachability_concurrency`** (added in #309), but the `DerivaML.download_dataset_bag` mixin forwarded `dataset.fetch_concurrency` and **not** `dataset.reachability_concurrency` — so the field was a **silent no-op** on its main consumer. Setting it on a `DatasetSpec` did nothing.

## Changes

End-to-end thread, default `8` preserved everywhere (behavior unchanged — this only adds the override and makes the existing `DatasetSpec` field take effect):

- `Dataset.download_dataset_bag` / `Dataset.cache` — new `reachability_concurrency: int = 8` param, forwarded.
- `get_dataset_minid` / `create_dataset_minid` / `_tier2_minid_path` / `_tier3_client_path` (bag_download.py) — forward it to every `generate_dataset_download_spec` and `build_bag` call (both the spec-hash computation and the regeneration arms).
- `DerivaML.download_dataset_bag` mixin — now forwards `dataset.reachability_concurrency` (the silent-no-op fix).
- Docstrings updated; distinct from `fetch_concurrency` (asset file downloads).

## Tests

- Signature + source-forwarding guards across `download_dataset_bag`, `cache`, `get_dataset_minid`, `create_dataset_minid`, and the mixin's `DatasetSpec` forward (`reachability_concurrency=dataset.reachability_concurrency`).
- Live download + format-b integration: **26 passed** (`DERIVA_HOST=localhost`).
- Broad fast unit sweep: **532 passed, 8 skipped** — no signature/validation breakage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)