### PR TITLE
fix(bag): cache_dataset forwards DatasetSpec.reachability_concurrency (missed in #312)

### DIFF
--- a/src/deriva_ml/core/mixins/dataset.py
+++ b/src/deriva_ml/core/mixins/dataset.py
@@ -634,7 +634,11 @@ class DatasetMixin:
 
         Args:
             dataset: Specification of the dataset, including version and
-                optional exclude_tables.
+                optional exclude_tables. Concurrency is taken from the spec:
+                ``DatasetSpec.fetch_concurrency`` (asset file downloads) and
+                ``DatasetSpec.reachability_concurrency`` (the edge-table
+                reachability fetch) — both default to 8. Set them on the spec
+                to tune, e.g. ``DatasetSpec(rid=..., fetch_concurrency=4)``.
             materialize: If True (default), download all asset files. If False,
                 download only table metadata.
 
@@ -650,6 +654,7 @@ class DatasetMixin:
             exclude_tables=dataset.exclude_tables,
             timeout=dataset.timeout,
             fetch_concurrency=dataset.fetch_concurrency,
+            reachability_concurrency=dataset.reachability_concurrency,
         )
 
     # ------------------------------------------------------------------

--- a/tests/dataset/test_format_b_bag.py
+++ b/tests/dataset/test_format_b_bag.py
@@ -335,15 +335,18 @@ def test_build_and_spec_expose_reachability_concurrency():
 
 
 def test_download_mixin_forwards_datasetspec_reachability_concurrency():
-    """The DerivaML.download_dataset_bag mixin must forward
+    """The spec-driven DerivaML mixins must forward
     DatasetSpec.reachability_concurrency to the Dataset method — otherwise the
-    DatasetSpec field is silently ignored on the download path."""
+    DatasetSpec field is silently ignored on that path."""
     import inspect
 
     from deriva_ml.core.mixins.dataset import DatasetMixin
 
-    src = inspect.getsource(DatasetMixin.download_dataset_bag)
-    assert "reachability_concurrency=dataset.reachability_concurrency" in src
+    # Every mixin wrapper that takes a DatasetSpec and triggers a reachability
+    # fetch must forward the spec's reachability_concurrency.
+    for name in ("download_dataset_bag", "cache_dataset", "estimate_bag_size", "bag_info"):
+        src = inspect.getsource(getattr(DatasetMixin, name))
+        assert "reachability_concurrency=dataset.reachability_concurrency" in src, name
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
## What

`cache_dataset` (the DerivaML-level convenience that warms the cache from a `DatasetSpec`) forwarded only `fetch_concurrency` from the spec, not `reachability_concurrency`. So `DatasetSpec(reachability_concurrency=N)` was a **silent no-op** on the cache path — the same bug #312 fixed for `download_dataset_bag` / `estimate_bag_size` / `bag_info`, but `cache_dataset` is a separate mixin method and was missed.

`Dataset.cache` already accepts `reachability_concurrency` (from #312); only the wrapper's forward was missing.

## Changes

- `cache_dataset` now forwards `reachability_concurrency=dataset.reachability_concurrency`.
- Docstring documents that concurrency is taken from the `DatasetSpec` fields (`fetch_concurrency`, `reachability_concurrency`, both default 8) — `cache_dataset` has no scalar kwargs for them, so the spec is where you set them.
- The mixin-forwarding test now covers **all four** spec-driven wrappers (`download_dataset_bag`, `cache_dataset`, `estimate_bag_size`, `bag_info`), so a future wrapper that drops the forward fails CI.

## How to set concurrency through cache_dataset (the practical answer)

```python
spec = DatasetSpec(rid="2-277G", version="...", fetch_concurrency=N)
ml.cache_dataset(spec)
```

No need to switch to `Dataset.cache()` or `download_dataset_bag` — the spec field is the knob.

27 passed (`test_format_b_bag.py` + dataset-spec unit). Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)