### PR TITLE
perf(cache): persist bag size_bytes; stop re-walking the cache on every storage query

### DIFF
--- a/src/deriva_ml/core/base.py
+++ b/src/deriva_ml/core/base.py
@@ -1640,20 +1640,19 @@ class DerivaML(
             >>> size = ml.get_cache_size()  # doctest: +SKIP
             >>> print(f"Cache size: {size['total_mb']:.1f} MB ({size['file_count']} files)")  # doctest: +SKIP
         """
-        stats = {"total_bytes": 0, "total_mb": 0.0, "file_count": 0, "dir_count": 0}
+        # Walk with the error-tolerant helper: a single unreadable file
+        # (e.g. a permission-denied file in a stale execution dir under the
+        # cache root) must not crash the whole size computation, which a bare
+        # ``Path.rglob`` would do on the first ``PermissionError``.
+        from deriva_ml.core.storage import _dir_stats
 
-        if not self.cache_dir.exists():
-            return stats
-
-        for entry in self.cache_dir.rglob("*"):
-            if entry.is_file():
-                stats["total_bytes"] += entry.stat().st_size
-                stats["file_count"] += 1
-            elif entry.is_dir():
-                stats["dir_count"] += 1
-
-        stats["total_mb"] = stats["total_bytes"] / (1024 * 1024)
-        return stats
+        total_bytes, file_count, dir_count = _dir_stats(self.cache_dir)
+        return {
+            "total_bytes": total_bytes,
+            "total_mb": total_bytes / (1024 * 1024),
+            "file_count": file_count,
+            "dir_count": dir_count,
+        }
 
     def list_execution_dirs(self) -> list[dict[str, Any]]:
         """List execution working directories.
@@ -1678,6 +1677,7 @@ class DerivaML(
         """
         from datetime import datetime
 
+        from deriva_ml.core.storage import _dir_stats
         from deriva_ml.core.upload_layout import upload_root
 
         results = []
@@ -1688,8 +1688,11 @@ class DerivaML(
 
         for entry in exec_root.iterdir():
             if entry.is_dir():
-                size_bytes = sum(f.stat().st_size for f in entry.rglob("*") if f.is_file())
-                file_count = sum(1 for f in entry.rglob("*") if f.is_file())
+                # Error-tolerant walk: a single unreadable/permission-denied
+                # file in one execution dir must not crash the whole listing
+                # (which a bare ``rglob`` + ``stat`` would do). One walk yields
+                # both size and file count.
+                size_bytes, file_count, _ = _dir_stats(entry)
                 mtime = datetime.fromtimestamp(entry.stat().st_mtime)
 
                 results.append(
@@ -1879,7 +1882,10 @@ class DerivaML(
             Note: ``bag_size_mb`` and ``asset_size_mb`` break down
             ``cache_size_mb`` by species — they are subsets of it, not
             additive with it; ``total_size_mb`` remains
-            ``cache_size_mb + execution_size_mb``.
+            ``cache_size_mb + execution_size_mb``. ``cache_file_count``
+            counts only files outside the ``bags/`` subtree (bag file
+            counts are not tracked in the index); it is a floor, not a
+            full tally.
 
         Example:
             >>> ml = DerivaML('deriva.example.org', 'my_catalog')  # doctest: +SKIP
@@ -1888,9 +1894,9 @@ class DerivaML(
             >>> print(f"  Cache: {summary['cache_size_mb']:.1f} MB")  # doctest: +SKIP
             >>> print(f"  Executions: {summary['execution_size_mb']:.1f} MB")  # doctest: +SKIP
         """
-        cache_stats = self.get_cache_size()
-        exec_dirs = self.list_execution_dirs()
+        from deriva_ml.core.storage import _PROTECTED_CACHE_ENTRIES, _dir_stats
 
+        exec_dirs = self.list_execution_dirs()
         exec_size_mb = sum(d["size_mb"] for d in exec_dirs)
 
         bags = self.list_cached_bags()
@@ -1906,14 +1912,44 @@ class DerivaML(
         bag_bytes = sum(sizes_by_checksum.values())
         asset_bytes = sum(a.size_bytes for a in assets)
 
+        # Cache total = index-known bag bytes (O(1), no re-walk) + asset bytes
+        # (from the asset listing) + any stray content under the cache root
+        # that is neither ``bags/``, ``assets/``, nor the bag-index SQLite
+        # files. The "other" slice is tiny, so walking it is cheap; this avoids
+        # the full-tree ``get_cache_size`` walk that re-measured the multi-GB
+        # ``bags/`` subtree on every call. The index files are cache machinery,
+        # not cached content, so they are excluded — matching the
+        # ``_PROTECTED_CACHE_ENTRIES`` set ``clear_cache`` uses, and keeping the
+        # total stable whether or not a listing has lazily created the index.
+        other_bytes = other_files = 0
+        if self.cache_dir.exists():
+            for entry in self.cache_dir.iterdir():
+                if entry.name in _PROTECTED_CACHE_ENTRIES:
+                    continue
+                if entry.is_dir():
+                    sub_bytes, sub_files, _ = _dir_stats(entry)
+                    other_bytes += sub_bytes
+                    other_files += sub_files
+                else:
+                    try:
+                        other_bytes += entry.stat().st_size
+                        other_files += 1
+                    except (OSError, PermissionError):
+                        continue
+        cache_bytes = bag_bytes + asset_bytes + other_bytes
+        cache_size_mb = cache_bytes / (1024 * 1024)
+        # File count excludes the bags/ subtree (not tracked per-bag in the
+        # index); assets/ + everything else is counted.
+        cache_file_count = sum(a.file_count for a in assets) + other_files
+
         return {
             "working_dir": str(self.working_dir),
             "cache_dir": str(self.cache_dir),
-            "cache_size_mb": cache_stats["total_mb"],
-            "cache_file_count": cache_stats["file_count"],
+            "cache_size_mb": cache_size_mb,
+            "cache_file_count": cache_file_count,
             "execution_dir_count": len(exec_dirs),
             "execution_size_mb": exec_size_mb,
-            "total_size_mb": cache_stats["total_mb"] + exec_size_mb,
+            "total_size_mb": cache_size_mb + exec_size_mb,
             # Per-species breakdown (spec 2026-06-11)
             "bag_count": len(bags),
             "bag_size_mb": bag_bytes / (1024 * 1024),

--- a/src/deriva_ml/core/storage.py
+++ b/src/deriva_ml/core/storage.py
@@ -134,6 +134,49 @@ def _dir_size(path: Path) -> int:
     return total
 
 
+def _dir_stats(path: Path) -> tuple[int, int, int]:
+    """Total bytes, file count, and dir count under ``path``.
+
+    The error-tolerant counterpart of :func:`_dir_size`, for callers
+    that also need the file/dir tallies (``get_cache_size``). Like
+    ``_dir_size`` it walks with ``os.walk(onerror=...)`` so a single
+    unreadable subdirectory is skipped rather than aborting the whole
+    walk, and guards each per-file ``stat`` against entries that vanish
+    or are unreadable mid-walk. ``rglob`` would propagate the first
+    ``PermissionError`` and crash the caller — which is exactly what
+    made ``get_cache_size`` fail on a cache containing one
+    permission-denied file.
+
+    Args:
+        path: Directory to measure.
+
+    Returns:
+        ``(total_bytes, file_count, dir_count)``; ``(0, 0, 0)`` when
+        ``path`` does not exist.
+
+    Example:
+        >>> from pathlib import Path
+        >>> _dir_stats(Path("/nonexistent/anywhere"))
+        (0, 0, 0)
+    """
+    if not path.exists():
+        return 0, 0, 0
+    total = file_count = dir_count = 0
+    for dirpath, dirnames, filenames in os.walk(path, onerror=lambda _e: None):
+        dir_count += len(dirnames)
+        base = Path(dirpath)
+        for name in filenames:
+            fp = base / name
+            try:
+                if fp.is_file():
+                    total += fp.stat().st_size
+                    file_count += 1
+            except (OSError, PermissionError):
+                # Entry vanished or is unreadable — skip it, keep counting.
+                continue
+    return total, file_count, dir_count
+
+
 def _parse_asset_dir_name(name: str) -> tuple[str, str] | None:
     """Split ``{rid}_{md5}`` (last underscore, md5 = 32 hex chars)."""
     rid, sep, md5 = name.rpartition("_")

--- a/src/deriva_ml/dataset/bag_cache.py
+++ b/src/deriva_ml/dataset/bag_cache.py
@@ -191,6 +191,17 @@ class BagCache:
         for row in self._index.list_bags():
             checksum = row["checksum"]
             version = (row.get("anchor_summary") or {}).get("version")
+            # ``size_bytes`` is persisted on the index row at download time
+            # (see ``_extract_archive_to_cache``). For bags recorded before
+            # that landed the column is NULL — walk the content-addressed bag
+            # directory once and write the result back, so the O(N-files) walk
+            # is amortized to at most one listing per stale bag rather than
+            # repeating on every call.
+            size_bytes = row.get("size_bytes")
+            if size_bytes is None:
+                size_bytes = _dir_size(self._index.bag_dir_for(checksum)) or None
+                if size_bytes is not None:
+                    self._backfill_size_bytes(checksum, row, size_bytes)
             for rid in anchors.get(checksum, []):
                 bag_dir = self._index.bag_dir_for(checksum) / f"Dataset_{rid}"
                 status = self._determine_index_status(checksum, bag_dir)
@@ -201,11 +212,40 @@ class BagCache:
                         checksum=checksum,
                         status=status,
                         built_at=_utc(datetime.fromisoformat(row["built_at"])),
-                        size_bytes=row.get("size_bytes") or _dir_size(bag_dir) or None,
+                        size_bytes=size_bytes,
                         path=bag_dir,
                     )
                 )
         return bags
+
+    def _backfill_size_bytes(self, checksum: str, row: dict[str, Any], size_bytes: int) -> None:
+        """Persist a just-computed ``size_bytes`` onto an existing index row.
+
+        Re-records the bag (an upsert keyed on ``checksum``) with its size so
+        the next ``list_bags`` reads it from the index instead of re-walking.
+        The metadata fields (``profile_id``, ``anchor_summary``, ``built_at``)
+        are passed through unchanged because ``record`` overwrites them from
+        its arguments — omitting one would null it. ``anchors`` is left empty:
+        ``record`` accumulates anchors, so the existing reverse-index rows are
+        preserved. Best-effort: a read-only or otherwise unwritable index is
+        logged and ignored — listing still returns the freshly-computed size,
+        it just won't be cached.
+
+        Args:
+            checksum: The bag's content-addressed checksum (index key).
+            row: The index row as returned by ``BagCacheIndex.list_bags``.
+            size_bytes: The on-disk size to persist, in bytes.
+        """
+        try:
+            self._index.record(
+                checksum=checksum,
+                profile_id=row.get("profile_id"),
+                anchor_summary=row.get("anchor_summary"),
+                size_bytes=size_bytes,
+                built_at=_utc(datetime.fromisoformat(row["built_at"])),
+            )
+        except Exception as e:  # read-only index, locked DB, schema drift
+            logger.debug("Could not persist size_bytes for bag %s: %s", checksum, e)
 
     def purge_dataset(self, dataset_rid: str, version: str | None = None) -> dict[str, int]:
         """Delete cached bags for a dataset (all versions, or one).

--- a/src/deriva_ml/dataset/bag_download.py
+++ b/src/deriva_ml/dataset/bag_download.py
@@ -188,10 +188,19 @@ def _extract_archive_to_cache(
     staging_dir.rename(bag_root)
 
     # Record the bag in the index so the next Tier-1 lookup finds it.
+    # Compute and persist ``size_bytes`` now, while the just-extracted
+    # files are still warm in the page cache — the walk is nearly free
+    # here. Without it the index column stays NULL and every later
+    # ``BagCache.list_bags`` (hence every ``get_storage_summary`` /
+    # storage-inspection run) re-walks the whole bag with ``_dir_size``,
+    # which is what makes those calls slow on a multi-GB cache.
+    from deriva_ml.core.storage import _dir_size
+
     index.record(
         checksum=checksum,
         anchors=[("Dataset", dataset_rid)],
         anchor_summary={"version": str(dataset_version)},
+        size_bytes=_dir_size(bag_root),
     )
     return bag_dir
 

--- a/tests/core/test_cache_introspection.py
+++ b/tests/core/test_cache_introspection.py
@@ -50,7 +50,10 @@ def _record_bag(
 
     Mirrors the production record() call in
     ``dataset/bag_download.py`` — anchors ``[("Dataset", rid)]``,
-    ``anchor_summary={"version": ...}``.
+    ``anchor_summary={"version": ...}`` — but deliberately omits
+    ``size_bytes`` (which production now persists), leaving the index
+    column NULL. That exercises the lazy back-fill path in
+    ``BagCache.list_bags`` for pre-existing caches.
 
     Returns the bag directory path (``bags/{checksum}/Dataset_{rid}``).
     """
@@ -657,3 +660,124 @@ class TestListBagsOrdering:
             bags = cache.list_bags()
 
         assert [b.dataset_rid for b in bags] == ["RID-NEWER", "RID-OLDER"]
+
+
+class TestBagSizePersistence:
+    """``size_bytes`` is persisted to the index, not re-walked every call.
+
+    Regression: ``list_bags`` read ``row.get('size_bytes') or _dir_size(...)``
+    but the column was never written, so every call re-walked the bag — making
+    ``get_storage_summary`` / storage inspection O(cache size) on each run.
+    Now download persists the size, and a NULL column (pre-existing cache) is
+    back-filled on the first listing.
+    """
+
+    def _index_size(self, cache_dir: Path, checksum: str) -> int | None:
+        from deriva.bag.cache_index import BagCacheIndex
+
+        index = BagCacheIndex(cache_dir)
+        try:
+            return (index.get(checksum) or {}).get("size_bytes")
+        finally:
+            index.dispose()
+
+    def test_list_bags_backfills_null_size_to_index(self, tmp_path: Path):
+        from deriva_ml.dataset.bag_cache import BagCache
+
+        cache_dir = tmp_path / "cache"
+        # _record_bag leaves size_bytes NULL (mirrors a pre-existing cache).
+        _record_bag(cache_dir, checksum="sz1", dataset_rid="RID-SZ")
+        assert self._index_size(cache_dir, "sz1") is None
+
+        with BagCache(cache_dir) as cache:
+            bags = cache.list_bags()
+        assert len(bags) == 1
+        assert bags[0].size_bytes is not None
+        assert bags[0].size_bytes > 0
+
+        # The walked size is now persisted on the index row.
+        persisted = self._index_size(cache_dir, "sz1")
+        assert persisted == bags[0].size_bytes
+
+    def test_backfill_does_not_re_walk_on_second_call(self, monkeypatch, tmp_path: Path):
+        from deriva_ml.core import storage
+        from deriva_ml.dataset.bag_cache import BagCache
+
+        cache_dir = tmp_path / "cache"
+        _record_bag(cache_dir, checksum="sz2", dataset_rid="RID-SZ2")
+
+        calls = {"n": 0}
+        real_dir_size = storage._dir_size
+
+        def counting_dir_size(path):
+            calls["n"] += 1
+            return real_dir_size(path)
+
+        monkeypatch.setattr(storage, "_dir_size", counting_dir_size)
+
+        # First listing walks once (NULL column) and back-fills.
+        with BagCache(cache_dir) as cache:
+            cache.list_bags()
+        first = calls["n"]
+        assert first >= 1
+
+        # Second listing reads size_bytes from the index — no further walk.
+        with BagCache(cache_dir) as cache:
+            cache.list_bags()
+        assert calls["n"] == first, "size_bytes should be read from the index, not re-walked"
+
+    def test_backfill_preserves_anchors_and_summary(self, tmp_path: Path):
+        """Re-recording to persist size must not drop anchors or version."""
+        from deriva.bag.cache_index import BagCacheIndex
+
+        from deriva_ml.dataset.bag_cache import BagCache
+
+        cache_dir = tmp_path / "cache"
+        _record_bag(cache_dir, checksum="sz3", dataset_rid="RID-A3", version="2.1.0")
+        # Second dataset anchors the same content-addressed bag.
+        index = BagCacheIndex(cache_dir)
+        try:
+            index.record(checksum="sz3", anchors=[("Dataset", "RID-B3")])
+        finally:
+            index.dispose()
+
+        with BagCache(cache_dir) as cache:
+            cache.list_bags()  # triggers back-fill
+
+        # Both anchors survive the back-fill upsert.
+        index = BagCacheIndex(cache_dir)
+        try:
+            assert set(index.find_bags_for_rid(table="Dataset", rid="RID-A3")) == {"sz3"}
+            assert set(index.find_bags_for_rid(table="Dataset", rid="RID-B3")) == {"sz3"}
+        finally:
+            index.dispose()
+
+
+class TestStorageSummaryNoFullWalk:
+    """``get_storage_summary`` derives the cache total from the index +
+    asset listing + stray entries, never re-walking the bags/ subtree.
+    """
+
+    def test_summary_does_not_call_get_cache_size(self, harness, monkeypatch):
+        from deriva_ml.core.base import DerivaML
+
+        harness.list_execution_dirs = lambda: DerivaML.list_execution_dirs(harness)
+        harness.list_cached_bags = lambda: DerivaML.list_cached_bags(harness)
+        harness.list_cached_assets = lambda: DerivaML.list_cached_assets(harness)
+
+        # If the summary still routed through the full-tree walker, this would
+        # fire. It must not — bag size comes from the index.
+        def boom():
+            raise AssertionError("get_storage_summary must not call get_cache_size")
+
+        harness.get_cache_size = boom
+
+        _record_bag(harness.cache_dir, checksum="nw1", dataset_rid="RID-NW")
+        _make_cached_asset(harness.cache_dir, "RID-NWA", MD5_A)
+
+        summary = DerivaML.get_storage_summary(harness)
+        assert summary["bag_count"] == 1
+        assert summary["bag_size_mb"] > 0
+        assert summary["asset_count"] == 1
+        # cache total includes bags + assets.
+        assert summary["cache_size_mb"] >= summary["bag_size_mb"] + summary["asset_size_mb"]

--- a/tests/core/test_storage_management.py
+++ b/tests/core/test_storage_management.py
@@ -301,6 +301,35 @@ def test_get_storage_summary_tallies_cache_and_executions(tmp_path):
     assert summary["cache_dir"] == str(h.cache_dir)
 
 
+def test_get_storage_summary_counts_stray_dirs_and_files(tmp_path):
+    """Cache content that is neither bags/ nor assets/ — stray top-level files
+    AND stray top-level directories — is still counted in cache_size_mb /
+    cache_file_count.
+
+    The bag-index SQLite machinery (index.sqlite*) is the only thing excluded;
+    that exclusion is covered separately by ``test_get_storage_summary_empty``
+    (which only ever creates the real, lazily-built index and still reports 0).
+    Here we focus on the inclusion of stray content and deliberately do not
+    fabricate an index file — a real index is a valid DB, not arbitrary bytes.
+    """
+    from deriva_ml.core.base import DerivaML
+
+    h = _make_harness(tmp_path)
+    # A stray top-level file …
+    (h.cache_dir / "leftover.tmp").write_bytes(b"x" * 100)
+    # … and a stray top-level directory with nested content.
+    junk = h.cache_dir / "oldjunk"
+    junk.mkdir()
+    (junk / "a.bin").write_bytes(b"y" * 200)
+    (junk / "nested").mkdir()
+    (junk / "nested" / "b.bin").write_bytes(b"z" * 300)
+
+    summary = DerivaML.get_storage_summary(h)  # type: ignore[arg-type]
+    # 100 + 200 + 300 = 600 bytes of stray content, all counted.
+    assert summary["cache_size_mb"] == pytest.approx(600 / (1024 * 1024))
+    assert summary["cache_file_count"] == 3  # leftover.tmp, a.bin, b.bin
+
+
 # ---------------------------------------------------------------------------
 # _dir_size resilience to PermissionError (regression: it caught only
 # FileNotFoundError, so a permission-denied subdir crashed list_cached_bags

--- a/tests/core/test_storage_management.py
+++ b/tests/core/test_storage_management.py
@@ -357,3 +357,79 @@ def test_dir_size_survives_permission_denied_subdir(monkeypatch, tmp_path):
     monkeypatch.setattr(os, "walk", walk_with_denied_dir)
     # Must not raise; counts the readable top-level file, skips the denied subdir.
     assert storage._dir_size(tmp_path) == 2
+
+
+# ---------------------------------------------------------------------------
+# _dir_stats — the (bytes, files, dirs) counterpart of _dir_size, used by
+# get_cache_size / list_execution_dirs. Same os.walk(onerror=...) resilience.
+# ---------------------------------------------------------------------------
+
+
+def test_dir_stats_empty_and_missing(tmp_path):
+    """Missing dir → all zeros; empty dir → all zeros."""
+    from deriva_ml.core import storage
+
+    assert storage._dir_stats(tmp_path / "nope") == (0, 0, 0)
+    (tmp_path / "empty").mkdir()
+    assert storage._dir_stats(tmp_path / "empty") == (0, 0, 0)
+
+
+def test_dir_stats_tallies_bytes_files_dirs(tmp_path):
+    """Bytes, file count, and dir count are all reported."""
+    from deriva_ml.core import storage
+
+    (tmp_path / "a.txt").write_text("hi")  # 2 bytes
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    (sub / "b.txt").write_text("yoyo")  # 4 bytes
+    total, files, dirs = storage._dir_stats(tmp_path)
+    assert total == 6
+    assert files == 2
+    assert dirs == 1  # one subdirectory, matching rglob("*") semantics
+
+
+def test_dir_stats_skips_permission_denied_file(monkeypatch, tmp_path):
+    """A file whose stat raises PermissionError is skipped, not fatal."""
+    from deriva_ml.core import storage
+
+    (tmp_path / "ok.txt").write_text("hello")  # 5 bytes
+    (tmp_path / "locked.txt").write_text("secret")
+
+    real_stat = Path.stat
+
+    def fake_stat(self, *a, **k):
+        if self.name == "locked.txt":
+            raise PermissionError(13, "Permission denied", str(self))
+        return real_stat(self, *a, **k)
+
+    monkeypatch.setattr(Path, "stat", fake_stat)
+    total, files, _dirs = storage._dir_stats(tmp_path)
+    assert total == 5  # only the readable file counted
+    assert files == 1
+
+
+def test_get_cache_size_survives_permission_denied_file(monkeypatch, tmp_path):
+    """get_cache_size must not crash on a permission-denied file in the cache.
+
+    Regression: the old implementation used a bare ``Path.rglob('*')`` +
+    ``stat()`` which propagated the first ``PermissionError`` (e.g. a locked
+    file in a stale execution dir under the cache root), aborting the whole
+    size computation. It now walks via the error-tolerant ``_dir_stats``.
+    """
+    from deriva_ml.core.base import DerivaML
+
+    h = _make_harness(tmp_path)
+    (h.cache_dir / "readable.dat").write_bytes(b"x" * 100)
+    (h.cache_dir / "denied.dat").write_bytes(b"y" * 50)
+
+    real_stat = Path.stat
+
+    def fake_stat(self, *a, **k):
+        if self.name == "denied.dat":
+            raise PermissionError(13, "Permission denied", str(self))
+        return real_stat(self, *a, **k)
+
+    monkeypatch.setattr(Path, "stat", fake_stat)
+    stats = DerivaML.get_cache_size(h)  # type: ignore[arg-type]
+    assert stats["total_bytes"] == 100  # readable file only; no crash
+    assert stats["file_count"] == 1


### PR DESCRIPTION
## Problem

`list_cached_bags` / `get_storage_summary` re-walked the **entire on-disk cache** on every call, making storage inspection `O(cache size)`. On a multi-GB cache a single `get_storage_summary()` (or the `inspect_storage` skill) took tens of seconds, dominated by filesystem `stat()` calls.

**Root cause:** the bag-cache index already has a `size_bytes` column (and `record()` persists it, `total_size_bytes()` aggregates it) — but deriva-ml **never wrote it**. So `BagCache.list_bags` always fell through to a full `_dir_size()` walk:

```python
size_bytes=row.get("size_bytes") or _dir_size(bag_dir) or None  # column was always NULL
```

Two secondary bugs in the same surface:

- `get_cache_size` and `list_execution_dirs` used a bare `Path.rglob("*")` + `stat()`, which **crashes on the first permission-denied file** (e.g. a locked file in a stale execution dir under the cache root) — aborting the whole computation instead of skipping the unreadable entry.
- `get_storage_summary` walked the full tree via `get_cache_size()` **and** independently sized bags + assets — triple-counting the same bytes' worth of walking.

## Fix (all library-side; no deriva-py change needed)

| Where | Change |
|-------|--------|
| `bag_download._extract_archive_to_cache` | Persist `size_bytes` to the index **at download time**, while the just-extracted files are warm in the page cache (the walk is nearly free there). Going forward the column is populated → `list_bags` is `O(1)`. |
| `BagCache.list_bags` + new `_backfill_size_bytes` | When the column is NULL (pre-existing caches), walk **once** and back-fill it via `index.record(...)` — preserving `profile_id` / `anchor_summary` / anchors. Self-healing: at most one walk per stale bag, ever. |
| `get_storage_summary` | Derive `cache_size_mb` from index-known bag bytes + the asset listing + stray top-level entries, instead of a redundant full-tree `get_cache_size()` walk. |
| `get_cache_size` / `list_execution_dirs` | Walk via a new error-tolerant `_dir_stats` helper (`os.walk(onerror=...)` + guarded `stat`), matching the existing `_dir_size` resilience. One unreadable file no longer aborts the size computation. |

`get_cache_size` itself is **kept as a faithful full-tree walk** (it's the primitive callers use to get real on-disk size + `dir_count`); it's just crash-safe now and no longer on the hot path.

## Behavior notes

- **`get_storage_summary().cache_file_count`** now excludes the `bags/` subtree (bag file counts aren't tracked in the index) — documented in the docstring as "a floor, not a full tally." Bag **bytes** are still exact.
- **Stray content is still counted:** non-bag/non-asset files *and* directories under the cache root are included in `cache_size_mb` / `cache_file_count`. Only the bag-index SQLite files (`index.sqlite*`) are excluded as machinery (~28 KB) — which also keeps the total stable whether or not a listing has lazily created the index.

## Tests

`tests/core/` → **275 passed, 11 skipped** (skips are live-catalog only). New regression coverage:

- `_dir_stats` tallies (bytes/files/dirs) + permission-denied resilience
- `get_cache_size` survives a permission-denied file
- `size_bytes` back-fill persistence, and that the **second** listing reads from the index (no re-walk)
- back-fill preserves anchors / version
- `get_storage_summary` never calls `get_cache_size`
- stray top-level files **and** directories are counted in the summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)