### PR TITLE
test(denormalize): fix stale-schema fixtures + xfail unimplemented composite-FK catalog fetch (#322)

### DIFF
--- a/tests/dataset/test_composite_fk_denormalize.py
+++ b/tests/dataset/test_composite_fk_denormalize.py
@@ -13,12 +13,11 @@ bag.get_denormalized_as_dataframe(["file", "biosample"]) to return 0 rows becaus
 3. Denormalization can't join through an empty table
 """
 
-import pytest
 from deriva.core.typed import BuiltinType, ColumnDef, ForeignKeyDef, KeyDef, TableDef
 
 from deriva_ml import DerivaML
-from deriva_ml.execution.execution import ExecutionConfiguration
 from deriva_ml.core.definitions import MLVocab
+from deriva_ml.execution.execution import ExecutionConfiguration
 
 
 class TestCompositeFKDenormalize:
@@ -98,6 +97,14 @@ class TestCompositeFKDenormalize:
                 ],
             )
         )
+
+        # The tables above were created on a fresh getCatalogModel(), which
+        # is a different object than the held model that ml.pathBuilder()
+        # builds from (and caches by model identity). Without a refresh, the
+        # subsequent _populate step's pathBuilder can't see the new tables
+        # (KeyError 'Group'). Rebind the held model + invalidate the
+        # path-builder cache so the new schema is visible.
+        ml.refresh_schema(force=True)
 
     def _populate_composite_fk_data(self, ml: DerivaML) -> dict:
         """Insert test data into composite FK tables.

--- a/tests/dataset/test_realworld_patterns.py
+++ b/tests/dataset/test_realworld_patterns.py
@@ -20,7 +20,6 @@ from deriva_ml import DerivaML
 from deriva_ml.core.definitions import MLVocab
 from deriva_ml.execution.execution import ExecutionConfiguration
 
-
 # ---------------------------------------------------------------------------
 # Helpers shared across test classes
 # ---------------------------------------------------------------------------
@@ -88,6 +87,11 @@ class TestDeepFKChains:
                     ],
                 )
             )
+
+        # Created on a fresh getCatalogModel(); rebind the held model so the
+        # cached ml.pathBuilder() sees the new tables (else KeyError in
+        # _populate). See test_composite_fk_denormalize for the full rationale.
+        ml.refresh_schema(force=True)
 
     def _populate_deep_chain(self, ml: DerivaML) -> dict:
         pb = ml.pathBuilder()
@@ -229,6 +233,8 @@ class TestNullableCompositeFKs:
             )
         )
 
+        ml.refresh_schema(force=True)  # rebind held model so pathBuilder sees new tables
+
     def _populate_nullable_composite(self, ml: DerivaML) -> dict:
         pb = ml.pathBuilder()
         domain = pb.schemas[ml.default_schema]
@@ -330,6 +336,8 @@ class TestCatalogSideCompositeFKDenormalize:
             )
         )
 
+        ml.refresh_schema(force=True)  # rebind held model so pathBuilder sees new tables
+
     def _populate(self, ml: DerivaML) -> dict:
         pb = ml.pathBuilder()
         domain = pb.schemas[ml.default_schema]
@@ -353,6 +361,17 @@ class TestCatalogSideCompositeFKDenormalize:
         )
         return {"groups": groups, "parents": parents, "children": children}
 
+    @pytest.mark.xfail(
+        strict=True,
+        reason=(
+            "Catalog-side fetch across a composite (multi-column) FK is not yet "
+            "implemented: _collect_fk_values raises NotImplementedError on >1 "
+            "workable join condition (RB-08, denormalize.py). Bag-side composite-FK "
+            "denormalize IS supported (see test_composite_fk_denormalize.py) — only "
+            "the source='catalog' fetch path has the gap. Remove this xfail when "
+            "_collect_fk_values learns to scope a composite FK by all its columns."
+        ),
+    )
     def test_catalog_denormalize_composite_fk(self, test_ml: DerivaML, tmp_path):
         """Catalog-side denormalization across composite FK."""
         self._create_composite_schema(test_ml)
@@ -366,6 +385,15 @@ class TestCatalogSideCompositeFKDenormalize:
         assert set(df["CatChild.Label"].tolist()) == {"C1", "C2"}
         assert set(df["CatParent.Name"].tolist()) == {"P1", "P2"}
 
+    @pytest.mark.xfail(
+        strict=True,
+        reason=(
+            "Catalog-side fetch across a composite (multi-column) FK is not yet "
+            "implemented: _collect_fk_values raises NotImplementedError (RB-08, "
+            "denormalize.py). Bag-side composite-FK denormalize IS supported. "
+            "Remove this xfail when the source='catalog' path scopes composite FKs."
+        ),
+    )
     def test_catalog_denormalize_composite_fk_three_table(self, test_ml: DerivaML, tmp_path):
         """Catalog-side three-table chain through composite FK."""
         self._create_composite_schema(test_ml)
@@ -476,6 +504,8 @@ class TestSelfReferentialFK:
             )
         )
 
+        ml.refresh_schema(force=True)  # rebind held model so pathBuilder sees new tables
+
     def _populate_hierarchy(self, ml: DerivaML) -> dict:
         pb = ml.pathBuilder()
         domain = pb.schemas[ml.default_schema]
@@ -563,6 +593,8 @@ class TestWideSchema:
                     ],
                 )
             )
+
+        ml.refresh_schema(force=True)  # rebind held model so pathBuilder sees new tables
 
     def test_wide_schema_path_discovery_terminates(self, test_ml: DerivaML):
         """Path discovery on a wide schema should terminate without explosion."""


### PR DESCRIPTION
Closes #322. Fixes the **non-membership half** of issue #322 — the 13 denormalize integration tests that were silently red on `main` for a reason unrelated to the #318 FK-reachable change.

## Root cause — two distinct problems

**1. Held-model staleness (11 tests) — fixed.** The composite-FK and real-world-pattern suites build their own bespoke schemas in `_create_*_schema` fixtures via `ml.catalog.getCatalogModel().create_table(...)`. That mutates a *fresh* model object — not `ml.model.model`, the held model `ml.pathBuilder()` builds from and caches by identity. So the new tables were invisible to the cached path builder, and `_populate`'s `domain.tables["Group"].insert(...)` raised `KeyError`. Fixed by `ml.refresh_schema(force=True)` at the end of each schema-creation helper (rebinds the held model + invalidates the path-builder cache). Verified: a fresh `getCatalogModel()` sees the new table; `pathBuilder()` doesn't until the refresh.

**2. Unimplemented feature (2 tests) — xfailed, not a test bug.** `TestCatalogSideCompositeFKDenormalize` exercises **catalog-side** denormalize across a **composite FK**, which `_collect_fk_values` deliberately rejects (`NotImplementedError`, RB-08: single-column FKs only). The tests are correct; the feature isn't built. Marked `@pytest.mark.xfail(strict=True)` with the reason, so the suite is green-and-honest and the xfail flags **XPASS** the day the feature lands. Tracked in #327. (Bag-side composite-FK denormalize **is** supported — only the `source="catalog"` fetch path has the gap.)

## The #322 three-way split, now fully resolved

| Class | Count | Resolution |
|---|---|---|
| Stale membership-count assertions | 6 | Fixed in #323, shipped in **v1.51.4** |
| Held-model fixture staleness | 11 | **Fixed here** |
| Catalog-side composite-FK (genuine gap) | 2 | **xfail(strict)** here + tracked in #327 |

## Verification (live localhost)
- `test_composite_fk_denormalize.py`: **4 passed**
- `test_realworld_patterns.py`: **13 passed, 2 xfailed**
- `test_denormalize.py`: 68 passed (already green from #323)
- ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)