### PR TITLE
fix(denormalize): correct multi-route JOIN order (#320 regression in #318)

### DIFF
--- a/src/deriva_ml/model/denormalize_planner.py
+++ b/src/deriva_ml/model/denormalize_planner.py
@@ -1806,6 +1806,15 @@ class DenormalizePlanner:
                 prefix = route[: elem_pos + 1]
 
                 path_names: list[str] = [t.name for t in prefix]
+                # Tables positioned by the prefix (Dataset -> ... -> element).
+                # Each is joined at its prefix position with the prefix edge's
+                # ON clause, which references the PRECEDING prefix table (already
+                # joined). The subtree edges below must NOT overwrite these — a
+                # subtree edge references the element (joined at/after the prefix
+                # end), so applying it to a table that sits earlier in the prefix
+                # would reference a not-yet-joined table (#320). See the
+                # join-order invariant in test_planner_rules.TestJoinOrderValidity.
+                prefix_names = set(path_names)
                 join_conditions: dict[str, set[tuple]] = {}
                 join_types: dict[str, str] = {}
 
@@ -1830,9 +1839,15 @@ class DenormalizePlanner:
                     if node.table_name not in path_names:
                         path_names.append(node.table_name)
 
-                # Add join conditions from the subtree edges (root has no parent
-                # edge; its condition comes from the prefix walk above).
+                # Add join conditions from the subtree edges, but ONLY for tables
+                # the subtree genuinely appends. A table already positioned by the
+                # prefix keeps its prefix-edge condition (valid for its position);
+                # the subtree edge references the element (joined at/after the
+                # prefix end) and would be invalid at an earlier prefix position
+                # (#320). The root (element) has no parent edge in walk_edges().
                 for _parent_node, child_node in tree.walk_edges():
+                    if child_node.table_name in prefix_names:
+                        continue
                     if child_node.fk_columns:
                         join_conditions[child_node.table_name] = set(child_node.fk_columns)
                         join_types[child_node.table_name] = child_node.join_type

--- a/tests/local_db/conftest.py
+++ b/tests/local_db/conftest.py
@@ -1533,6 +1533,7 @@ def _base_schema_doc() -> dict:
 
 # Absolute path to the demo catalog schema shipped with the dataset tests.
 _DEMO_CATALOG_SCHEMA = Path(__file__).resolve().parents[1] / "dataset" / "demo-catalog-schema.json"
+_EYE_AI_CATALOG_SCHEMA = Path(__file__).resolve().parents[1] / "dataset" / "eye-ai-catalog-schema.json"
 
 
 class _DenormDatasetStub:
@@ -1591,6 +1592,35 @@ def demo_catalog_planner() -> tuple[Any, _DenormDatasetStub, str]:
     # RIDs are opaque: synthesize a unique placeholder rather than embedding a
     # literal. The planner never treats this as a live catalog RID in the
     # catalog-free path; it only flows through the join plan as an identifier.
+    dataset_rid = f"1-{uuid.uuid4().hex[:8].upper()}"
+    dataset_stub = _DenormDatasetStub(dataset_rid)
+    return deriva_model._planner, dataset_stub, dataset_rid
+
+
+@pytest.fixture
+def eye_ai_planner() -> tuple[Any, _DenormDatasetStub, str]:
+    """Catalog-free planner over the committed eye-ai schema fixture.
+
+    The eye-ai schema has the multi-route topology that exposed the #320
+    JOIN-order regression: ``Subject`` and ``Observation`` are reachable from
+    ``Dataset`` via membership associations (e.g. ``Subject_Dataset``), while
+    ``Image`` is FK-reachable through ``Observation`` (``Image.Observation``).
+    A request over ``[Subject, Observation, Image]`` therefore yields routes
+    whose ``Dataset -> ... -> Image`` prefix places ``Observation``/``Subject``
+    *before* ``Image`` — the shape that makes a subtree edge's ON clause
+    reference a not-yet-joined table.
+
+    Returns ``(planner, dataset_stub, dataset_rid)`` mirroring
+    :func:`demo_catalog_planner`.
+    """
+    model = Model.fromfile("file-system", _EYE_AI_CATALOG_SCHEMA)
+    ml_schema = "deriva-ml"
+    domain_schemas = {s for s in model.schemas.keys() if s != ml_schema}
+    deriva_model = DerivaModel(
+        model=model,
+        ml_schema=ml_schema,
+        domain_schemas=domain_schemas,
+    )
     dataset_rid = f"1-{uuid.uuid4().hex[:8].upper()}"
     dataset_stub = _DenormDatasetStub(dataset_rid)
     return deriva_model._planner, dataset_stub, dataset_rid

--- a/tests/local_db/test_planner_rules.py
+++ b/tests/local_db/test_planner_rules.py
@@ -574,3 +574,55 @@ class TestTransparencyPredicates:
         assert broad == {"Image_Classification"}, (
             f"bidirectional reach should still see Image_Classification through the bridge, got {broad}"
         )
+
+
+class TestJoinOrderValidity:
+    """Every emitted route must order its JOINs so that no ON clause references
+    a table joined later (#320 regression).
+
+    The consumer (``_denormalize_impl``) joins the tables of each route in
+    ``path_names`` order, using ``join_conditions[table]`` for the ON clause.
+    SQLite (and any SQL engine) rejects ``... JOIN B ON A.x = B.y ...`` when
+    ``A`` is joined *after* ``B`` ("ON clause references tables to its right").
+
+    #318 introduced multi-hop ``Dataset -> ... -> element`` route prefixes. On a
+    multi-route topology (a table reachable via a membership association while
+    another requested table is FK-reachable through it), the prefix can place a
+    subtree table *before* the element, yet the subtree edge's ON clause
+    references the element — producing an invalid join order. This pins the
+    invariant that prevented it.
+    """
+
+    @staticmethod
+    def _on_clause_tables(col_pairs) -> set[str]:
+        """Tables referenced by an ON clause (both sides of each fk/pk pair)."""
+        tables: set[str] = set()
+        for fk_col, pk_col in col_pairs:
+            tables.add(fk_col.table.name)
+            tables.add(pk_col.table.name)
+        return tables
+
+    def test_no_join_references_a_later_table(self, eye_ai_planner) -> None:
+        """For the [Subject, Observation, Image] request on the eye-ai schema,
+        no route emits a JOIN whose ON clause references a not-yet-joined table.
+        """
+        planner, stub, dataset_rid = eye_ai_planner
+        element_tables, _cols, _multi = planner._prepare_wide_table(
+            stub, dataset_rid, ["Subject", "Observation", "Image"]
+        )
+        assert element_tables, "planner produced no routes"
+
+        violations: list[str] = []
+        for key, (path, join_conditions, _join_types) in element_tables.items():
+            for i, table_name in enumerate(path):
+                col_pairs = join_conditions.get(table_name)
+                if not col_pairs:
+                    continue  # root/Dataset or no condition
+                later_tables = set(path[i + 1 :])
+                refs_later = self._on_clause_tables(col_pairs) & later_tables
+                if refs_later:
+                    violations.append(
+                        f"route '{key}': JOIN {table_name} ON references "
+                        f"not-yet-joined {sorted(refs_later)} (path={path})"
+                    )
+        assert not violations, "invalid JOIN order (#320):\n" + "\n".join(violations)


### PR DESCRIPTION
Fixes #320.

## Summary

After #318, `DatasetBag.get_denormalized_as_dataframe(["Subject","Observation","Image"])` raised `sqlite3.OperationalError: ON clause references tables to its right` on datasets where members are reached one way (e.g. a `Subject`/`OCT_DICOM` membership association) while a requested table (`Image`) is FK-reachable another way (via `Observation`).

## Root cause

#318's multi-route emission builds, for each route, a `Dataset -> ... -> element` **prefix** (positioning + conditioning each prefix table via its prefix edge), then applies the element's shared **subtree** edges. On a multi-route topology the prefix can place a subtree table (e.g. `Observation`) *before* the element (`Image`) — but the subtree-edge loop **unconditionally overwrote** that table's prefix condition with the subtree edge `Image.Observation = Observation.RID`, which references the element. The consumer then emitted `JOIN Observation ON Image.Observation = ...` **before** `Image` was joined → invalid SQL.

Confirmed by instrumenting the planner on the real `2-C9PP` bag: 5 of 6 emitted routes had a JOIN whose ON clause referenced a not-yet-joined table.

## Fix

Skip subtree edges for tables already positioned by the prefix. A prefix table keeps its order-valid prefix-edge condition (which references its already-joined predecessor); subtree edges apply only to tables the subtree genuinely appends after the element. One guard in `_prepare_wide_table` Phase 3.

## Tests

- **New catalog-free regression** `test_planner_rules.TestJoinOrderValidity::test_no_join_references_a_later_table` — over the committed **eye-ai schema fixture** (`Subject_Dataset` membership + `Image.Observation` FK reproduces the topology). Asserts the join-order invariant: no route emits a JOIN whose ON clause references a later table. **FAILS before the fix** (lists the exact #320 violations), **passes after**.
- Full `tests/local_db/` suite: **358 passed** (no planner regression).
- **Live `2-C9PP` v2.10.10 acceptance** (manual): `get_denormalized_as_dataframe([Subject,Observation,Image])` no longer crashes and returns **8,654 rows / 7,916 distinct FK-reachable Images** — the rows that crashed on HEAD and were silently dropped pre-#318. So the issue's "neither HEAD nor pre-#318 is correct" is resolved: correct FK-reachable data, no crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)