### PR TITLE
fix(dataset): find_datasets_referencing excludes soft-deleted datasets (#355)

### DIFF
--- a/src/deriva_ml/core/mixins/dataset.py
+++ b/src/deriva_ml/core/mixins/dataset.py
@@ -267,7 +267,9 @@ class DatasetMixin:
         """
         return self.model.list_dataset_element_types()
 
-    def find_datasets_referencing(self, table: str | Table, column: str | None = None) -> list[DatasetReference]:
+    def find_datasets_referencing(
+        self, table: str | Table, column: str | None = None, deleted: bool = False
+    ) -> list[DatasetReference]:
         """Find the datasets impacted by a change to ``table`` (schema-evolution impact analysis).
 
         Answers the catalog-evolver question "what breaks if I change
@@ -281,15 +283,24 @@ class DatasetMixin:
         narrow the result; pair the two methods for a full impact
         report.
 
-        One bulk query per call: the association table's dataset FK
-        column is fetched once and grouped in memory (same pattern as
-        the asset bulk reads).
+        Soft-deleted datasets are **excluded by default**, so this surface
+        agrees with :meth:`find_datasets` and :meth:`lookup_dataset` (both
+        default-exclude ``Deleted`` datasets). A soft delete keeps the
+        membership junction rows, so an association-only query would otherwise
+        report datasets that ``lookup_dataset`` then refuses (issue #355). Pass
+        ``deleted=True`` to include tombstoned datasets.
+
+        One bulk query for the members, plus one bulk query for the datasets'
+        ``Deleted`` status (skipped when ``deleted=True``).
 
         Args:
             table: Name of the table (str) or ``Table`` object to check.
             column: Optional column name, accepted for API symmetry.
                 Dataset impact is table-granular, so this does not
                 narrow the result.
+            deleted: If True, include soft-deleted datasets. Defaults to False
+                (soft-deleted datasets are excluded), matching
+                :meth:`find_datasets` / :meth:`lookup_dataset`.
 
         Returns:
             One :class:`DatasetReference` per dataset with members in
@@ -319,6 +330,20 @@ class DatasetMixin:
         for row in apath.attributes(apath.columns[dataset_col]).fetch():
             rid = row[dataset_col]
             counts[rid] = counts.get(rid, 0) + 1
+
+        if not deleted and counts:
+            # Drop soft-deleted datasets so this surface agrees with
+            # find_datasets / lookup_dataset. The membership junctions persist
+            # after a soft delete, so the counts above can include tombstoned
+            # datasets. One bulk read of the Dataset table's Deleted column.
+            dpath = pb.schemas[self._dataset_table.schema.name].tables[self._dataset_table.name]
+            deleted_rids = {
+                row["RID"]
+                for row in dpath.attributes(dpath.RID, dpath.Deleted).fetch()
+                if row.get("Deleted")
+            }
+            counts = {rid: n for rid, n in counts.items() if rid not in deleted_rids}
+
         return [
             DatasetReference(dataset_rid=rid, element_table=target.name, member_count=n)
             for rid, n in sorted(counts.items())

--- a/tests/dataset/test_impact.py
+++ b/tests/dataset/test_impact.py
@@ -48,6 +48,57 @@ class TestFindDatasetsReferencing:
         by_column = impact_ml.find_datasets_referencing("Image", column="URL")
         assert {r.dataset_rid for r in by_column} == {r.dataset_rid for r in by_table}
 
+    @staticmethod
+    def _soft_delete_an_image_dataset(impact_ml):
+        """Soft-delete one Image-referencing dataset; return its RID.
+
+        Sets ``Deleted=true`` directly on the Dataset row (what a soft delete
+        does at the data level), which keeps the membership junction rows — the
+        exact state that made #355's association-only query leak the dataset.
+        Done via the path-builder rather than ``delete_dataset`` so the test is
+        independent of that method's nesting guard (the demo datasets are
+        nested).
+        """
+        refs = impact_ml.find_datasets_referencing("Image")
+        assert refs, "fixture must have Image-referencing datasets"
+        victim = refs[0].dataset_rid
+
+        pb = impact_ml.pathBuilder()
+        ds_table = pb.schemas[impact_ml._dataset_table.schema.name].tables[impact_ml._dataset_table.name]
+        ds_table.update([{"RID": victim, "Deleted": True}])
+
+        # Sanity: it is now soft-deleted (lookup_dataset refuses it by default).
+        from deriva_ml import DerivaMLException
+
+        try:
+            impact_ml.lookup_dataset(victim)
+            raise AssertionError("victim should be soft-deleted (lookup_dataset should refuse it)")
+        except DerivaMLException:
+            pass
+        return victim
+
+    def test_soft_deleted_datasets_excluded_by_default(self, impact_ml):
+        """A soft-deleted dataset must NOT appear in the default result — it
+        agrees with find_datasets / lookup_dataset, which default-exclude
+        deleted datasets. Junction rows persist after a soft delete, so the
+        association-only query would otherwise leak the deleted dataset (#355).
+        """
+        victim = self._soft_delete_an_image_dataset(impact_ml)
+
+        # Default: the soft-deleted dataset is gone; the surface now agrees
+        # with lookup_dataset (which raises for the same RID).
+        default_rids = {r.dataset_rid for r in impact_ml.find_datasets_referencing("Image")}
+        assert victim not in default_rids, "soft-deleted dataset must be excluded by default"
+
+    def test_soft_deleted_datasets_included_with_flag(self, impact_ml):
+        """``deleted=True`` opts back into soft-deleted datasets — the
+        impact-analysis 'what still references this row, even in tombstoned
+        datasets' use case."""
+        victim = self._soft_delete_an_image_dataset(impact_ml)
+
+        with_deleted = {r.dataset_rid for r in impact_ml.find_datasets_referencing("Image", deleted=True)}
+        assert victim in with_deleted, "deleted=True must include soft-deleted datasets"
+
 
 class TestFindFeaturesReferencing:
     def test_features_on_target_table(self, impact_ml):


### PR DESCRIPTION
Closes #355.

## The bug

`find_datasets_referencing(table)` enumerated dataset RIDs from the membership association table (`Dataset_<Table>`) only — it never joined to `Dataset.Deleted`. A soft delete sets `Deleted=true` but **keeps the junction rows**, so soft-deleted datasets leaked into the result, while `lookup_dataset(rid)` and `find_datasets()` both **default-exclude** them.

A pipeline that does the natural thing — enumerate with `find_datasets_referencing`, then operate via `lookup_dataset` — crashes on the first soft-deleted dataset. Real case from the issue: a catalog-wide re-versioning got 131 RIDs, 36 soft-deleted, and died on the first one. The `Deleted` flag is invisible at that API layer, so it looked like referential corruption.

## The fix

Added `deleted: bool = False` to `find_datasets_referencing`. The default now bulk-reads `Dataset.RID,Deleted` and drops soft-deleted RIDs (one extra bulk query, skipped when `deleted=True`). All three surfaces now agree:

| Surface | Default |
|---|---|
| `find_datasets(deleted=False)` | excludes soft-deleted |
| `lookup_dataset(..., deleted=False)` | excludes soft-deleted |
| `find_datasets_referencing(..., deleted=False)` | **now** excludes soft-deleted |

**Naming:** used `deleted=` (matching the two siblings) rather than the issue's suggested `include_deleted=` — one param name across the trio, same semantics.

## Verification

Two new tests in `test_impact.py`: `test_soft_deleted_datasets_excluded_by_default` (RED confirmed the leak — `'5R0'` present in the default result — → GREEN) and `test_soft_deleted_datasets_included_with_flag`. Full impact suite: **9 passed**. Lint clean; doctests pass.

(Test note: `delete_dataset` refuses nested datasets and the demo fixture's Image datasets are all nested, so the test soft-deletes by setting `Deleted=True` on the row directly — what a soft delete does at the data layer, keeping the junctions that trigger the bug.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)