### PR TITLE
fix(rids): chunk resolve_rids any() query so large RID sets don't overflow the URL

### DIFF
--- a/src/deriva_ml/core/mixins/rid_resolution.py
+++ b/src/deriva_ml/core/mixins/rid_resolution.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 # Deriva imports - use importlib to avoid shadowing by local 'deriva.py' files
 import importlib
 from dataclasses import dataclass
+from itertools import batched
 from typing import TYPE_CHECKING, Any
 
 _datapath = importlib.import_module("deriva.core.datapath")
@@ -35,6 +36,19 @@ __all__ = [
     "RidResolutionMixin",
     "BatchRidResult",
 ]
+
+# Maximum number of RIDs placed in a single ``RID = Any(...)`` filter.
+#
+# That filter renders into the GET URL *path* (deriva-py datapath builds
+# ``base_uri + str(path_expression)`` and issues ``catalog.get(path)``), so the
+# request line grows ~13 bytes per RID (a 12-char RID + comma + urlquoting).
+# The front Apache rejects a request line over its ``LimitRequestLine`` (~4 KB
+# measured on localhost: 994 three-char RIDs succeed, 995 fail) *before ERMrest
+# sees it*. A cap of 200 keeps the filter ~2.6 KB even with worst-case 12-char
+# RIDs, leaving headroom for the path prefix. Without this, resolving a few
+# hundred+ RIDs in one shot overflowed the URL and the failure was silently
+# turned into a spurious "RIDs not found".
+_MAX_RIDS_PER_QUERY = 200
 
 
 @dataclass
@@ -177,34 +191,45 @@ class RidResolutionMixin:
 
             schema_name = table.schema.name
             table_name = table.name
-
-            # Build a query with RID filter for all remaining RIDs
             table_path = pb.schemas[schema_name].tables[table_name]
 
-            # Use ERMrest's Any quantifier for IN-style query
-            # Query only for RID column to minimize data transfer
-            try:
-                # Filter: RID = any(rid1, rid2, ...) - ERMrest's way of doing IN clause
-                found_entities = list(
-                    table_path.filter(table_path.RID == AnyQuantifier(*remaining_rids))
-                    .attributes(table_path.RID)
-                    .fetch()
-                )
-            except Exception as e:
-                logger.debug(f"RID resolution query failed for {schema_name}.{table_name}: {e}")
-                continue
-
-            # Process found RIDs
-            for entity in found_entities:
-                rid = entity["RID"]
-                if rid in remaining_rids:
-                    results[rid] = BatchRidResult(
-                        rid=rid,
-                        table=table,
-                        table_name=table_name,
-                        schema_name=schema_name,
+            # The ``RID = Any(...)`` filter renders into the GET URL path, so a
+            # single query over hundreds of RIDs overflows the server's request
+            # URL limit and fails. Chunk the remaining RIDs into URL-safe
+            # batches (``_MAX_RIDS_PER_QUERY``) and union the matches. Snapshot
+            # the RID list first because ``remaining_rids`` is mutated below.
+            for rid_chunk in batched(list(remaining_rids), _MAX_RIDS_PER_QUERY):
+                # Filter: RID = any(rid1, rid2, ...) — ERMrest's IN clause.
+                # Query only the RID column to minimize data transfer.
+                try:
+                    found_entities = list(
+                        table_path.filter(table_path.RID == AnyQuantifier(*rid_chunk))
+                        .attributes(table_path.RID)
+                        .fetch()
                     )
-                    remaining_rids.remove(rid)
+                except Exception as e:
+                    # Resilience across heterogeneous candidate tables: a query
+                    # that errors on one table shouldn't abort the whole scan —
+                    # the RIDs simply stay in ``remaining_rids`` and surface as a
+                    # legitimate DerivaMLRidsNotFound if no table matched them.
+                    # This is narrow now: the oversized-URL failure that used to
+                    # land here (and get masked into a spurious not-found) is
+                    # prevented by the chunking above, so an error reaching this
+                    # point is a genuine per-table condition, logged loudly.
+                    logger.warning(f"RID resolution query failed for {schema_name}.{table_name}: {e}")
+                    continue
+
+                # Process found RIDs
+                for entity in found_entities:
+                    rid = entity["RID"]
+                    if rid in remaining_rids:
+                        results[rid] = BatchRidResult(
+                            rid=rid,
+                            table=table,
+                            table_name=table_name,
+                            schema_name=schema_name,
+                        )
+                        remaining_rids.remove(rid)
 
         # Check if any RIDs were not found. Raise the typed
         # ``DerivaMLRidsNotFound`` so callers can pull the unresolved

--- a/src/deriva_ml/core/mixins/rid_resolution.py
+++ b/src/deriva_ml/core/mixins/rid_resolution.py
@@ -151,21 +151,36 @@ class RidResolutionMixin:
     ) -> dict[RID, BatchRidResult]:
         """Batch resolve multiple RIDs efficiently.
 
-        Resolves multiple RIDs in batched queries, significantly faster than
-        calling resolve_rid() for each RID individually. Instead of N network
-        calls for N RIDs, this makes one query per candidate table.
+        Resolves multiple RIDs in batched queries, far faster than calling
+        ``resolve_rid`` once per RID. RIDs are matched against a table with a
+        single chunked ``RID = Any(...)`` query rather than N per-RID lookups.
+
+        Two strategies depending on ``candidate_tables``:
+
+        - **Explicit candidate tables** (e.g. dataset element types): each
+          listed table is bulk-matched in turn until every RID is resolved.
+        - **No candidate tables** (``None``): instead of scanning *every* table
+          in the domain + ML schemas (a wasted zero-row query per table that
+          holds none of the RIDs), the server is asked which table a sample RID
+          lives in via ``resolve_rid`` (one ``/entity_rid`` call, catalog-wide),
+          the rest are bulk-matched in that table, and the process repeats for
+          any RIDs in other tables. Cost is ~one probe per distinct table the
+          RIDs actually span, independent of catalog size.
 
         Args:
             rids: Set or list of RIDs to resolve.
             candidate_tables: Optional list of Table objects to search in.
-                If not provided, searches all tables in domain and ML schemas.
+                If not provided, the server resolves each RID's table directly
+                (probe strategy above) — note this resolves catalog-wide, so a
+                RID in any schema is found, not only domain/ML schemas.
 
         Returns:
             dict[RID, BatchRidResult]: Mapping from each resolved RID to its
                 BatchRidResult containing table information.
 
         Raises:
-            DerivaMLException: If any RID cannot be resolved.
+            DerivaMLRidsNotFound: If any RID cannot be resolved; the unresolved
+                set is available as ``e.missing_rids``.
 
         Example:
             >>> results = ml.resolve_rids(["1-ABC", "2-DEF", "3-GHI"])  # doctest: +SKIP
@@ -178,32 +193,25 @@ class RidResolutionMixin:
 
         results: dict[RID, BatchRidResult] = {}
         remaining_rids = set(rids)
-
-        # Determine which tables to search
-        if candidate_tables is None:
-            # Search all tables in domain and ML schemas
-            candidate_tables = []
-            for schema_name in [*self.model.domain_schemas, self.model.ml_schema]:
-                schema = self.model.model.schemas.get(schema_name)
-                if schema:
-                    candidate_tables.extend(schema.tables.values())
-
+        # RIDs the probe strategy proves don't exist anywhere in the catalog.
+        # Tracked separately because they're removed from ``remaining_rids`` to
+        # keep the probe loop progressing, but must still surface in the final
+        # DerivaMLRidsNotFound.
+        missing_rids: set[RID] = set()
         pb = self.pathBuilder()
 
-        # Query each candidate table for matching RIDs
-        for table in candidate_tables:
-            if not remaining_rids:
-                break
+        def match_in_table(table: Table) -> None:
+            """Bulk-match ``remaining_rids`` against one table, recording hits.
 
+            The ``RID = Any(...)`` filter renders into the GET URL path, so a
+            single query over hundreds of RIDs overflows the server's request
+            URL limit. Chunk into URL-safe batches (``_MAX_RIDS_PER_QUERY``) and
+            union the matches; every matched RID is recorded and dropped from
+            ``remaining_rids``.
+            """
             schema_name = table.schema.name
             table_name = table.name
             table_path = pb.schemas[schema_name].tables[table_name]
-
-            # The ``RID = Any(...)`` filter renders into the GET URL path, so a
-            # single query over hundreds of RIDs overflows the server's request
-            # URL limit and fails. Chunk the remaining RIDs into URL-safe
-            # batches (``_MAX_RIDS_PER_QUERY``) and union the matches. Snapshot
-            # the RID list first because ``remaining_rids`` is mutated below.
             for rid_chunk in batched(list(remaining_rids), _MAX_RIDS_PER_QUERY):
                 # Filter: RID = any(rid1, rid2, ...) — ERMrest's IN clause.
                 # Query only the RID column to minimize data transfer.
@@ -214,18 +222,16 @@ class RidResolutionMixin:
                         .fetch()
                     )
                 except Exception as e:
-                    # Resilience across heterogeneous candidate tables: a query
-                    # that errors on one table shouldn't abort the whole scan —
-                    # the RIDs simply stay in ``remaining_rids`` and surface as a
-                    # legitimate DerivaMLRidsNotFound if no table matched them.
-                    # This is narrow now: the oversized-URL failure that used to
-                    # land here (and get masked into a spurious not-found) is
-                    # prevented by the chunking above, so an error reaching this
-                    # point is a genuine per-table condition, logged loudly.
+                    # Resilience: a query that errors on one candidate table
+                    # shouldn't abort the whole resolution — the RIDs stay in
+                    # ``remaining_rids`` and surface as a legitimate
+                    # DerivaMLRidsNotFound if nothing matches them. Narrow now:
+                    # the oversized-URL failure that used to land here (and get
+                    # masked into a spurious not-found) is prevented by the
+                    # chunking above, so an error here is a genuine per-table
+                    # condition, logged loudly.
                     logger.warning(f"RID resolution query failed for {schema_name}.{table_name}: {e}")
                     continue
-
-                # Process found RIDs
                 for entity in found_entities:
                     rid = entity["RID"]
                     if rid in remaining_rids:
@@ -237,13 +243,56 @@ class RidResolutionMixin:
                         )
                         remaining_rids.remove(rid)
 
-        # Check if any RIDs were not found. Raise the typed
-        # ``DerivaMLRidsNotFound`` so callers can pull the unresolved
-        # set off ``e.missing_rids`` without string-parsing the
-        # message — see ``DerivaML.validate_rids``, which previously
-        # had to grep the message for ``"Invalid RIDs:"`` because
-        # this raise site emitted a bare ``DerivaMLException``.
-        if remaining_rids:
-            raise DerivaMLRidsNotFound(remaining_rids)
+        if candidate_tables is not None:
+            # Caller already narrowed the search (e.g. dataset element types).
+            # Scan exactly those tables, bulk-matching in each.
+            for table in candidate_tables:
+                if not remaining_rids:
+                    break
+                match_in_table(table)
+        else:
+            # No candidate tables given. Rather than scan EVERY table in the
+            # domain + ML schemas (firing a zero-row query at each table that
+            # holds none of the RIDs), ask the server which table a sample RID
+            # lives in — ``resolve_rid`` hits ``/entity_rid`` and resolves
+            # catalog-wide in one cheap call — then bulk-match the rest there,
+            # and repeat. Cost is ~one probe per distinct table the RIDs span
+            # plus the chunk queries, independent of catalog size.
+            while remaining_rids:
+                probe_rid = next(iter(remaining_rids))
+                try:
+                    probe_table = self.resolve_rid(probe_rid).table
+                except DerivaMLException:
+                    # The probe RID doesn't exist anywhere in the catalog. Move
+                    # it to ``missing_rids`` (out of the working set so the loop
+                    # progresses) — it surfaces in the final
+                    # DerivaMLRidsNotFound. Don't abort: other RIDs may be valid
+                    # and in other tables.
+                    remaining_rids.discard(probe_rid)
+                    missing_rids.add(probe_rid)
+                    continue
+                before = len(remaining_rids)
+                match_in_table(probe_table)
+                # ``match_in_table`` removed every RID it found in
+                # ``probe_table``; ``probe_rid`` itself is guaranteed gone (the
+                # server placed it there), so progress is guaranteed and the
+                # loop terminates.
+                if len(remaining_rids) == before:  # pragma: no cover - defensive
+                    # Server resolved probe_rid to a table that the bulk match
+                    # didn't return it from (should not happen). Treat it as
+                    # unresolved to guarantee termination.
+                    remaining_rids.discard(probe_rid)
+                    missing_rids.add(probe_rid)
+
+        # Check if any RIDs were not found. ``remaining_rids`` holds anything no
+        # candidate table matched; ``missing_rids`` holds probes the server said
+        # don't exist. Raise the typed ``DerivaMLRidsNotFound`` so callers can
+        # pull the unresolved set off ``e.missing_rids`` without string-parsing
+        # the message — see ``DerivaML.validate_rids``, which previously had to
+        # grep the message for ``"Invalid RIDs:"`` because this raise site
+        # emitted a bare ``DerivaMLException``.
+        unresolved = remaining_rids | missing_rids
+        if unresolved:
+            raise DerivaMLRidsNotFound(unresolved)
 
         return results

--- a/src/deriva_ml/core/mixins/rid_resolution.py
+++ b/src/deriva_ml/core/mixins/rid_resolution.py
@@ -40,15 +40,21 @@ __all__ = [
 # Maximum number of RIDs placed in a single ``RID = Any(...)`` filter.
 #
 # That filter renders into the GET URL *path* (deriva-py datapath builds
-# ``base_uri + str(path_expression)`` and issues ``catalog.get(path)``), so the
-# request line grows ~13 bytes per RID (a 12-char RID + comma + urlquoting).
-# The front Apache rejects a request line over its ``LimitRequestLine`` (~4 KB
-# measured on localhost: 994 three-char RIDs succeed, 995 fail) *before ERMrest
-# sees it*. A cap of 200 keeps the filter ~2.6 KB even with worst-case 12-char
-# RIDs, leaving headroom for the path prefix. Without this, resolving a few
-# hundred+ RIDs in one shot overflowed the URL and the failure was silently
-# turned into a spurious "RIDs not found".
-_MAX_RIDS_PER_QUERY = 200
+# ``base_uri + str(path_expression)`` and issues ``catalog.get(path)``), so over
+# enough RIDs the request line exceeds the server's URI length limit and the
+# query fails (a 10k-RID URL is ~70 KB → HTTP 414). Without chunking, resolving
+# a few hundred+ RIDs in one shot overflowed the URL and the failure was
+# silently turned into a spurious "RIDs not found".
+#
+# 500 matches deriva-py's ``RID_SET_CHUNK_SIZE`` (its URL-safe batch size for
+# the bulk ``get_as_file(rid_set=...)`` path) — proven in production against
+# www.eye-ai.org's long-form RIDs (20 chunks of 500 fetched cleanly, no 414).
+# Kept in lockstep deliberately: both place ``RID=any(...)`` chunks in a GET URL
+# and share the same limit. (A stricter localhost Apache caps ~4 KB ≈ 994
+# three-char RIDs; production allows more, which is why 500 long RIDs is safe
+# there. The test environment uses short RIDs, so 500 is well under even the
+# localhost limit.)
+_MAX_RIDS_PER_QUERY = 500
 
 
 @dataclass

--- a/tests/core/test_rid_resolution.py
+++ b/tests/core/test_rid_resolution.py
@@ -115,6 +115,96 @@ class TestRidResolution:
         assert result.rid == dataset_rid
         assert result.table.name == "Dataset"
 
+    def test_resolve_rids_default_candidates_probes_not_scans(self, test_ml):
+        """With candidate_tables=None, resolve_rids discovers each RID's table
+        via the server (resolve_rid / /entity_rid) instead of scanning every
+        table in the catalog.
+
+        Pre-optimization, the default path looped over ALL tables in the domain
+        and ML schemas, firing a RID=any() query at each until the RIDs were
+        found — wasting a query per table that holds none of them. The probe
+        approach asks the server which table a sample RID lives in, then
+        bulk-matches the rest there, and repeats; so resolving RIDs that all
+        live in ONE table costs ~1 probe + the chunk queries, regardless of how
+        many tables the catalog has.
+
+        We count server round-trips (catalog.get) and require the resolve to
+        cost far fewer than the number of candidate tables it would otherwise
+        scan. RIDs come from freshly-inserted catalog rows, never literals.
+        """
+        ml_instance = test_ml
+
+        # How many tables the legacy scan would have walked.
+        n_tables = sum(
+            len(ml_instance.model.model.schemas[s].tables)
+            for s in [*ml_instance.model.domain_schemas, ml_instance.model.ml_schema]
+            if s in ml_instance.model.model.schemas
+        )
+        assert n_tables >= 5, "need a catalog with several tables to show scan avoidance"
+
+        pb = ml_instance.pathBuilder()
+        file_path = pb.schemas[ml_instance.ml_schema].tables["File"]
+        rows = [
+            {"URL": f"tag://probe,2026-06-24:file:///p/f{i}.txt", "MD5": f"{i:032x}", "Length": 1}
+            for i in range(50)
+        ]
+        rids = [r["RID"] for r in file_path.insert(rows)]
+
+        # Count server round-trips during the resolve.
+        get_calls = {"n": 0}
+        real_get = ml_instance.catalog.get
+
+        def counting_get(*args, **kwargs):
+            get_calls["n"] += 1
+            return real_get(*args, **kwargs)
+
+        ml_instance.catalog.get = counting_get
+        try:
+            results = ml_instance.resolve_rids(rids)  # candidate_tables=None → probe path
+        finally:
+            ml_instance.catalog.get = real_get
+
+        assert len(results) == len(rids)
+        assert all(r.table_name == "File" for r in results.values())
+        # All 50 RIDs are in ONE table (File), which sorts late in the scan
+        # order. The legacy scan fired a zero-row RID=any() query at every
+        # earlier table first (~22 requests on a stock catalog). The probe
+        # path costs ~1 server resolve + 1 chunk query = a small constant,
+        # independent of catalog size. Require that small constant — a bound
+        # the table-scan cannot meet.
+        assert get_calls["n"] <= 4, (
+            f"resolve_rids made {get_calls['n']} requests for 50 RIDs in a single table; "
+            f"the probe path should need ~2 (one /entity_rid resolve + one chunk query), "
+            f"not a per-table scan of up to {n_tables} tables."
+        )
+
+    def test_resolve_rids_probe_path_mixes_valid_and_invalid(self, test_ml):
+        """The probe (candidate_tables=None) path resolves valid RIDs and routes
+        an invalid one into the not-found set rather than aborting.
+
+        The probe loop samples a RID and resolves its table via the server. If
+        that sample happens to be the invalid RID, the server lookup fails — the
+        code must drop it into ``missing_rids`` and keep going so the valid RIDs
+        still resolve. This guards the regression introduced by the probe
+        rewrite (an unhandled invalid probe could either crash or, worse,
+        silently return without raising).
+        """
+        from deriva_ml.core.exceptions import DerivaMLRidsNotFound
+
+        ml_instance = test_ml
+        pb = ml_instance.pathBuilder()
+        file_path = pb.schemas[ml_instance.ml_schema].tables["File"]
+        rows = [
+            {"URL": f"tag://mix,2026-06-24:file:///m/f{i}.txt", "MD5": f"{i:032x}", "Length": 1}
+            for i in range(3)
+        ]
+        valid_rids = [r["RID"] for r in file_path.insert(rows)]
+
+        with pytest.raises(DerivaMLRidsNotFound) as exc_info:
+            ml_instance.resolve_rids(valid_rids + ["INVALID-RID-999"])
+        # Only the invalid RID is reported missing; the valid ones resolved.
+        assert exc_info.value.missing_rids == {"INVALID-RID-999"}
+
     def test_resolve_rids_large_batch_chunks_under_url_limit(self, test_ml):
         """resolve_rids resolves a large RID set by chunking its queries.
 

--- a/tests/core/test_rid_resolution.py
+++ b/tests/core/test_rid_resolution.py
@@ -2,7 +2,6 @@
 
 import pytest
 
-from deriva_ml import DerivaMLException
 from deriva_ml.core.mixins.rid_resolution import BatchRidResult
 
 
@@ -115,3 +114,39 @@ class TestRidResolution:
         result = ml_instance.resolve_rid(dataset_rid)
         assert result.rid == dataset_rid
         assert result.table.name == "Dataset"
+
+    def test_resolve_rids_large_batch_chunks_under_url_limit(self, test_ml):
+        """resolve_rids resolves a large RID set by chunking its queries.
+
+        A single ``RID = Any(*rids)`` filter goes into the GET URL path, so
+        for enough RIDs the request line exceeds the server's URL limit (the
+        front Apache rejects it before ERMrest sees it). Pre-fix, resolve_rids
+        issued ONE such query and a ``bare except: continue`` swallowed the
+        failure — every RID was reported as DerivaMLRidsNotFound even though
+        the rows exist. The fix chunks the query into URL-safe batches.
+
+        We insert well over the short-RID URL boundary (~994 three-char RIDs
+        ~= 4 KB) so the single-query path is guaranteed to overflow, then
+        resolve them all and require every one to come back. RIDs come from
+        the freshly-inserted catalog rows, never literals.
+        """
+        ml_instance = test_ml
+        pb = ml_instance.pathBuilder()
+        file_path = pb.schemas[ml_instance.ml_schema].tables["File"]
+
+        n = 1100  # comfortably past the ~994 short-RID single-query boundary
+        rows = [
+            {"URL": f"tag://chunktest,2026-06-24:file:///c/f{i}.txt", "MD5": f"{i:032x}", "Length": 1}
+            for i in range(n)
+        ]
+        inserted = list(file_path.insert(rows))
+        rids = [r["RID"] for r in inserted]
+        assert len(rids) == n
+
+        # All RIDs are real File rows — every one must resolve to the File
+        # table. On the pre-fix single-query path this raises
+        # DerivaMLRidsNotFound (the oversized URL fails and is swallowed).
+        candidate = [ml_instance.model.name_to_table("File")]
+        results = ml_instance.resolve_rids(rids, candidate_tables=candidate)
+        assert len(results) == n
+        assert all(r.table_name == "File" for r in results.values())

--- a/tests/core/test_rid_resolution.py
+++ b/tests/core/test_rid_resolution.py
@@ -126,15 +126,21 @@ class TestRidResolution:
         the rows exist. The fix chunks the query into URL-safe batches.
 
         We insert well over the short-RID URL boundary (~994 three-char RIDs
-        ~= 4 KB) so the single-query path is guaranteed to overflow, then
-        resolve them all and require every one to come back. RIDs come from
-        the freshly-inserted catalog rows, never literals.
+        ~= 4 KB on the localhost test server) so the pre-fix single-query path
+        is guaranteed to overflow, then resolve them all and require every one
+        to come back. The count is also > the chunk cap, so the fixed path is
+        forced to issue more than one query. RIDs come from the freshly-inserted
+        catalog rows, never literals.
         """
+        from deriva_ml.core.mixins.rid_resolution import _MAX_RIDS_PER_QUERY
+
         ml_instance = test_ml
         pb = ml_instance.pathBuilder()
         file_path = pb.schemas[ml_instance.ml_schema].tables["File"]
 
-        n = 1100  # comfortably past the ~994 short-RID single-query boundary
+        # Past BOTH the ~994 short-RID single-query overflow boundary (so the
+        # pre-fix path fails) AND the chunk cap (so the fix must split).
+        n = max(1100, _MAX_RIDS_PER_QUERY * 2 + 1)
         rows = [
             {"URL": f"tag://chunktest,2026-06-24:file:///c/f{i}.txt", "MD5": f"{i:032x}", "Length": 1}
             for i in range(n)


### PR DESCRIPTION
## Symptom

`exe.add_files(specs)` with a few-hundred+ file references (e.g. a ~1000-image-per-directory CIFAR load) dies with `DerivaMLRidsNotFound` listing **all the just-inserted File RIDs**, plus a `400 Bad Request — index row size exceeds btree maximum 2704`.

## Root cause (systematic diagnosis)

The chain is `add_files` → builds dataset → `add_dataset_members(members=~1000 RIDs)` → `resolve_rids(members)` to validate.

`resolve_rids` issued **one** `RID = Any(*remaining_rids)` query. That filter renders into the **GET URL path** (deriva-py `datapath`: `uri = base_uri + str(path_expression)`, fetched via `catalog.get(path)`), so for hundreds of RIDs the request line exceeds the server's URL limit — and the front Apache rejects the over-limit URI before ERMrest even sees it. The failure was then **silently swallowed** by `except Exception: continue` (logged at `debug` only), leaving every RID in `remaining_rids` → reported as `DerivaMLRidsNotFound`.

**Empirically measured** (binary search on a live localhost catalog): **994 three-char RIDs succeed, 995 fail** — ~4 KB URI. The limit is **bytes of URL, not count of RIDs**, so production's longer RIDs (`2-AB3C`-style) overflow at *a few hundred* — exactly the reported symptom.

**Read-after-write visibility is ruled out:** the existing 15-file `add_files` test inserts then immediately resolves successfully; the failure is size-dependent, not freshness-dependent.

**The btree-2704 400 is a red herring:** the execution state machine writing the giant ~1000-RID error *message* (~3.3 KB) into the indexed `Execution.Status_Detail` column — downstream of the real failure.

## Does deriva-py need changing? No.

deriva-py's `ErmrestCatalog.resolve_rid` is **single-RID** (`GET /entity_rid/<rid>` — one short URL, no `Any()` filter), so it has no scaling problem and is not in the bug path. The bug lived entirely in deriva-ml's `resolve_rids` (**plural**), a deriva-ml-only batched helper that builds the `RID=any(...)` filter itself. **No deriva-py change required.**

(deriva-py *does* already chunk `RID=any()` for its bulk `get_as_file(rid_set=...)` path via private helpers + `RID_SET_CHUNK_SIZE = 500`, but those are private and file-fetch-specific — no public "resolve a large RID set to tables" API exists to delegate to.)

## Fix

In `resolve_rids` (`rid_resolution.py`):
- **Chunk** the per-table `Any()` query with `itertools.batched(list(remaining_rids), _MAX_RIDS_PER_QUERY)` and union the matches.
- **`_MAX_RIDS_PER_QUERY = 500`**, deliberately matched to deriva-py's `RID_SET_CHUNK_SIZE` (same `RID=any()`-in-GET-URL mechanism, kept in lockstep). 500 is production-proven (deriva-py fetches eye-ai's long-form RIDs in chunks of 500 with no 414).
- **Un-mask failures:** the per-table `try/except` is kept (resilience across heterogeneous candidate tables — RIDs surface as a *legitimate* not-found) but raised from `debug` → `warning`. The oversized-URL failure it used to mask no longer occurs.

## Verification

- **End-to-end:** `exe.add_files(specs)` over **1000 real files** in one directory now builds a 1000-member dataset (against a live localhost catalog). Pre-fix it raised `DerivaMLRidsNotFound`.
- **Unit pin:** new `test_resolve_rids_large_batch_chunks_under_url_limit` inserts `max(1100, cap*2+1)` File rows (past both the ~994 single-query overflow boundary and the chunk cap) and requires all to resolve. Verified RED (raised `DerivaMLRidsNotFound` listing the inserted RIDs) → GREEN.
- **No regressions:** 5 passed / 1 skipped in `test_rid_resolution.py`; 13 passed in `test_file.py`. Lint clean (also removed a pre-existing unused import in the test file). Doctests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Follow-up (same PR): probe instead of scanning all tables

Per review, also fixed the latent inefficiency in the `candidate_tables=None` path.

**Before:** that path scanned **every** table in the domain + ML schemas, firing a zero-row `RID=any()` query at each table holding none of the RIDs. Measured: resolving 50 File RIDs cost **22–32 `catalog.get` calls** (File sorts late, so ~21–31 wasted zero-row queries fire first).

**After:** ask the server which table a sample RID lives in via `resolve_rid` (`/entity_rid`, catalog-wide, one call), bulk-match the rest there, repeat for RIDs in other tables. Cost ≈ one probe per **distinct** table the RIDs span + the chunk queries — independent of catalog size (**50-in-one-table: 32 → 2 calls**).

- The **explicit-candidate** path is unchanged (already targeted — `add_files` passes `[File]` and never paid the scan cost). The chunked bulk-match is factored into a shared `match_in_table` helper.
- An invalid probe RID is routed into a `missing_rids` set so `resolve_rids(["INVALID"])` still raises `DerivaMLRidsNotFound`.
- The `None` path now resolves **catalog-wide** (any schema), where the old scan only covered domain/ML — strictly more correct.

**Answers two design questions raised in review:** (1) yes, `resolve_rids` can and now does use `resolve_rid` to discover the table then bulk-match; (2) the two routines return mostly-equivalent info (both: `Table` + normalized RID), except deriva-py's `ResolveRidResult` also carries a per-RID `datapath` that `BatchRidResult` doesn't need.

**Pinned by** `test_resolve_rids_default_candidates_probes_not_scans` (≤4 calls for 50 RIDs in one table) and `test_resolve_rids_probe_path_mixes_valid_and_invalid`.