### PR TITLE
chore(deps): pin deriva-py by immutable SHA so consumers stay in sync

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -469,6 +469,53 @@ Don't use `bump-my-version` directly as it doesn't push changes.
 
 Run `bump-version` only on `main`, after the feature PR has merged.
 
+**ALWAYS verify the deriva-py pin is current BEFORE bumping** (see
+"Updating the deriva-py pin" below). A release that ships a stale pin
+silently freezes every downstream consumer on an old deriva-py — the
+2026-06-16 eye-ai bag over-fetch (a fixed deriva-py bug reappearing
+because the consumer's lock was behind the pin) is the failure mode
+this prevents.
+
+### Updating the deriva-py pin
+
+deriva-py is pinned to an **immutable commit SHA**, not the
+`deriva-ml` branch, in **two** places that must stay in lockstep:
+
+- `project.dependencies` in `pyproject.toml`:
+  `"deriva @ git+...deriva-py@<sha>"`
+- `[tool.uv.sources]` in `pyproject.toml`:
+  `deriva = { git = "...deriva-py", rev = "<sha>" }`
+
+**Why a SHA and not the branch.** A git-*branch* dependency carries no
+"newer-than" version semantics, and `[tool.uv.sources]` is **not
+transitive** (uv only reads it from the workspace-root project). So a
+downstream project (e.g. eye-ai-vgg19) that bumps `deriva-ml` will
+**not** advance deriva-py — its own lock stays frozen on whatever
+deriva-py commit it last resolved, even though deriva-ml moved. A
+**commit SHA in `project.dependencies` is transitive and immutable**:
+uv records it in deriva-ml's published metadata, so bumping deriva-ml
+*forces* every consumer's resolver to pull deriva-py at exactly that
+commit. This is the mechanism that keeps the two repos in sync
+automatically.
+
+**To advance the pin** (when deriva-ml needs a newer deriva-py — e.g.
+after merging a deriva-py PR on the `deriva-ml` branch):
+
+1. Get the target commit (usually `origin/deriva-ml` HEAD after the
+   deriva-py PR merged):
+   ```bash
+   git -C ../../deriva-py rev-parse origin/deriva-ml
+   ```
+2. Replace the SHA in **both** the `project.dependencies` URL and the
+   `[tool.uv.sources]` `rev` (they must match).
+3. `uv lock && uv sync` and run the suite to confirm the new deriva-py
+   works.
+4. Land via PR like any change, then `bump-version` on `main`.
+
+**The pin advance is part of the bump, not separate.** When a release
+depends on a deriva-py fix, advancing the SHA and bumping the version
+go together — never bump with a stale pin.
+
 ### Asset Upload
 
 Use `asset_file_path()` API to register files for upload:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,13 @@ requires-python = ">=3.12"
 dependencies = [
     "bump-my-version",
     "bdbag @ git+https://github.com/fair-research/bdbag@1.9.0-dev",
-    "deriva @ git+https://github.com/informatics-isi-edu/deriva-py@deriva-ml",
+    # Pinned to an immutable commit (NOT the `deriva-ml` branch) so the pin is
+    # transitive: a downstream project that bumps deriva-ml is forced by uv to
+    # advance deriva-py to this exact commit. A branch pin carries no
+    # "newer-than" signal, so consumers silently freeze on a stale deriva-py
+    # (see CLAUDE.md "Updating the deriva-py pin"). Advance this SHA whenever
+    # deriva-ml needs a newer deriva-py — and BEFORE every bump-version.
+    "deriva @ git+https://github.com/informatics-isi-edu/deriva-py@93add8069d03a8411c7239ca576145f1ac1d9507",
     "deepdiff",
     "nbconvert",
     "pandas",
@@ -53,7 +59,10 @@ build-backend = "setuptools.build_meta"
 python-preference = "only-managed"
 
 [tool.uv.sources]
-deriva = { git = "https://github.com/informatics-isi-edu/deriva-py", branch = "deriva-ml" }
+# Keep this rev in lockstep with the SHA in project.dependencies above. uv
+# applies this source override locally; pinning the same immutable rev (not the
+# branch) keeps dev resolution identical to what consumers get transitively.
+deriva = { git = "https://github.com/informatics-isi-edu/deriva-py", rev = "93add8069d03a8411c7239ca576145f1ac1d9507" }
 
 
 [tool.setuptools.package-data]

--- a/uv.lock
+++ b/uv.lock
@@ -853,7 +853,7 @@ wheels = [
 [[package]]
 name = "deriva"
 version = "2.0.0.dev0"
-source = { git = "https://github.com/informatics-isi-edu/deriva-py?branch=deriva-ml#93add8069d03a8411c7239ca576145f1ac1d9507" }
+source = { git = "https://github.com/informatics-isi-edu/deriva-py?rev=93add8069d03a8411c7239ca576145f1ac1d9507#93add8069d03a8411c7239ca576145f1ac1d9507" }
 dependencies = [
     { name = "bdbag" },
     { name = "fair-identifiers-client" },
@@ -928,7 +928,7 @@ requires-dist = [
     { name = "bdbag", git = "https://github.com/fair-research/bdbag?rev=1.9.0-dev" },
     { name = "bump-my-version" },
     { name = "deepdiff" },
-    { name = "deriva", git = "https://github.com/informatics-isi-edu/deriva-py?branch=deriva-ml" },
+    { name = "deriva", git = "https://github.com/informatics-isi-edu/deriva-py?rev=93add8069d03a8411c7239ca576145f1ac1d9507" },
     { name = "hydra-zen" },
     { name = "nbconvert" },
     { name = "nbstripout" },


### PR DESCRIPTION
## Problem

deriva-py was pinned to the **`deriva-ml` branch** (in both `project.dependencies` and `[tool.uv.sources]`). Two properties of that make downstream syncing impossible:

1. A git-**branch** dependency has no version semantics — `deriva @ branch=deriva-ml` is *permanently* satisfied by whatever commit a lock already recorded. `uv lock` never advances it on its own.
2. `[tool.uv.sources]` is **not transitive** — uv only reads it from the workspace-root project, never from a dependency.

**Net effect:** a downstream project (e.g. eye-ai-vgg19) that bumps `deriva-ml` does *not* advance deriva-py. Its own lock stays frozen on whatever deriva-py commit it last resolved, even though deriva-ml moved.

This is exactly the failure observed 2026-06-16: eye-ai-vgg19 on **deriva-ml 1.50.1** but a **pre-#275 deriva-py** (`f3f9889`), reintroducing the already-fixed asset over-fetch — `fetch.txt` listed the entire catalog (225,345 images / 846 GB) for a 2,795-image / 1.67 GB dataset. The deriva-ml fix was shipped; the consumer never picked it up.

## Fix

Pin deriva-py to the **immutable commit SHA** (`93add80` — current `origin/deriva-ml` HEAD, the merged #275 work) in **both**:
- `project.dependencies`: `deriva @ git+...deriva-py@93add80...`
- `[tool.uv.sources]`: `rev = "93add80..."`

A SHA in `project.dependencies` is **transitive and immutable**: uv records it in deriva-ml's published metadata, so bumping deriva-ml **forces** every consumer's resolver to pull deriva-py at exactly that commit. That's the mechanism that makes "update deriva-ml → deriva-py follows" work automatically, with zero consumer-side knowledge.

Resolves to the **same commit** as before → behavior-neutral for deriva-ml itself (`uv lock --check` clean, 31 unit tests pass, #275 fix still installed).

## CLAUDE.md

- New "Updating the deriva-py pin" subsection: the SHA-pin rationale + the 4-step procedure to advance it (both places must stay in lockstep).
- "verify/advance the deriva-py pin" is now a **required step of `bump-version`** — a release must never ship a stale pin. Cross-referenced to the eye-ai over-fetch as the failure mode.

## Downstream note

Consumers like eye-ai-vgg19 still need a one-time `uv lock --upgrade-package deriva && uv sync` to pick up the corrected pin (their existing lock predates this). From the *next* deriva-ml bump onward, the SHA pin keeps them in sync automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)