### PR TITLE
docs(denormalize): close spec gaps + agent/manual completeness (2nd-pass review)

### DIFF
--- a/docs/design/denormalization-contract.md
+++ b/docs/design/denormalization-contract.md
@@ -437,6 +437,13 @@ For each `row_per` row R:
   (R, T-row) combination. The `row_per` count grows accordingly
   — the output then has `|row_per × (average T-links per
   row_per)|` rows.
+- **Each hop's join type is `LEFT OUTER JOIN` when the FK column is
+  nullable, `INNER JOIN` when it is `NOT NULL`** (`_build_join_tree`
+  sets `join_type="left"` iff `fk_col.nullok`; `_denormalize_impl`
+  emits `outerjoin` vs `join` accordingly). A nullable FK therefore
+  never drops a `row_per` row — the row survives with `NULL` columns
+  for that upstream table. An `INNER JOIN` is correct only because the
+  `NOT NULL` constraint guarantees a match.
 
 #### Downstream-leaf rejection (explicit `row_per` with downstream table → error)
 

--- a/docs/reference/denormalization.md
+++ b/docs/reference/denormalization.md
@@ -111,6 +111,22 @@ the dataset's members define which rows are in scope) and
 [**return shapes**](#return-shapes) (what each of the four methods hands
 back). Both follow the rules table.
 
+## Terminology
+
+These terms are used precisely and consistently across this page, the
+[tutorial](../user-guide/denormalization.md), and the
+[contract](../design/denormalization-contract.md):
+
+| Term | Meaning |
+|---|---|
+| **`row_per` table** / **grain** / **sink** / **leaf** | The table whose rows become output rows — one row per instance of it. "Sink" and "leaf" name the same table from the FK-graph side (it has no outbound FK to another requested table). |
+| **upstream / downstream** | Relative to FK direction. In `Subject ◄── Observation ◄── Image` (Image references Observation references Subject), `Image` is **downstream**, `Subject` is **upstream**. A table is downstream of another if you reach it by following FKs *outward* (`A.fk → B.RID`). |
+| **anchor** | A dataset member — a specific row of a member table — that scopes the output. The anchor *set* is the dataset's members, taken recursively across nested datasets. (Used interchangeably with "member"; "anchor" is the precise term once it's serving as a scope.) |
+| **in scope** | A `row_per` row is in scope if it is **FK-reachable from some anchor**, in either direction — not necessarily a direct dataset member. |
+| **transparent intermediate** | An association table on a join path between two requested tables. It is joined *through* but contributes **no columns** (a "bridge"). Feature-association tables are transparent intermediates too. |
+| **orphan row** | A row produced for an anchor that is in `include_tables` but reaches no `row_per` row: its own columns are populated, the `row_per`-side columns are `NULL` (a LEFT-JOIN-shaped row). |
+| **route** vs **path** | A **route** is a `Dataset → … → element` chain (one of possibly several ways the dataset reaches an element); routes to the *same* element are unioned ([FK-reachable scoping](#fk-reachable-scoping)). A **path** is a `row_per → … → table` FK chain between two requested tables; *distinct* paths to the same table are an error ([Path ambiguity](#path-ambiguity)). They are different concepts — see each rule. |
+
 ## Formal rules
 
 <a id="row-grain"></a>
@@ -120,14 +136,27 @@ back). Both follow the rules table.
 `row_per` defaults to the furthest-downstream requested table.**
 
 "In scope" means **FK-reachable from a dataset member**, not *member-of*
-(see [FK-reachable scoping](#fk-reachable-scoping)). By default `row_per`
-is **auto-inferred**: among `include_tables`, the one that no other
-requested table points to via FK — the "deepest" / furthest-downstream
-table — becomes the grain. Auto-inference **raises** if two candidates
-tie (`DerivaMLDenormalizeMultiLeaf`) or the FK subgraph has a cycle with
-no sink (`DerivaMLDenormalizeNoSink`); pass `row_per=` explicitly to
-resolve. (Setting `row_per` to a table *downstream* of another requested
-table is rejected — see [Downstream-leaf rejection](#downstream-leaf-rejection).)
+(see [FK-reachable scoping](#fk-reachable-scoping)).
+
+**Auto-inference (the default).** Build a directed graph over
+`include_tables ∪ via` whose edges are **direct** FK references between
+domain tables (`A.fk_col → B.RID`). Association tables — M:N bridges and
+feature-association tables — are **not** edges here: two tables linked
+only *through* an association establish no downstream direction between
+them (the bridge is a 1:1:1 hop, not a fan-out). The **sinks** of this
+graph (tables with no outbound edge) are the `row_per` candidates,
+restricted to `include_tables` — a `via` table participates in the graph
+but can never be the grain, since its columns aren't projected. Then:
+
+- **exactly one sink** → that table is `row_per`;
+- **two or more sinks** → `DerivaMLDenormalizeMultiLeaf` (pass `row_per=`
+  to pick one);
+- **no sink** (an FK cycle) → `DerivaMLDenormalizeNoSink`.
+
+**Explicit `row_per`.** Must name a table in `include_tables` (it has no
+meaning if its columns aren't in the output) — otherwise `ValueError`.
+Setting it to a table *downstream* of another requested table is
+rejected — see [Downstream-leaf rejection](#downstream-leaf-rejection).
 `[deriva-ml]`
 `src/deriva_ml/local_db/denormalizer.py::Denormalizer.as_dataframe`
 (`row_per` argument; sink-finding is
@@ -161,6 +190,14 @@ star-schema shape. A table reached through an N-to-N link produces one
 output row per `(row_per, linked-row)` combination, so the `row_per`
 count can grow. Output columns use `Table.column` notation (e.g.
 `Subject.Name`).
+
+**Join type follows FK nullability.** Each hop to an upstream table is an
+`INNER JOIN` when the FK column is `NOT NULL` and a `LEFT OUTER JOIN`
+when the FK column is nullable. This matters: a `row_per` row with a
+`NULL` FK survives the join (its columns for that upstream table come
+back `NULL`) rather than being dropped — so a nullable FK never reduces
+the `row_per` row count. An `INNER JOIN` is safe only because the
+`NOT NULL` constraint guarantees a matching upstream row.
 
 This is also where a **feature `selector`** acts: when `include_tables`
 contains **exactly one** feature-association table, the optional
@@ -216,7 +253,16 @@ same element and never raises.)
 ### Anchor disposition
 
 **Every dataset member (anchor) contributes in exactly one way,
-determined by its table and reachability.** The six cases:
+determined by its table and reachability.**
+
+**"Reaches a `row_per` row" is direction-agnostic.** An anchor reaches
+`row_per` if there is *any* FK chain connecting the anchor's table and
+`row_per`, **in either direction** — the anchor either sits upstream of
+`row_per` (its columns get hoisted onto the `row_per` rows it points to)
+or downstream (it points *at* `row_per`, scoping which `row_per` rows are
+in play). Both serve as a filter on the output. A reader who assumes
+"reaches" means strictly-downstream-only would wrongly drop the upstream
+case. The six cases:
 
 | Case | Anchor table | Reaches a `row_per` row? | Contribution |
 |---|---|---|---|
@@ -367,10 +413,15 @@ table to hoist ([Column hoisting](#column-hoisting)).
 
 ### A multi-table star-schema flatten (illustrative)
 
-*Illustrative* — described on a small hand-drawn schema; the real demo
-catalog wasn't captured for this multi-table shape. With the FK chain
-`Subject ◄── Observation ◄── Image` (Image references Observation,
-Observation references Subject):
+!!! note "Illustrative — not captured output"
+    The schema and the result table below are **hand-drawn** to show the
+    star-schema *shape*; they are not pasted from a real catalog capture
+    (unlike the single-table example above, which is verified against demo
+    catalog `106`). Treat the row counts and values as schematic, not as
+    ground truth — verify against your own schema before relying on them.
+
+With the FK chain `Subject ◄── Observation ◄── Image` (Image references
+Observation, Observation references Subject):
 
 ```python
 bag.get_denormalized_as_dataframe(["Subject", "Observation", "Image"])

--- a/docs/user-guide/denormalization.md
+++ b/docs/user-guide/denormalization.md
@@ -421,8 +421,9 @@ a dataset member**, not member-of — see
 [Dataset membership scopes by FK-reachability](#dataset-membership-scopes-by-fk-reachability-not-by-direct-membership).
 
 **Column projection.** Columns come from `include_tables`. Tables in
-`via`, and association tables that only bridge two requested tables, are
-joined *through* but contribute no columns.
+`via`, and the association tables that only bridge two requested tables
+(*transparent intermediates*), are joined *through* but contribute no
+columns.
 
 **Column hoisting.** For each `row_per` row, upstream columns are hoisted
 from the FK graph and **repeated verbatim** across rows sharing the same

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,6 +56,9 @@ nav:
       - Bag Export: reference/bag-export.md
       - Denormalization (formal): reference/denormalization.md
       - Schema: reference/schema.md
+  - Design & Implementation:
+      - Denormalization (implementation contract): design/denormalization-contract.md
+      - Bag-based upload engine: design/bag-based-upload-engine.md
   - Configuration:
       - Overview: configuration/overview.md
       - Configuration Groups: configuration/groups.md


### PR DESCRIPTION
**Stacked on #324** (the doc restructure), which is itself stacked on the merged #323. This branch includes #324's commits as its base; review/merge **#324 first**, then this PR's own diff collapses to the single `docs(denormalize): close spec gaps …` commit.

A second deep review — one pass as a **senior engineer evaluating the reference as an implementation spec**, one as a **documentation specialist evaluating it as a complete reference manual for human + agent consumption** — surfaced a bounded, high-confidence set of gaps. This closes them without re-expanding the docs we just trimmed.

## Spec gaps (each verified against the planner/denormalizer code)

| Gap | Fix |
|---|---|
| **Join type was specified nowhere** — nullable FK → LEFT vs NOT NULL → INNER decides whether a `row_per` row with a NULL FK survives | Stated in Column hoisting (reference **and** contract) |
| **"Reaches a `row_per` row" undefined** — code is direction-agnostic; a reader assumes strict-downstream and mis-buckets upstream anchors | Anchor disposition now defines reachability as "any FK chain, either direction" |
| **Sink-finding wording invited the wrong reading** — association tables are *not* outbound edges; sinks restricted to `include_tables`; `via` can't be the grain | Row grain auto-inference restated precisely |
| **`row_per` must be in `include_tables`** (raises `ValueError`) | Now stated |

## Manual / agent completeness
- **Terminology section** in the reference defines the load-bearing terms in one retrieval-friendly place (`row_per`/sink/leaf, upstream/downstream, anchor, in-scope, transparent intermediate, orphan row, **route vs path**) — closing several "term used but undefined" findings at once and drawing the route-vs-path distinction sharply.
- **Contract is now in the mkdocs nav** (new "Design & Implementation" section) instead of footnote-only; the orphaned `bag-based-upload-engine.md` is wired up too.
- **Illustrative example** wrapped in a "not captured output" admonition — visually + machine-readably distinct from the verified one.
- Unified "association tables that bridge" → "transparent intermediates" in the tutorial.

## What I deliberately did NOT do
The reviews also recommended re-stating definitions at the top of every section (fights the "fewest words" goal — the glossary is the single-source version) and promoting planner internals (`_is_feature_association` marker predicate, the monotonic-direction diamond filter, route-emission architecture) into the *reference*. Those are *how the planner is built*, not *what the rules are* — they belong in the contract, where most already live. Declined, to keep the reference a spec, not an implementation dump.

## Verification
- Docs-only; no code change.
- `mkdocs build` surfaces no nav/link errors (only the pre-existing `griffe` env gap).
- All named-rule anchors and the new cross-links/glossary resolve; no numbered-rule or D-anchor references reintroduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)