### PR TITLE
chore(deps): bump bdbag in lock to 1.9.0-dev HEAD

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -320,8 +320,8 @@ wheels = [
 
 [[package]]
 name = "bdbag"
-version = "1.9.0.dev0"
-source = { git = "https://github.com/fair-research/bdbag?rev=1.9.0-dev#4de3a48b2132afb7e0ee26768b745da5cfd6cbe6" }
+version = "1.9.0.dev1"
+source = { git = "https://github.com/fair-research/bdbag?rev=1.9.0-dev#8d65512307ddb9ea66f8a2c96115027bfdfb5907" }
 dependencies = [
     { name = "bagit" },
     { name = "bagit-profile" },


### PR DESCRIPTION
## Summary

Updates `uv.lock` to the latest available versions of the two git-tracked deps:

- **bdbag**: re-resolved the `1.9.0-dev` branch to its current HEAD — `4de3a48b` → `8d655123` (v1.9.0.dev0 → dev1). The branch had moved past the previously-locked commit.
- **deriva-py**: **already at the latest** on the branch it tracks. It's pinned to an immutable SHA `7df3e45e` in `pyproject.toml`, which equals `refs/heads/deriva-ml` HEAD on GitHub (verified via `git ls-remote`). Nothing newer exists on that branch, so the pin and lock are unchanged. (Note: deriva-py's `master` branch has diverged with 8 commits not on `deriva-ml`, but `deriva-ml` is the project's pin target by convention — see CLAUDE.md "Updating the deriva-py pin".)

Lock-only change; `pyproject.toml` is untouched (bdbag tracks the `1.9.0-dev` branch ref, so no spec edit is needed — only the resolved commit in the lock moves).

## Verification

- `uv sync` installed bdbag 1.9.0.dev1.
- deriva-ml imports cleanly against it; the `bdb.materialize` / `bdb.make_bag` API deriva-ml's bag download/build path depends on is intact.
- **120 passed / 5 skipped** in the no-catalog model + path-tree suites against the new bdbag — no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)