### PR TITLE
feat(files): force-tag add_files datasets with built-in Directory type

### DIFF
--- a/docs/reference/schema.md
+++ b/docs/reference/schema.md
@@ -161,6 +161,7 @@ kind: vocabulary
 terms:
 - name: Complete
 - name: File
+- name: Directory
 - name: Training
 - name: Testing
 - name: Validation

--- a/src/deriva_ml/core/mixins/file.py
+++ b/src/deriva_ml/core/mixins/file.py
@@ -16,10 +16,11 @@ from urllib.parse import urlsplit
 
 datapath = importlib.import_module("deriva.core.datapath")
 
+from deriva.core.ermrest_model import timestamptz_to_snaptime
+
 from deriva_ml.core.definitions import RID, FileSpec, MLTable, MLVocab, VocabularyTerm
 from deriva_ml.core.exceptions import DerivaMLInvalidTerm, DerivaMLTableTypeError
 from deriva_ml.dataset.aux_classes import DatasetVersion
-from deriva.core.ermrest_model import timestamptz_to_snaptime
 
 if TYPE_CHECKING:
     from deriva.core.ermrest_catalog import ResolveRidResult
@@ -121,11 +122,15 @@ class FileMixin:
         if spec_types - defined_types:
             raise DerivaMLInvalidTerm(MLVocab.asset_type.name, f"{spec_types - defined_types}")
 
-        # Normalize dataset_types, make sure File type is included.
-        if isinstance(dataset_types, list):
-            dataset_types = ["File"] + dataset_types if "File" not in dataset_types else dataset_types
-        else:
-            dataset_types = ["File", dataset_types] if dataset_types else ["File"]
+        # Normalize dataset_types. Two types are force-included on every dataset
+        # this routine creates, in addition to any caller-supplied types:
+        #   - "File": the datasets hold File-asset members.
+        #   - "Directory": marks the dataset as an auto-created directory-structure
+        #     dataset, distinguishing these byproducts from curated datasets so a
+        #     query can find (or exclude) them.
+        caller_types = [dataset_types] if isinstance(dataset_types, str) else list(dataset_types or [])
+        builtin_types = ["File", "Directory"]
+        dataset_types = builtin_types + [t for t in caller_types if t not in builtin_types]
         for ds_type in dataset_types:
             self.lookup_term(MLVocab.dataset_type, ds_type)
 

--- a/src/deriva_ml/schema/create_schema.py
+++ b/src/deriva_ml/schema/create_schema.py
@@ -881,6 +881,13 @@ def initialize_ml_schema(model: Model, schema_name: str = "deriva-ml"):
         [
             {"Name": "Complete", "Description": "A dataset containing all available records of a given type."},
             {"Name": "File", "Description": "A dataset that contains file assets."},
+            {
+                "Name": "Directory",
+                "Description": (
+                    "A dataset auto-created by add_files to mirror an ingested source directory "
+                    "structure; nested Directory datasets reflect the source folder hierarchy."
+                ),
+            },
             {"Name": "Training", "Description": "A dataset subset used for model training."},
             {"Name": "Testing", "Description": "A dataset subset used for model testing/evaluation."},
             {"Name": "Validation", "Description": "A dataset subset used for model validation during training."},

--- a/tests/core/test_file.py
+++ b/tests/core/test_file.py
@@ -122,6 +122,26 @@ class TestFile:
                 ds = subdir.list_dataset_members()
                 assert len(ds["File"]) == 5
 
+    def test_add_files_tags_datasets_as_directory(self, file_table_setup):
+        """Every dataset add_files creates carries the built-in ``Directory``
+        type (force-included like ``File``), marking it as an auto-created
+        directory-structure dataset — distinguishing these byproduct datasets
+        from curated ones. A caller-supplied dataset_type is additive."""
+        test_dir = file_table_setup.test_dir
+        execution = file_table_setup.execution
+
+        with execution.execute() as exe:
+            filespecs = FileSpec.create_filespecs(test_dir, "Test Directory")
+            file_dataset = exe.add_files(filespecs, dataset_types="Complete")
+
+        # The returned (top) dataset and every nested child must be tagged
+        # Directory + File, plus the caller's "Complete".
+        assert "Directory" in file_dataset.dataset_types
+        assert "File" in file_dataset.dataset_types
+        assert "Complete" in file_dataset.dataset_types
+        for subdir in file_dataset.list_dataset_children():
+            assert "Directory" in subdir.dataset_types
+
     def test_add_files_links_as_input(self, file_table_setup):
         """add_files registers an external File reference and links it as an
         INPUT — intrinsically, with no role parameter.


### PR DESCRIPTION
## Summary

`add_files` always creates one `Dataset` per distinct source parent directory to mirror the ingested folder structure (nested deepest-first). These are byproduct datasets — not curated ones — but nothing distinguished them in a query.

This PR adds a built-in **`Directory`** `Dataset_Type` and **force-includes it on every dataset `add_files` creates**, mirroring how `"File"` is already forced. A query can now find (or exclude) these auto-created directory-structure datasets by type.

The user's three-part ask was:
1. ✅ pass a `Dataset_Type` to tag the datasets — **already existed** (`dataset_types` param)
2. ✅ provide a description — **already existed** (`description` param)
3. 🆕 a built-in default type marking the dataset as a directory structure — **this PR**

## Changes

- **`schema/create_schema.py`** — seed a new `Directory` `Dataset_Type` term (right after `File`), so it exists on every fresh catalog.
- **`core/mixins/file.py`** — normalize `dataset_types` to prepend the two built-ins `["File", "Directory"]`, then layer caller types on top with a dedup filter (handles `str | list | None`, and a caller passing `"File"`/`"Directory"` explicitly won't double up).
- **`tests/core/test_file.py`** — `test_add_files_tags_datasets_as_directory`: asserts the returned dataset *and* all nested children carry `Directory`, `File`, and the caller's `Complete` type.

## Verification

- `tests/core/test_file.py` — **12 passed** (incl. the new test); the new test verified RED→GREEN against the gap.
- `ruff check` clean on `file.py`; the E501s in `create_schema.py` and the E731 in `test_file.py` are pre-existing on `main` (confirmed via stash + `--no-cache`), zero introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)