### PR TITLE
feat(auth): add DerivaML.is_authenticated() and whoami()

### DIFF
--- a/src/deriva_ml/core/base.py
+++ b/src/deriva_ml/core/base.py
@@ -454,13 +454,14 @@ class DerivaML(
         working directory reads the JSON we write here. Online mode
         never reads it back.
 
-        No pre-flight auth probe: the legacy ``/authn/session`` endpoint
-        that deriva-py's ``get_authn_session()`` calls is not exposed by
-        credenza, which is now the only supported auth backend.
-        Authentication failures surface as 401s on the first real
-        ermrest call (``getCatalogSchema()`` below) — accurate and
-        source-true, instead of a synthetic "you are not authorized"
-        wrapper masking the real cause.
+        No pre-flight auth probe *here*: ``_init_online`` does not gate
+        construction on a session — authentication failures surface as
+        401s on the first real ermrest call (``getCatalogSchema()``
+        below), source-true rather than a synthetic wrapper. (Callers who
+        want an explicit, friendly check before doing work can use
+        :meth:`is_authenticated` / :meth:`whoami`, which DO hit
+        ``GET /authn/session`` and return a clean result — verified
+        returning 200 + the client identity on current servers.)
         """
         from deriva_ml.model.catalog import DerivaModel
 
@@ -804,6 +805,75 @@ class DerivaML(
             True if the underlying catalog has a snapshot timestamp, False otherwise.
         """
         return hasattr(self.catalog, "_snaptime")
+
+    def whoami(self) -> dict | None:
+        """Return the authenticated client identity, or ``None`` if not logged in.
+
+        Asks the **server** for the current session via
+        ``GET /authn/session`` (deriva-py's
+        :meth:`~deriva.core.ErmrestCatalog.get_authn_session`). On a valid
+        session the server returns the logged-in client, and this returns that
+        ``client`` dict (``id``, ``display_name``, ``email``, ``full_name``,
+        ``identities``). When there is no session the endpoint returns 401/404
+        and this returns ``None``.
+
+        This makes a network call. A successful (non-``None``) result is a safe
+        bet that catalog operations will work — it proves the credential is
+        present, unexpired, and accepted by the server's auth layer (the thing
+        that otherwise blanket-401s). It confirms *authentication* (the server
+        knows who you are), not *authorization* for any specific operation — a
+        write to a read-only table can still be refused with a valid session.
+
+        Returns:
+            dict | None: The ``client`` identity dict, or ``None`` if there is
+                no authenticated session.
+
+        Raises:
+            requests.exceptions.HTTPError: For HTTP errors other than 401/404
+                (e.g. a 5xx server error) — these are real failures, not a
+                "no session" answer, so they propagate.
+
+        Example:
+            >>> who = ml.whoami()  # doctest: +SKIP
+            >>> who["display_name"] if who else "not logged in"  # doctest: +SKIP
+            'user@example.org'
+        """
+        from requests.exceptions import HTTPError
+
+        try:
+            session = self.catalog.get_authn_session()
+        except HTTPError as e:
+            # 401 (classic webauthn) and 404 (no session on the current backend)
+            # both mean "not authenticated". Anything else is a real error.
+            if e.response is not None and e.response.status_code in (401, 404):
+                return None
+            raise
+        return session.json().get("client")
+
+    def is_authenticated(self) -> bool:
+        """Whether there is a valid authenticated session for this catalog.
+
+        Thin boolean over :meth:`whoami`: ``True`` if the server returns a
+        client identity (``GET /authn/session`` → 200), ``False`` if there is no
+        session (401/404). Makes one network call.
+
+        A ``True`` result is a safe bet that catalog operations will work (the
+        credential is accepted by the server). It means "I am logged in," not
+        "every privileged operation will pass ACLs" — see :meth:`whoami` for the
+        authentication-vs-authorization distinction.
+
+        Returns:
+            bool: True if authenticated, False otherwise.
+
+        Raises:
+            requests.exceptions.HTTPError: For non-auth HTTP errors (propagated
+                from :meth:`whoami`).
+
+        Example:
+            >>> if not ml.is_authenticated():  # doctest: +SKIP
+            ...     raise SystemExit("Log in first: deriva-globus-auth-utils login --host ...")
+        """
+        return self.whoami() is not None
 
     def catalog_snapshot(self, version_snapshot: str) -> Self:
         """Return a new DerivaML instance connected to a specific catalog snapshot.

--- a/tests/core/test_base.py
+++ b/tests/core/test_base.py
@@ -367,3 +367,106 @@ def test_catalog_snapshot_forwards_connection_kwargs():
     # The schema-reuse fast path (perf spec §3.1) forwards the parent's
     # already-parsed schema so the snapshot skips its own /schema fetch.
     assert captured["reuse_schema_json"] == {"schemas": {}}
+
+
+# ---------------------------------------------------------------------------
+# is_authenticated / whoami — session check via the server-level
+# get_authn_session() (GET /authn/session). 200+client → authenticated;
+# 401/404 → not. Pure unit tests: the catalog binding is mocked so both
+# the success and no-session paths are deterministic with no live server.
+# ---------------------------------------------------------------------------
+
+
+def _ml_with_mock_catalog(catalog):
+    """A DerivaML instance with only its ``catalog`` attribute set.
+
+    Built via ``__new__`` to bypass ``__init__`` (no network) — these tests
+    exercise only the auth methods, which touch ``self.catalog``.
+    """
+    from deriva_ml.core.base import DerivaML
+
+    ml = DerivaML.__new__(DerivaML)
+    ml.catalog = catalog
+    return ml
+
+
+def test_whoami_returns_client_identity_when_session_valid():
+    """whoami() returns the server's ``client`` identity dict on a 200."""
+    from unittest.mock import MagicMock
+
+    client = {
+        "id": "https://auth.globus.org/abc",
+        "display_name": "user@example.org",
+        "full_name": "Example User",
+        "email": "user@example.org",
+        "identities": [],
+    }
+    resp = MagicMock()
+    resp.json.return_value = {"client": client, "seconds_remaining": 3600}
+    catalog = MagicMock()
+    catalog.get_authn_session.return_value = resp
+
+    ml = _ml_with_mock_catalog(catalog)
+    who = ml.whoami()
+
+    assert who == client
+    catalog.get_authn_session.assert_called_once()
+
+
+def test_whoami_returns_none_when_no_session():
+    """whoami() returns None when /authn/session 404s (no session)."""
+    from unittest.mock import MagicMock
+
+    from requests.exceptions import HTTPError
+
+    err = HTTPError()
+    err.response = MagicMock(status_code=404)
+    catalog = MagicMock()
+    catalog.get_authn_session.side_effect = err
+
+    ml = _ml_with_mock_catalog(catalog)
+    assert ml.whoami() is None
+
+
+def test_is_authenticated_true_when_session_valid():
+    """is_authenticated() is True when a session resolves."""
+    from unittest.mock import MagicMock
+
+    resp = MagicMock()
+    resp.json.return_value = {"client": {"id": "x"}}
+    catalog = MagicMock()
+    catalog.get_authn_session.return_value = resp
+
+    ml = _ml_with_mock_catalog(catalog)
+    assert ml.is_authenticated() is True
+
+
+def test_is_authenticated_false_on_401_and_404():
+    """is_authenticated() is False for both 401 and 404 (no session)."""
+    from unittest.mock import MagicMock
+
+    from requests.exceptions import HTTPError
+
+    for status in (401, 404):
+        err = HTTPError()
+        err.response = MagicMock(status_code=status)
+        catalog = MagicMock()
+        catalog.get_authn_session.side_effect = err
+        ml = _ml_with_mock_catalog(catalog)
+        assert ml.is_authenticated() is False, f"status {status} should be not-authenticated"
+
+
+def test_is_authenticated_reraises_unexpected_http_error():
+    """A non-auth HTTPError (e.g. 500) propagates — not swallowed as 'not authed'."""
+    from unittest.mock import MagicMock
+
+    from requests.exceptions import HTTPError
+
+    err = HTTPError()
+    err.response = MagicMock(status_code=500)
+    catalog = MagicMock()
+    catalog.get_authn_session.side_effect = err
+
+    ml = _ml_with_mock_catalog(catalog)
+    with pytest.raises(HTTPError):
+        ml.is_authenticated()


### PR DESCRIPTION
Adds two public methods to `DerivaML` for checking the authenticated session, using the mechanism Carl identified: `GET /authn/session` returning 200 + a client identity means you're logged in and catalog ops should work.

## API

- **`whoami() -> dict | None`** — the primitive. Calls `catalog.get_authn_session()` (server-level `GET /authn/session`). Returns the server's `client` identity dict (`id`, `display_name`, `email`, `full_name`, `identities`) on a 200; `None` when there's no session (401/404). Other HTTP errors (e.g. 5xx) propagate — they're real failures, not "no session".
- **`is_authenticated() -> bool`** — thin boolean: `whoami() is not None`. One network call.

Both are **methods** (not properties), since they do network I/O. `whoami` is the single round-trip; `is_authenticated` derives from it.

**Semantics (documented):** a `True`/non-`None` result is a safe bet catalog ops will work — it proves the credential is present, unexpired, and accepted by the server's auth layer (the thing that otherwise blanket-401s). It confirms **authentication** (the server knows who you are), not per-op **authorization** — a write to a read-only table can still 403 with a valid session.

## Also: fixes a stale comment

The `_init_online` comment (base.py:458) claimed `/authn/session` is "not exposed by credenza." Verified that's **wrong** on current servers — `get_authn_session()` returns 200 + identity on dev/www.eye-ai.org and localhost. Replaced with an accurate note pointing at these new methods for a friendly pre-check.

## Verification

5 pure-unit tests (mock `get_authn_session`: 200→client dict / True, 404→None, 401&404→False, 500→re-raise) — no live catalog, deterministic. **18 passed** in `test_base.py`; zero new lint; doctests collect (examples are `+SKIP`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)