### PR TITLE
fix(deps): re-pin deriva-py to live deriva-ml HEAD (dangling-SHA cleanup)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     # "newer-than" signal, so consumers silently freeze on a stale deriva-py
     # (see CLAUDE.md "Updating the deriva-py pin"). Advance this SHA whenever
     # deriva-ml needs a newer deriva-py — and BEFORE every bump-version.
-    "deriva @ git+https://github.com/informatics-isi-edu/deriva-py@7ef28fcd12341d47836f721c0481528fcea22165",
+    "deriva @ git+https://github.com/informatics-isi-edu/deriva-py@7df3e45eeea569c98746acedac8a67b723f21363",
     "deepdiff",
     "nbconvert",
     "pandas",
@@ -62,7 +62,7 @@ python-preference = "only-managed"
 # Keep this rev in lockstep with the SHA in project.dependencies above. uv
 # applies this source override locally; pinning the same immutable rev (not the
 # branch) keeps dev resolution identical to what consumers get transitively.
-deriva = { git = "https://github.com/informatics-isi-edu/deriva-py", rev = "7ef28fcd12341d47836f721c0481528fcea22165" }
+deriva = { git = "https://github.com/informatics-isi-edu/deriva-py", rev = "7df3e45eeea569c98746acedac8a67b723f21363" }
 
 
 [tool.setuptools.package-data]

--- a/uv.lock
+++ b/uv.lock
@@ -853,7 +853,7 @@ wheels = [
 [[package]]
 name = "deriva"
 version = "2.0.0.dev0"
-source = { git = "https://github.com/informatics-isi-edu/deriva-py?rev=7ef28fcd12341d47836f721c0481528fcea22165#7ef28fcd12341d47836f721c0481528fcea22165" }
+source = { git = "https://github.com/informatics-isi-edu/deriva-py?rev=7df3e45eeea569c98746acedac8a67b723f21363#7df3e45eeea569c98746acedac8a67b723f21363" }
 dependencies = [
     { name = "bdbag" },
     { name = "fair-identifiers-client" },
@@ -928,7 +928,7 @@ requires-dist = [
     { name = "bdbag", git = "https://github.com/fair-research/bdbag?rev=1.9.0-dev" },
     { name = "bump-my-version" },
     { name = "deepdiff" },
-    { name = "deriva", git = "https://github.com/informatics-isi-edu/deriva-py?rev=7ef28fcd12341d47836f721c0481528fcea22165" },
+    { name = "deriva", git = "https://github.com/informatics-isi-edu/deriva-py?rev=7df3e45eeea569c98746acedac8a67b723f21363" },
     { name = "hydra-zen" },
     { name = "nbconvert" },
     { name = "nbstripout" },


### PR DESCRIPTION
## Why

Prep for cutting a patch release (the #322 denormalize cartesian fix in #323 is unreleased on `main`). The bump checklist requires verifying the deriva-py pin first — and it turned out to be **dangling**, not behind.

The pinned SHA `7ef28fcd` is **content-identical** to current `origin/deriva-ml` HEAD `7df3e45e` — both are the same `add_asset resolves symlink sources` fix (#319) — but `7ef28fcd` is on **no branch**: deriva-py's `deriva-ml` branch was force-pushed/rebased after we pinned it, rewriting that commit's SHA. The orphaned commit still resolves today, but an upstream GC would break downstream resolution.

## What

Re-pin **both** locations (`project.dependencies` URL + `[tool.uv.sources] rev`) from `7ef28fcd` → `7df3e45e` (a SHA actually on `origin/deriva-ml`) and re-lock. **No functional change to deriva-py** — purely a provenance/durability fix so the pin points at a real branch commit.

## Verification
- `uv lock && uv sync` advance the pin cleanly (`7ef28fcd → 7df3e45e`; lockfile fully updated).
- Catalog-free suites (`tests/local_db` + `tests/asset`): **444 passed, 4 skipped** with the re-pinned deriva-py.

After this merges, `bump-version patch` cuts the release with a current, non-dangling pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)