### PR TITLE
Role from context: add_files links as Input; remove AssetSpec.asset_role

### DIFF
--- a/docs/reference/provenance-contract.md
+++ b/docs/reference/provenance-contract.md
@@ -435,9 +435,27 @@ For every **driven** execution the catalog records:
    - **Assets** — via `<Asset>_Execution` with `Asset_Role="Output"` and an
      `Output_File` Asset_Type tag.
    - **Feature values** — written with this execution's provenance.
-5. **Role is unambiguous.** Input lives in `Dataset_Execution` /
-   `Asset_Role="Input"`; output lives in `Dataset_Version.Execution` /
-   `Asset_Role="Output"`. A single artifact is never silently both.
+5. **Role is unambiguous, and is always derived from context — never
+   specified by the caller.** Where the role is *recorded* differs by
+   artifact kind, but in every case it follows from *what the execution did*,
+   not from a user-supplied flag:
+   - **Datasets** — role is **structural**: an input is a row in
+     `Dataset_Execution`; an output is `Dataset_Version.Execution`
+     authorship. Different tables, so role cannot be misstated and there is
+     nothing to specify.
+   - **Assets / files** — role is the **`Asset_Role` column** on the
+     `<Asset>_Execution` / `File_Execution` association row, set by the
+     **operation**: materializing a declared input (download at execution
+     start, or a `LocalFile`/asset declared in `assets=`) writes
+     `Asset_Role="Input"`; producing a file (the commit / output-staging
+     path, including `add_files` in the execution body) writes
+     `Asset_Role="Output"`. The framework assigns the role from the call
+     context; the user never passes it.
+
+   A single artifact is never silently both. **The contract requirement: an
+   asset's role is determined by context (consume ⇒ Input, produce ⇒
+   Output), exactly as for datasets. APIs must not ask the caller to name a
+   role.**
 
 Per [ADR-0001](../adr/0001-lineage-walks-data-flow-not-orchestration.md),
 data-flow lineage is *derived* by walking these edges
@@ -701,23 +719,23 @@ deliberate safety boundary, not just style:
 This mirrors the dataset rule (Goal 2: declare, don't infer): intent is
 declared by *type*, never recovered by inspecting a string's shape.
 
-For a `LocalFile`, deriva-ml does the rest — computes the checksum, mints the
-`File` row, and writes the `<File>_Execution` input edge, reusing existing
-helpers (`FileSpec.create_filespecs` + `add_files`). Inside the run, the file
-is read through the **same `asset_paths` surface** as any input asset. An
-imperative form exists too — `exe.add_files(FileSpec.create_filespecs(path,
-…), asset_role="Input")` — for code that registers a file directly. The
+For a `LocalFile`, deriva-ml does the rest — computes the checksum (reusing
+`FileSpec.create_filespecs`), mints the `File` row, and writes the
+`<File>_Execution` edge with **`Asset_Role="Input"` derived from context**:
+because the file is declared in `assets=`, it is a consumed input, so the
+Input edge is written by the same input-edge mechanism the asset *download*
+path already uses. The caller never names the role. Inside the run, the file
+is read through the **same `asset_paths` surface** as any input asset. The
 *implementation model* (the thin config spec, the on-the-fly registration
-hook, the download-skip for references, and the `add_files` `asset_role`
-fix) is in *Implementation notes*; no user-side checksum work is imposed
-(Goal 5).
+hook, the input-edge write, the download-skip for references) is in
+*Implementation notes*; no user-side checksum work and no role flag is
+imposed (Goal 5; role-from-context).
 
 **Rule:** an external file consumed by an execution MUST be declared as an
-input asset — a `File`-table row (mandatory `MD5`) linked via
-`<File>_Execution` with `Asset_Role="Input"`, registered through
-`add_files(..., asset_role="Input")` (with `FileSpec.create_filespecs`
-building the spec from the path). Only an **un-declared loose file** — read
-off disk with no `File` row at all — violates the rule.
+input — a `File`-table row (mandatory `MD5`) linked via `<File>_Execution`
+with `Asset_Role="Input"`. The role is assigned by context (the file is in
+`assets=`), not specified by the caller. Only an **un-declared loose file** —
+read off disk with no `File` row at all — violates the rule.
 
 #### What minting a `File` RID records
 
@@ -810,9 +828,9 @@ recorded as "unknown input." The residual, unavoidable limit is narrow: the
 check cannot distinguish a *legitimately* input-less run (a schema extension)
 from one that *forgot* to register its file — both warn, and a human
 reading the description distinguishes them. What no machine can do is
-reconstruct *which* file a forgetful run should have named. The one-call
-`add_files(..., asset_role="Input")` path keeps the "forgot" case rare by
-making registration trivial.
+reconstruct *which* file a forgetful run should have named. Declaring the
+file as a `LocalFile` in `assets=` (Input by context) is a one-liner, which
+keeps the "forgot" case rare by making declaration trivial.
 
 ### The two unknown-provenance sentinels
 
@@ -928,8 +946,9 @@ No single mechanism is sufficient; the guarantee is the stack. The
 zero-input check is hard (an artifact-producer that declares nothing is
 caught); what no machine can do is reconstruct *which* undeclared file a run
 should have named — that is recorded as explicitly unknown and resolved by a
-human. The one-call `add_files(..., asset_role="Input")` path keeps the
-"forgot to declare" case rare by making registration the easy path.
+human. Declaring an input is a one-liner — a `LocalFile` (or RID) in
+`assets=` — which keeps the "forgot to declare" case rare by making the
+honest path the easy one.
 
 ## Reproducibility: what the graph does and does not give you
 
@@ -1100,12 +1119,14 @@ contract version*.
      any other.)
   4. **The framework registers it; an already-registered file works by RID.**
      Two entry points to the same input:
-     - **By `LocalFile(path)` (general case):** the framework registers it —
-       minting the `File` RID via the existing `FileSpec.create_filespecs(path,
-       …)` (which computes `MD5`/length and the `tag:` URI) + the `add_files`
-       registration — **during input resolution**, then proceeds as a normal
-       File-RID input. The user does **not** register it by hand and computes
-       nothing.
+     - **By `LocalFile(path)` (general case):** the framework registers it
+       **during input resolution** — minting the `File` row via the existing
+       `FileSpec.create_filespecs(path, …)` (which computes `MD5`/length and
+       the `tag:` URI), then writing the `File_Execution` Input edge with the
+       role assigned **by context** (it is in `assets=`, so it is consumed),
+       using the same input-edge mechanism the asset download path uses. The
+       user does **not** register it by hand, computes nothing, and never
+       names a role.
      - **By RID (already registered):** an existing `File` row is named by its
        RID (a bare string) and used directly — this is just
        `AssetSpec(rid=<file_rid>)`, since `File` is an asset table whose RID
@@ -1158,20 +1179,21 @@ contract version*.
   - **`validate_assets` shape-routing** (`execution_configuration.py:87`) so
     `path`-keyed entries become `LocalFile` and bare strings / `rid`-keyed
     entries stay `AssetSpec` — the hydra seam and the safety chokepoint;
-  - a **resolution hook** that registers a `LocalFile` path→`File` RID on the
-    fly before download (point 4-general);
+  - a **resolution hook** that, for a `LocalFile`, mints the `File` row and
+    writes its `File_Execution` Input edge — the role assigned by context (in
+    `assets=` ⇒ Input), via the same input-edge write the asset download path
+    uses (`_update_asset_execution_table(..., asset_role="Input")`). **No
+    `add_files` change and no role parameter** — `add_files` stays
+    Output-by-context (it registers files the run *produced*); the input case
+    is the `assets=`/`LocalFile` path. The unknown-provenance `File` sentinel
+    reuses this same context-assigned Input edge.
   - a **download skip** for `File`-table / `tag:`-URI inputs — a `File`
     reference has no Hatrac bytes to fetch, so `download_asset` no-ops the
-    fetch and records the path/reference (the "not downloaded" exception);
-  - the **`add_files` `asset_role` parameter** — it currently hardcodes
-    `Asset_Role="Output"` (`core/mixins/file.py`), so a file cannot yet be
-    linked as an `Input`; `AssetSpec` already carries the
-    `Literal["Input","Output"]` field, so this just brings `add_files` into
-    line. The on-the-fly registration and the unknown-provenance sentinel
-    both use this `Asset_Role="Input"` `File_Execution` edge.
+    fetch and records the path/reference (the "not downloaded" exception).
 
-  No user-side checksum work and no special use-time API: the file is an
-  asset everywhere it matters.
+  No user-side checksum work, no role flag, and no special use-time API: the
+  file is an asset everywhere it matters, and its role is derived from
+  context.
 
 - **Seed the two sentinels at catalog initialization.** The platform-defaults
   block of `create_ml_schema` (`schema/create_schema.py`, alongside the
@@ -1261,8 +1283,9 @@ violations:
 
 - **Undeclared input asset.** The correct shape is
   `File (the CSV) → Execution → Dataset (6-05M4)`: the CSV is an input
-  *asset* (registered via `add_files(..., asset_role="Input")`), and
-  `6-05M4` is the output. The run declared neither, so no input edge exists.
+  *asset* (declared as a `LocalFile` in `assets=`, where context makes it an
+  Input), and `6-05M4` is the output. The run declared neither, so no input
+  edge exists.
   (A tempting mis-reading is that the run "consumed dataset `6-05M4`" because
   the CSV's RIDs match its members — but the RIDs are file *contents*, not a
   provenance edge; the dataset is the run's output, not its input.)
@@ -1271,9 +1294,9 @@ violations:
   workflow with an empty checksum.
 
 Under this contract the correct remedy is to re-create the work via the
-blessed path — a committed, checksummed workflow that registers the CSV as
-an input file (`add_files(..., asset_role="Input")`) and produces `6-05M4`
-as output — not to hand-edit catalog edges. (The sibling run `6-09Z8`, which
+blessed path — a committed, checksummed workflow that declares the CSV as a
+`LocalFile` input in `assets=` (Input by context) and produces `6-05M4` as
+output — not to hand-edit catalog edges. (The sibling run `6-09Z8`, which
 later wrote the 470 glaucoma labels for the same cohort, consumed the same
 CSV and is the same shape: its source file should likewise be registered as
 an input asset.)

--- a/src/deriva_ml/asset/aux_classes.py
+++ b/src/deriva_ml/asset/aux_classes.py
@@ -9,14 +9,14 @@ This module defines helper classes for asset operations including:
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Literal, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from hydra_zen import hydrated_dataclass
-from pydantic import BaseModel, model_validator
+from pydantic import BaseModel, ConfigDict, model_validator
 
 from deriva_ml.core.definitions import RID
-from deriva_ml.core.validation import VALIDATION_CONFIG
 from deriva_ml.core.logging_config import get_logger
+from deriva_ml.core.validation import VALIDATION_CONFIG
 
 if TYPE_CHECKING:
     from deriva_ml.asset.asset_record import AssetRecord
@@ -151,22 +151,22 @@ class AssetFilePath(Path):
 
 
 class AssetSpec(BaseModel):
-    """Specification for an asset in execution configurations.
+    """Specification for an asset consumed as an input to an execution.
 
     Used to reference assets as inputs to executions, similar to how
     DatasetSpec is used for datasets. Supports optional checksum-based
     caching for large assets like model weights.
 
+    An asset's **role is determined by context, never by this spec**: an asset
+    referenced here (in an execution's input configuration) is an *input*;
+    assets a run *produces* are written via ``commit_output_assets`` as
+    *outputs*. There is intentionally no ``asset_role`` field — role is not a
+    caller choice (the same rule as datasets, whose role is structural). The
+    model forbids extra fields, so a stray ``asset_role=`` is rejected rather
+    than silently ignored.
+
     Attributes:
         rid: Resource Identifier of the asset.
-        asset_role: Role of the asset (``"Input"`` or ``"Output"``).
-            Defaults to ``"Input"``. ``Literal``-typed so a typo
-            (``"Imput"``) or case mismatch (``"input"``) is
-            rejected by Pydantic validation rather than silently
-            flowing through to the catalog as a free-form string
-            and either no-op'ing or failing on FK lookup. The two
-            values match the ``Asset_Role`` controlled-vocabulary
-            terms seeded by ``initialize_ml_schema``.
         cache: If True, cache the downloaded asset by MD5 checksum in the
             DerivaML cache directory. Cached assets are reused across executions
             when the checksum matches, avoiding repeated downloads of large files.
@@ -174,14 +174,12 @@ class AssetSpec(BaseModel):
     Example:
         >>> spec = AssetSpec(rid="3JSE")
         >>> spec = AssetSpec(rid="3JSE", cache=True)  # enable caching
-        >>> spec = AssetSpec(rid="3JSE", asset_role="Output")  # mark as output
     """
 
     rid: RID
-    asset_role: Literal["Input", "Output"] = "Input"
     cache: bool = False
 
-    model_config = VALIDATION_CONFIG
+    model_config = ConfigDict(**VALIDATION_CONFIG, extra="forbid")
 
     @model_validator(mode="before")
     @classmethod
@@ -196,18 +194,12 @@ class AssetSpecConfig:
     """Hydra-zen configuration interface for ``AssetSpec``.
 
     Exposes the asset attributes that are meaningful to *configure*: the
-    asset ``rid`` and whether to ``cache`` it. It deliberately does **not**
-    expose ``asset_role`` — an asset's role (``Input`` / ``Output``) is
-    determined by **context**, not by configuration: an asset referenced in
-    an execution's input configuration is an *input*, and assets written via
-    ``commit_output_assets`` are *outputs*. ``AssetSpec.asset_role`` therefore
-    keeps its ``"Input"`` default here and is set by the producing/consuming
-    operation, never by the config author.
-
-    (Exposing ``asset_role`` as a configurable, ``Literal``-typed field also
-    broke structured-config registration under omegaconf < 2.4, which cannot
-    serialize ``Literal`` annotations — another reason it does not belong on
-    this interface.)
+    asset ``rid`` and whether to ``cache`` it. There is no role to configure —
+    asset role is determined by **context**, never specified: an asset
+    referenced in an execution's input configuration is an *input*, and assets
+    written via ``commit_output_assets`` are *outputs*. (``AssetSpec`` carries
+    no ``asset_role`` field at all, so the config has nothing to mirror; full
+    field parity holds.)
 
     Use in hydra-zen store definitions to specify assets, optionally cached:
 

--- a/src/deriva_ml/core/mixins/dataset.py
+++ b/src/deriva_ml/core/mixins/dataset.py
@@ -1404,27 +1404,20 @@ class DatasetMixin:
                     )
                 )
 
-        # Assets: group by RID, then by role.
-        as_by_rid: dict[str, list[str]] = {}
+        # Assets: an asset's role is context-derived (inputs by virtue of
+        # being in the config), not carried on the spec, so there is no
+        # role-conflict to detect — only a duplicate RID listed more than once.
+        as_counts: dict[str, int] = {}
         for s in asset_specs:
-            as_by_rid.setdefault(s.rid, []).append(s.asset_role)
+            as_counts[s.rid] = as_counts.get(s.rid, 0) + 1
 
-        for rid, roles in as_by_rid.items():
-            distinct = set(roles)
-            if len(distinct) > 1:
-                issues.append(
-                    CrossSpecIssue(
-                        issue="role_conflict",
-                        rids=[rid],
-                        detail=(f"Asset {rid} listed with conflicting roles: {sorted(distinct)}."),
-                    )
-                )
-            elif len(roles) > 1:
+        for rid, count in as_counts.items():
+            if count > 1:
                 issues.append(
                     CrossSpecIssue(
                         issue="duplicate_rid",
                         rids=[rid],
-                        detail=(f"Asset {rid} listed {len(roles)} times with role {roles[0]!r}."),
+                        detail=(f"Asset {rid} listed {count} times in the configuration."),
                     )
                 )
 

--- a/src/deriva_ml/core/mixins/file.py
+++ b/src/deriva_ml/core/mixins/file.py
@@ -11,7 +11,7 @@ import importlib
 from collections import defaultdict
 from itertools import chain
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Iterable, Literal
+from typing import TYPE_CHECKING, Any, Callable, Iterable
 from urllib.parse import urlsplit
 
 datapath = importlib.import_module("deriva.core.datapath")
@@ -66,24 +66,26 @@ class FileMixin:
         execution_rid: RID,
         dataset_types: str | list[str] | None = None,
         description: str = "",
-        asset_role: Literal["Input", "Output"] = "Output",
     ) -> "Dataset":
-        """Adds files to the catalog with their metadata.
+        """Register external file *references* and link them as execution inputs.
 
-        Registers files in the catalog along with their metadata (MD5, length, URL) and associates them with
-        specified file types. Links files to the specified execution record for provenance tracking.
+        Inserts a ``File``-table row per file (URL + MD5 + length) — a
+        *reference* to bytes the catalog does **not** host (no Hatrac upload).
+        Each file is linked to the execution as an **input**
+        (``File_Execution.Asset_Role="Input"``).
+
+        Role is intrinsic, not a choice: referencing an external file means
+        *naming* a file the run consumed/depended on, so it is always an
+        Input. A file the run *produced* is a Hatrac-backed execution asset —
+        register those via ``asset_file_path`` + ``commit_output_assets``,
+        never here. (Provenance contract: asset role is derived from context;
+        a ``File`` reference is an input by its nature.)
 
         Args:
             files: File specifications containing MD5 checksum, length, and URL.
             execution_rid: Execution RID to associate files with (required for provenance).
             dataset_types: One or more dataset type terms from File_Type vocabulary.
             description: Description of the files.
-            asset_role: Whether the files are an ``"Input"`` to or an
-                ``"Output"`` of the execution. Recorded on the
-                ``File_Execution`` association row's ``Asset_Role``. Defaults
-                to ``"Output"`` (files produced by the run). Pass ``"Input"``
-                to register a file the run *consumed* (e.g. an external data
-                file ingested into the catalog).
 
         Returns:
             Dataset: Dataset that represents the newly added files.
@@ -147,10 +149,12 @@ class FileMixin:
         ]
         pb.schemas[self.ml_schema].tables[atable].insert(file_type_records)
 
-        # Link files to the execution for provenance tracking.
+        # Link each file to the execution as an INPUT. A File-table row is a
+        # reference to externally-hosted bytes — naming a file the run
+        # consumed — so its role is intrinsically Input (never a parameter).
         pb.schemas[self.ml_schema].File_Execution.insert(
             [
-                {"File": file_record["RID"], "Execution": execution_rid, "Asset_Role": asset_role}
+                {"File": file_record["RID"], "Execution": execution_rid, "Asset_Role": "Input"}
                 for file_record in file_records
             ]
         )

--- a/src/deriva_ml/execution/execution.py
+++ b/src/deriva_ml/execution/execution.py
@@ -37,7 +37,7 @@ import os
 import sys
 from datetime import datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Iterable, List, Literal
+from typing import TYPE_CHECKING, Any, Callable, Iterable, List
 
 if TYPE_CHECKING:
     from deriva_ml.asset.asset import Asset
@@ -2040,19 +2040,20 @@ class Execution:
         files: Iterable[FileSpec],
         dataset_types: str | list[str] | None = None,
         description: str = "",
-        asset_role: Literal["Input", "Output"] = "Output",
     ) -> "Dataset":
-        """Adds files to the catalog with their metadata.
+        """Register external file *references* and link them as execution inputs.
 
-        Registers files in the catalog along with their metadata (MD5, length, URL) and associates them with
-        specified file types.
+        Inserts a ``File``-table row per file (a reference to externally-hosted
+        bytes — URL + MD5, not uploaded to Hatrac) and links each as an
+        **input** of this execution. Role is intrinsic, not a parameter: a
+        ``File`` reference names a file the run consumed, so it is always an
+        Input. Files the run *produced* are Hatrac-backed execution assets —
+        use ``asset_file_path`` + ``commit_output_assets`` for those.
 
         Args:
             files: File specifications containing MD5 checksum, length, and URL.
             dataset_types: One or more dataset type terms from File_Type vocabulary.
             description: Description of the files.
-            asset_role: ``"Input"`` (file consumed by this execution) or
-                ``"Output"`` (file produced by it). Defaults to ``"Output"``.
 
         Returns:
             RID: Dataset  that identifies newly added files. Will be nested to mirror original directory structure
@@ -2062,22 +2063,15 @@ class Execution:
             DerivaMLInvalidTerm: If file_types are invalid or execution_rid is not an execution record.
 
         Examples:
-            Add a single file type:
+            Register external files as inputs:
                 >>> files = [FileSpec(url="path/to/file.txt", md5="abc123", length=1000)]  # doctest: +SKIP
                 >>> rids = exe.add_files(files, dataset_types="text")  # doctest: +SKIP
-
-            Add multiple file types:
-                >>> rids = exe.add_files(  # doctest: +SKIP
-                ...     files=[FileSpec(url="image.png", md5="def456", length=2000)],  # doctest: +SKIP
-                ...     dataset_types=["image", "png"],  # doctest: +SKIP
-                ... )  # doctest: +SKIP
         """
         return self._ml_object.add_files(
             files=files,
             execution_rid=self.execution_rid,
             dataset_types=dataset_types,
             description=description,
-            asset_role=asset_role,
         )
 
     # =========================================================================

--- a/src/deriva_ml/execution/execution_configuration.py
+++ b/src/deriva_ml/execution/execution_configuration.py
@@ -92,16 +92,24 @@ class ExecutionConfiguration(BaseModel):
         Accepts plain RID strings, DictConfig from Hydra, AssetSpec objects,
         or dicts with 'rid' and optional 'cache' keys.
         """
+        def _drop_legacy_role(d: dict) -> dict:
+            # ``AssetSpec`` no longer has an ``asset_role`` field (role is
+            # context-derived, never specified) and now forbids extra fields.
+            # A persisted config from before the removal may still carry an
+            # ``asset_role`` key — drop it so old configs still load (the field
+            # was always a no-op) rather than failing deserialization.
+            return {k: val for k, val in d.items() if k != "asset_role"}
+
         result = []
         for v in value:
             if isinstance(v, AssetSpec):
                 result.append(v)
             elif isinstance(v, dict):
                 # Dict with rid/cache keys (e.g., from JSON config)
-                result.append(AssetSpec(**v))
+                result.append(AssetSpec(**_drop_legacy_role(v)))
             elif isinstance(v, DictConfig):
                 # OmegaConf DictConfig from Hydra — may have rid+cache or just rid
-                d = dict(v)
+                d = _drop_legacy_role(dict(v))
                 if "rid" in d:
                     result.append(AssetSpec(**d))
                 else:

--- a/tests/asset/test_asset_spec_parity.py
+++ b/tests/asset/test_asset_spec_parity.py
@@ -5,18 +5,16 @@ reference. ``AssetSpecConfig`` (hydra-zen dataclass interface) is its
 *configuration* surface — it exposes only the attributes that are meaningful
 to configure.
 
-The two are intentionally **not** field-for-field identical. ``AssetSpec``
-carries ``asset_role`` (``Input`` / ``Output``), but that role is determined
-by **context**, never configured:
+Asset **role is determined by context, never specified** (the same rule as
+datasets, whose role is structural):
 
 - An asset referenced in an execution's input configuration is an *input*.
 - Assets written via ``commit_output_assets`` are *outputs*.
 
-So ``asset_role`` must NOT appear on ``AssetSpecConfig``: there is no scenario
-where a config author legitimately marks a config-declared asset as an Output,
-and exposing it as a configurable ``Literal``-typed field additionally broke
-structured-config registration under omegaconf < 2.4 (which cannot serialize
-``Literal`` annotations). This test pins that contract as a CI gate.
+So neither ``AssetSpec`` nor ``AssetSpecConfig`` carries an ``asset_role``
+field — it was removed entirely (it had been a no-op runtime field never read
+to set the edge). The two are now full-parity on configurable fields. This
+test pins that contract as a CI gate.
 """
 
 from __future__ import annotations
@@ -26,9 +24,10 @@ import dataclasses
 from deriva_ml.asset.aux_classes import AssetSpec, AssetSpecConfig
 
 # Fields that exist on AssetSpec but are intentionally NOT configurable.
-# asset_role is set by context (input config vs. commit_output_assets), so it
-# is excluded from the hydra-zen configuration surface by design.
-CONTEXT_DETERMINED_FIELDS = {"asset_role"}
+# (Empty: asset_role was removed entirely — role is context-derived, never a
+# field on either AssetSpec or AssetSpecConfig. AssetSpec and AssetSpecConfig
+# are now full-parity on configurable fields.)
+CONTEXT_DETERMINED_FIELDS: set[str] = set()
 
 
 def test_config_exposes_configurable_fields_with_matching_defaults() -> None:
@@ -77,13 +76,36 @@ def test_config_exposes_configurable_fields_with_matching_defaults() -> None:
     )
 
 
+def test_assetspec_has_no_asset_role_field() -> None:
+    """``AssetSpec`` must NOT carry an ``asset_role`` field at all.
+
+    Asset role is determined by context (consuming an input vs. producing via
+    ``commit_output_assets``) and is never specified by the caller — the same
+    rule as datasets, whose role is structural. ``asset_role`` was previously a
+    no-op runtime field (never read to set the edge), which only invited
+    callers to set something the system ignores. Removed entirely.
+    """
+    assert "asset_role" not in AssetSpec.model_fields, (
+        "AssetSpec must not declare ``asset_role`` — role is context-derived, "
+        "never user-specified."
+    )
+
+
+def test_assetspec_rejects_asset_role_kwarg() -> None:
+    """Passing ``asset_role`` to ``AssetSpec`` is rejected (not silently
+    ignored) — a typo or a stale call that names a role fails loudly."""
+    import pytest
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        AssetSpec(rid="1-ABCD", asset_role="Output")
+
+
 def test_config_does_not_expose_asset_role() -> None:
     """``AssetSpecConfig`` must NOT expose ``asset_role`` (context-determined).
 
     Direct regression guard: asset role is set by where the asset is used
     (input config vs. ``commit_output_assets``), not by the config author.
-    Re-adding ``asset_role`` here would also reintroduce the omegaconf
-    ``Literal`` structured-config break.
     """
     config_field_names = {f.name for f in dataclasses.fields(AssetSpecConfig)}
     assert "asset_role" not in config_field_names, (
@@ -93,12 +115,11 @@ def test_config_does_not_expose_asset_role() -> None:
     )
 
 
-def test_config_instantiates_to_assetspec_with_input_default() -> None:
-    """A configured asset instantiates to an AssetSpec defaulting to Input.
+def test_config_instantiates_to_assetspec() -> None:
+    """A configured asset instantiates to an AssetSpec.
 
-    ``rid`` + ``cache`` round-trip; the runtime ``asset_role`` takes its
-    ``"Input"`` default (the role is then set by the consuming/producing
-    operation).
+    ``rid`` + ``cache`` round-trip. There is no ``asset_role`` field — role is
+    set by the consuming/producing operation, never carried on the spec.
     """
     from hydra_zen import instantiate
 
@@ -106,4 +127,4 @@ def test_config_instantiates_to_assetspec_with_input_default() -> None:
     assert isinstance(spec, AssetSpec)
     assert spec.rid == "3JSE"
     assert spec.cache is True
-    assert spec.asset_role == "Input"
+    assert not hasattr(spec, "asset_role")

--- a/tests/core/test_file.py
+++ b/tests/core/test_file.py
@@ -122,28 +122,49 @@ class TestFile:
                 ds = subdir.list_dataset_members()
                 assert len(ds["File"]) == 5
 
-    def test_add_files_input_role(self, file_table_setup):
-        """add_files(asset_role="Input") records File_Execution edges with
-        Asset_Role="Input" (provenance contract: external files can be
-        consumed inputs, not only produced outputs).
+    def test_add_files_links_as_input(self, file_table_setup):
+        """add_files registers an external File reference and links it as an
+        INPUT — intrinsically, with no role parameter.
 
-        Default behavior remains Output; this pins the new Input capability.
+        The File table holds references to bytes the catalog does NOT host
+        (URL + MD5, no Hatrac upload). Registering such a reference means
+        "name an external file so I have a catalog handle to it" — which is
+        consuming/referencing it, never producing it. A produced file is a
+        Hatrac-backed execution asset via asset_file_path/commit, not a File
+        reference. So add_files is the input-reference mechanism: role is not
+        a variable, it is always Input.
         """
         ml_instance = file_table_setup.ml_instance
         test_dir = file_table_setup.test_dir
         execution = file_table_setup.execution
 
         with execution.execute() as exe:
-            filespecs = list(FileSpec.create_filespecs(test_dir, "Input files"))
-            exe.add_files(filespecs, asset_role="Input")
+            filespecs = list(FileSpec.create_filespecs(test_dir, "Referenced files"))
+            exe.add_files(filespecs)  # no role argument — Input by nature
 
-        # Read File_Execution rows for this execution and check the role.
         pb = ml_instance.pathBuilder()
         fe = pb.schemas[ml_instance.ml_schema].File_Execution
         rows = [r for r in fe.entities().fetch() if r["Execution"] == execution.execution_rid]
         assert rows, "expected File_Execution rows for the execution"
         roles = {r["Asset_Role"] for r in rows}
-        assert roles == {"Input"}, f"expected all Input-role edges, got {roles}"
+        assert roles == {"Input"}, f"add_files must link File references as Input, got {roles}"
+
+    def test_add_files_has_no_role_parameter(self, file_table_setup):
+        """add_files must NOT expose a role parameter — role is not a user
+        choice (provenance contract: role is derived from context, and a File
+        reference is intrinsically an input).
+
+        ``Execution.add_files`` is ``@validate_call``-wrapped, so an unknown
+        kwarg is rejected as a pydantic ``ValidationError`` (a subclass-free
+        ``TypeError`` would come from a plain function); accept either.
+        """
+        from pydantic import ValidationError
+
+        execution = file_table_setup.execution
+        with execution.execute() as exe:
+            filespecs = list(FileSpec.create_filespecs(file_table_setup.test_dir, "x"))
+            with pytest.raises((TypeError, ValidationError)):
+                exe.add_files(filespecs, asset_role="Output")  # role param must not exist
 
     def test_list_files(self, file_table_setup):
         ml_instance = file_table_setup.ml_instance

--- a/tests/dataset/test_validate_execution_configuration_unit.py
+++ b/tests/dataset/test_validate_execution_configuration_unit.py
@@ -273,17 +273,19 @@ def test_version_conflict_same_rid_two_versions():
     assert report.all_valid is False
 
 
-def test_role_conflict_input_and_output():
+def test_duplicate_asset_rid_flagged():
+    """The same asset RID listed twice is a duplicate (role is not on the
+    spec, so there is no role-conflict to detect — only duplication)."""
     ml = _FakeML()
     ml.add_asset("3JSE", asset_table="Image", filename="x.jpg")
     config = ExecutionConfiguration(
         assets=[
-            AssetSpec(rid="3JSE", asset_role="Input"),
-            AssetSpec(rid="3JSE", asset_role="Output"),
+            AssetSpec(rid="3JSE"),
+            AssetSpec(rid="3JSE"),
         ],
     )
     report = ml.validate_execution_configuration(config)
-    issues = [i for i in report.cross_spec_issues if i.issue == "role_conflict"]
+    issues = [i for i in report.cross_spec_issues if i.issue == "duplicate_rid"]
     assert len(issues) == 1
     assert report.all_valid is False
 


### PR DESCRIPTION
## Summary

Establishes and enforces the principle: **asset/file role is always derived from context, never specified by the caller** — the same model as datasets, whose role is structural (`Dataset_Execution` vs `Dataset_Version.Execution` authorship). Two user-facing role knobs are removed.

## 1. `add_files` links as Input intrinsically

`add_files` / the `File` table is a **reference** mechanism: it inserts a row (URL + MD5), it does **not** upload bytes to Hatrac. Registering a `File` reference means *"name an external file I consumed"* — intrinsically an **Input**. A file the run *produced* is a Hatrac-backed execution asset (`asset_file_path` → `commit_output_assets`), never a `File` reference; an `add_files` "output" is conceptually wrong and nothing relied on it.

- Removed the `asset_role` parameter from both `add_files` signatures (the one #333 added).
- Changed the hardcoded `File_Execution` link from `Asset_Role="Output"` to `"Input"`.

## 2. Remove `AssetSpec.asset_role`

`AssetSpec.asset_role` was a **no-op** runtime field — input resolution reads only `rid`/`cache`; the edge role is set by the operation. It only invited callers to set something the system ignored (its docstring even showed a misleading `asset_role="Output"` example).

- Removed the field; added `extra="forbid"` so a stray `asset_role=` is rejected loudly, not silently dropped.
- `validate_assets` tolerates a legacy `asset_role` key in a persisted config dict (drops it) so pre-removal configs still load.
- The cross-spec `role_conflict` validator (which read `spec.asset_role`) is removed — no role on the spec ⇒ no conflict; the duplicate-RID check stays.
- `AssetSpec`/`AssetSpecConfig` are now full-parity on configurable fields.

## Spec

Provenance-contract rule #5 rewritten: *"role is unambiguous AND always derived from context — never specified by the caller; APIs must not ask the caller to name a role."* All `add_files`-asset_role references replaced with "`LocalFile` in `assets=` → Input by context."

## Why this supersedes #333

#333 (merged) added an `asset_role` param to `add_files`. Design review concluded that's the wrong model — role is contextual (never user-set), and `add_files`/`File` is intrinsically an input-reference. This PR is the forward correction.

## Tests

TDD throughout (each change: RED against current behavior, then GREEN). Touched suites green on a live localhost catalog:
- `tests/core/test_file.py` — 11 passed (`add_files` → Input; no role param)
- `tests/asset/test_asset_spec_parity.py` — AssetSpec has no `asset_role`; kwarg rejected; full parity
- `tests/dataset/test_validate_execution_configuration_unit.py` — `role_conflict` → `duplicate_rid`
- 29 passed across the three together; no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)