### PR TITLE
feat(file): add asset_role param to add_files (Input vs Output)

### DIFF
--- a/src/deriva_ml/core/mixins/file.py
+++ b/src/deriva_ml/core/mixins/file.py
@@ -11,7 +11,7 @@ import importlib
 from collections import defaultdict
 from itertools import chain
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Iterable
+from typing import TYPE_CHECKING, Any, Callable, Iterable, Literal
 from urllib.parse import urlsplit
 
 datapath = importlib.import_module("deriva.core.datapath")
@@ -66,6 +66,7 @@ class FileMixin:
         execution_rid: RID,
         dataset_types: str | list[str] | None = None,
         description: str = "",
+        asset_role: Literal["Input", "Output"] = "Output",
     ) -> "Dataset":
         """Adds files to the catalog with their metadata.
 
@@ -77,6 +78,12 @@ class FileMixin:
             execution_rid: Execution RID to associate files with (required for provenance).
             dataset_types: One or more dataset type terms from File_Type vocabulary.
             description: Description of the files.
+            asset_role: Whether the files are an ``"Input"`` to or an
+                ``"Output"`` of the execution. Recorded on the
+                ``File_Execution`` association row's ``Asset_Role``. Defaults
+                to ``"Output"`` (files produced by the run). Pass ``"Input"``
+                to register a file the run *consumed* (e.g. an external data
+                file ingested into the catalog).
 
         Returns:
             Dataset: Dataset that represents the newly added files.
@@ -143,7 +150,7 @@ class FileMixin:
         # Link files to the execution for provenance tracking.
         pb.schemas[self.ml_schema].File_Execution.insert(
             [
-                {"File": file_record["RID"], "Execution": execution_rid, "Asset_Role": "Output"}
+                {"File": file_record["RID"], "Execution": execution_rid, "Asset_Role": asset_role}
                 for file_record in file_records
             ]
         )

--- a/src/deriva_ml/execution/execution.py
+++ b/src/deriva_ml/execution/execution.py
@@ -37,7 +37,7 @@ import os
 import sys
 from datetime import datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Iterable, List
+from typing import TYPE_CHECKING, Any, Callable, Iterable, List, Literal
 
 if TYPE_CHECKING:
     from deriva_ml.asset.asset import Asset
@@ -2040,6 +2040,7 @@ class Execution:
         files: Iterable[FileSpec],
         dataset_types: str | list[str] | None = None,
         description: str = "",
+        asset_role: Literal["Input", "Output"] = "Output",
     ) -> "Dataset":
         """Adds files to the catalog with their metadata.
 
@@ -2050,6 +2051,8 @@ class Execution:
             files: File specifications containing MD5 checksum, length, and URL.
             dataset_types: One or more dataset type terms from File_Type vocabulary.
             description: Description of the files.
+            asset_role: ``"Input"`` (file consumed by this execution) or
+                ``"Output"`` (file produced by it). Defaults to ``"Output"``.
 
         Returns:
             RID: Dataset  that identifies newly added files. Will be nested to mirror original directory structure
@@ -2074,6 +2077,7 @@ class Execution:
             execution_rid=self.execution_rid,
             dataset_types=dataset_types,
             description=description,
+            asset_role=asset_role,
         )
 
     # =========================================================================

--- a/tests/core/test_file.py
+++ b/tests/core/test_file.py
@@ -122,6 +122,29 @@ class TestFile:
                 ds = subdir.list_dataset_members()
                 assert len(ds["File"]) == 5
 
+    def test_add_files_input_role(self, file_table_setup):
+        """add_files(asset_role="Input") records File_Execution edges with
+        Asset_Role="Input" (provenance contract: external files can be
+        consumed inputs, not only produced outputs).
+
+        Default behavior remains Output; this pins the new Input capability.
+        """
+        ml_instance = file_table_setup.ml_instance
+        test_dir = file_table_setup.test_dir
+        execution = file_table_setup.execution
+
+        with execution.execute() as exe:
+            filespecs = list(FileSpec.create_filespecs(test_dir, "Input files"))
+            exe.add_files(filespecs, asset_role="Input")
+
+        # Read File_Execution rows for this execution and check the role.
+        pb = ml_instance.pathBuilder()
+        fe = pb.schemas[ml_instance.ml_schema].File_Execution
+        rows = [r for r in fe.entities().fetch() if r["Execution"] == execution.execution_rid]
+        assert rows, "expected File_Execution rows for the execution"
+        roles = {r["Asset_Role"] for r in rows}
+        assert roles == {"Input"}, f"expected all Input-role edges, got {roles}"
+
     def test_list_files(self, file_table_setup):
         ml_instance = file_table_setup.ml_instance
         test_dir = file_table_setup.test_dir


### PR DESCRIPTION
## What

Adds an `asset_role: Literal["Input", "Output"]` parameter to `add_files` (both `DerivaML.add_files` and the `Execution.add_files` wrapper), defaulting to `"Output"`.

## Why

`add_files` hardcoded `Asset_Role="Output"` on the `File_Execution` link, so an external file could only ever be an *output* of an execution. The provenance contract (#331) requires files registerable as consumed **inputs** — an external data file ingested into the catalog. This is also the shared foundation for two follow-on deliverables: the `LocalFile` input spec and the unknown-provenance `File` sentinel (both write an `Asset_Role="Input"` `File_Execution` edge).

## Change

- `src/deriva_ml/core/mixins/file.py` — `add_files` gains `asset_role` (default `"Output"`); the `File_Execution` insert uses it instead of the hardcoded literal.
- `src/deriva_ml/execution/execution.py` — `Execution.add_files` wrapper passes `asset_role` through.
- Both import `Literal`.

Backward-compatible: the default is `"Output"`, so existing callers are unchanged.

## Test

`tests/core/test_file.py::TestFile::test_add_files_input_role` (new) pins that `asset_role="Input"` produces Input-role `File_Execution` edges. The existing `test_add_files` (default Output) is unchanged.

```
tests/core/test_file.py: 10 passed
```

(TDD: the new test failed first — `ValidationError: unexpected kwarg asset_role` — then passed after the param was added.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)