### PR TITLE
chore(deps): bump bdbag in lock to 1.9.0-dev HEAD (dev1 -> dev2)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -320,8 +320,8 @@ wheels = [
 
 [[package]]
 name = "bdbag"
-version = "1.9.0.dev1"
-source = { git = "https://github.com/fair-research/bdbag?rev=1.9.0-dev#8d65512307ddb9ea66f8a2c96115027bfdfb5907" }
+version = "1.9.0.dev2"
+source = { git = "https://github.com/fair-research/bdbag?rev=1.9.0-dev#bebcd1cedf44581e0078bfc97799da841ad38cd7" }
 dependencies = [
     { name = "bagit" },
     { name = "bagit-profile" },


### PR DESCRIPTION
Re-resolves `uv.lock` to the current HEAD of bdbag's `1.9.0-dev` branch — `8d655123` → `bebcd1ce` (v1.9.0.dev1 → dev2). The branch moved again; this picks it up.

Lock-only change. deriva-py is untouched (immutable SHA pin, already at `deriva-ml` branch HEAD).

**Verified:** deriva-ml imports cleanly against bdbag 1.9.0.dev2; `bdb.materialize` / `bdb.make_bag` intact; **483 passed / 9 skipped** in the no-catalog model + local_db + path-tree suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)