### PR TITLE
chore(deps): advance deriva-py pin to live deriva-ml HEAD (943bfa39)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     # "newer-than" signal, so consumers silently freeze on a stale deriva-py
     # (see CLAUDE.md "Updating the deriva-py pin"). Advance this SHA whenever
     # deriva-ml needs a newer deriva-py — and BEFORE every bump-version.
-    "deriva @ git+https://github.com/informatics-isi-edu/deriva-py@7df3e45eeea569c98746acedac8a67b723f21363",
+    "deriva @ git+https://github.com/informatics-isi-edu/deriva-py@943bfa394c8246ae379b4a15b3f7b615d7da1fdd",
     "deepdiff",
     "nbconvert",
     "pandas",
@@ -62,7 +62,7 @@ python-preference = "only-managed"
 # Keep this rev in lockstep with the SHA in project.dependencies above. uv
 # applies this source override locally; pinning the same immutable rev (not the
 # branch) keeps dev resolution identical to what consumers get transitively.
-deriva = { git = "https://github.com/informatics-isi-edu/deriva-py", rev = "7df3e45eeea569c98746acedac8a67b723f21363" }
+deriva = { git = "https://github.com/informatics-isi-edu/deriva-py", rev = "943bfa394c8246ae379b4a15b3f7b615d7da1fdd" }
 
 
 [tool.setuptools.package-data]

--- a/uv.lock
+++ b/uv.lock
@@ -853,7 +853,7 @@ wheels = [
 [[package]]
 name = "deriva"
 version = "2.0.0.dev0"
-source = { git = "https://github.com/informatics-isi-edu/deriva-py?rev=7df3e45eeea569c98746acedac8a67b723f21363#7df3e45eeea569c98746acedac8a67b723f21363" }
+source = { git = "https://github.com/informatics-isi-edu/deriva-py?rev=943bfa394c8246ae379b4a15b3f7b615d7da1fdd#943bfa394c8246ae379b4a15b3f7b615d7da1fdd" }
 dependencies = [
     { name = "bdbag" },
     { name = "fair-identifiers-client" },
@@ -928,7 +928,7 @@ requires-dist = [
     { name = "bdbag", git = "https://github.com/fair-research/bdbag?rev=1.9.0-dev" },
     { name = "bump-my-version" },
     { name = "deepdiff" },
-    { name = "deriva", git = "https://github.com/informatics-isi-edu/deriva-py?rev=7df3e45eeea569c98746acedac8a67b723f21363" },
+    { name = "deriva", git = "https://github.com/informatics-isi-edu/deriva-py?rev=943bfa394c8246ae379b4a15b3f7b615d7da1fdd" },
     { name = "hydra-zen" },
     { name = "nbconvert" },
     { name = "nbstripout" },


### PR DESCRIPTION
The deriva-py `deriva-ml` branch was **rebased**. The pinned SHA `7df3e45e` is now a **dangling commit** — not an ancestor of the new branch HEAD `943bfa39` — even though both point to the **identical tree** (`git diff 7df3e45e..943bfa39` is empty; the "new" commits are the same work with rewritten SHAs).

The current pin still installs identical content today, but a dangling SHA breaks if deriva-py ever GCs the orphaned commit. This repoints **both** pin locations (`project.dependencies` and `[tool.uv.sources]`) to the live branch HEAD `943bfa39`.

**No deriva-py code change ships** — same content, just a live (non-dangling) ref. Lock re-resolved to match.

**Verified:** deriva-ml + deriva-py import at the new pin; **120 passed / 5 skipped** in the no-catalog suites.

This is the mandatory pre-bump pin refresh (CLAUDE.md "Updating the deriva-py pin").

🤖 Generated with [Claude Code](https://claude.com/claude-code)