### PR TITLE
feat: LocalFile input — declare a local file as an execution input (re-PR onto main)

### DIFF
--- a/src/deriva_ml/asset/__init__.py
+++ b/src/deriva_ml/asset/__init__.py
@@ -11,8 +11,8 @@ This module provides classes for managing assets (files) in a Deriva catalog:
 
 from .asset import Asset
 from .asset_record import AssetRecord, asset_record_class
-from .aux_classes import AssetFilePath, AssetSpec, AssetSpecConfig
-from .manifest import AssetManifest, AssetEntry
+from .aux_classes import AssetFilePath, AssetSpec, AssetSpecConfig, LocalFile, LocalFileConfig
+from .manifest import AssetEntry, AssetManifest
 
 __all__ = [
     "Asset",
@@ -22,5 +22,7 @@ __all__ = [
     "AssetRecord",
     "AssetSpec",
     "AssetSpecConfig",
+    "LocalFile",
+    "LocalFileConfig",
     "asset_record_class",
 ]

--- a/src/deriva_ml/asset/aux_classes.py
+++ b/src/deriva_ml/asset/aux_classes.py
@@ -218,3 +218,73 @@ class AssetSpecConfig:
 
     rid: str
     cache: bool = False
+
+
+class LocalFile(BaseModel):
+    """Specification for a local file consumed as an input to an execution.
+
+    Declares a file on the local filesystem (or an external URL) that the
+    execution consumes. Used in ``ExecutionConfiguration.assets`` alongside
+    :class:`AssetSpec`: an ``AssetSpec`` names a *catalog-resident* asset by
+    RID, while a ``LocalFile`` names a file by **path**, which the framework
+    registers in the ``File`` table on the caller's behalf (computing its MD5,
+    minting a ``File`` RID) during input resolution.
+
+    Role is **Input by context** — a file declared in ``assets=`` is consumed,
+    so it is an input. There is no role field (the same rule as ``AssetSpec``);
+    files a run *produces* are Hatrac-backed execution assets, not
+    ``LocalFile`` declarations. The model forbids extra fields, so a stray
+    ``asset_role=`` is rejected.
+
+    Attributes:
+        path: Local filesystem path (or URL) of the file to register and
+            consume. A bare string is accepted as shorthand.
+        cache: If True, cache by MD5 checksum in the DerivaML cache directory
+            (mirrors ``AssetSpec.cache``).
+
+    Example:
+        >>> spec = LocalFile(path="/data/labels.csv")
+        >>> spec = LocalFile(path="/data/labels.csv", cache=True)
+        >>> # Bare-string shorthand works inside ``assets=`` lists (where the
+        >>> # value is validated), routing on shape — a ``{"path": ...}`` entry
+        >>> # becomes a LocalFile, a bare RID string an AssetSpec.
+    """
+
+    path: str
+    cache: bool = False
+
+    model_config = ConfigDict(**VALIDATION_CONFIG, extra="forbid")
+
+    @model_validator(mode="before")
+    @classmethod
+    def _check_bare_path(cls, data: Any) -> Any:
+        """Allow a bare path string as shorthand."""
+        return {"path": data} if isinstance(data, str) else data
+
+
+# Interface for hydra-zen
+@hydrated_dataclass(LocalFile)
+class LocalFileConfig:
+    """Hydra-zen configuration interface for ``LocalFile``.
+
+    Lets a ``.yaml`` experiment declare a local-file input by path. Plain
+    scalar fields only (``path``, ``cache``) — no ``Literal`` fields, which
+    omegaconf < 2.4 cannot serialize. Role is not configurable (a declared
+    file is an input by context).
+
+    Use in hydra-zen store definitions::
+
+        >>> from hydra_zen import store  # doctest: +SKIP
+        >>> asset_store = store(group="assets")  # doctest: +SKIP
+        >>> asset_store(  # doctest: +SKIP
+        ...     [LocalFileConfig(path="/data/labels.csv")],
+        ...     name="external_labels",
+        ... )
+
+    Attributes:
+        path: Local filesystem path (or URL). Mirrors ``LocalFile.path``.
+        cache: Mirrors ``LocalFile.cache``.
+    """
+
+    path: str
+    cache: bool = False

--- a/src/deriva_ml/execution/execution.py
+++ b/src/deriva_ml/execution/execution.py
@@ -45,7 +45,7 @@ if TYPE_CHECKING:
     from deriva_ml.local_db.manifest_store import ManifestStore
 from pydantic import validate_call
 
-from deriva_ml.asset.aux_classes import AssetFilePath
+from deriva_ml.asset.aux_classes import AssetFilePath, LocalFile
 from deriva_ml.asset.manifest import AssetManifest
 from deriva_ml.core.base import DerivaML
 from deriva_ml.core.connection_mode import ConnectionMode
@@ -359,7 +359,13 @@ class Execution:
                 raise DerivaMLException("Dataset specified in execution configuration is not a dataset")
 
         for a in self.configuration.assets:
-            if not self._model.is_asset(self._ml_object.resolve_rid(a.rid).table.name):
+            if isinstance(a, LocalFile):
+                # A LocalFile references a not-yet-registered local file; it has
+                # no catalog RID to resolve. Validate the file exists instead —
+                # it is registered (File row + Input edge) during resolution.
+                if not Path(a.path).is_file():
+                    raise DerivaMLException(f"LocalFile input not found on disk: {a.path}")
+            elif not self._model.is_asset(self._ml_object.resolve_rid(a.rid).table.name):
                 raise DerivaMLException("Asset specified in execution configuration is not an asset table")
 
         schema_path = self._ml_object.pathBuilder().schemas[self._ml_object.ml_schema]
@@ -692,11 +698,29 @@ class Execution:
         """
         self._logger.info("Downloading assets ...")
         self.asset_paths = {}
-        # Batch-resolve every asset RID up front (one query per
+
+        # LocalFile inputs are *references* to local files, not catalog assets:
+        # register each as a File row and link it to the execution as an Input
+        # (role from context — a declared input is consumed). They are NOT
+        # downloaded (a File reference has no Hatrac bytes to fetch); the local
+        # path is recorded as-is. Handle these first, then fall through to the
+        # RID-based AssetSpec download path below.
+        local_files = [s for s in self.configuration.assets if isinstance(s, LocalFile)]
+        if local_files and not (reload or self._dry_run):
+            from deriva_ml.core.definitions import FileSpec
+
+            specs: list[FileSpec] = []
+            for lf in local_files:
+                specs.extend(FileSpec.create_filespecs(lf.path, description="Execution input file"))
+            # add_files registers the File rows and links them as Input
+            # (File_Execution Asset_Role="Input") — role from context.
+            self._ml_object.add_files(specs, execution_rid=self.execution_rid)
+
+        # Batch-resolve every catalog asset RID up front (one query per
         # candidate table) instead of one resolve_rid round-trip per
         # asset. Skip cleanly when there are no asset specs so an
         # empty configuration doesn't fire a no-op resolve_rids call.
-        asset_specs = list(self.configuration.assets)
+        asset_specs = [s for s in self.configuration.assets if not isinstance(s, LocalFile)]
         if asset_specs:
             asset_rids = [spec.rid for spec in asset_specs]
             rid_results = self._ml_object.resolve_rids(asset_rids)

--- a/src/deriva_ml/execution/execution_configuration.py
+++ b/src/deriva_ml/execution/execution_configuration.py
@@ -30,7 +30,7 @@ from typing import Any
 from omegaconf import DictConfig
 from pydantic import BaseModel, Field, field_validator
 
-from deriva_ml.asset.aux_classes import AssetSpec
+from deriva_ml.asset.aux_classes import AssetSpec, LocalFile
 from deriva_ml.core.validation import VALIDATION_CONFIG
 from deriva_ml.dataset.aux_classes import DatasetSpec
 from deriva_ml.execution.workflow import Workflow
@@ -76,7 +76,7 @@ class ExecutionConfiguration(BaseModel):
     """
 
     datasets: list[DatasetSpec] = []
-    assets: list[AssetSpec] = []
+    assets: list[AssetSpec | LocalFile] = []
     workflow: Workflow | None = None
     description: str = ""
     argv: list[str] = Field(default_factory=lambda: sys.argv)
@@ -87,10 +87,18 @@ class ExecutionConfiguration(BaseModel):
     @field_validator("assets", mode="before")
     @classmethod
     def validate_assets(cls, value: Any) -> Any:
-        """Normalize asset entries to AssetSpec objects.
+        """Normalize asset entries, routing on shape (the safety chokepoint).
 
-        Accepts plain RID strings, DictConfig from Hydra, AssetSpec objects,
-        or dicts with 'rid' and optional 'cache' keys.
+        Routing rule:
+          - a ``LocalFile`` instance, or a mapping with a ``path`` key → a
+            ``LocalFile`` (a local-file input, registered during resolution);
+          - an ``AssetSpec`` instance, a mapping with a ``rid`` key, or a
+            **bare string** → an ``AssetSpec`` (a catalog asset, by RID).
+
+        A bare string is *always* a RID — never type-sniffed into a path. A
+        filesystem read happens only for an explicitly-typed ``LocalFile``
+        (or a ``{path: ...}`` mapping), never for an arbitrary (possibly
+        injected) string. This is the abuse-surface boundary.
         """
         def _drop_legacy_role(d: dict) -> dict:
             # ``AssetSpec`` no longer has an ``asset_role`` field (role is
@@ -102,23 +110,22 @@ class ExecutionConfiguration(BaseModel):
 
         result = []
         for v in value:
-            if isinstance(v, AssetSpec):
+            if isinstance(v, (AssetSpec, LocalFile)):
                 result.append(v)
-            elif isinstance(v, dict):
-                # Dict with rid/cache keys (e.g., from JSON config)
-                result.append(AssetSpec(**_drop_legacy_role(v)))
-            elif isinstance(v, DictConfig):
-                # OmegaConf DictConfig from Hydra — may have rid+cache or just rid
+            elif isinstance(v, (dict, DictConfig)):
+                # A mapping (plain dict from JSON, or a Hydra DictConfig).
+                # Route on shape: a ``path`` key is a local-file input; a
+                # ``rid`` key (the default) is a catalog asset.
                 d = _drop_legacy_role(dict(v))
-                if "rid" in d:
-                    result.append(AssetSpec(**d))
+                if "path" in d:
+                    result.append(LocalFile(**d))
                 else:
-                    # Bare DictConfig with just a .rid attribute.
-                    result.append(AssetSpec(rid=v.rid, cache=getattr(v, "cache", False)))
+                    result.append(AssetSpec(**d))
             elif isinstance(v, str):
+                # A bare string is ALWAYS a RID — never sniffed into a path.
                 result.append(AssetSpec(rid=v))
             else:
-                # Unknown type — try string coercion
+                # Unknown type — coerce to a RID string (never a path).
                 result.append(AssetSpec(rid=str(v)))
         return result
 

--- a/tests/execution/test_local_file_input.py
+++ b/tests/execution/test_local_file_input.py
@@ -83,3 +83,46 @@ def test_E5_localfile_wrapper_is_the_only_path_entry_point():
     # to declare a path.
     with pytest.raises(ValidationError):
         ExecutionConfiguration(assets=["/data/labels.csv"])
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# E4 — live: a LocalFile input is registered as a File and linked as Input,
+# and is NOT downloaded (it is a reference, not a Hatrac asset).
+# ─────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.integration
+def test_E4_localfile_input_registered_and_linked_as_input(test_ml, tmp_path):
+    """E4 — A LocalFile in assets= is registered as a File row and linked to
+    the execution as an Input (File_Execution Asset_Role="Input"), by context.
+
+    The file is referenced, not uploaded; its role comes from being declared
+    in assets=, never from a flag.
+    """
+    from deriva_ml import MLVocab as vc
+    from deriva_ml.asset.aux_classes import LocalFile
+
+    ml = test_ml
+    ml.add_term(vc.workflow_type, "LocalFile Test Workflow", description="local-file input test")
+    workflow = ml.create_workflow(name="localfile_test", workflow_type="LocalFile Test Workflow")
+
+    # A real local file on disk.
+    src = tmp_path / "labels.csv"
+    src.write_text("RID_Subject,glc_dx\n1-AAAA,0\n")
+
+    config = ExecutionConfiguration(
+        description="Consumes a local file",
+        workflow=workflow,
+        assets=[LocalFile(path=str(src))],
+    )
+
+    exe = ml.create_execution(config)
+
+    # A File_Execution row with Asset_Role="Input" must exist for this run.
+    pb = ml.pathBuilder()
+    fe = pb.schemas[ml.ml_schema].File_Execution
+    rows = [r for r in fe.entities().fetch() if r["Execution"] == exe.execution_rid]
+    assert rows, "expected a File_Execution row for the LocalFile input"
+    assert {r["Asset_Role"] for r in rows} == {"Input"}, (
+        "a LocalFile declared in assets= must be linked as Input (role from context)"
+    )

--- a/tests/execution/test_local_file_input.py
+++ b/tests/execution/test_local_file_input.py
@@ -53,17 +53,10 @@ def test_E6_rid_keyed_dict_routes_to_assetspec():
 # ─────────────────────────────────────────────────────────────────────────
 
 
-@pytest.mark.xfail(
-    reason="LocalFile + validate_assets shape-routing not implemented. A "
-    "{'path': ...} entry must route to a LocalFile spec; today the validator "
-    "only knows rid-keyed/bare-string entries and would mishandle a path key. "
-    "Flip to a real assertion when LocalFile lands.",
-    strict=True,
-)
 def test_E6_path_keyed_dict_routes_to_localfile():
     """A {'path': ...} entry (from a hydra .yaml) routes to a LocalFile spec,
     not an AssetSpec — the path is an explicit local-file input declaration."""
-    from deriva_ml.asset.aux_classes import LocalFile  # noqa: F401 — not yet implemented
+    from deriva_ml.asset.aux_classes import LocalFile
 
     config = ExecutionConfiguration(assets=[{"path": "/data/labels.csv"}])
     spec = config.assets[0]
@@ -71,22 +64,22 @@ def test_E6_path_keyed_dict_routes_to_localfile():
     assert str(spec.path) == "/data/labels.csv"
 
 
-@pytest.mark.xfail(
-    reason="LocalFile not implemented. A bare path string must NOT be sniffed "
-    "into a path — it stays a RID (safety). A local file requires the explicit "
-    "LocalFile wrapper. This pins that the wrapper is the only path entry point.",
-    strict=True,
-)
 def test_E5_localfile_wrapper_is_the_only_path_entry_point():
-    """A local file is declared via LocalFile('/path'); a bare path string is
-    still treated as a RID, never sniffed into a filesystem read."""
+    """A local file is declared via an explicit LocalFile; a bare string is
+    NEVER sniffed into a path — it is treated only as a RID."""
+    import pytest
+    from pydantic import ValidationError
+
     from deriva_ml.asset.aux_classes import LocalFile
 
-    config = ExecutionConfiguration(assets=[LocalFile("/data/labels.csv")])
+    config = ExecutionConfiguration(assets=[LocalFile(path="/data/labels.csv")])
     spec = config.assets[0]
     assert isinstance(spec, LocalFile)
+    assert str(spec.path) == "/data/labels.csv"
 
-    # A bare path-looking string is NOT a LocalFile — it is a RID.
-    config2 = ExecutionConfiguration(assets=["/data/labels.csv"])
-    assert isinstance(config2.assets[0], AssetSpec)
-    assert config2.assets[0].rid == "/data/labels.csv"
+    # A bare path-looking string is NOT routed to a LocalFile. It is treated
+    # only as a RID — and since it is not a valid RID, it is rejected outright
+    # (never silently read as a filesystem path). The wrapper is the ONLY way
+    # to declare a path.
+    with pytest.raises(ValidationError):
+        ExecutionConfiguration(assets=["/data/labels.csv"])


### PR DESCRIPTION
## Summary

Implements `LocalFile` — declaring a **local file as an execution input** via `assets=` (the external-ingest path from the provenance contract; the `6-05M4` CSV case). Role is **Input by context**; the file is registered as a `File` reference, never user-role-tagged, never downloaded.

> **Re-PR note:** the original #336 was stacked on #335's branch and merged into it, but #335 was squash-merged to main — which dropped the LocalFile commits. This branch is rebased directly onto main (now carrying #335's add_files→Input + AssetSpec-removal) and contains only the two LocalFile commits.

## What it does

```python
ExecutionConfiguration(
    assets=[
        AssetSpec("<asset-rid>"),           # catalog asset, by RID
        LocalFile(path="/data/labels.csv"), # local file — framework registers it
    ],
)
```

A `LocalFile` in `assets=`:
1. is **registered** during input resolution (File row via `FileSpec.create_filespecs` — MD5 + `tag:` URI — + `add_files`),
2. is **linked as an Input** (`File_Execution.Asset_Role="Input"`) — role from context, never specified,
3. is **not downloaded** (a `File` reference has no Hatrac bytes).

## Layers

- **Config** (`asset/aux_classes.py`): `LocalFile` (BaseModel: `path`+`cache`, `extra="forbid"`, no role) + `LocalFileConfig` (hydra-zen, plain scalars). Exported from `deriva_ml.asset`.
- **Routing** (`execution_configuration.py`): `assets` → `list[AssetSpec | LocalFile]`; `validate_assets` routes on shape — `{path}` → LocalFile, `{rid}`/bare string → AssetSpec. A bare string is always a RID, never a path; a path-looking bare string is rejected as an invalid RID.
- **Runtime** (`execution.py`): `__init__` validates the LocalFile path exists; `_download_input_assets` registers LocalFiles (Input edge) and skips download.

## Tests

`tests/execution/test_local_file_input.py` — **5 passed** (4 unit routing/shape + 1 live E4 resolution), flipping the merged E xfails to real assertions. Rebased onto current main; verified green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)