### PR TITLE
feat(annotations): facet feature tables on the producing workflow

### DIFF
--- a/backfill_feature_annotations.py
+++ b/backfill_feature_annotations.py
@@ -1,0 +1,122 @@
+"""Backfill the standard feature-table annotation across an eye-ai catalog.
+
+``feature_annotation()`` only runs at ``create_feature()`` time, so feature
+tables that predate it (8 of 10 on eye-ai) carry no visible-columns annotation
+at all. This re-applies the current standard annotation — including the new
+Workflow / Workflow Name / Workflow Type provenance facets — to every feature
+table.
+
+Target resolution: the ``Execution_<Target>_<Feature>`` naming convention picks
+the target FK for 8 tables. ``find_features()`` is NOT used for this because it
+mis-reports the target on multi-FK tables (it returns ``Image_Side`` for
+``Execution_Subject_Chart_Label``, whose real target is ``Subject``). The two
+tables that predate the naming convention are resolved from an explicit map.
+
+Usage:
+    # Show the diff without writing anything (default):
+    uv run python backfill_feature_annotations.py --host dev.eye-ai.org --catalog 2073
+
+    # Actually write:
+    uv run python backfill_feature_annotations.py --host dev.eye-ai.org --catalog 2073 --apply
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from unittest.mock import patch
+
+from deriva.core import tag as deriva_tags
+
+from deriva_ml import DerivaML
+from deriva_ml.schema.annotations import feature_annotation
+
+SCHEMA = "eye-ai"
+
+# Feature tables whose name predates the Execution_<Target>_<Feature> convention.
+# Both plainly target Image (they carry an Image FK + Feature_Name + Execution).
+LEGACY_TARGETS = {
+    "Annotation": "Image",
+    "Image_Diagnosis": "Image",
+}
+
+
+def resolve_target(table) -> str | None:
+    """Return the feature table's target-table FK column name, or None."""
+    if table.name in LEGACY_TARGETS:
+        return LEGACY_TARGETS[table.name]
+    if not table.name.startswith("Execution_"):
+        return None
+    rest = table.name[len("Execution_") :]
+    for fk in table.foreign_keys:
+        col = fk.columns[0].name
+        if col in ("RCB", "RMB", "Execution", "Feature_Name"):
+            continue
+        # The target is the FK whose column name prefixes the <Feature> segment.
+        if rest.startswith(col + "_"):
+            return col
+    return None
+
+
+def is_feature_table(table) -> bool:
+    cols = {c.name for c in table.columns}
+    return {"Execution", "Feature_Name"} <= cols
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--host", required=True)
+    ap.add_argument("--catalog", required=True)
+    ap.add_argument("--apply", action="store_true", help="write to the catalog (default: dry run)")
+    args = ap.parse_args()
+
+    ml = DerivaML(args.host, catalog_id=args.catalog, default_schema=SCHEMA)
+    model = ml.model
+
+    targets = []
+    for table in model.schemas[SCHEMA].tables.values():
+        if not is_feature_table(table):
+            continue
+        target = resolve_target(table)
+        if target is None:
+            print(f"  SKIP {table.name}: cannot resolve target table", file=sys.stderr)
+            continue
+        targets.append((table, target))
+
+    print(f"{'=' * 78}\n{args.host}/{args.catalog} — {len(targets)} feature tables\n{'=' * 78}")
+
+    changed = 0
+    for table, target in sorted(targets, key=lambda t: t[0].name):
+        # Deep-copy the pre-state: feature_annotation mutates table.annotations
+        # in place, so a shallow reference would compare equal to itself and
+        # report every table as "unchanged".
+        before = json.loads(json.dumps(table.annotations.get(deriva_tags.visible_columns, {})))
+        had_annotation = bool(before)
+
+        # Build the annotation in memory. model.apply() is blocked unless --apply.
+        if args.apply:
+            feature_annotation(table, target)
+        else:
+            with patch.object(type(model), "apply", lambda self, *a, **k: None):
+                feature_annotation(table, target)
+
+        after = table.annotations.get(deriva_tags.visible_columns, {})
+        facets = [f.get("markdown_name", f.get("source")) for f in after["filter"]["and"]]
+        had = "yes" if had_annotation else "NO (unannotated)"
+        status = "unchanged" if before == after else "UPDATED"
+        if before != after:
+            changed += 1
+        print(f"\n{table.name}  (target={target})")
+        print(f"  had annotation: {had}   -> {status}")
+        print(f"  facets: {' | '.join(str(f) for f in facets)}")
+
+    verb = "APPLIED to" if args.apply else "would change"
+    print(f"\n{'=' * 78}\n{verb} {changed}/{len(targets)} tables")
+    if not args.apply:
+        print("Dry run — nothing written. Re-run with --apply to write.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backfill_feature_annotations.py
+++ b/backfill_feature_annotations.py
@@ -7,10 +7,13 @@ Workflow / Workflow Name / Workflow Type provenance facets — to every feature
 table.
 
 Target resolution: the ``Execution_<Target>_<Feature>`` naming convention picks
-the target FK for 8 tables. ``find_features()`` is NOT used for this because it
-mis-reports the target on multi-FK tables (it returns ``Image_Side`` for
-``Execution_Subject_Chart_Label``, whose real target is ``Subject``). The two
-tables that predate the naming convention are resolved from an explicit map.
+the target FK. ``find_features()`` is NOT used for this because it mis-reports
+the target on multi-FK tables (it returns ``Image_Side`` for
+``Execution_Subject_Chart_Label``, whose real target is ``Subject``).
+
+Tables that don't follow the convention are skipped with a warning rather than
+guessed at. On eye-ai the only two non-conforming tables (``Annotation``,
+``Image_Diagnosis``) are slated for deletion, so skipping them is correct.
 
 Usage:
     # Show the diff without writing anything (default):
@@ -34,18 +37,14 @@ from deriva_ml.schema.annotations import feature_annotation
 
 SCHEMA = "eye-ai"
 
-# Feature tables whose name predates the Execution_<Target>_<Feature> convention.
-# Both plainly target Image (they carry an Image FK + Feature_Name + Execution).
-LEGACY_TARGETS = {
-    "Annotation": "Image",
-    "Image_Diagnosis": "Image",
-}
-
 
 def resolve_target(table) -> str | None:
-    """Return the feature table's target-table FK column name, or None."""
-    if table.name in LEGACY_TARGETS:
-        return LEGACY_TARGETS[table.name]
+    """Return the feature table's target-table FK column name, or None.
+
+    Only the ``Execution_<Target>_<Feature>`` convention is honored. A table
+    that doesn't conform returns None and is skipped — guessing the target
+    would annotate the row-name and target facet against the wrong column.
+    """
     if not table.name.startswith("Execution_"):
         return None
     rest = table.name[len("Execution_") :]

--- a/src/deriva_ml/schema/annotations.py
+++ b/src/deriva_ml/schema/annotations.py
@@ -15,7 +15,8 @@ Public entry points:
 from deriva.core.ermrest_model import Model, Table
 from deriva.core.utils.core_utils import tag as deriva_tags
 
-from deriva_ml.core.constants import DerivaAssetColumns
+from deriva_ml.core.constants import ML_SCHEMA, DerivaAssetColumns
+from deriva_ml.core.exceptions import DerivaMLException
 from deriva_ml.core.upload_layout import bulk_upload_configuration
 from deriva_ml.model.catalog import DerivaModel
 
@@ -446,7 +447,19 @@ def feature_annotation(feature_table: Table, target_table_name: str) -> None:
     * **visible-columns** leads with the target, the feature's own value/term/asset
       columns, then the producing Execution (provenance) and audit columns;
     * **facets** on the target, the feature's term columns (the natural
-      "show me all rows labelled X" axis), and the producing Execution.
+      "show me all rows labelled X" axis), the producing Execution, and the
+      workflow behind that execution (RID, name, and type).
+
+    **Workflow facets** let a user select feature values by *what produced them*
+    rather than only by the value itself ("show me every Chart_Label from a
+    Prediction-type workflow"). Three facets ride the provenance FK chain:
+
+    * *Workflow* — ``Execution -> Workflow``, faceted on RID;
+    * *Workflow Name* — the same hop faceted on ``Workflow.Name``, the
+      human-readable axis (``Workflow`` has no ``Workflow_Type`` column);
+    * *Workflow Type* — ``Workflow_Type`` is a **many-to-many** behind the
+      ``Workflow_Workflow_Type`` association, so this facet is a 4-hop
+      outbound/inbound/outbound path rather than a plain FK chain.
 
     Mutates ``feature_table.annotations`` and applies the model.
 
@@ -454,9 +467,37 @@ def feature_annotation(feature_table: Table, target_table_name: str) -> None:
         feature_table: The ``Execution_<Target>_<Feature>`` association table.
         target_table_name: Name of the feature's target table (its FK column on
             the feature table — e.g. ``"Subject"`` or ``"Image"``).
+
+    Raises:
+        DerivaMLException: If the feature table has no outbound FK to
+            ``Execution`` or to ``target_table_name`` — without those the
+            provenance facets can't be built.
     """
     schema = feature_table.schema.name
     fname = feature_table.name
+
+    # Resolve FK constraint names from the MODEL rather than interpolating
+    # f"{fname}_Execution_fkey". Postgres truncates constraint names past 63
+    # chars and ERMrest appends a hash — e.g.
+    # "Execution_Obs.._Glaucoma_Diagnosis_fkey_hQUme". Those truncated names
+    # differ per catalog (dev and prod carry *different* hashes for the same
+    # logical FK), so a constructed name silently produces a dead facet.
+    def _fkey_name_to(pk_table_name: str, from_column: str) -> str | None:
+        """Return the constraint name of feature_table's FK on ``from_column``."""
+        for fk in feature_table.foreign_keys:
+            cols = [c.name for c in fk.columns]
+            if cols == [from_column] and fk.pk_table.name == pk_table_name:
+                return fk.constraint_name
+        return None
+
+    execution_fkey = _fkey_name_to("Execution", "Execution")
+    target_fkey = _fkey_name_to(target_table_name, target_table_name)
+    if execution_fkey is None or target_fkey is None:
+        raise DerivaMLException(
+            f"Feature table {schema}:{fname} is missing a required outbound FK "
+            f"(Execution={execution_fkey}, {target_table_name}={target_fkey}); "
+            "cannot build feature annotation."
+        )
 
     # The feature's own payload columns: everything that isn't a system column,
     # the structural Execution/Feature_Name FKs, or the target FK. Sorted for
@@ -477,23 +518,58 @@ def feature_annotation(feature_table: Table, target_table_name: str) -> None:
         return [fk[0].name, fk[1]] if fk else col_name
 
     target_source = {
-        "source": [{"outbound": [schema, f"{fname}_{target_table_name}_fkey"]}, "RID"],
+        "source": [{"outbound": [schema, target_fkey]}, "RID"],
         "markdown_name": target_table_name,
     }
     execution_source = {
-        "source": [{"outbound": [schema, f"{fname}_Execution_fkey"]}, "RID"],
+        "source": [{"outbound": [schema, execution_fkey]}, "RID"],
         "markdown_name": "Produced By",
     }
 
-    # Facets: the target, the producing execution, and each term/asset (FK-backed)
-    # payload column — the natural "filter rows by this label/value" axes.
-    facet_sources = [target_source, execution_source]
+    # Provenance facets that reach past the Execution into the Workflow that
+    # produced it. The first two hops are shared by all three; only the tail
+    # differs. Constraint names in the deriva-ml schema are fixed by
+    # create_schema.py (short enough never to truncate), so they're literals.
+    _to_workflow = [
+        {"outbound": [schema, execution_fkey]},
+        {"outbound": [ML_SCHEMA, "Execution_Workflow_fkey"]},
+    ]
+    workflow_source = {
+        "source": [*_to_workflow, "RID"],
+        "markdown_name": "Workflow",
+    }
+    workflow_name_source = {
+        "source": [*_to_workflow, "Name"],
+        "markdown_name": "Workflow Name",
+    }
+    # Workflow_Type is many-to-many behind Workflow_Workflow_Type: hop *into*
+    # the association (inbound), then back *out* to the vocabulary term.
+    workflow_type_source = {
+        "source": [
+            *_to_workflow,
+            {"inbound": [ML_SCHEMA, "Workflow_Workflow_Type_Workflow_fkey"]},
+            {"outbound": [ML_SCHEMA, "Workflow_Workflow_Type_Workflow_Type_fkey"]},
+            "Name",
+        ],
+        "markdown_name": "Workflow Type",
+    }
+
+    # Facets: the target, the producing execution, the workflow behind it
+    # (RID / name / type), and each term/asset (FK-backed) payload column —
+    # the natural "filter rows by this label/value" axes.
+    facet_sources = [
+        target_source,
+        execution_source,
+        workflow_source,
+        workflow_name_source,
+        workflow_type_source,
+    ]
     for c in payload_columns:
         if c in fk_by_column:
             facet_sources.append({"source": [{"outbound": [schema, fk_by_column[c][1]]}, "RID"], "markdown_name": c})
 
     # Row name: "<target RID>: <feature name>" via the target FK pseudo-column.
-    target_fkey_ref = f"$fkey_{schema}_{fname}_{target_table_name}_fkey"
+    target_fkey_ref = f"$fkey_{schema}_{target_fkey}"
     row_name_pattern = "{{{" + target_fkey_ref + ".RID}}}: {{{Feature_Name}}}"
 
     feature_table.annotations.update(

--- a/tests/schema/test_asset_and_generate_annotation.py
+++ b/tests/schema/test_asset_and_generate_annotation.py
@@ -13,12 +13,16 @@ non-determinism in ``asset_annotation``).
 
 from __future__ import annotations
 
+import json
 from unittest.mock import MagicMock
 
+import pytest
 from deriva.core import tag as deriva_tags
 
+from deriva_ml.core.exceptions import DerivaMLException
 from deriva_ml.schema.annotations import (
     asset_annotation,
+    feature_annotation,
     generate_annotation,
 )
 
@@ -334,33 +338,178 @@ class TestDatasetAnnotationFolderColumn:
         compact = vc.get("*", [])
 
         # Must be present in detailed.
-        folder_sources = [
-            s for s in detailed
-            if isinstance(s, dict) and s.get("markdown_name") == "Folder"
-        ]
+        folder_sources = [s for s in detailed if isinstance(s, dict) and s.get("markdown_name") == "Folder"]
         assert folder_sources, "Dataset detailed visible-columns must include a 'Folder' source"
 
         # Must NOT be present in compact (*).
-        assert not any(
-            isinstance(s, dict) and s.get("markdown_name") == "Folder" for s in compact
-        ), "Folder must NOT appear in the compact (*) context"
+        assert not any(isinstance(s, dict) and s.get("markdown_name") == "Folder" for s in compact), (
+            "Folder must NOT appear in the compact (*) context"
+        )
 
         folder = folder_sources[0]
         src_path = folder["source"]
 
         # Source walks inbound to Directory_Dataset then reads Path.
         assert any(
-            isinstance(seg, dict)
-            and "inbound" in seg
-            and "Directory_Dataset" in seg["inbound"][1]
-            for seg in src_path
+            isinstance(seg, dict) and "inbound" in seg and "Directory_Dataset" in seg["inbound"][1] for seg in src_path
         ), f"Folder source must walk inbound via Directory_Dataset; got source={src_path!r}"
-        assert src_path[-1] == "Path", (
-            f"Folder source must terminate with 'Path'; got source={src_path!r}"
-        )
+        assert src_path[-1] == "Path", f"Folder source must terminate with 'Path'; got source={src_path!r}"
 
         # show_null false → Chaise hides the field when Path is null.
         assert folder.get("display", {}).get("show_null") is False, (
-            "Folder source must have display.show_null=False so Chaise hides it "
-            "on non-directory datasets"
+            "Folder source must have display.show_null=False so Chaise hides it on non-directory datasets"
         )
+
+
+# ---------------------------------------------------------------------------
+# feature_annotation — workflow provenance facets
+# ---------------------------------------------------------------------------
+
+
+def _make_feature_table(
+    *,
+    schema_name: str = "eye-ai",
+    table_name: str = "Execution_Subject_Subject_Diagnosis",
+    target: str = "Subject",
+    execution_fkey_name: str | None = None,
+    target_fkey_name: str | None = None,
+) -> MagicMock:
+    """Build a minimal ``Table``-shaped mock for feature_annotation tests.
+
+    ``execution_fkey_name`` / ``target_fkey_name`` default to the natural
+    ``{table}_{col}_fkey`` form but can be overridden to simulate the
+    truncated + hash-suffixed constraint names ERMrest generates when the
+    natural name exceeds Postgres's 63-char limit.
+    """
+    table = MagicMock()
+    table.schema.name = schema_name
+    table.name = table_name
+
+    class _Columns(dict):
+        def __iter__(self):
+            return iter(self.values())
+
+    col_objs = {}
+    for name in ("RID", "RCT", "RMT", "RCB", "RMB", "Execution", "Feature_Name", target):
+        c = MagicMock()
+        c.name = name
+        col_objs[name] = c
+    table.columns = _Columns(col_objs)
+
+    def _fk(col_name: str, pk_table_name: str, constraint_name: str) -> MagicMock:
+        fk = MagicMock()
+        col = MagicMock()
+        col.name = col_name
+        fk.columns = [col]
+        fk.column_map = [col]
+        fk.pk_table.name = pk_table_name
+        fk.constraint_name = constraint_name
+        fk.name = (MagicMock(name=schema_name), constraint_name)
+        fk.name[0].name = schema_name
+        return fk
+
+    table.foreign_keys = [
+        _fk("Execution", "Execution", execution_fkey_name or f"{table_name}_Execution_fkey"),
+        _fk(target, target, target_fkey_name or f"{table_name}_{target}_fkey"),
+    ]
+    table.annotations = {}
+    return table
+
+
+def _facets(table) -> list:
+    return table.annotations[deriva_tags.visible_columns]["filter"]["and"]
+
+
+def _facet_by_name(table, markdown_name: str):
+    for f in _facets(table):
+        if isinstance(f, dict) and f.get("markdown_name") == markdown_name:
+            return f
+    raise AssertionError(f"no facet named {markdown_name!r}")
+
+
+class TestFeatureAnnotationWorkflowFacets:
+    """Pin the workflow provenance facets on feature tables.
+
+    Feature values are selected by *what produced them* — the workflow behind
+    the execution — not only by their own value. Three facets ride the
+    provenance chain; ``Workflow_Type`` is many-to-many so its facet must
+    traverse the ``Workflow_Workflow_Type`` association rather than a plain
+    FK chain.
+    """
+
+    def test_workflow_facet_hops_execution_then_workflow(self):
+        table = _make_feature_table()
+        feature_annotation(table, "Subject")
+
+        source = _facet_by_name(table, "Workflow")["source"]
+        assert source == [
+            {"outbound": ["eye-ai", "Execution_Subject_Subject_Diagnosis_Execution_fkey"]},
+            {"outbound": ["deriva-ml", "Execution_Workflow_fkey"]},
+            "RID",
+        ]
+
+    def test_workflow_name_facet_targets_name_column(self):
+        """Workflow has no Workflow_Type column; Name is the readable axis."""
+        table = _make_feature_table()
+        feature_annotation(table, "Subject")
+
+        source = _facet_by_name(table, "Workflow Name")["source"]
+        assert source[-1] == "Name"
+        assert source[1] == {"outbound": ["deriva-ml", "Execution_Workflow_fkey"]}
+
+    def test_workflow_type_facet_traverses_association_table(self):
+        """Workflow_Type is many-to-many: inbound to the association, then
+        outbound to the vocabulary term."""
+        table = _make_feature_table()
+        feature_annotation(table, "Subject")
+
+        source = _facet_by_name(table, "Workflow Type")["source"]
+        assert source == [
+            {"outbound": ["eye-ai", "Execution_Subject_Subject_Diagnosis_Execution_fkey"]},
+            {"outbound": ["deriva-ml", "Execution_Workflow_fkey"]},
+            {"inbound": ["deriva-ml", "Workflow_Workflow_Type_Workflow_fkey"]},
+            {"outbound": ["deriva-ml", "Workflow_Workflow_Type_Workflow_Type_fkey"]},
+            "Name",
+        ]
+
+    def test_workflow_facets_do_not_leak_into_visible_columns(self):
+        """Facet-only change: the row rendering must be untouched."""
+        table = _make_feature_table()
+        feature_annotation(table, "Subject")
+
+        vc = table.annotations[deriva_tags.visible_columns]
+        for context in ("*", "detailed"):
+            rendered = json.dumps(vc[context])
+            assert "Execution_Workflow_fkey" not in rendered
+            assert "Workflow_Workflow_Type" not in rendered
+
+
+class TestFeatureAnnotationResolvesTruncatedFkeyNames:
+    """FK constraint names must come from the model, not string interpolation.
+
+    Postgres truncates constraint names past 63 chars and ERMrest appends a
+    hash — and the same logical FK carries *different* hashes in different
+    catalogs. A constructed ``f"{table}_Execution_fkey"`` silently produces a
+    dead facet on those tables.
+    """
+
+    def test_truncated_execution_fkey_is_used_verbatim(self):
+        truncated = "Execution_Obs.._Execution_fkey_hQUme"
+        table = _make_feature_table(
+            table_name="Execution_Observation_Observation_Diagnosis",
+            target="Observation",
+            execution_fkey_name=truncated,
+        )
+        feature_annotation(table, "Observation")
+
+        # Every provenance facet must ride the real (truncated) name.
+        for name in ("Produced By", "Workflow", "Workflow Name", "Workflow Type"):
+            source = _facet_by_name(table, name)["source"]
+            assert source[0] == {"outbound": ["eye-ai", truncated]}
+
+    def test_missing_execution_fkey_raises(self):
+        table = _make_feature_table()
+        table.foreign_keys = [fk for fk in table.foreign_keys if fk.pk_table.name != "Execution"]
+
+        with pytest.raises(DerivaMLException, match="missing a required outbound FK"):
+            feature_annotation(table, "Subject")


### PR DESCRIPTION
## Summary

Feature values are selected by *what produced them*, not only by their own value. `feature_annotation()` now emits three provenance facets on every feature table:

| Facet | Path | Selects by |
|---|---|---|
| **Workflow** | `Execution` → `Workflow` → `RID` | the specific workflow |
| **Workflow Name** | `Execution` → `Workflow` → `Name` | readable name (165 workflows in prod — RID alone isn't a selectable axis) |
| **Workflow Type** | `Execution` → `Workflow` → *(inbound)* `Workflow_Workflow_Type` → `Workflow_Type` | Analysis, Prediction, Embedding, … |

`Workflow` has **no** `Workflow_Type` column — type is **many-to-many** behind the `Workflow_Workflow_Type` association, so that facet is a 4-hop `outbound → outbound → inbound → outbound` path rather than a plain FK chain. Both chains were verified live against `www.eye-ai.org` (they traverse and return real `Workflow_Type` terms).

**Facet-only by design:** no workflow pseudo-column is added to `*`/`detailed`, so feature-row rendering is unchanged. A test pins that the workflow FKs never leak into the rendered contexts, so a later "add the column" change has to be deliberate.

## Bug fix: never interpolate FK constraint names

The old code built the Execution FK ref as `f"{fname}_Execution_fkey"`. Postgres truncates constraint names past 63 chars and ERMrest appends a hash, so real tables carry names like `Execution_Obs.._Glaucoma_Diagnosis_fkey_hQUme` — and **the same logical FK has different hashes in dev vs prod**. An interpolated name silently yields a facet that never matches. Constraint names now resolve from the model, and a missing Execution/target FK raises instead of emitting a broken facet.

## Backfill script

`feature_annotation()` runs **only** at `create_feature()` time and there's no regenerate surface (`apply_annotations()` is just `model.apply()` — a flush). So tables predating the annotation stay unannotated forever: **6 of 8** eye-ai feature tables had no annotation at all.

`backfill_feature_annotations.py` re-applies the standard annotation. Target resolution uses the `Execution_<Target>_<Feature>` convention — **not** `find_features()`, which mis-reports the target on multi-FK tables (returns `Image_Side` for `Execution_Subject_Chart_Label`, whose real target is `Subject`). Non-conforming tables are skipped, never guessed at. Dry-run by default; `--apply` writes.

## Applied

Both catalogs backfilled and verified by a **fresh `getCatalogSchema()` server read** (not the in-process model):

- `dev.eye-ai.org/2073` — 8/8 feature tables carry all 3 facets
- `www.eye-ai.org/eye-ai` — 8/8 feature tables carry all 3 facets

`Annotation` and `Image_Diagnosis` are skipped — they're slated for deletion.

## Verification

- **19 tests pass** in `tests/schema/test_asset_and_generate_annotation.py` (6 new).
- The truncated-FK tests are **red-green verified**: they fail against the pre-fix interpolation, pass with the fix.
- `tests/schema/ tests/model/`: 110 passed on this branch vs 104 on `main` (+6). The 4 failures / 51 errors are **pre-existing on clean `main`** — live-catalog tests against a local Deriva stack that isn't running here.
- Lint + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)