### PR TITLE
chore(deps): advance deriva-py pin to 0913e84 (bag mirror all-NULL unique-column fix, #285)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     # "newer-than" signal, so consumers silently freeze on a stale deriva-py
     # (see CLAUDE.md "Updating the deriva-py pin"). Advance this SHA whenever
     # deriva-ml needs a newer deriva-py — and BEFORE every bump-version.
-    "deriva @ git+https://github.com/informatics-isi-edu/deriva-py@c93e71e480e2ef501ed58077e5fff3705bcdb5a1",
+    "deriva @ git+https://github.com/informatics-isi-edu/deriva-py@0913e84959f34129c7d502c8416b72ad140c9924",
     "deepdiff",
     "nbconvert",
     "pandas",
@@ -62,7 +62,7 @@ python-preference = "only-managed"
 # Keep this rev in lockstep with the SHA in project.dependencies above. uv
 # applies this source override locally; pinning the same immutable rev (not the
 # branch) keeps dev resolution identical to what consumers get transitively.
-deriva = { git = "https://github.com/informatics-isi-edu/deriva-py", rev = "c93e71e480e2ef501ed58077e5fff3705bcdb5a1" }
+deriva = { git = "https://github.com/informatics-isi-edu/deriva-py", rev = "0913e84959f34129c7d502c8416b72ad140c9924" }
 
 
 [tool.setuptools.package-data]

--- a/uv.lock
+++ b/uv.lock
@@ -853,7 +853,7 @@ wheels = [
 [[package]]
 name = "deriva"
 version = "2.0.0.dev0"
-source = { git = "https://github.com/informatics-isi-edu/deriva-py?rev=c93e71e480e2ef501ed58077e5fff3705bcdb5a1#c93e71e480e2ef501ed58077e5fff3705bcdb5a1" }
+source = { git = "https://github.com/informatics-isi-edu/deriva-py?rev=0913e84959f34129c7d502c8416b72ad140c9924#0913e84959f34129c7d502c8416b72ad140c9924" }
 dependencies = [
     { name = "bdbag" },
     { name = "fair-identifiers-client" },
@@ -929,7 +929,7 @@ requires-dist = [
     { name = "bdbag", git = "https://github.com/fair-research/bdbag?rev=1.9.0-dev" },
     { name = "bump-my-version" },
     { name = "deepdiff" },
-    { name = "deriva", git = "https://github.com/informatics-isi-edu/deriva-py?rev=c93e71e480e2ef501ed58077e5fff3705bcdb5a1" },
+    { name = "deriva", git = "https://github.com/informatics-isi-edu/deriva-py?rev=0913e84959f34129c7d502c8416b72ad140c9924" },
     { name = "hydra-zen" },
     { name = "nbconvert" },
     { name = "nbstripout" },


### PR DESCRIPTION
## Summary

Advances the deriva-py pin **c93e71e → 0913e84** in both `project.dependencies` and `[tool.uv.sources]` (kept in lockstep), plus the matching `uv.lock` update.

## Why

The three new deriva-py commits fix **deriva-py #285**, which is the real root cause of the GLEAM multi-image `commit_output_assets` failure tracked in **deriva-ml #357**:

- **`de7bd2d` fix(bag): mirror drops N≥2 asset rows when a nullable unique column is all-NULL.** Bag CSVs serialize NULL as `""`; SQLite (unlike ERMrest/Postgres) treats `""` as comparable in unique indexes. An asset table with a nullable UNIQUE column that is NULL across a batch (e.g. `eye-ai:Image.Image_ID`) collided on `""`, and `SQLiteSink`'s `on_conflict="ignore"` silently dropped every row after the first. The loader then loaded 1 of N asset rows, and the association tables FK-referenced asset RIDs the destination never received → `Key (Image)=(...) is not present in table "Image"`. **N=1 can never collide — which is why every single-asset commit (and single-image repro) passed.** Fix coerces `""`→NULL on nullable columns before the mirror insert, returns the true inserted count, and WARNs when the conflict policy drops rows.
- **`b19a80e` fix(bag):** mirror conflicts fail loudly except legitimate PK dedup.
- **`0913e84` test(bag):** production-shaped commit-bag fixture (#285 postmortem).

Verified upstream against the actual failing bag (execution 7-B6V0, 5 images): pre-fix 1/5 Image rows loaded; post-fix all 5 load and both associations reference valid destination RIDs.

## Verification

- Clean fast-forward: `0913e84` = current pin `c93e71e` + 3 commits, no rebase.
- `uv lock && uv sync` clean; both pin locations carry the new SHA, no stale `c93e71e`.
- Tests: **576 passed, 9 skipped** (`tests/local_db tests/asset tests/model tests/execution/test_bag_commit_unit.py`) against the new pin.

Closes the deriva-ml side of #357 (fixed-by-pin; upstream dup of deriva-py #285).

🤖 Generated with [Claude Code](https://claude.com/claude-code)