### PR TITLE
feat(execution): best-effort GPU/accelerator capture in env snapshot

### DIFF
--- a/src/deriva_ml/execution/environment.py
+++ b/src/deriva_ml/execution/environment.py
@@ -18,9 +18,12 @@ Typical usage example:
 """
 
 import importlib.metadata
+import importlib.util
 import os
 import platform
+import shutil
 import site
+import subprocess
 import sys
 from typing import Any, Dict
 
@@ -52,7 +55,91 @@ def get_execution_environment() -> Dict[str, Any]:
         sys_path=sys.path,
         site=get_site_info(),
         platform=get_platform_info(),
+        gpu=get_gpu_info(),
     )
+
+
+def get_gpu_info() -> Dict[str, Any]:
+    """Best-effort, dependency-free GPU / accelerator snapshot.
+
+    The CPU and architecture are already captured by ``get_platform_info``;
+    ``platform`` does not see the GPU. This probes for GPU details without
+    adding a hard dependency and without ever raising — a failed probe must
+    never break the environment snapshot.
+
+    Probe order:
+      1. ``nvidia-smi`` via subprocess (no Python dependency) — model(s),
+         count, total memory, driver version.
+      2. ``torch.cuda`` *only if torch is importable* (guarded by
+         ``importlib.util.find_spec`` so torch is never imported into a
+         non-ML process) — device names plus the CUDA / cuDNN versions torch
+         was built against, which ``nvidia-smi`` does not report.
+
+    Returns:
+        Dict[str, Any]: Always contains ``available`` (bool). When a GPU is
+        found, also carries ``source`` and probe-specific fields. When
+        nothing succeeds, ``{"available": False}`` (optionally with a
+        ``probe_error``). Never raises.
+
+    Example:
+        >>> info = get_gpu_info()  # doctest: +SKIP
+        >>> info["available"]  # doctest: +SKIP
+        True
+    """
+    info: Dict[str, Any] = {"available": False}
+
+    # --- Probe 1: nvidia-smi (no added dependency) ---------------------
+    try:
+        smi = shutil.which("nvidia-smi")
+        if smi:
+            result = subprocess.run(
+                [
+                    smi,
+                    "--query-gpu=name,memory.total,driver_version",
+                    "--format=csv,noheader",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            if result.returncode == 0 and result.stdout.strip():
+                gpus = []
+                for line in result.stdout.strip().splitlines():
+                    parts = [p.strip() for p in line.split(",")]
+                    if len(parts) >= 3:
+                        gpus.append({"name": parts[0], "memory_total": parts[1], "driver_version": parts[2]})
+                if gpus:
+                    info = {
+                        "available": True,
+                        "source": "nvidia-smi",
+                        "count": len(gpus),
+                        "devices": gpus,
+                    }
+    except Exception as exc:  # noqa: BLE001 — best-effort, never raise
+        info.setdefault("probe_error", f"nvidia-smi: {exc}")
+
+    # --- Probe 2: torch.cuda (only if torch is already installed) ------
+    # Adds the CUDA/cuDNN build versions, which nvidia-smi does not report.
+    try:
+        if importlib.util.find_spec("torch") is not None:
+            import torch  # local import — never pulled into a non-ML process
+
+            if torch.cuda.is_available():
+                names = [torch.cuda.get_device_name(i) for i in range(torch.cuda.device_count())]
+                info["available"] = True
+                info.setdefault("source", "torch.cuda")
+                info["torch"] = {
+                    "device_count": torch.cuda.device_count(),
+                    "device_names": names,
+                    "cuda_version": torch.version.cuda,
+                    "cudnn_version": (
+                        torch.backends.cudnn.version() if torch.backends.cudnn.is_available() else None
+                    ),
+                }
+    except Exception as exc:  # noqa: BLE001 — best-effort, never raise
+        info.setdefault("probe_error", f"torch: {exc}")
+
+    return info
 
 
 def get_loaded_modules() -> Dict[str, str]:

--- a/tests/execution/test_environment.py
+++ b/tests/execution/test_environment.py
@@ -129,24 +129,29 @@ class TestGetExecutionEnvironment:
 class TestGetGpuInfo:
     """Provenance contract I6 — best-effort GPU capture.
 
-    ``get_gpu_info`` does not exist yet; these are the executable spec for it
-    (xfail until it lands). Per the contract it must be best-effort and
-    dependency-free: probe ``nvidia-smi`` / guarded ``torch.cuda``, and
-    degrade to ``{"available": False}`` (never raise) when neither is present.
+    ``get_gpu_info`` is best-effort and dependency-free: it probes
+    ``nvidia-smi`` / guarded ``torch.cuda`` and degrades to
+    ``{"available": False}`` (never raises) when neither is present.
     """
 
-    @pytest.mark.xfail(reason="get_gpu_info not implemented", strict=True)
     def test_returns_dict_and_degrades_gracefully(self):
         from deriva_ml.execution.environment import get_gpu_info
 
         info = get_gpu_info()
         assert isinstance(info, dict)
-        # On a host with no GPU and no torch, it must report absence
-        # explicitly rather than raise or omit.
-        if not info.get("available", False):
-            assert info.get("available") is False
+        # Always carries an explicit boolean ``available`` — present whether or
+        # not a GPU/torch is found, and the call never raises.
+        assert isinstance(info.get("available"), bool)
 
-    @pytest.mark.xfail(reason="get_gpu_info not wired into get_execution_environment", strict=True)
     def test_gpu_section_in_aggregate(self):
         env = get_execution_environment()
         assert "gpu" in env, f"expected a 'gpu' section in the env snapshot: keys = {sorted(env.keys())}"
+        assert isinstance(env["gpu"].get("available"), bool)
+
+    def test_is_json_serializable_with_gpu(self):
+        """The gpu section must JSON-serialize (it's part of the metadata asset)."""
+        import json
+
+        from deriva_ml.execution.environment import get_gpu_info
+
+        json.dumps(get_gpu_info(), default=str)


### PR DESCRIPTION
## Summary

Adds `get_gpu_info()` to the execution environment snapshot — the GPU/accelerator capture the provenance contract recommends. `platform` already records CPU/architecture but not the GPU; this fills the gap **without a hard dependency** and **without ever raising**.

## How

Probe order (best-effort, dependency-free):
1. **`nvidia-smi` via subprocess** (no Python dep) — GPU name(s), total memory, driver version.
2. **`torch.cuda`, guarded by `importlib.util.find_spec("torch")`** so torch is never imported into a non-ML process — device names + the **CUDA/cuDNN versions torch was built against** (which `nvidia-smi` doesn't report).
3. **Fallback** `{"available": False}` — absence recorded explicitly. All probe exceptions are swallowed (same pattern as `get_platform_info`), so a failed probe can't break the snapshot.

Wired into `get_execution_environment()` as the `gpu` key, so it lands in the `environment_snapshot` metadata asset automatically — no schema change, no new asset type.

## Tests

`tests/execution/test_environment.py` — **12 passed**. On a host with no GPU and no torch (CI/dev), `get_gpu_info()` returns `{"available": False}`, the aggregate has a `gpu` section, and it's JSON-serializable. Flips the I6 xfails (from #332) to real assertions.

(Independent of the LocalFile / sentinels work — touches only `environment.py`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)