### PR TITLE
feat(execution): re-export LocalFile/LocalFileConfig from deriva_ml.execution

### DIFF
--- a/src/deriva_ml/execution/__init__.py
+++ b/src/deriva_ml/execution/__init__.py
@@ -8,8 +8,16 @@ full provenance tracking.
 
 from typing import TYPE_CHECKING
 
-# Re-export AssetSpec and AssetSpecConfig from their canonical location
-from deriva_ml.asset.aux_classes import AssetSpec, AssetSpecConfig
+# Re-export the input-spec types from their canonical location. AssetSpec names
+# a catalog-resident asset by RID; LocalFile names a local file by path (the
+# framework registers it in the File table on input resolution). Both are used
+# in ``ExecutionConfiguration.assets``, so both belong on the execution surface.
+from deriva_ml.asset.aux_classes import (
+    AssetSpec,
+    AssetSpecConfig,
+    LocalFile,
+    LocalFileConfig,
+)
 
 # Safe imports - no circular dependencies
 from deriva_ml.execution.base_config import (
@@ -66,6 +74,8 @@ __all__ = [
     "Workflow",
     "AssetSpec",
     "AssetSpecConfig",
+    "LocalFile",
+    "LocalFileConfig",
     "run_model",
     "create_model_config",
     "reset_multirun_state",

--- a/tests/execution/test_local_file_input.py
+++ b/tests/execution/test_local_file_input.py
@@ -17,7 +17,6 @@ import pytest
 from deriva_ml.asset.aux_classes import AssetSpec
 from deriva_ml.execution.execution_configuration import ExecutionConfiguration
 
-
 # ─────────────────────────────────────────────────────────────────────────
 # E5/E6 safety boundary — a bare string in assets= is ALWAYS a RID.
 # (Characterization: the existing validator already does this; pin it so the
@@ -126,3 +125,29 @@ def test_E4_localfile_input_registered_and_linked_as_input(test_ml, tmp_path):
     assert {r["Asset_Role"] for r in rows} == {"Input"}, (
         "a LocalFile declared in assets= must be linked as Input (role from context)"
     )
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Public export surface — LocalFile/LocalFileConfig are usable from the same
+# place as AssetSpec (deriva_ml.execution), so consumers (e.g. data-curation's
+# hydra-zen configs) have a stable public import, not an internal module path.
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def test_localfile_is_exported_from_execution_package():
+    """``LocalFile``/``LocalFileConfig`` re-export from ``deriva_ml.execution``.
+
+    They live canonically in ``deriva_ml.asset.aux_classes`` but, like
+    ``AssetSpec``, are used in ``ExecutionConfiguration.assets`` — so they must
+    be reachable from the execution surface that consumers import from. Pins the
+    public path so it can't silently regress to an internal-only import.
+    """
+    from deriva_ml.asset.aux_classes import LocalFile as _CanonicalLocalFile
+    from deriva_ml.execution import LocalFile, LocalFileConfig
+
+    # Same object as the canonical definition (a true re-export, not a shadow).
+    assert LocalFile is _CanonicalLocalFile
+    # Constructs as documented (keyword form; bare-string shorthand is only for
+    # inside an assets= list, where the validator coerces it).
+    assert LocalFile(path="/data/labels.csv").path == "/data/labels.csv"
+    assert LocalFileConfig is not None


### PR DESCRIPTION
`AssetSpec`/`AssetSpecConfig` are re-exported from `deriva_ml.execution` (canonical home: `deriva_ml.asset.aux_classes`), but `LocalFile`/`LocalFileConfig` were not — even though both are used in `ExecutionConfiguration.assets`.

A consumer declaring a local-file input (e.g. data-curation's hydra-zen config for the LAC chart-label ingest) had no stable public import and would have to reach into the internal `aux_classes` module. This adds the missing re-export so the public path is:

```python
from deriva_ml.execution import LocalFile, LocalFileConfig
```

Test `test_localfile_is_exported_from_execution_package` pins it (same object as the canonical class, constructs as documented). Full `test_local_file_input.py`: 6 passed.

Prerequisite for converting `data-curation`'s `lac_chartlabel_ingest` from the `asset_file_path`+`copyfile` capture (uploads the MRN-bearing CSV bytes to Hatrac) to a `LocalFile` input declaration (File-table reference + Input edge, no byte upload).

🤖 Generated with [Claude Code](https://claude.com/claude-code)