### PR TITLE
docs(denormalize): close spec gaps from codex review (goal, FK shapes, feature grain)

### DIFF
--- a/docs/reference/denormalization.md
+++ b/docs/reference/denormalization.md
@@ -3,20 +3,42 @@
 > Verified against a populated demo catalog
 > (`create_demo_catalog(create_features=True, create_datasets=True)`,
 > deriva-ml v1.46.x, catalog `106`, captured 2026-06-13). Every rule on
-> this page is tagged `[deriva-ml]` — denormalization is **pure local
-> computation** inside deriva-ml's own code, with no deriva-py engine
-> involvement and no catalog access. The "Worked examples" section
-> pastes verified excerpts from `docs/reference/.examples/denorm.txt`.
+> this page is tagged `[deriva-ml]` — the denormalization **rules and
+> SQL shaping** are pure local computation inside deriva-ml's own code,
+> with no deriva-py engine involvement. (The *shaping* is always local;
+> a live `Dataset` additionally **fetches its rows from the catalog**
+> into local SQLite first — see [Mental model](#mental-model). A
+> `DatasetBag` reads only the bag's local SQLite and touches no
+> catalog.) The "Worked
+> examples" section pastes verified excerpts from
+> `docs/reference/.examples/denorm.txt`.
 >
 > **For a gentle, example-led introduction**, read the
 > [denormalization tutorial](../user-guide/denormalization.md) first.
 > This page is the formal counterpart — it states the rules precisely
 > and names the code locations, but does not re-teach the concepts.
 
-Denormalization turns an **already-downloaded** dataset bag into a
-single **wide table** — one row per ML observation, with columns pulled
-side-by-side from related tables along the bag's foreign-key graph. The
-four entry points are methods on `DatasetBag`:
+## What denormalization returns (the goal)
+
+Denormalization flattens a dataset (a downloaded `DatasetBag`, or a live
+`Dataset`) into a single **wide table**. Precisely, it returns:
+
+> **One row per `row_per`-table instance that is FK-reachable from the
+> dataset's (recursive) members, with the requested columns projected and
+> upstream context duplicated across rows that share it. It does no
+> aggregation; an explicitly-requested upstream table that reaches no
+> `row_per` row contributes a NULL-filled orphan row.**
+
+That is the contract to hold the result against. "One row per ML
+observation" is the *intuition* — but the observation is whatever table
+becomes `row_per` ([Row grain](#row-grain)): `Image`, `Observation`, a
+`file`, or a feature-association row. It is **not** "one row per dataset
+member" (scope is FK-reachable, not membership —
+[FK-reachable scoping](#fk-reachable-scoping)) and it is **not**
+aggregated (N feature rows per image stay N rows unless a `selector`
+collapses them — [Column hoisting](#column-hoisting)).
+
+The four entry points are methods on `DatasetBag`:
 
 | Method | Returns | Fetches data? |
 |---|---|---|
@@ -140,11 +162,17 @@ These terms are used precisely and consistently across this page, the
 
 **Auto-inference (the default).** Build a directed graph over
 `include_tables ∪ via` whose edges are **direct** FK references between
-domain tables (`A.fk_col → B.RID`). Association tables — M:N bridges and
-feature-association tables — are **not** edges here: two tables linked
-only *through* an association establish no downstream direction between
-them (the bridge is a 1:1:1 hop, not a fan-out). The **sinks** of this
-graph (tables with no outbound edge) are the `row_per` candidates,
+domain tables (`A.fk_col → B.RID`). **Read the arrow as "A holds the FK,
+so A is *downstream* of B"** — the edge points from the table that *has*
+the foreign key toward the table it *references*. (e.g. `Image.Subject →
+Subject.RID` means `Image` is downstream of `Subject`; in
+`Subject ◄ Observation ◄ Image`, `Image` is the most-downstream table.)
+Association tables — M:N bridges and feature-association tables — are
+**not** edges here: two tables linked only *through* an association
+establish no downstream direction between them (the bridge is a 1:1:1
+hop, not a fan-out). The **sinks** of this graph (tables with **no
+outbound edge** — i.e. they hold no FK to another requested table, so
+nothing is downstream of them) are the `row_per` candidates,
 restricted to `include_tables` — a `via` table participates in the graph
 but can never be the grain, since its columns aren't projected. Then:
 
@@ -176,6 +204,21 @@ to resolve a [path ambiguity](#path-ambiguity) without cluttering the
 output. Feature names (e.g. `"Image_Classification"`) in `include_tables`
 are resolved to the underlying feature-association table before
 projection (see [the contract §8.4](../design/denormalization-contract.md)).
+
+**"Transparent" is a topology heuristic, not a purity judgment — and you
+can override it.** A table is treated as a transparent intermediate when
+it has **exactly two domain FKs** (`_is_topological_association`) — *not*
+when it is "pure." This is the right default (it skips `Dataset_Image`-style
+link tables), but it has a real-catalog edge: a two-FK table that *also*
+carries meaningful columns (a `Role`, `Ordinal`, `Comment`, or — on
+catalogs like **facebase** — a genuine domain entity that happens to have
+two FKs) is **still treated as transparent and its columns are dropped**
+unless you opt in. **The escape hatch:** name that table explicitly in
+`include_tables` and its columns appear (it loses transparent status for
+that call). So the rule is: *two-FK tables are hidden by default; request
+them by name to project their columns.* (Feature-association tables are a
+separate, marker-based case — one FK to `Feature_Name` + one to
+`Execution` — and are always transparent unless named; see the contract.)
 `[deriva-ml]` `src/deriva_ml/local_db/denormalizer.py` (`include_tables`
 / `via` arguments; transparent-intermediate detection in the planner).
 
@@ -202,8 +245,13 @@ the `row_per` row count. An `INNER JOIN` is safe only because the
 This is also where a **feature `selector`** acts: when `include_tables`
 contains **exactly one** feature-association table, the optional
 `selector` callable reduces each feature's multi-row group (e.g. several
-annotators' labels for one image) to a single chosen row before
-hoisting. Its signature is
+annotators' labels for one image) to a single chosen row. The reduction
+runs **after the SQL join materializes** — the full N-row-per-anchor
+frame is produced first, then grouped by the feature's target RID and
+collapsed in Python. (So without a `selector` the result is *not* one
+row per `row_per` instance when features fan out; *with* one it is. This
+is also why `describe_denormalized`'s pre-run row estimate counts the
+un-collapsed rows.) Its signature is
 `Callable[[list[FeatureRecord]], FeatureRecord | None]` — identical to
 `DerivaML.feature_values`'s `selector`; built-ins on `FeatureRecord`
 include `select_newest`, `select_first`, `select_by_workflow`, and a
@@ -262,16 +310,23 @@ determined by its table and reachability.**
 or downstream (it points *at* `row_per`, scoping which `row_per` rows are
 in play). Both serve as a filter on the output. A reader who assumes
 "reaches" means strictly-downstream-only would wrongly drop the upstream
-case. The six cases:
+case. In the table below, **"FK-connected to `row_per`"** means exactly
+this either-direction relationship — the anchor sits upstream of
+`row_per`, downstream of it, or *is* it. The six cases:
 
 | Case | Anchor table | Reaches a `row_per` row? | Contribution |
 |---|---|---|---|
 | 1 | `== row_per` | — | one output row (itself, upstream hoisted) |
-| 2 | `∈ include_tables`, upstream of `row_per` | yes | filter-only (appears via the `row_per` row that hoists it) |
-| 3 | `∈ include_tables`, upstream of `row_per` | no | one **orphan** row — its columns populated, `row_per`-side columns `NULL` (LEFT-JOIN shape) |
-| 4 | `∉ include_tables`, upstream of `row_per` | yes | filter-only (no row of its own — its columns aren't projected) |
-| 5 | `∉ include_tables`, upstream of `row_per` | no | silently dropped (would not affect output) |
+| 2 | `∈ include_tables`, FK-connected to `row_per` | yes | filter-only (appears via the `row_per` row that hoists or points at it) |
+| 3 | `∈ include_tables`, FK-connected to `row_per` | no | one **orphan** row — its columns populated, `row_per`-side columns `NULL` (LEFT-JOIN shape) |
+| 4 | `∉ include_tables`, FK-connected to `row_per` | yes | filter-only (no row of its own — its columns aren't projected) |
+| 5 | `∉ include_tables`, FK-connected to `row_per` | no | silently dropped (would not affect output) |
 | 6 | no FK path to any `include_tables ∪ via` table | — | raises `DerivaMLDenormalizeUnrelatedAnchor` unless `ignore_unrelated_anchors=True` (then silently dropped) |
+
+(An orphan row — case 3 — only arises for an anchor that is *upstream*
+of `row_per` and reaches none; a *downstream* anchor that reaches no
+`row_per` row simply scopes nothing and falls under case 5. "Connected
+but unreached" is the orphan trigger only on the upstream side.)
 
 `ignore_unrelated_anchors` (default `False`) controls **only** case 6;
 it does **not** affect orphan (case 3) emission. Empty anchor sets are
@@ -529,6 +584,36 @@ bag.get_denormalized_as_dataframe(["Image"])
 bag.get_denormalized_as_dataframe(["Image"], ignore_unrelated_anchors=True)
 # OK — the File members are silently dropped.
 ```
+
+## Known limitations (FK shapes)
+
+The rules above assume the **single-column, RID-targeted FKs** that
+DerivaML schemas in active use (CSA, CFDE, GPCR, eye-ai) rely on. Two FK
+shapes found on other Deriva catalogs are not fully supported:
+
+- **Composite (multi-column) FKs, catalog-side.** A FK spanning several
+  columns — e.g. facebase's `file(biosample, dataset) → biosample(RID,
+  dataset)` — is handled on the **bag** path (the local SQL emits a
+  multi-column `AND` join) but **not** on the live-`Dataset` (catalog
+  fetch) path: `_collect_fk_values` raises `NotImplementedError` rather
+  than under-scoping the fetch (RB-08). So `Dataset.get_denormalized_*`
+  across a composite FK fails loudly; `DatasetBag.get_denormalized_*` on
+  a downloaded bag works. Tracked in
+  [issue #327](https://github.com/informatics-isi-edu/deriva-ml/issues/327).
+
+- **Self-referential FKs (a table referencing itself).** A hierarchy like
+  `HierNode.Parent_Node → HierNode.RID` is **not** denormalized as a
+  parent/child relationship. The planner deduplicates join paths by table
+  *name* and labels output columns `Table.column`, so it cannot alias the
+  same table in two roles — parent-`HierNode.*` and child-`HierNode.*`
+  would collide. Single-table requests (`["HierNode"]`) work and path
+  discovery terminates without looping; but you **cannot** project a
+  node's parent columns alongside its own in one call. To flatten a
+  hierarchy, denormalize the single table and resolve the parent links in
+  pandas.
+
+Both are about FK *shape*, not dataset content; a schema with only
+single-column RID FKs (the common case) hits neither.
 
 ## See also
 

--- a/docs/user-guide/denormalization.md
+++ b/docs/user-guide/denormalization.md
@@ -317,7 +317,15 @@ ds.get_denormalized_as_dataframe(
     ["Image", "Image_Class"],
     row_per="Image",
 )
-# OK: one row per Image, Image_Class.Name projected.
+# Image_Class.Name is projected onto Image rows — BUT this is "one row
+# per Image" ONLY when each Image has exactly ONE feature value. The
+# join still passes through the (hidden) feature-association table, which
+# has one row per (Image, Execution) annotation. If an Image was
+# annotated by N executions/annotators, that Image appears N times, each
+# with its own Image_Class.Name. Denormalize does NOT aggregate. To force
+# one row per Image, reduce the feature group with a `selector=` (see the
+# "Feature values on images" example) — that collapses the N annotations
+# to one BEFORE projection.
 
 # Intent B: "one row per feature observation." Let auto-inference
 # pick the feature-association table as row_per (the default


### PR DESCRIPTION
An independent **codex** consult on the denormalization spec — run against the real **eye-ai** (subject-partitioned, single-column FK) and **facebase** (composite FK) catalog shapes — surfaced a set of doc-accuracy gaps. All fixes here are **documentation-only**; the code is correct in every case, the docs were imprecise or silent.

(Codex's flagship "FK-direction bug" was a misread of the arrow semantics — verified against `reference:164`. Addressed with a clarifying gloss, not a code change.)

## Gaps closed

| # | Gap | Fix |
|---|---|---|
| G1 | "One ML observation" goal too squishy | Stated the operational contract: one row per `row_per`-grain instance FK-reachable from recursive members, columns projected, context duplicated, no aggregation, orphans appended |
| G2 | "Pure local / no catalog access" contradicts the live-Dataset fetch path | Scoped "pure-local" to the rules/SQL shaping; live Dataset fetches into SQLite first; bag touches no catalog |
| G3 | Anchor-disposition table only covered upstream anchors, but prose says direction-agnostic | Generalized cases 2–5 to "FK-connected (either direction)", matching `_classify_anchors`; clarified orphans are upstream-only |
| G4 | Feature-table "one row per Image" overclaim | Corrected: rows multiply through the hidden feature-assoc table; selector reduces *after* materialization |
| G5 | Two-FK transparency presented as a law | Documented as a topology heuristic + the escape hatch (name the table in `include_tables` to project its columns) — a real facebase risk |
| G6 | Self-referential FKs unspecified | New "Known limitations" section: can't alias a table in two roles; single-table works (test-backed), parent/child hoisting doesn't |
| G7 | FK-direction wording easy to invert (codex did) | Added "A→B means A holds the FK, A is downstream of B" gloss |

Also surfaced the composite-FK catalog-fetch limitation (#327) in the reference's new Known-limitations section, so it's discoverable from the spec, not just the test xfail.

## Verification
- Docs-only (reference + user-guide); no code change.
- `mkdocs build` clean (no denormalize link errors); all reference anchors resolve.
- Catalog-free planner tests green; the self-referential single-table claim is backed by `test_self_referential_denormalize` (passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)