### PR TITLE
fix(dataset): tf/torch adapters enumerate FK-reachable elements (match restructure_assets)

### DIFF
--- a/docs/superpowers/plans/2026-06-16-adapter-fk-reachable-elements.md
+++ b/docs/superpowers/plans/2026-06-16-adapter-fk-reachable-elements.md
@@ -1,0 +1,380 @@
+# tf/torch adapters: FK-reachable element enumeration — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `as_tf_dataset` / `as_torch_dataset` enumerate FK-reachable elements (matching `restructure_assets`), via ONE shared reachability core consumed by all three paths.
+
+**Architecture:** Extract a single layer-1 enumeration core (`resolve_reachable_rows`) in `target_resolution.py`; restructure's `_get_reachable_assets` becomes a thin wrapper over it; a `resolve_element_rids` projection (RIDs, order-preserving dedup, `reachable` opt-out) backs both adapters. Layer-2 (materialize-tree vs lazy-yield) stays separate per consumer. Default `reachable=True`.
+
+**Tech Stack:** Python 3.12, `uv`, pytest, SQLAlchemy (bag SQLite), live demo + eye-ai catalogs.
+
+**Spec:** `docs/superpowers/specs/2026-06-16-adapter-fk-reachable-elements-design.md`
+
+---
+
+### Task 1: Shared core `resolve_reachable_rows` + `resolve_element_rids`
+
+**Files:**
+- Modify: `src/deriva_ml/dataset/target_resolution.py`
+- Test: `tests/dataset/test_reachable_enumeration.py` (new)
+
+- [ ] **Step 1: Write failing unit tests (stub bag — no catalog)**
+
+```python
+"""resolve_reachable_rows / resolve_element_rids: the shared FK-reachable
+element enumeration used by restructure_assets + the tf/torch adapters."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from deriva_ml.dataset.target_resolution import (
+    resolve_reachable_rows,
+    resolve_element_rids,
+)
+
+
+def _stub_bag(rows, *, has_table=True):
+    """Bag whose _dataset_table_view-backed reachable query yields `rows`."""
+    bag = MagicMock()
+    # resolve_reachable_rows reads rows via the same mechanism _get_reachable_assets
+    # uses; stub the helper boundary so the test is catalog-free.
+    bag._reachable_rows_impl = lambda table: list(rows)  # see Step 3 seam
+    # table-existence check
+    bag.model.name_to_table = {"Image": object()} if has_table else {}
+    return bag
+
+
+def test_resolve_reachable_rows_returns_rows_for_reachable_table():
+    rows = [{"RID": "i1", "Filename": "a.png"}, {"RID": "i2", "Filename": "b.png"}]
+    bag = _stub_bag(rows)
+    out = resolve_reachable_rows(bag, "Image")
+    assert out == rows  # full rows, not deduped here
+
+
+def test_resolve_element_rids_reachable_dedups_preserving_order():
+    # Same RID surfaced twice via two FK paths must yield once, in first-seen order.
+    rows = [{"RID": "i1"}, {"RID": "i2"}, {"RID": "i1"}, {"RID": "i3"}]
+    bag = _stub_bag(rows)
+    assert resolve_element_rids(bag, "Image", reachable=True) == ["i1", "i2", "i3"]
+
+
+def test_resolve_element_rids_direct_uses_list_members():
+    bag = MagicMock()
+    bag.list_dataset_members.return_value = {"Image": [{"RID": "d1"}, {"RID": "d2"}]}
+    out = resolve_element_rids(bag, "Image", reachable=False)
+    assert out == ["d1", "d2"]
+    bag.list_dataset_members.assert_called_once_with(recurse=True)
+
+
+def test_resolve_element_rids_unknown_type_raises():
+    from deriva_ml.core.exceptions import DerivaMLException
+
+    bag = _stub_bag([], has_table=False)
+    with pytest.raises(DerivaMLException, match="not found|not resolvable"):
+        resolve_element_rids(bag, "Nope", reachable=True)
+```
+
+- [ ] **Step 2: Run → fail (ImportError)**
+
+Run: `cd /Users/carl/GitHub/DerivaML/deriva-ml && DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/dataset/test_reachable_enumeration.py -q`
+Expected: FAIL — `cannot import name 'resolve_reachable_rows'`.
+
+- [ ] **Step 3: Implement the core + projection**
+
+In `target_resolution.py` add (importing `Session` from `sqlalchemy.orm` and the
+exceptions module):
+
+```python
+def resolve_reachable_rows(bag, table: str) -> list[dict]:
+    """All rows of `table` reachable from this dataset via any FK path.
+
+    Single source of truth for dataset element reachability. Wraps
+    ``bag._dataset_table_view(table)`` (Dataset -> ... -> table UNION over all
+    FK paths, scoped to this dataset + nested datasets). Returns full row dicts.
+    NOT RID-deduped (a UNION can surface a RID via two paths; restructure
+    collapses by filename, the adapters dedup in resolve_element_rids).
+    """
+    from sqlalchemy.orm import Session
+
+    if not _bag_has_table(bag, table):
+        raise DerivaMLException(
+            f"Element type {table!r} not found in bag; available types: "
+            f"{sorted(_bag_table_names(bag))}"
+        )
+    sql_query = bag._dataset_table_view(table)
+    with Session(bag.engine) as session:
+        return [dict(m) for m in session.execute(sql_query).mappings().all()]
+
+
+def resolve_element_rids(bag, element_type: str, *, reachable: bool = True) -> list[str]:
+    """RIDs of `element_type` rows belonging to this dataset (order-preserving,
+    RID-deduped). reachable=True (default): FK reachability; reachable=False:
+    direct members only."""
+    if not reachable:
+        members = bag.list_dataset_members(recurse=True)
+        if element_type not in members:
+            raise DerivaMLException(
+                f"Element type {element_type!r} not found in bag; available "
+                f"types: {sorted(members.keys())}"
+            )
+        rows = members[element_type]
+    else:
+        rows = resolve_reachable_rows(bag, element_type)
+    seen, out = set(), []
+    for r in rows:
+        rid = r["RID"]
+        if rid not in seen:
+            seen.add(rid)
+            out.append(rid)
+    return out
+```
+
+Add small helpers `_bag_has_table(bag, table)` / `_bag_table_names(bag)` using
+the bag's existing model surface (mirror whatever `get_table_as_dict` / the
+adapters' current `_bag_element_is_asset` use to resolve a table — reuse, don't
+invent). Adjust the Step-1 stub's `_reachable_rows_impl` seam to match the real
+attribute the impl reads (likely patch `bag._dataset_table_view` + `bag.engine`
+instead — update the test stub accordingly so it exercises the real path).
+
+- [ ] **Step 4: Run → pass**
+
+Run: `cd /Users/carl/GitHub/DerivaML/deriva-ml && DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/dataset/test_reachable_enumeration.py -q`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml
+git add src/deriva_ml/dataset/target_resolution.py tests/dataset/test_reachable_enumeration.py
+git commit -m "feat(dataset): shared FK-reachable element enumeration (resolve_reachable_rows / resolve_element_rids)"
+```
+
+---
+
+### Task 2: Route `restructure._get_reachable_assets` onto the shared core
+
+Eliminate restructure's duplicate reachability impl so all paths share one.
+
+**Files:**
+- Modify: `src/deriva_ml/dataset/restructure.py` (`_get_reachable_assets`, ~line 207)
+- Test: existing restructure tests must stay green (regression guard)
+
+- [ ] **Step 1: Implement**
+
+Replace `_get_reachable_assets`'s body (the inline `Session`/`_dataset_table_view`
+block) with a delegation:
+
+```python
+def _get_reachable_assets(bag, asset_table: str) -> list[dict[str, Any]]:
+    """Get all assets reachable from this dataset through any FK path.
+
+    Thin wrapper over the shared reachability core so restructure and the
+    tf/torch adapters use one traversal implementation.
+    """
+    from deriva_ml.dataset.target_resolution import resolve_reachable_rows
+
+    return resolve_reachable_rows(bag, asset_table)
+```
+
+Keep the docstring's worked example. Both call sites (lines ~199, ~882) are
+unchanged — they still get full rows.
+
+- [ ] **Step 2: Run restructure tests (no behavior change)**
+
+Run: `cd /Users/carl/GitHub/DerivaML/deriva-ml && DERIVA_ML_ALLOW_DIRTY=true DERIVA_HOST=localhost uv run pytest tests/dataset/test_restructure.py tests/dataset/test_restructure_helpers.py -q`
+Expected: PASS (unchanged behavior; restructure now sources rows from the core).
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml
+git add src/deriva_ml/dataset/restructure.py
+git commit -m "refactor(dataset): restructure._get_reachable_assets delegates to shared core"
+```
+
+---
+
+### Task 3: Wire both adapters through `resolve_element_rids` + add `reachable`
+
+**Files:**
+- Modify: `src/deriva_ml/dataset/tf_adapter.py` (`build_tf_dataset`, lines ~102/126)
+- Modify: `src/deriva_ml/dataset/torch_adapter.py` (`build_torch_dataset`, lines ~91/115)
+- Test: `tests/dataset/test_format_b_bag.py` or a new adapter-wiring test (source-level)
+
+- [ ] **Step 1: Write failing wiring test**
+
+```python
+def test_adapters_enumerate_via_resolve_element_rids():
+    """Both builders enumerate via resolve_element_rids (FK-reachable), not
+    list_dataset_members directly, and expose a `reachable` param."""
+    import inspect
+    from deriva_ml.dataset import tf_adapter, torch_adapter
+
+    for mod, fn in ((tf_adapter, "build_tf_dataset"), (torch_adapter, "build_torch_dataset")):
+        src = inspect.getsource(getattr(mod, fn))
+        assert "resolve_element_rids" in src, fn
+        assert "members_by_type[element_type]" not in src, fn  # old path gone
+        sig = inspect.signature(getattr(mod, fn))
+        assert "reachable" in sig.parameters, fn
+        assert sig.parameters["reachable"].default is True, fn
+```
+
+- [ ] **Step 2: Run → fail**
+
+Run: `cd /Users/carl/GitHub/DerivaML/deriva-ml && DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/dataset/test_format_b_bag.py::test_adapters_enumerate_via_resolve_element_rids -q`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement in BOTH adapters**
+
+Add `reachable: bool = True` to `build_tf_dataset` / `build_torch_dataset`
+signatures. Replace the enumeration+validation block:
+
+```python
+# OLD:
+members_by_type = bag.list_dataset_members(recurse=True)
+if element_type not in members_by_type:
+    raise DerivaMLException(...)
+...
+all_rids = [m["RID"] for m in members_by_type[element_type]]
+
+# NEW:
+from deriva_ml.dataset.target_resolution import resolve_element_rids
+all_rids = resolve_element_rids(bag, element_type, reachable=reachable)
+```
+
+Leave the `is_asset`/`sample_loader` check, `_resolve_targets`,
+`targets`/`missing` filtering, `_build_row_lookup`, and the generator body
+UNCHANGED. (Note `_build_row_lookup` already uses `get_table_as_dict` — whole
+table — so reachable RIDs resolve.)
+
+- [ ] **Step 4: Run wiring test + adapter no-catalog tests**
+
+Run: `cd /Users/carl/GitHub/DerivaML/deriva-ml && DERIVA_ML_ALLOW_DIRTY=true uv run pytest tests/dataset/test_format_b_bag.py::test_adapters_enumerate_via_resolve_element_rids tests/dataset/test_tf_adapter_no_tf.py tests/dataset/test_torch_adapter_no_torch.py -q`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml
+git add src/deriva_ml/dataset/tf_adapter.py src/deriva_ml/dataset/torch_adapter.py tests/dataset/test_format_b_bag.py
+git commit -m "fix(dataset): tf/torch adapters enumerate FK-reachable elements via shared core (reachable=True default)"
+```
+
+---
+
+### Task 4: Surface `reachable` on the public DatasetBag methods
+
+**Files:**
+- Modify: `src/deriva_ml/dataset/dataset_bag.py` (`as_tf_dataset` ~1373, `as_torch_dataset` ~1199)
+- Test: signature test
+
+- [ ] **Step 1: Failing signature test**
+
+```python
+def test_public_dataset_methods_expose_reachable():
+    import inspect
+    from deriva_ml.dataset.dataset_bag import DatasetBag
+
+    for name in ("as_tf_dataset", "as_torch_dataset"):
+        sig = inspect.signature(getattr(DatasetBag, name))
+        assert "reachable" in sig.parameters, name
+        assert sig.parameters["reachable"].default is True, name
+```
+
+- [ ] **Step 2: Run → fail.** `pytest tests/dataset/test_format_b_bag.py::test_public_dataset_methods_expose_reachable -q`
+
+- [ ] **Step 3: Implement**
+
+Add `reachable: bool = True` to both public method signatures; forward
+`reachable=reachable` into the `build_tf_dataset(...)` / `build_torch_dataset(...)`
+calls (lines ~1363/1544). Document the param in each docstring (default True =
+FK-reachable, matching restructure_assets / bag_info; pass False for
+direct-members-only).
+
+- [ ] **Step 4: Run signature test + full no-catalog adapter suite.** Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml
+git add src/deriva_ml/dataset/dataset_bag.py tests/dataset/test_format_b_bag.py
+git commit -m "feat(dataset): expose reachable on as_tf_dataset / as_torch_dataset"
+```
+
+---
+
+### Task 5: Live regression (demo) + eye-ai acceptance + lint + PR
+
+**Files:**
+- Test: `tests/dataset/test_tf_adapter_e2e.py` / `test_torch_adapter_e2e.py` (add subject-partitioned case)
+
+- [ ] **Step 1: Demo-catalog regression test (subject-partitioned)**
+
+Add a live test: build (or use a fixture) dataset whose members are a non-asset
+type with assets reachable only via FK (e.g. members = Subject, Images via
+Subject→...→Image — mirror whatever the demo catalog supports). Assert:
+- `as_tf_dataset(element_type="Image")` (default reachable) yields a NON-empty
+  set whose RID set == `resolve_reachable_rows(bag, "Image")` RID set (deduped).
+- `restructure_assets(asset_table="Image")` finds the same RID set.
+- `as_tf_dataset(..., reachable=False)` reproduces the (empty or direct-only) set.
+Mirror for torch.
+
+```python
+@pytest.mark.skipif(os.environ.get("DERIVA_HOST") in (None, ""), reason="needs catalog")
+def test_as_tf_dataset_finds_fk_reachable_images(catalog_with_datasets):
+    ml, _ = catalog_with_datasets
+    # ... obtain/build a subject-partitioned dataset bag with FK-reachable Images ...
+    from deriva_ml.dataset.target_resolution import resolve_element_rids
+    expected = set(resolve_element_rids(bag, "Image", reachable=True))
+    assert expected, "fixture must have FK-reachable images"
+    yielded = {rid for *_rest, rid in bag.as_tf_dataset(element_type="Image", sample_loader=lambda p, r: p)}
+    assert yielded == expected
+    # opt-out reproduces direct-members
+    direct = set(resolve_element_rids(bag, "Image", reachable=False))
+    yielded_direct = {rid for *_rest, rid in bag.as_tf_dataset(element_type="Image", sample_loader=lambda p, r: p, reachable=False)} if direct else set()
+    assert yielded_direct == direct
+```
+
+- [ ] **Step 2: Run demo regression**
+
+Run: `cd /Users/carl/GitHub/DerivaML/deriva-ml && DERIVA_ML_ALLOW_DIRTY=true DERIVA_HOST=localhost uv run pytest tests/dataset/test_tf_adapter_e2e.py tests/dataset/test_torch_adapter_e2e.py -q`
+Expected: PASS.
+
+- [ ] **Step 3: eye-ai 2-277G acceptance (manual, this session has access — NOT a committed test)**
+
+Run a throwaway script against `www.eye-ai.org`/`eye-ai`, dataset `2-277G`
+v4.8.0: `as_tf_dataset(element_type="Image", targets={"Image_Diagnosis":
+select_initial_diagnosis}, missing="skip")` → assert it yields ~28,546
+`(image, label, rid)` triples (not empty), matching
+`_get_reachable_assets(bag, "Image")` / `restructure_assets`. Same for torch.
+Record the actual count in the PR. (Do NOT commit a live-eye-ai test — it needs
+a token; the demo regression is the committed gate.)
+
+- [ ] **Step 4: Lint + broad suite**
+
+Run: `cd /Users/carl/GitHub/DerivaML/deriva-ml && uv run ruff check --fix <touched files> && uv run ruff format <touched files>` (touched files only — do NOT `ruff format tests/dataset/` wholesale).
+Then: `DERIVA_ML_ALLOW_DIRTY=true DERIVA_HOST=localhost uv run pytest tests/dataset/test_reachable_enumeration.py tests/dataset/test_restructure.py tests/dataset/test_format_b_bag.py tests/dataset/test_tf_adapter_e2e.py tests/dataset/test_torch_adapter_e2e.py tests/dataset/test_tf_adapter_no_tf.py tests/dataset/test_torch_adapter_no_torch.py -q`
+Expected: all PASS.
+
+- [ ] **Step 5: Branch, commit, PR**
+
+```bash
+cd /Users/carl/GitHub/DerivaML/deriva-ml
+git add -A
+git commit -m "test(dataset): live regression — adapters yield FK-reachable elements"
+git push -u origin fix/adapter-fk-reachable-elements
+gh pr create --title "fix(dataset): tf/torch adapters enumerate FK-reachable elements (match restructure_assets)" --body "<summary + spec link + the shared-core architecture + eye-ai 2-277G acceptance count + opt-out>"
+```
+
+---
+
+## Self-Review notes
+
+- **Spec coverage:** T1 shared core+projection (with dedup); T2 restructure onto core (one impl); T3 both adapters wired + `reachable`; T4 public methods; T5 live regression + eye-ai acceptance + PR. All spec sections covered.
+- **One impl of reachability:** after T2, `_dataset_table_view`-based enumeration exists in exactly one place (`resolve_reachable_rows`); restructure + both adapters consume it.
+- **Dedup placement:** in `resolve_element_rids` (RID iteration), NOT the row core (restructure keeps path-duplicates, collapses by filename). Pinned by `test_resolve_element_rids_reachable_dedups_preserving_order`.
+- **Behavior-preserving opt-out:** `reachable=False` reproduces the old `list_dataset_members` set everywhere; pinned in T1 + T5.
+- **Default reachable** = the approved choice; no-op for datasets without FK indirection, fixes subject-partitioned datasets.
+- **Scope discipline:** lint/format touched files only (avoid the wholesale-format trap from earlier PRs).

--- a/docs/superpowers/specs/2026-06-16-adapter-fk-reachable-elements-design.md
+++ b/docs/superpowers/specs/2026-06-16-adapter-fk-reachable-elements-design.md
@@ -1,0 +1,199 @@
+# tf/torch adapters: enumerate FK-reachable elements (match restructure_assets)
+
+**Date:** 2026-06-16
+**Status:** Design — approved approach (reachable-by-default + shared helper)
+
+## Problem
+
+`DatasetBag.as_tf_dataset(element_type="Image")` and `as_torch_dataset(...)`
+return an **empty generator** for datasets whose elements are FK-*reachable*
+but not *direct* members — e.g. a subject-partitioned dataset (members are
+`Subject`s; images reachable via `Subject → Observation → Image`). The older
+`restructure_assets(asset_table="Image")` path handles these correctly. This
+is a behavioral regression for anyone migrating from
+`restructure_assets`/`ImageDataGenerator` to the framework adapters, and it
+blocks every eye-ai LAC/kyle training dataset (all subject-partitioned).
+
+## Root cause (verified in source)
+
+The two paths enumerate elements differently:
+
+- `restructure_assets` → `_get_reachable_assets(bag, table)`
+  (`dataset/restructure.py:207`) → `bag._dataset_table_view(table)`
+  (`dataset/dataset_bag.py:365`): a SQL UNION over **all FK paths** from
+  `Dataset` to the target table, scoped to the dataset RID + nested-dataset
+  RIDs. Finds FK-reachable rows.
+- `as_tf_dataset` → `tf_adapter.build_tf_dataset`
+  (`dataset/tf_adapter.py:102`): `members_by_type =
+  bag.list_dataset_members(recurse=True)` then `all_rids = [m["RID"] for m in
+  members_by_type[element_type]]` (line 126). `list_dataset_members(recurse=True)`
+  recurses **nested Datasets only** — it does not traverse the
+  `Subject→Observation→Image` FK chain. So `members_by_type["Image"]` is empty
+  → empty generator → raises at `tf_adapter.py:166`.
+- `torch_adapter.build_torch_dataset` (lines 91/115) has the identical
+  structure.
+
+**Reproduction** (eye-ai `2-277G` v4.8.0): `list_dataset_members(recurse=True)`
+→ `{Subject: 4212, Dataset: 49}`, 0 Images. `_get_reachable_assets(bag,
+"Image")` → 28,546 Images. `as_tf_dataset(element_type="Image", ...)` raises;
+`restructure_assets(asset_table="Image", ...)` finds 28,546.
+
+## Key finding that scopes the fix tightly
+
+Only the **RID set** is wrong. The surrounding machinery already operates on
+the whole table, not direct members:
+
+- `_build_row_lookup(bag, element_type)` (`tf_adapter.py:202`) uses
+  `bag.get_table_as_dict(element_type)` — the **whole element table** from the
+  bag's local SQLite, keyed by RID. So the row dict for every reachable RID is
+  *already present* in `row_lookup`.
+- `_resolve_targets(bag, element_type, ...)` (`target_resolution.py`) joins
+  feature values by RID — RID-keyed, works for any RID.
+- `_resolve_asset_path`, `missing=` handling — operate per-RID, source-agnostic.
+
+So the fix replaces *where `all_rids` comes from* (direct members →
+reachability) and the *existence validation*. Everything downstream is
+unchanged — exactly as the report requested.
+
+## Design
+
+### Architecture: ONE shared enumeration core, THREE consumers
+
+The three paths have two layers. Only the first is currently divergent (and
+buggy); the second is legitimately different and must NOT be merged:
+
+| Layer | restructure | tf | torch | share? |
+|---|---|---|---|---|
+| **(1) "which rows of `table` are reachable from this dataset?"** | `_get_reachable_assets` (FK) | `list_dataset_members` ✗ | `list_dataset_members` ✗ | **YES** |
+| **(2) what to do per element** | symlink/copy into `output_dir` tree | `_resolve_asset_path` + `sample_loader` + target → lazy `yield` | same as tf | **NO** |
+
+Layer (2) is each consumer's actual job (materialize an on-disk ImageFolder
+tree vs. lazily yield `(sample, label, rid)` into a streaming dataset) —
+different return types, different laziness. Forcing them together would be
+wrong. The bug is entirely in layer (1): all three need the same FK-reachable
+row set, but restructure computes it right and the adapters compute it wrong.
+
+So: extract **one** layer-(1) core that all three route through.
+
+### 1a. The shared core (new) — returns full rows
+
+```python
+def resolve_reachable_rows(bag: "DatasetBag", table: str) -> list[dict]:
+    """All rows of `table` reachable from this dataset via any FK path.
+
+    The single source of truth for dataset element reachability. Wraps
+    bag._dataset_table_view(table) (Dataset -> ... -> table UNION over all FK
+    paths, scoped to this dataset + nested datasets). Returns full row dicts so
+    restructure (needs Filename etc.) and the adapters (project RID) share one
+    traversal. Rows are NOT RID-deduped here: a UNION over multiple FK paths can
+    surface the same RID twice, and restructure collapses by filename — callers
+    that iterate by RID must dedup (see resolve_element_rids).
+    """
+```
+
+Place it in `dataset/target_resolution.py` (already imported by both adapters)
+or a new `dataset/_reachability_view.py`. `_get_reachable_assets` in
+`restructure.py` becomes a thin wrapper over (or is replaced by) this — so
+restructure's existing live coverage also protects the adapters' enumeration.
+
+### 1b. The adapter projection (new) — RIDs, deduped
+
+```python
+def resolve_element_rids(
+    bag: "DatasetBag", element_type: str, *, reachable: bool = True
+) -> list[str]:
+    """RIDs of `element_type` rows belonging to this dataset, order-preserving,
+    RID-deduped (a UNION can surface a RID via two FK paths → don't double-yield).
+
+    reachable=True (default): resolve_reachable_rows (FK reachability — same
+    semantics as restructure_assets / bag_info).
+    reachable=False: direct members only (list_dataset_members(recurse=True)).
+    Raises DerivaMLException if element_type is not resolvable in the bag.
+    """
+```
+
+- **reachable=True**: `resolve_reachable_rows(bag, element_type)`, project
+  `row["RID"]`, **order-preserving dedup** (the bug-prevention point — restructure
+  doesn't dedup because it keys by filename; the adapters iterate RIDs so a
+  path-duplicate RID would yield a sample twice). Works for asset AND non-asset
+  element types (`_dataset_table_view` is general).
+- **reachable=False**: `[m["RID"] for m in
+  bag.list_dataset_members(recurse=True).get(element_type, [])]` — old behavior,
+  preserved as the opt-out.
+- **Validation**: replace the current `element_type not in members_by_type`
+  check. Reuse the bag's existing table-existence check (the one
+  `get_table_as_dict` relies on) so an unknown `element_type` still raises a
+  clear error listing available types.
+
+### 2. Wire both adapters through it
+
+In `build_tf_dataset` and `build_torch_dataset`, replace:
+
+```python
+members_by_type = bag.list_dataset_members(recurse=True)
+if element_type not in members_by_type: raise ...
+...
+all_rids = [m["RID"] for m in members_by_type[element_type]]
+```
+
+with:
+
+```python
+all_rids = resolve_element_rids(bag, element_type, reachable=reachable)
+```
+
+(the existence check moves into the helper). Everything else in each adapter —
+`is_asset` / `sample_loader` validation, `_resolve_targets`, the
+`targets`/`missing` RID filtering, `_build_row_lookup`, the generator body — is
+**unchanged**.
+
+### 3. Surface `reachable` on the public methods
+
+Add `reachable: bool = True` to `DatasetBag.as_tf_dataset` and
+`as_torch_dataset` (`dataset_bag.py:1373` / `:1199`), forwarded to the
+builders. Default True = the fix (reachable). Pass `reachable=False` to force
+direct-members-only (the old behavior, for callers who want it).
+
+**Default is reachable** (the user's choice): the adapters then agree with
+`bag_info`, `restructure_assets`, and `_get_reachable_assets` on "what's in the
+dataset." For a dataset with no FK indirection, the reachable set == the direct
+set, so default-True is a no-op there; it only *adds* the currently-missing
+elements for subject-partitioned datasets.
+
+## Testing
+
+1. **Unit (catalog-free where possible):** `resolve_element_rids` with a stub
+   bag — `reachable=True` calls `_dataset_table_view`; `reachable=False` calls
+   `list_dataset_members`. Assert the right source is used and RIDs returned.
+2. **Adapter wiring (source-level):** assert both `build_tf_dataset` and
+   `build_torch_dataset` call `resolve_element_rids` (not
+   `list_dataset_members` directly) and expose `reachable`.
+3. **Live regression (demo catalog):** build a subject-partitioned dataset on
+   the demo catalog (Subjects as members, Images via Subject→...→Image) and
+   assert `as_tf_dataset(element_type="Image")` yields the FK-reachable images,
+   not empty — and that the count matches `_get_reachable_assets` /
+   `restructure_assets` on the same bag.
+4. **Acceptance (live eye-ai, this session has access):** on `2-277G` v4.8.0,
+   `as_tf_dataset(element_type="Image", targets={"Image_Diagnosis":
+   select_initial_diagnosis}, missing="skip")` yields ~28,546 `(image, label,
+   rid)` triples (matching `restructure_assets` / `_get_reachable_assets`), not
+   an empty generator. Same count for `as_torch_dataset`.
+5. **Opt-out preserved:** `reachable=False` reproduces the old direct-members
+   set (asserts the escape hatch works and didn't change).
+
+## Risks / things to watch
+
+- **Row-shape parity:** `_dataset_table_view` rows and `get_table_as_dict` rows
+  both come from the same bag SQLite table, so `row_lookup` (keyed by RID)
+  resolves every reachable RID. Verify in the live test that
+  `_resolve_asset_path` finds the file for FK-reachable RIDs (it uses
+  `row["Filename"]` from `row_lookup`, which is whole-table → present).
+- **Duplicate RIDs from the UNION:** `_dataset_table_view` UNIONs multiple FK
+  paths; the same element RID may appear via two paths. `_get_reachable_assets`
+  returns rows as-is. The helper should **dedupe RIDs** (preserve order) so the
+  adapter doesn't yield the same sample twice. (restructure may not dedupe
+  because it writes by filename; the adapters iterate RIDs, so dedupe matters
+  here — confirm against the live count, which should be distinct images.)
+- **Non-asset element types:** default-reachable must still work for a
+  non-asset `element_type` (e.g. `Subject`). `_dataset_table_view` handles it;
+  the test matrix should include one non-asset case.

--- a/src/deriva_ml/dataset/dataset_bag.py
+++ b/src/deriva_ml/dataset/dataset_bag.py
@@ -1205,6 +1205,7 @@ class DatasetBag:
         targets: list[str] | dict[str, Any] | None = None,
         target_transform: Callable[..., Any] | None = None,
         missing: Literal["error", "skip", "unknown"] = "error",
+        reachable: bool = True,
     ) -> "torch.utils.data.Dataset":
         """Build a ``torch.utils.data.Dataset`` from this bag.
 
@@ -1307,6 +1308,17 @@ class DatasetBag:
                   returning a sentinel class index or an ignore-mask value).
                   Useful for semi-supervised and self-training workflows.
 
+            reachable: When ``True`` (default), the dataset's elements are
+                every ``element_type`` row reachable from this dataset by any
+                FK path — the same traversal ``restructure_assets`` uses. This
+                matters for subject-partitioned datasets: if the members are
+                ``Subject`` rows and ``Image`` is reachable via
+                ``Subject -> Observation -> Image``, those Images are found
+                even though they are not direct dataset members. When
+                ``False``, only direct members (``list_dataset_members(
+                recurse=True)``) are used — the opt-out for callers who want
+                strictly the rows enumerated in the dataset's membership.
+
         Returns:
             A ``torch.utils.data.Dataset`` whose ``__getitem__`` returns:
 
@@ -1368,6 +1380,7 @@ class DatasetBag:
             targets=targets,
             target_transform=target_transform,
             missing=missing,
+            reachable=reachable,
         )
 
     def as_tf_dataset(
@@ -1380,6 +1393,7 @@ class DatasetBag:
         target_transform: Callable[..., Any] | None = None,
         missing: Literal["error", "skip", "unknown"] = "error",
         output_signature: "tf.TensorSpec | tuple[tf.TensorSpec, ...] | None" = None,
+        reachable: bool = True,
     ) -> "tf.data.Dataset":
         """Build a ``tf.data.Dataset`` from this bag.
 
@@ -1486,6 +1500,17 @@ class DatasetBag:
                 explicit signature avoids the eager-inference overhead and
                 is preferred for production use.
 
+            reachable: When ``True`` (default), the dataset's elements are
+                every ``element_type`` row reachable from this dataset by any
+                FK path — the same traversal ``restructure_assets`` uses. This
+                matters for subject-partitioned datasets: if the members are
+                ``Subject`` rows and ``Image`` is reachable via
+                ``Subject -> Observation -> Image``, those Images are found
+                even though they are not direct dataset members. When
+                ``False``, only direct members (``list_dataset_members(
+                recurse=True)``) are used — the opt-out for callers who want
+                strictly the rows enumerated in the dataset's membership.
+
         Returns:
             A ``tf.data.Dataset`` whose elements are:
 
@@ -1550,6 +1575,7 @@ class DatasetBag:
             target_transform=target_transform,
             missing=missing,
             output_signature=output_signature,
+            reachable=reachable,
         )
 
     def restructure_assets(

--- a/src/deriva_ml/dataset/restructure.py
+++ b/src/deriva_ml/dataset/restructure.py
@@ -50,8 +50,6 @@ import shutil
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Literal
 
-from sqlalchemy.orm import Session
-
 from deriva_ml.core.definitions import RID
 from deriva_ml.core.exceptions import DerivaMLException
 from deriva_ml.feature import FeatureRecord
@@ -213,24 +211,21 @@ def _get_reachable_assets(bag, asset_table: str) -> list[dict[str, Any]]:
     Subjects, and Subject -> Encounter -> Image, this method will find those
     Images even though they're not directly in the Dataset_Image association table.
 
+    Thin wrapper over :func:`~deriva_ml.dataset.target_resolution.resolve_reachable_rows`
+    so restructure and the tf/torch adapters share ONE reachability traversal
+    (the divergence this consolidation removes was the cause of the adapters
+    missing FK-reachable elements). restructure consumes full rows (Filename
+    etc.) and collapses by filename, so the un-deduped row list is fine here.
+
     Args:
         asset_table: Name of the asset table (e.g., "Image")
 
     Returns:
         List of asset records as dictionaries.
     """
-    # Use the _dataset_table_view query which traverses all FK paths
-    sql_query = bag._dataset_table_view(asset_table)
+    from deriva_ml.dataset.target_resolution import resolve_reachable_rows
 
-    with Session(bag.engine) as session:
-        # ``.mappings().all()`` returns row mappings as
-        # public-API ``RowMapping`` objects — same shape as
-        # ``dict(row._mapping)`` but without reaching into a
-        # SQLAlchemy private attribute. Audit Ds-restr P3.
-        result = session.execute(sql_query)
-        rows = [dict(m) for m in result.mappings().all()]
-
-    return rows
+    return resolve_reachable_rows(bag, asset_table)
 
 
 def _detect_asset_table(bag) -> str | None:

--- a/src/deriva_ml/dataset/target_resolution.py
+++ b/src/deriva_ml/dataset/target_resolution.py
@@ -15,6 +15,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Callable, Literal
 
+from sqlalchemy.orm import Session
+
 from deriva_ml.core.exceptions import DerivaMLException
 
 if TYPE_CHECKING:
@@ -22,6 +24,92 @@ if TYPE_CHECKING:
     from deriva_ml.feature import FeatureRecord
 
     FeatureSelector = Callable[[list["FeatureRecord"]], "FeatureRecord | None"]
+
+
+def resolve_reachable_rows(bag: "DatasetBag", table: str) -> list[dict[str, Any]]:
+    """All rows of ``table`` reachable from this dataset via any FK path.
+
+    The single source of truth for dataset *element reachability*, shared by
+    :func:`~deriva_ml.dataset.restructure._get_reachable_assets` and the
+    tf/torch adapters (via :func:`resolve_element_rids`). Wraps
+    :meth:`DatasetBag._dataset_table_view` — a SQL UNION over every FK path
+    ``Dataset -> ... -> table``, scoped to this dataset RID plus its nested
+    datasets — so an element reachable only indirectly (e.g. ``Image`` via
+    ``Subject -> Observation -> Image``) is still found. ``list_dataset_members``
+    would miss it (it recurses nested datasets only, not the FK chain).
+
+    Returns full row dicts (so restructure can read ``Filename`` etc. and the
+    adapters can project ``RID``). Rows are **not** RID-deduped here: the UNION
+    can surface the same RID via two FK paths. restructure collapses by
+    filename; callers that iterate by RID must dedup (see
+    :func:`resolve_element_rids`).
+
+    Args:
+        bag: The downloaded :class:`DatasetBag`.
+        table: Element/asset table name (e.g. ``"Image"``).
+
+    Returns:
+        List of row dicts for every reachable ``table`` row.
+
+    Raises:
+        DerivaMLException: If ``table`` is not a table in the bag's model.
+
+    Example:
+        >>> # Needs a live bag — see tests/dataset/test_reachable_enumeration.py
+        >>> rows = resolve_reachable_rows(bag, "Image")  # doctest: +SKIP
+    """
+    try:
+        bag.model.name_to_table(table)
+    except Exception as exc:  # noqa: BLE001 — model surface raises KeyError/AttributeError
+        raise DerivaMLException(f"Element type {table!r} not found in bag (not a known table).") from exc
+
+    sql_query = bag._dataset_table_view(table)
+    with Session(bag.engine) as session:
+        return [dict(m) for m in session.execute(sql_query).mappings().all()]
+
+
+def resolve_element_rids(bag: "DatasetBag", element_type: str, *, reachable: bool = True) -> list[str]:
+    """RIDs of ``element_type`` rows belonging to this dataset.
+
+    Order-preserving and RID-deduped — a UNION over multiple FK paths can
+    surface the same RID twice, and the adapters iterate by RID, so a duplicate
+    would yield the same sample twice.
+
+    Args:
+        bag: The downloaded :class:`DatasetBag`.
+        element_type: Element table name.
+        reachable: ``True`` (default) — FK-reachable rows via
+            :func:`resolve_reachable_rows` (same semantics as
+            ``restructure_assets`` / ``bag_info``). ``False`` — direct members
+            only (``bag.list_dataset_members(recurse=True)``), the opt-out.
+
+    Returns:
+        Order-preserving, deduped list of element RIDs.
+
+    Raises:
+        DerivaMLException: If ``element_type`` is not resolvable in the bag.
+
+    Example:
+        >>> rids = resolve_element_rids(bag, "Image")  # doctest: +SKIP
+    """
+    if not reachable:
+        members = bag.list_dataset_members(recurse=True)
+        if element_type not in members:
+            raise DerivaMLException(
+                f"Element type {element_type!r} not found in bag; available types: {sorted(members.keys())}"
+            )
+        rows: list[dict[str, Any]] = members[element_type]
+    else:
+        rows = resolve_reachable_rows(bag, element_type)
+
+    seen: set[str] = set()
+    out: list[str] = []
+    for r in rows:
+        rid = r["RID"]
+        if rid not in seen:
+            seen.add(rid)
+            out.append(rid)
+    return out
 
 
 # Maximum unlabeled-RID count to show in missing="error" message before

--- a/src/deriva_ml/dataset/tf_adapter.py
+++ b/src/deriva_ml/dataset/tf_adapter.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Literal
 
 from deriva_ml.core.exceptions import DerivaMLException
-from deriva_ml.dataset.target_resolution import _resolve_targets
+from deriva_ml.dataset.target_resolution import _resolve_targets, resolve_element_rids
 
 if TYPE_CHECKING:
     import tensorflow as tf
@@ -45,6 +45,7 @@ def build_tf_dataset(
     target_transform: "Callable[..., Any] | None" = None,
     missing: Literal["error", "skip", "unknown"] = "error",
     output_signature: "tf.TensorSpec | tuple | None" = None,
+    reachable: bool = True,
 ) -> "tf.data.Dataset":
     """Build a tf.data.Dataset from a DatasetBag.
 
@@ -71,6 +72,11 @@ def build_tf_dataset(
             generator. When ``None`` (default), the first sample is consumed
             eagerly to infer the signature via ``tf.type_spec_from_value``,
             then the generator is re-wrapped so the first sample is not lost.
+        reachable: ``True`` (default) enumerates every ``element_type`` row
+            FK-reachable from this dataset — matching ``restructure_assets``,
+            so an ``Image`` reachable only via ``Subject -> Observation ->
+            Image`` is still included. ``False`` restricts to direct dataset
+            members (``list_dataset_members(recurse=True)``), the opt-out.
 
     Returns:
         A ``tf.data.Dataset`` whose elements are:
@@ -98,12 +104,11 @@ def build_tf_dataset(
     except ImportError as e:
         raise ImportError(_TF_INSTALL_HINT) from e
 
-    # Validate element_type exists in the bag.
-    members_by_type = bag.list_dataset_members(recurse=True)
-    if element_type not in members_by_type:
-        raise DerivaMLException(
-            f"Element type {element_type!r} not found in bag; available types: {sorted(members_by_type.keys())}"
-        )
+    # Enumerate the element RIDs belonging to this dataset. reachable=True
+    # (default) finds FK-reachable elements (e.g. Image via Subject -> ... ->
+    # Image), matching restructure_assets / bag_info; reachable=False is the
+    # direct-members-only opt-out. Raises if element_type is unresolvable.
+    all_rids = resolve_element_rids(bag, element_type, reachable=reachable)
 
     # Validate sample_loader is provided for asset-table element types.
     is_asset = _bag_element_is_asset(bag, element_type)
@@ -121,9 +126,8 @@ def build_tf_dataset(
     # Resolve targets once at construction time.
     target_map = _resolve_targets(bag, element_type, targets=targets, missing=missing)
 
-    # Build the RID list — all elements if targets=None, only labeled
-    # elements if targets is set.
-    all_rids = [m["RID"] for m in members_by_type[element_type]]
+    # Filter the RID list — all reachable elements if targets=None, only
+    # labeled elements if targets is set.
     if targets is None:
         rids = all_rids
     elif missing == "skip":

--- a/src/deriva_ml/dataset/torch_adapter.py
+++ b/src/deriva_ml/dataset/torch_adapter.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Literal
 
 from deriva_ml.core.exceptions import DerivaMLException
-from deriva_ml.dataset.target_resolution import _resolve_targets
+from deriva_ml.dataset.target_resolution import _resolve_targets, resolve_element_rids
 
 if TYPE_CHECKING:
     import torch.utils.data
@@ -41,6 +41,7 @@ def build_torch_dataset(
     targets: "list[str] | dict[str, FeatureSelector] | None" = None,
     target_transform: "Callable[..., Any] | None" = None,
     missing: Literal["error", "skip", "unknown"] = "error",
+    reachable: bool = True,
 ) -> "torch.utils.data.Dataset":
     """Build a torch.utils.data.Dataset from a DatasetBag.
 
@@ -62,6 +63,11 @@ def build_torch_dataset(
         missing: Policy for elements with no feature value. ``"error"``
             raises at construction; ``"skip"`` drops unlabeled elements;
             ``"unknown"`` keeps them with target=None.
+        reachable: ``True`` (default) enumerates every ``element_type`` row
+            FK-reachable from this dataset — matching ``restructure_assets``,
+            so an ``Image`` reachable only via ``Subject -> Observation ->
+            Image`` is still included. ``False`` restricts to direct dataset
+            members (``list_dataset_members(recurse=True)``), the opt-out.
 
     Returns:
         A ``torch.utils.data.Dataset`` whose ``__getitem__`` returns:
@@ -87,12 +93,11 @@ def build_torch_dataset(
     except ImportError as e:
         raise ImportError(_TORCH_INSTALL_HINT) from e
 
-    # Validate element_type exists in the bag.
-    members_by_type = bag.list_dataset_members(recurse=True)
-    if element_type not in members_by_type:
-        raise DerivaMLException(
-            f"Element type {element_type!r} not found in bag; available types: {sorted(members_by_type.keys())}"
-        )
+    # Enumerate the element RIDs belonging to this dataset. reachable=True
+    # (default) finds FK-reachable elements (e.g. Image via Subject -> ... ->
+    # Image), matching restructure_assets / bag_info; reachable=False is the
+    # direct-members-only opt-out. Raises if element_type is unresolvable.
+    all_rids = resolve_element_rids(bag, element_type, reachable=reachable)
 
     # Validate sample_loader is provided for asset-table element types.
     is_asset = _bag_element_is_asset(bag, element_type)
@@ -110,9 +115,8 @@ def build_torch_dataset(
     # Resolve targets once at construction time.
     target_map = _resolve_targets(bag, element_type, targets=targets, missing=missing)
 
-    # Build the RID list — all elements if targets=None, only labeled
-    # elements if targets is set.
-    all_rids = [m["RID"] for m in members_by_type[element_type]]
+    # Filter the RID list — all reachable elements if targets=None, only
+    # labeled elements if targets is set.
     if targets is None:
         rids = all_rids
     elif missing == "skip":

--- a/tests/dataset/test_format_b_bag.py
+++ b/tests/dataset/test_format_b_bag.py
@@ -349,6 +349,23 @@ def test_download_mixin_forwards_datasetspec_reachability_concurrency():
         assert "reachability_concurrency=dataset.reachability_concurrency" in src, name
 
 
+def test_adapters_enumerate_via_resolve_element_rids():
+    """Both builders enumerate elements via the shared resolve_element_rids
+    (FK-reachable), not list_dataset_members directly, and expose `reachable`."""
+    import inspect
+
+    from deriva_ml.dataset import tf_adapter, torch_adapter
+
+    for mod, fn in ((tf_adapter, "build_tf_dataset"), (torch_adapter, "build_torch_dataset")):
+        src = inspect.getsource(getattr(mod, fn))
+        assert "resolve_element_rids" in src, fn
+        # The old direct-members enumeration is gone.
+        assert "members_by_type[element_type]" not in src, fn
+        sig = inspect.signature(getattr(mod, fn))
+        assert "reachable" in sig.parameters, fn
+        assert sig.parameters["reachable"].default is True, fn
+
+
 @pytest.mark.skipif(
     os.environ.get("DERIVA_HOST") in (None, ""),
     reason="needs a live catalog",

--- a/tests/dataset/test_format_b_bag.py
+++ b/tests/dataset/test_format_b_bag.py
@@ -366,6 +366,19 @@ def test_adapters_enumerate_via_resolve_element_rids():
         assert sig.parameters["reachable"].default is True, fn
 
 
+def test_public_adapter_methods_expose_reachable():
+    """DatasetBag.as_torch_dataset / as_tf_dataset expose `reachable=True`
+    so callers can opt out of FK-reachable enumeration."""
+    import inspect
+
+    from deriva_ml.dataset.dataset_bag import DatasetBag
+
+    for name in ("as_torch_dataset", "as_tf_dataset"):
+        sig = inspect.signature(getattr(DatasetBag, name))
+        assert "reachable" in sig.parameters, name
+        assert sig.parameters["reachable"].default is True, name
+
+
 @pytest.mark.skipif(
     os.environ.get("DERIVA_HOST") in (None, ""),
     reason="needs a live catalog",

--- a/tests/dataset/test_reachable_enumeration.py
+++ b/tests/dataset/test_reachable_enumeration.py
@@ -1,0 +1,81 @@
+"""resolve_reachable_rows / resolve_element_rids — the shared FK-reachable
+element enumeration used by restructure_assets AND the tf/torch adapters.
+
+Catalog-free: the bag's _dataset_table_view + SQLAlchemy Session are stubbed so
+the traversal contract is exercised without a live catalog.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from deriva_ml.core.exceptions import DerivaMLException
+from deriva_ml.dataset.target_resolution import (
+    resolve_element_rids,
+    resolve_reachable_rows,
+)
+
+
+def _bag_yielding(rows, *, table_exists=True):
+    """A bag whose _dataset_table_view + engine produce `rows` (list of dicts).
+
+    resolve_reachable_rows runs ``Session(bag.engine).execute(query).mappings()``
+    — we stub _dataset_table_view to return a sentinel and patch the Session in
+    the test so .mappings().all() yields `rows`.
+    """
+    bag = MagicMock()
+    bag._dataset_table_view.return_value = "SENTINEL_QUERY"
+    if table_exists:
+        bag.model.name_to_table.return_value = object()
+    else:
+        bag.model.name_to_table.side_effect = KeyError("no such table")
+    return bag
+
+
+def _patched_session(rows):
+    """Context-manager patch making Session(...).execute(q).mappings().all() == rows."""
+    session_cm = MagicMock()
+    session = session_cm.__enter__.return_value
+    session.execute.return_value.mappings.return_value.all.return_value = rows
+    return patch("deriva_ml.dataset.target_resolution.Session", return_value=session_cm)
+
+
+def test_resolve_reachable_rows_returns_full_rows():
+    rows = [{"RID": "i1", "Filename": "a.png"}, {"RID": "i2", "Filename": "b.png"}]
+    bag = _bag_yielding(rows)
+    with _patched_session(rows):
+        out = resolve_reachable_rows(bag, "Image")
+    assert out == rows  # full rows, NOT deduped here
+    bag._dataset_table_view.assert_called_once_with("Image")
+
+
+def test_resolve_reachable_rows_unknown_table_raises():
+    bag = _bag_yielding([], table_exists=False)
+    with pytest.raises(DerivaMLException, match="not found|not resolvable|Image"):
+        resolve_reachable_rows(bag, "Image")
+
+
+def test_resolve_element_rids_reachable_dedups_preserving_order():
+    # Same RID surfaced twice via two FK paths -> yield once, first-seen order.
+    rows = [{"RID": "i1"}, {"RID": "i2"}, {"RID": "i1"}, {"RID": "i3"}]
+    bag = _bag_yielding(rows)
+    with _patched_session(rows):
+        out = resolve_element_rids(bag, "Image", reachable=True)
+    assert out == ["i1", "i2", "i3"]
+
+
+def test_resolve_element_rids_direct_uses_list_members():
+    bag = MagicMock()
+    bag.list_dataset_members.return_value = {"Image": [{"RID": "d1"}, {"RID": "d2"}]}
+    out = resolve_element_rids(bag, "Image", reachable=False)
+    assert out == ["d1", "d2"]
+    bag.list_dataset_members.assert_called_once_with(recurse=True)
+
+
+def test_resolve_element_rids_direct_unknown_type_raises():
+    bag = MagicMock()
+    bag.list_dataset_members.return_value = {"Subject": [{"RID": "s1"}]}
+    with pytest.raises(DerivaMLException, match="not found|Image"):
+        resolve_element_rids(bag, "Image", reachable=False)

--- a/tests/dataset/test_tf_adapter_e2e.py
+++ b/tests/dataset/test_tf_adapter_e2e.py
@@ -3,6 +3,7 @@
 Gated on tensorflow being importable. Uses catalog_with_datasets fixture
 to build a real bag, then iterates under tf.data.Dataset.batch().prefetch().
 """
+
 from __future__ import annotations
 
 import pytest
@@ -12,7 +13,10 @@ tf = pytest.importorskip("tensorflow")
 
 def test_bag_to_tf_dataset_yields_batches(catalog_with_datasets, tmp_path):
     ml, dataset_desc = catalog_with_datasets
-    bag = dataset_desc.dataset.download_dataset_bag(version="1.0.0")
+    ds_obj = dataset_desc.dataset
+    # current_version is the snapshot AFTER add_dataset_members; "1.0.0" is the
+    # empty pre-membership snapshot and would yield zero Image samples.
+    bag = ds_obj.download_dataset_bag(version=ds_obj.current_version)
 
     ds = bag.as_tf_dataset(
         element_type="Image",
@@ -22,4 +26,65 @@ def test_bag_to_tf_dataset_yields_batches(catalog_with_datasets, tmp_path):
     ds = ds.batch(2).prefetch(2)
     batches = list(ds)
     assert len(batches) > 0
-    assert batches[0].shape[0] <= 2
+    # Unlabeled dataset yields (sample, rid); batching gives a
+    # (sample_batch, rid_batch) tuple. The sample batch carries the batch dim.
+    sample_batch, rid_batch = batches[0]
+    assert sample_batch.shape[0] <= 2
+    assert rid_batch.shape[0] == sample_batch.shape[0]
+
+
+def test_as_tf_dataset_enumerates_fk_reachable_images(catalog_with_datasets, tmp_path):
+    """The tf adapter enumerates the SAME element set as the shared FK-reachable
+    core (resolve_element_rids / resolve_reachable_rows) that restructure_assets
+    uses — Images reachable via Subject -> ... -> Image, not just direct members.
+
+    Regression for the bug where as_tf_dataset enumerated via
+    list_dataset_members (direct + nested only) and missed FK-reachable assets.
+    """
+    from deriva_ml.dataset.target_resolution import (
+        resolve_element_rids,
+        resolve_reachable_rows,
+    )
+
+    ml, dataset_desc = catalog_with_datasets
+    ds_obj = dataset_desc.dataset
+    # current_version is the snapshot AFTER add_dataset_members; "1.0.0" is the
+    # empty pre-membership snapshot and has no Image rows.
+    bag = ds_obj.download_dataset_bag(version=ds_obj.current_version)
+
+    # The shared core (what restructure_assets delegates to) is the oracle.
+    expected = set(resolve_element_rids(bag, "Image", reachable=True))
+    assert expected, "fixture bag must contain FK-reachable Image rows"
+
+    # The adapter must yield exactly that RID set (RID is the last tuple value).
+    ds = bag.as_tf_dataset(
+        element_type="Image",
+        sample_loader=lambda p, row: tf.constant([0.0]),
+        targets=None,
+    )
+    yielded = {rid for *_rest, rid in ds.as_numpy_iterator()}
+    # tf surfaces the RID as bytes through the generator; normalize to str.
+    yielded = {r.decode() if isinstance(r, bytes) else r for r in yielded}
+    assert yielded == expected
+
+    # resolve_reachable_rows (un-deduped rows) dedups to the same RID set.
+    row_rids = {r["RID"] for r in resolve_reachable_rows(bag, "Image")}
+    assert row_rids == expected
+
+    # Opt-out: reachable=False yields the direct-member RID set.
+    direct = set(resolve_element_rids(bag, "Image", reachable=False))
+    ds_direct = bag.as_tf_dataset(
+        element_type="Image",
+        sample_loader=lambda p, row: tf.constant([0.0]),
+        targets=None,
+        reachable=False,
+    )
+    yielded_direct = {rid for *_rest, rid in ds_direct.as_numpy_iterator()}
+    yielded_direct = {r.decode() if isinstance(r, bytes) else r for r in yielded_direct}
+    assert yielded_direct == direct
+
+    # The bug: FK-reachable enumeration surfaces Images (reachable via the
+    # nested Subject datasets) that direct-membership recursion misses. On this
+    # fixture, reachable finds strictly more than direct.
+    assert direct <= expected
+    assert len(expected) > len(direct)

--- a/tests/dataset/test_torch_adapter_e2e.py
+++ b/tests/dataset/test_torch_adapter_e2e.py
@@ -3,6 +3,7 @@
 Gated on torch being importable. Uses catalog_with_datasets fixture
 to build a real bag, then iterates under a real DataLoader.
 """
+
 from __future__ import annotations
 
 import pytest
@@ -13,7 +14,10 @@ from torch.utils.data import DataLoader  # noqa: E402
 
 def test_bag_to_dataloader_yields_tensors(catalog_with_datasets, tmp_path):
     ml, dataset_desc = catalog_with_datasets
-    bag = dataset_desc.dataset.download_dataset_bag(version="1.0.0")
+    ds_obj = dataset_desc.dataset
+    # current_version is the snapshot AFTER add_dataset_members; "1.0.0" is the
+    # empty pre-membership snapshot and would yield zero Image samples.
+    bag = ds_obj.download_dataset_bag(version=ds_obj.current_version)
 
     ds = bag.as_torch_dataset(
         element_type="Image",
@@ -23,4 +27,63 @@ def test_bag_to_dataloader_yields_tensors(catalog_with_datasets, tmp_path):
     loader = DataLoader(ds, batch_size=2, shuffle=False)
     batches = list(loader)
     assert len(batches) > 0
-    assert batches[0].shape[0] <= 2
+    # Unlabeled dataset yields (sample, rid); default collate gives
+    # [sample_batch, rid_batch]. The sample batch carries the batch dim.
+    sample_batch, rid_batch = batches[0]
+    assert sample_batch.shape[0] <= 2
+    assert len(rid_batch) == sample_batch.shape[0]
+
+
+def test_as_torch_dataset_enumerates_fk_reachable_images(catalog_with_datasets, tmp_path):
+    """The torch adapter enumerates the SAME element set as the shared
+    FK-reachable core (resolve_element_rids / resolve_reachable_rows) that
+    restructure_assets uses — Images reachable via Subject -> ... -> Image,
+    not just direct members.
+
+    Regression for the bug where as_torch_dataset enumerated via
+    list_dataset_members (direct + nested only) and missed FK-reachable assets.
+    """
+    from deriva_ml.dataset.target_resolution import (
+        resolve_element_rids,
+        resolve_reachable_rows,
+    )
+
+    ml, dataset_desc = catalog_with_datasets
+    ds_obj = dataset_desc.dataset
+    # current_version is the snapshot AFTER add_dataset_members; "1.0.0" is the
+    # empty pre-membership snapshot and has no Image rows.
+    bag = ds_obj.download_dataset_bag(version=ds_obj.current_version)
+
+    # The shared core (what restructure_assets delegates to) is the oracle.
+    expected = set(resolve_element_rids(bag, "Image", reachable=True))
+    assert expected, "fixture bag must contain FK-reachable Image rows"
+
+    # The adapter must yield exactly that RID set (RID is the last item).
+    ds = bag.as_torch_dataset(
+        element_type="Image",
+        sample_loader=lambda p, row: torch.tensor([0.0]),
+        targets=None,
+    )
+    yielded = {ds[i][-1] for i in range(len(ds))}
+    assert yielded == expected
+
+    # resolve_reachable_rows (un-deduped rows) dedups to the same RID set.
+    row_rids = {r["RID"] for r in resolve_reachable_rows(bag, "Image")}
+    assert row_rids == expected
+
+    # Opt-out: reachable=False yields the direct-member RID set.
+    direct = set(resolve_element_rids(bag, "Image", reachable=False))
+    ds_direct = bag.as_torch_dataset(
+        element_type="Image",
+        sample_loader=lambda p, row: torch.tensor([0.0]),
+        targets=None,
+        reachable=False,
+    )
+    yielded_direct = {ds_direct[i][-1] for i in range(len(ds_direct))}
+    assert yielded_direct == direct
+
+    # The bug: FK-reachable enumeration surfaces Images (reachable via the
+    # nested Subject datasets) that direct-membership recursion misses. On this
+    # fixture, reachable finds strictly more than direct.
+    assert direct <= expected
+    assert len(expected) > len(direct)


### PR DESCRIPTION
## Summary

`DatasetBag.as_tf_dataset` / `as_torch_dataset` enumerated their elements
with `list_dataset_members(recurse=True)` — **direct + nested members only**.
For subject-partitioned datasets (members are `Subject`s; `Image`s are
reachable via `Subject → Observation → Image`), this returned an **empty
generator**, while `restructure_assets(asset_table="Image")` handled them
correctly. The two tools disagreed on what "the dataset's Images" are.

This routes adapter element-enumeration through **FK reachability** (Option B),
so the adapters surface the same elements `restructure_assets` does.

## The fix: one shared core, three consumers

The reachability traversal now lives in **one** place —
`deriva_ml/dataset/target_resolution.py`:

- **`resolve_reachable_rows(bag, table)`** — full row dicts for every `table`
  row reachable from the dataset by any FK path (wraps `_dataset_table_view`,
  a UNION over all FK paths `Dataset → … → table`, scoped to the dataset +
  its nested datasets). Not RID-deduped (the UNION can surface a RID twice).
- **`resolve_element_rids(bag, element_type, *, reachable=True)`** —
  order-preserving, RID-deduped element RIDs. `reachable=False` is the
  direct-members-only opt-out.

The three consumers now share that core instead of each walking the catalog
their own way:

| Consumer | Before | After |
|---|---|---|
| `restructure._get_reachable_assets` | `_dataset_table_view` inline | delegates to `resolve_reachable_rows` |
| `build_torch_dataset` | `list_dataset_members[...]` | `resolve_element_rids(reachable=…)` |
| `build_tf_dataset` | `list_dataset_members[...]` | `resolve_element_rids(reachable=…)` |

Because `restructure` already had strong live coverage, delegating it onto the
core means restructure's tests now also guard the adapters' enumeration.

## Public API

`as_torch_dataset` / `as_tf_dataset` gain **`reachable: bool = True`**
(reachable-by-default, with opt-out), forwarded to the builders. Docstrings
document the subject-partitioned case.

## Validation

**Demo-catalog regression (committed gate)** —
`tests/dataset/test_{torch,tf}_adapter_e2e.py`: both adapters yield the same
RID set as `resolve_element_rids(reachable=True)` / `resolve_reachable_rows`;
on the demo bag this is **8** Images (reachable via the nested Subject
datasets) vs **4** direct members — `reachable ⊋ direct` — and `reachable=False`
reproduces the direct set. (Also fixed two pre-existing bugs in those e2e
tests: they downloaded the empty `version="1.0.0"` snapshot, and indexed a
collated `(sample, rid)` tuple as a bare tensor.)

**Catalog-free core** — `tests/dataset/test_reachable_enumeration.py`
(5 tests, stubbed Session): full rows returned, unknown table raises, reachable
dedups preserving order, direct path uses `list_dataset_members`.

**eye-ai `2-277G` v4.8.0 acceptance** (manual, not committed — needs a token):

```
resolve_element_rids(reachable=True):  28546   ← adapters now yield this
resolve_element_rids(reachable=False):  9383   ← the buggy old count
resolve_reachable_rows rows:           28546
_get_reachable_assets (restructure):   28546
dedup(reachable_rows) == reachable set: True
restructure RID set == reachable set:   True
```

The adapters now yield **28,546** Images (matching `restructure_assets`),
not the **9,383** direct-members the bug produced.

## Notes
- RIDs treated as opaque throughout (equality only; no parsing).
- `restructure.py` has pre-existing blank-line format debt elsewhere in the
  file (present on `main`); left untouched to keep this PR's diff scoped.

Spec: `docs/superpowers/specs/2026-06-16-adapter-fk-reachable-elements-design.md`
Plan: `docs/superpowers/plans/2026-06-16-adapter-fk-reachable-elements.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)