### PR TITLE
feat(denormalize): suggest bridge tables on multi-leaf row_per (real eye-ai usability fix)

### DIFF
--- a/docs/reference/denormalization.md
+++ b/docs/reference/denormalization.md
@@ -38,6 +38,16 @@ member" (scope is FK-reachable, not membership —
 aggregated (N feature rows per image stay N rows unless a `selector`
 collapses them — [Column hoisting](#column-hoisting)).
 
+**Scope: deriva-ml catalogs only.** Denormalization is anchored on a
+deriva-ml **`Dataset`** — it reads a dataset's members and walks the FK
+graph from there. It therefore runs only on a catalog that has the
+deriva-ml `Dataset` machinery (e.g. eye-ai). A plain Deriva catalog
+without it (e.g. facebase, whose `isa.dataset` is an ordinary domain
+table, not the deriva-ml membership model) is **not** a denormalize
+target — there is no dataset to anchor the walk. The *rules* below
+(grain, hoisting, ambiguity) are general FK-graph logic, but the entry
+points require a `Dataset`.
+
 The four entry points are methods on `DatasetBag`:
 
 | Method | Returns | Fetches data? |
@@ -177,8 +187,14 @@ restricted to `include_tables` — a `via` table participates in the graph
 but can never be the grain, since its columns aren't projected. Then:
 
 - **exactly one sink** → that table is `row_per`;
-- **two or more sinks** → `DerivaMLDenormalizeMultiLeaf` (pass `row_per=`
-  to pick one);
+- **two or more sinks** → `DerivaMLDenormalizeMultiLeaf`. The requested
+  tables aren't on one FK chain. Either pass `row_per=` to pick a grain,
+  **or add a connecting table** so they form a chain — the exception's
+  `bridge_suggestions` field (and message) names the intermediate table(s)
+  on a path between the candidates, when one exists. (e.g. on eye-ai,
+  `["Subject", "Clinical_Records"]` suggests adding `Observation` /
+  `Clinical_Records_Observation` — the tables that bridge them.) Empty when
+  the candidates share no path.
 - **no sink** (an FK cycle) → `DerivaMLDenormalizeNoSink`.
 
 **Explicit `row_per`.** Must name a table in `include_tables` (it has no

--- a/docs/reference/denormalization.md
+++ b/docs/reference/denormalization.md
@@ -3,20 +3,42 @@
 > Verified against a populated demo catalog
 > (`create_demo_catalog(create_features=True, create_datasets=True)`,
 > deriva-ml v1.46.x, catalog `106`, captured 2026-06-13). Every rule on
-> this page is tagged `[deriva-ml]` — denormalization is **pure local
-> computation** inside deriva-ml's own code, with no deriva-py engine
-> involvement and no catalog access. The "Worked examples" section
-> pastes verified excerpts from `docs/reference/.examples/denorm.txt`.
+> this page is tagged `[deriva-ml]` — the denormalization **rules and
+> SQL shaping** are pure local computation inside deriva-ml's own code,
+> with no deriva-py engine involvement. (The *shaping* is always local;
+> a live `Dataset` additionally **fetches its rows from the catalog**
+> into local SQLite first — see [Mental model](#mental-model). A
+> `DatasetBag` reads only the bag's local SQLite and touches no
+> catalog.) The "Worked
+> examples" section pastes verified excerpts from
+> `docs/reference/.examples/denorm.txt`.
 >
 > **For a gentle, example-led introduction**, read the
 > [denormalization tutorial](../user-guide/denormalization.md) first.
 > This page is the formal counterpart — it states the rules precisely
 > and names the code locations, but does not re-teach the concepts.
 
-Denormalization turns an **already-downloaded** dataset bag into a
-single **wide table** — one row per ML observation, with columns pulled
-side-by-side from related tables along the bag's foreign-key graph. The
-four entry points are methods on `DatasetBag`:
+## What denormalization returns (the goal)
+
+Denormalization flattens a dataset (a downloaded `DatasetBag`, or a live
+`Dataset`) into a single **wide table**. Precisely, it returns:
+
+> **One row per `row_per`-table instance that is FK-reachable from the
+> dataset's (recursive) members, with the requested columns projected and
+> upstream context duplicated across rows that share it. It does no
+> aggregation; an explicitly-requested upstream table that reaches no
+> `row_per` row contributes a NULL-filled orphan row.**
+
+That is the contract to hold the result against. "One row per ML
+observation" is the *intuition* — but the observation is whatever table
+becomes `row_per` ([Row grain](#row-grain)): `Image`, `Observation`, a
+`file`, or a feature-association row. It is **not** "one row per dataset
+member" (scope is FK-reachable, not membership —
+[FK-reachable scoping](#fk-reachable-scoping)) and it is **not**
+aggregated (N feature rows per image stay N rows unless a `selector`
+collapses them — [Column hoisting](#column-hoisting)).
+
+The four entry points are methods on `DatasetBag`:
 
 | Method | Returns | Fetches data? |
 |---|---|---|
@@ -140,11 +162,17 @@ These terms are used precisely and consistently across this page, the
 
 **Auto-inference (the default).** Build a directed graph over
 `include_tables ∪ via` whose edges are **direct** FK references between
-domain tables (`A.fk_col → B.RID`). Association tables — M:N bridges and
-feature-association tables — are **not** edges here: two tables linked
-only *through* an association establish no downstream direction between
-them (the bridge is a 1:1:1 hop, not a fan-out). The **sinks** of this
-graph (tables with no outbound edge) are the `row_per` candidates,
+domain tables (`A.fk_col → B.RID`). **Read the arrow as "A holds the FK,
+so A is *downstream* of B"** — the edge points from the table that *has*
+the foreign key toward the table it *references*. (e.g. `Image.Subject →
+Subject.RID` means `Image` is downstream of `Subject`; in
+`Subject ◄ Observation ◄ Image`, `Image` is the most-downstream table.)
+Association tables — M:N bridges and feature-association tables — are
+**not** edges here: two tables linked only *through* an association
+establish no downstream direction between them (the bridge is a 1:1:1
+hop, not a fan-out). The **sinks** of this graph (tables with **no
+outbound edge** — i.e. they hold no FK to another requested table, so
+nothing is downstream of them) are the `row_per` candidates,
 restricted to `include_tables` — a `via` table participates in the graph
 but can never be the grain, since its columns aren't projected. Then:
 
@@ -176,6 +204,21 @@ to resolve a [path ambiguity](#path-ambiguity) without cluttering the
 output. Feature names (e.g. `"Image_Classification"`) in `include_tables`
 are resolved to the underlying feature-association table before
 projection (see [the contract §8.4](../design/denormalization-contract.md)).
+
+**"Transparent" is a topology heuristic, not a purity judgment — and you
+can override it.** A table is treated as a transparent intermediate when
+it has **exactly two domain FKs** (`_is_topological_association`) — *not*
+when it is "pure." This is the right default (it skips `Dataset_Image`-style
+link tables), but it has a real-catalog edge: a two-FK table that *also*
+carries meaningful columns (a `Role`, `Ordinal`, `Comment`, or — on
+catalogs like **facebase** — a genuine domain entity that happens to have
+two FKs) is **still treated as transparent and its columns are dropped**
+unless you opt in. **The escape hatch:** name that table explicitly in
+`include_tables` and its columns appear (it loses transparent status for
+that call). So the rule is: *two-FK tables are hidden by default; request
+them by name to project their columns.* (Feature-association tables are a
+separate, marker-based case — one FK to `Feature_Name` + one to
+`Execution` — and are always transparent unless named; see the contract.)
 `[deriva-ml]` `src/deriva_ml/local_db/denormalizer.py` (`include_tables`
 / `via` arguments; transparent-intermediate detection in the planner).
 
@@ -202,8 +245,13 @@ the `row_per` row count. An `INNER JOIN` is safe only because the
 This is also where a **feature `selector`** acts: when `include_tables`
 contains **exactly one** feature-association table, the optional
 `selector` callable reduces each feature's multi-row group (e.g. several
-annotators' labels for one image) to a single chosen row before
-hoisting. Its signature is
+annotators' labels for one image) to a single chosen row. The reduction
+runs **after the SQL join materializes** — the full N-row-per-anchor
+frame is produced first, then grouped by the feature's target RID and
+collapsed in Python. (So without a `selector` the result is *not* one
+row per `row_per` instance when features fan out; *with* one it is. This
+is also why `describe_denormalized`'s pre-run row estimate counts the
+un-collapsed rows.) Its signature is
 `Callable[[list[FeatureRecord]], FeatureRecord | None]` — identical to
 `DerivaML.feature_values`'s `selector`; built-ins on `FeatureRecord`
 include `select_newest`, `select_first`, `select_by_workflow`, and a
@@ -262,16 +310,23 @@ determined by its table and reachability.**
 or downstream (it points *at* `row_per`, scoping which `row_per` rows are
 in play). Both serve as a filter on the output. A reader who assumes
 "reaches" means strictly-downstream-only would wrongly drop the upstream
-case. The six cases:
+case. In the table below, **"FK-connected to `row_per`"** means exactly
+this either-direction relationship — the anchor sits upstream of
+`row_per`, downstream of it, or *is* it. The six cases:
 
 | Case | Anchor table | Reaches a `row_per` row? | Contribution |
 |---|---|---|---|
 | 1 | `== row_per` | — | one output row (itself, upstream hoisted) |
-| 2 | `∈ include_tables`, upstream of `row_per` | yes | filter-only (appears via the `row_per` row that hoists it) |
-| 3 | `∈ include_tables`, upstream of `row_per` | no | one **orphan** row — its columns populated, `row_per`-side columns `NULL` (LEFT-JOIN shape) |
-| 4 | `∉ include_tables`, upstream of `row_per` | yes | filter-only (no row of its own — its columns aren't projected) |
-| 5 | `∉ include_tables`, upstream of `row_per` | no | silently dropped (would not affect output) |
+| 2 | `∈ include_tables`, FK-connected to `row_per` | yes | filter-only (appears via the `row_per` row that hoists or points at it) |
+| 3 | `∈ include_tables`, FK-connected to `row_per` | no | one **orphan** row — its columns populated, `row_per`-side columns `NULL` (LEFT-JOIN shape) |
+| 4 | `∉ include_tables`, FK-connected to `row_per` | yes | filter-only (no row of its own — its columns aren't projected) |
+| 5 | `∉ include_tables`, FK-connected to `row_per` | no | silently dropped (would not affect output) |
 | 6 | no FK path to any `include_tables ∪ via` table | — | raises `DerivaMLDenormalizeUnrelatedAnchor` unless `ignore_unrelated_anchors=True` (then silently dropped) |
+
+(An orphan row — case 3 — only arises for an anchor that is *upstream*
+of `row_per` and reaches none; a *downstream* anchor that reaches no
+`row_per` row simply scopes nothing and falls under case 5. "Connected
+but unreached" is the orphan trigger only on the upstream side.)
 
 `ignore_unrelated_anchors` (default `False`) controls **only** case 6;
 it does **not** affect orphan (case 3) emission. Empty anchor sets are
@@ -529,6 +584,36 @@ bag.get_denormalized_as_dataframe(["Image"])
 bag.get_denormalized_as_dataframe(["Image"], ignore_unrelated_anchors=True)
 # OK — the File members are silently dropped.
 ```
+
+## Known limitations (FK shapes)
+
+The rules above assume the **single-column, RID-targeted FKs** that
+DerivaML schemas in active use (CSA, CFDE, GPCR, eye-ai) rely on. Two FK
+shapes found on other Deriva catalogs are not fully supported:
+
+- **Composite (multi-column) FKs, catalog-side.** A FK spanning several
+  columns — e.g. facebase's `file(biosample, dataset) → biosample(RID,
+  dataset)` — is handled on the **bag** path (the local SQL emits a
+  multi-column `AND` join) but **not** on the live-`Dataset` (catalog
+  fetch) path: `_collect_fk_values` raises `NotImplementedError` rather
+  than under-scoping the fetch (RB-08). So `Dataset.get_denormalized_*`
+  across a composite FK fails loudly; `DatasetBag.get_denormalized_*` on
+  a downloaded bag works. Tracked in
+  [issue #327](https://github.com/informatics-isi-edu/deriva-ml/issues/327).
+
+- **Self-referential FKs (a table referencing itself).** A hierarchy like
+  `HierNode.Parent_Node → HierNode.RID` is **not** denormalized as a
+  parent/child relationship. The planner deduplicates join paths by table
+  *name* and labels output columns `Table.column`, so it cannot alias the
+  same table in two roles — parent-`HierNode.*` and child-`HierNode.*`
+  would collide. Single-table requests (`["HierNode"]`) work and path
+  discovery terminates without looping; but you **cannot** project a
+  node's parent columns alongside its own in one call. To flatten a
+  hierarchy, denormalize the single table and resolve the parent links in
+  pandas.
+
+Both are about FK *shape*, not dataset content; a schema with only
+single-column RID FKs (the common case) hits neither.
 
 ## See also
 

--- a/docs/user-guide/denormalization.md
+++ b/docs/user-guide/denormalization.md
@@ -317,7 +317,15 @@ ds.get_denormalized_as_dataframe(
     ["Image", "Image_Class"],
     row_per="Image",
 )
-# OK: one row per Image, Image_Class.Name projected.
+# Image_Class.Name is projected onto Image rows — BUT this is "one row
+# per Image" ONLY when each Image has exactly ONE feature value. The
+# join still passes through the (hidden) feature-association table, which
+# has one row per (Image, Execution) annotation. If an Image was
+# annotated by N executions/annotators, that Image appears N times, each
+# with its own Image_Class.Name. Denormalize does NOT aggregate. To force
+# one row per Image, reduce the feature group with a `selector=` (see the
+# "Feature values on images" example) — that collapses the N annotations
+# to one BEFORE projection.
 
 # Intent B: "one row per feature observation." Let auto-inference
 # pick the feature-association table as row_per (the default

--- a/src/deriva_ml/core/exceptions.py
+++ b/src/deriva_ml/core/exceptions.py
@@ -681,23 +681,48 @@ class DerivaMLDenormalizeMultiLeaf(DerivaMLDenormalizeError):
         candidates: list of table names that all qualify as sinks.
         include_tables: the ``include_tables`` argument that triggered
             the ambiguity, for reference.
+        bridge_suggestions: table names **not** in ``include_tables`` that
+            lie on an FK path connecting two of the candidates. Adding one
+            of these to ``include_tables`` joins the otherwise-disconnected
+            candidates into a single chain (so auto-inference resolves to a
+            single grain). Empty when the candidates share no connecting
+            path — they are genuinely disjoint and only an explicit
+            ``row_per`` will resolve them.
 
     Example:
         >>> try:  # doctest: +SKIP
-        ...     d.as_dataframe(["Dataset", "Subject"])
+        ...     d.as_dataframe(["Subject", "Clinical_Records"])
         ... except DerivaMLDenormalizeMultiLeaf as e:
-        ...     print(f"Pick one of {e.candidates} as row_per")
-        ...     # Then retry: d.as_dataframe(..., row_per="Subject")
+        ...     if e.bridge_suggestions:
+        ...         # add a bridge to connect them, e.g. ["Subject", "Visit", "Clinical_Records"]
+        ...         print(f"add one of {e.bridge_suggestions} to include_tables")
+        ...     else:
+        ...         print(f"pick one of {e.candidates} as row_per")
     """
 
-    def __init__(self, candidates: list[str], include_tables: list[str]) -> None:
+    def __init__(
+        self,
+        candidates: list[str],
+        include_tables: list[str],
+        bridge_suggestions: list[str] | None = None,
+    ) -> None:
         self.candidates = list(candidates)
         self.include_tables = list(include_tables)
-        super().__init__(
+        self.bridge_suggestions = list(bridge_suggestions or [])
+        msg = (
             f"Multiple candidates for row_per: {candidates}. "
-            f"Specify row_per=... explicitly. "
-            f"(include_tables={include_tables})"
+            f"They are not on a single foreign-key chain within "
+            f"include_tables={include_tables}. "
         )
+        if self.bridge_suggestions:
+            msg += (
+                f"Add a connecting table to include_tables to join them — "
+                f"e.g. one of {self.bridge_suggestions} — or specify "
+                f"row_per=... explicitly to pick a grain."
+            )
+        else:
+            msg += "Specify row_per=... explicitly to pick a grain."
+        super().__init__(msg)
 
 
 class DerivaMLDenormalizeNoSink(DerivaMLDenormalizeError):

--- a/src/deriva_ml/model/denormalize_planner.py
+++ b/src/deriva_ml/model/denormalize_planner.py
@@ -1114,8 +1114,80 @@ class DenormalizePlanner:
             raise DerivaMLDenormalizeMultiLeaf(
                 candidates=sinks,
                 include_tables=list(include_tables),
+                bridge_suggestions=self._bridge_suggestions(sinks, all_tables),
             )
         return sinks[0]
+
+    def _bridge_suggestions(self, sinks: list[str], requested: set[str]) -> list[str]:
+        """Intermediate tables that would connect disconnected sinks.
+
+        When auto-inference finds multiple sinks, they are tables with no
+        downstream FK to another *requested* table — i.e. the requested set
+        doesn't put them on one chain. But the schema may still connect two
+        sinks through tables the caller didn't name. This returns those
+        connecting tables so the caller can add one to ``include_tables``
+        and collapse the multi-leaf into a single grain (the eye-ai
+        ``["Subject", "Clinical_Records"]`` case, bridged by ``Visit`` /
+        ``Observation``).
+
+        For each unordered pair of sinks, find a shortest **undirected** FK
+        path (the FK-neighbor graph is walked direction-agnostically, since
+        two sinks typically connect through a common upstream ancestor or an
+        M:N association — e.g. eye-ai's ``Subject`` and ``Clinical_Records``
+        connect via ``Subject ◄ Observation ◄ Clinical_Records_Observation ►
+        Clinical_Records``). The interior tables of that path, minus any the
+        caller already requested, are the suggestions. Returns a sorted,
+        de-duplicated list; empty when a pair shares no path.
+
+        Uses :meth:`_fk_neighbors` (undirected, no ``Dataset`` dependency),
+        not :meth:`_enumerate_paths` — the latter is coupled to the
+        deriva-ml ``Dataset`` model and would not run here.
+
+        Args:
+            sinks: the tied ``row_per`` candidates.
+            requested: ``include_tables ∪ via`` — tables already named, which
+                are not themselves suggestions.
+
+        Returns:
+            Sorted list of connecting intermediate table names (possibly
+            empty).
+        """
+        from collections import deque
+
+        suggestions: set[str] = set()
+        max_hops = 6  # bound the search; deep bridges are rarely actionable
+        for i, a in enumerate(sinks):
+            for b in sinks[i + 1 :]:
+                # BFS on the undirected FK-neighbor graph from a to b.
+                prev: dict[str, str | None] = {a: None}
+                q: deque[tuple[str, int]] = deque([(a, 0)])
+                found = False
+                while q and not found:
+                    cur, depth = q.popleft()
+                    if depth >= max_hops:
+                        continue
+                    try:
+                        neighbors = self._fk_neighbors(cur)
+                    except Exception:
+                        continue
+                    for nbr in neighbors:
+                        name = nbr.name
+                        if name in prev:
+                            continue
+                        prev[name] = cur
+                        if name == b:
+                            found = True
+                            break
+                        q.append((name, depth + 1))
+                if not found:
+                    continue
+                # Reconstruct the path b <- ... <- a; collect interior nodes.
+                node: str | None = b
+                while node is not None and node != a:
+                    if node not in (a, b) and node not in requested:
+                        suggestions.add(node)
+                    node = prev.get(node)
+        return sorted(suggestions)
 
     def _enumerate_paths(
         self,

--- a/tests/local_db/test_denormalize_grain_inference.py
+++ b/tests/local_db/test_denormalize_grain_inference.py
@@ -1,0 +1,215 @@
+"""Grain-inference robustness on real-catalog FK shapes.
+
+Two concerns surfaced by evaluating the planner against the live eye-ai and
+facebase catalogs:
+
+1. **CV-name (non-RID) FK targets.** A controlled-vocabulary term's *name*
+   (a non-RID unique key) is a legitimate FK target in Deriva. Grain
+   inference must treat such an FK as a real downstream edge, exactly like
+   an FK that targets ``RID``. (This already works; the test pins it so a
+   future RID-only filter can't silently regress it.)
+
+2. **Disconnected-sink diagnostics.** When two requested tables are not on
+   one downstream FK chain *within the requested set*, ``_determine_row_per``
+   raises ``DerivaMLDenormalizeMultiLeaf``. The error must name the
+   intermediate **bridge table(s)** that would connect them (eye-ai's
+   ``["Subject", "Clinical_Records"]`` is the motivating real case), so the
+   user knows what to add to ``include_tables`` instead of hitting a dead
+   end.
+
+These run catalog-free: a synthetic ``Model`` is built from a hand-authored
+schema JSON, so no live catalog is needed.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from deriva.core.ermrest_model import Model
+
+from deriva_ml.core.exceptions import DerivaMLDenormalizeMultiLeaf
+from deriva_ml.model.catalog import DerivaModel
+
+# ---------------------------------------------------------------------------
+# Synthetic-schema helpers (catalog-free)
+# ---------------------------------------------------------------------------
+
+_SYS_COLS = ["RID", "RCT", "RMT", "RCB", "RMB"]
+
+
+def _col(name: str, typename: str = "text", nullok: bool = True) -> dict:
+    return {"name": name, "type": {"typename": typename}, "nullok": nullok}
+
+
+def _sys_cols() -> list[dict]:
+    return [
+        _col("RID", "ermrest_rid", nullok=False),
+        _col("RCT", "ermrest_rct"),
+        _col("RMT", "ermrest_rmt"),
+        _col("RCB", "ermrest_rcb"),
+        _col("RMB", "ermrest_rmb"),
+    ]
+
+
+def _table(name: str, extra_cols: list[dict], fks: list[dict], extra_keys: list[list[str]] | None = None) -> dict:
+    keys = [{"names": [["test", f"{name}_RID_key"]], "unique_columns": ["RID"]}]
+    for kcols in extra_keys or []:
+        keys.append({"names": [["test", f"{name}_{'_'.join(kcols)}_key"]], "unique_columns": kcols})
+    return {
+        "kind": "table",
+        "schema_name": "test",
+        "table_name": name,
+        "column_definitions": _sys_cols() + extra_cols,
+        "keys": keys,
+        "foreign_keys": fks,
+    }
+
+
+def _fk(name: str, from_table: str, from_col: str, to_table: str, to_col: str) -> dict:
+    return {
+        "names": [["test", name]],
+        "foreign_key_columns": [{"schema_name": "test", "table_name": from_table, "column_name": from_col}],
+        "referenced_columns": [{"schema_name": "test", "table_name": to_table, "column_name": to_col}],
+    }
+
+
+def _model(tables: dict) -> DerivaModel:
+    schema = {"schemas": {"test": {"schema_name": "test", "tables": tables}}}
+    m = Model.fromfile("file-system", _write_tmp(schema))
+    return DerivaModel(model=m, ml_schema="test", domain_schemas={"test"})
+
+
+def _write_tmp(obj: dict) -> str:
+    import tempfile
+
+    f = tempfile.NamedTemporaryFile("w", suffix=".json", delete=False)
+    json.dump(obj, f)
+    f.flush()
+    return f.name
+
+
+# ---------------------------------------------------------------------------
+# 1. CV-name / non-RID FK targets infer grain correctly (pin already-correct)
+# ---------------------------------------------------------------------------
+
+
+def test_cv_name_fk_is_a_downstream_edge():
+    """An FK targeting a CV's Name (non-RID unique key) must be a real edge.
+
+    ``Sample.Stage → Stage.Name`` (not ``Stage.RID``) is the controlled-
+    vocabulary pattern. The planner's downstream-edge detection
+    (``referenced_by``-based) must see it, so ``Stage`` is *not* mistaken
+    for a co-sink with ``Sample``.
+    """
+    tables = {
+        "Stage": _table("Stage", [_col("Name", nullok=False)], [], extra_keys=[["Name"]]),
+        "Sample": _table(
+            "Sample",
+            [_col("Label"), _col("Stage")],
+            [_fk("Sample_Stage_fk", "Sample", "Stage", "Stage", "Name")],  # FK -> Stage.Name, NOT RID
+        ),
+    }
+    pl = _model(tables)._planner
+
+    # Stage is pointed at by Sample.Stage -> downstream_fk_sources(Stage) == {Sample}
+    downstream_of_stage = {t.name for t in pl._downstream_fk_sources("Stage")}
+    assert downstream_of_stage == {"Sample"}, (
+        f"CV-name FK (Sample.Stage -> Stage.Name) must register as a downstream edge; "
+        f"got downstream_fk_sources(Stage)={downstream_of_stage}"
+    )
+
+    # Grain inference picks Sample (downstream of Stage), NOT a MultiLeaf.
+    row_per = pl._determine_row_per(include_tables=["Stage", "Sample"], via=[], row_per=None)
+    assert row_per == "Sample", f"expected row_per=Sample for the CV-name-FK chain, got {row_per!r}"
+
+
+def test_cv_name_fk_chain_three_tables():
+    """A mixed chain — CV-name FK then RID FK — still infers the deepest table."""
+    tables = {
+        "Stage": _table("Stage", [_col("Name", nullok=False)], [], extra_keys=[["Name"]]),
+        "Sample": _table(
+            "Sample",
+            [_col("Label"), _col("Stage")],
+            [_fk("Sample_Stage_fk", "Sample", "Stage", "Stage", "Name")],
+        ),
+        "Image": _table(
+            "Image",
+            [_col("File"), _col("Sample")],
+            [_fk("Image_Sample_fk", "Image", "Sample", "Sample", "RID")],  # normal RID FK
+        ),
+    }
+    pl = _model(tables)._planner
+    row_per = pl._determine_row_per(include_tables=["Stage", "Sample", "Image"], via=[], row_per=None)
+    assert row_per == "Image", f"expected row_per=Image (deepest), got {row_per!r}"
+
+
+# ---------------------------------------------------------------------------
+# 2. MultiLeaf must suggest the connecting bridge table(s)
+# ---------------------------------------------------------------------------
+
+
+def test_multileaf_suggests_bridge_table():
+    """Two requested tables that are genuine co-sinks (neither downstream of
+    the other) but connect through an *unrequested* upstream/association
+    bridge must name that bridge in the error.
+
+    Models eye-ai's ``["Subject", "Clinical_Records"]`` exactly:
+
+        Subject ◄── Observation ◄── CR_Observation ──► Clinical_Records
+
+    Both ``Subject`` and ``Clinical_Records`` are sinks of the requested set
+    (neither has an FK to the other). They connect only through ``Observation``
+    (a common upstream of Subject) and ``CR_Observation`` (an M:N association
+    pointing at both Observation and Clinical_Records). The user should be
+    told to add ``Observation`` / ``CR_Observation``.
+    """
+    tables = {
+        "Subject": _table("Subject", [_col("Name")], []),
+        "Observation": _table(
+            "Observation",
+            [_col("Date"), _col("Subject")],
+            [_fk("Obs_Subject_fk", "Observation", "Subject", "Subject", "RID")],  # Observation -> Subject
+        ),
+        "Clinical_Records": _table("Clinical_Records", [_col("Diagnosis")], []),
+        # M:N association linking Observation and Clinical_Records.
+        "CR_Observation": _table(
+            "CR_Observation",
+            [_col("Observation"), _col("Clinical_Records")],
+            [
+                _fk("CRO_Obs_fk", "CR_Observation", "Observation", "Observation", "RID"),
+                _fk("CRO_CR_fk", "CR_Observation", "Clinical_Records", "Clinical_Records", "RID"),
+            ],
+        ),
+    }
+    pl = _model(tables)._planner
+
+    with pytest.raises(DerivaMLDenormalizeMultiLeaf) as exc:
+        pl._determine_row_per(include_tables=["Subject", "Clinical_Records"], via=[], row_per=None)
+
+    e = exc.value
+    assert set(e.candidates) == {"Subject", "Clinical_Records"}
+    # The fix: the error carries the bridge suggestion.
+    assert hasattr(e, "bridge_suggestions"), "MultiLeaf must expose bridge_suggestions"
+    assert e.bridge_suggestions, f"a connecting bridge should be suggested; got {e.bridge_suggestions!r}"
+    # The connecting path runs through Observation and/or CR_Observation.
+    assert {"Observation", "CR_Observation"} & set(e.bridge_suggestions), (
+        f"bridge should include Observation/CR_Observation; got {e.bridge_suggestions!r}"
+    )
+    # ...and a suggested table should appear in the message.
+    assert any(b in str(e) for b in e.bridge_suggestions), f"bridge table should appear in the message: {e}"
+
+
+def test_multileaf_no_bridge_when_genuinely_disconnected():
+    """Two tables with no connecting path at all: still MultiLeaf, but
+    bridge_suggestions is empty (don't fabricate a bridge)."""
+    tables = {
+        "Alpha": _table("Alpha", [_col("A")], []),
+        "Beta": _table("Beta", [_col("B")], []),
+    }
+    pl = _model(tables)._planner
+    with pytest.raises(DerivaMLDenormalizeMultiLeaf) as exc:
+        pl._determine_row_per(include_tables=["Alpha", "Beta"], via=[], row_per=None)
+    assert exc.value.bridge_suggestions == [], (
+        f"no path exists, so no bridge should be invented; got {exc.value.bridge_suggestions!r}"
+    )


### PR DESCRIPTION
Evaluated the denormalize planner against the **live eye-ai and facebase** catalogs (fetched their schema JSON, ran the real `_determine_row_per` / `_find_sinks` / `_find_path_ambiguities` offline). The evaluation is as valuable for what it *disproved* as what it found.

## What the evaluation found

| Concern | Verdict | Action |
|---|---|---|
| Non-RID / **CV-name FK targets** break grain inference | **Already correct** — `_downstream_fk_sources` is `referenced_by`-based, target-column-agnostic. My first probe wrongly excluded the `vocab` schema. | **Regression test** pins it (guards the CV-name-as-FK requirement) |
| Diamonds shadowed by MultiLeaf | **Same probe artifact** — resolves with referenced schemas in scope | none |
| **MultiLeaf names dead-ends, not the bridge** | **Real, eye-ai-facing** | **Fixed** (this PR) |
| Denormalize requires a deriva-ml `Dataset` | Real scope fact (facebase can't denormalize) | **Documented** |

## The fix (the one real gap)

When two requested tables are **co-sinks** (neither downstream of the other), auto-inference raised `MultiLeaf` naming the two candidates but **not the connecting table**. On eye-ai, `["Subject", "Clinical_Records"]` connect only through:

```
Subject ◄── Observation ◄── Clinical_Records_Observation ──► Clinical_Records
```

— which a user had no way to discover from the error. Now `MultiLeaf` carries a `bridge_suggestions` field (and message): a BFS over the **undirected FK-neighbor graph** between candidate pairs collects the interior unrequested tables. Verified on **live eye-ai** — the error now says *"add one of `['Clinical_Records_Observation', 'Observation']`"*. Empty when the sinks share no path (no fabricated bridge). Uses `_fk_neighbors` (no `Dataset` coupling), not `_enumerate_paths`.

## Verification
- New tests (`test_denormalize_grain_inference.py`): 4 passed — 2 pin CV-name-FK grain inference, 2 cover bridge suggestion (with-path and no-path).
- Catalog-free suites: **363 passed**, 0 regressions. No successful-call behavior changes — only the `MultiLeaf` error gets richer.
- Live eye-ai: suggestion matches the hand-traced real bridge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)