### PR TITLE
fix(execution): reconcile-based retry for RID-lease POST (#360)

### DIFF
--- a/src/deriva_ml/execution/rid_lease.py
+++ b/src/deriva_ml/execution/rid_lease.py
@@ -7,10 +7,38 @@ before adding asset / association rows to the transient commit bag.
 Why a dedicated module: the POST body format, chunking, and
 error-handling choices are specific to the lease table and worth
 isolating from higher-level orchestration.
+
+Transient-failure handling (issue #360)
+---------------------------------------
+The lease POST is the *last* step of an arbitrarily long commit
+(assets + feature rows + provenance already landed). A single
+transient ERMrest hiccup on this bookkeeping POST must not discard
+the success signal of the whole run, so ``post_lease_batch`` retries
+transient failures with bounded exponential backoff.
+
+The retry is **reconcile-based**, not blind re-POST. It relies on an
+ERMrest guarantee about ``public:ERMrest_RID_Lease``:
+
+    The table has a composite unique key ``(RCB, ID)``, where ``RCB``
+    is the row-created-by (authenticated client) and ``ID`` is our
+    client-generated UUID4 lease token. ``ID`` alone is NOT unique.
+
+Because of that key, a POST that *landed* on the server but whose
+response was lost cannot simply be re-sent — re-POSTing the same
+tokens would 409 against the rows that already succeeded. So before
+each retry we query which of our tokens already exist and re-POST
+only the missing ones. This is exactly what the UUID4 ``ID`` token
+was designed for (see :func:`generate_lease_token`).
+
+This ERMrest guarantee is pinned for *our* CI by
+``tests/execution/test_rid_lease_idempotency_contract.py`` — if a
+future server/deriva-py change drops the ``(RCB, ID)`` unique key,
+that test fails and this reconcile logic must be revisited.
 """
 
 from __future__ import annotations
 
+import time
 import uuid
 from typing import TYPE_CHECKING, Iterable
 
@@ -24,6 +52,178 @@ logger = get_logger(__name__)
 # ERMrest URL and body-size limits while amortizing round-trip cost.
 # See spec §2.6 — may be tuned by tests via monkeypatch.
 PENDING_ROWS_LEASE_CHUNK = 500
+
+# Reconcile-retry tuning for the lease POST (issue #360). Mirrors
+# deriva-py's ``datapath._request_with_retry`` shape (exponential
+# backoff of ``factor ** (attempt - 1)`` seconds), with 409 added to
+# the transient set because the observed production failure was a
+# *spurious* 409 ("Schema public does not exist") against a healthy
+# lease table. Reconciliation makes retrying a 409 safe.
+# Tunable by tests via monkeypatch.
+LEASE_MAX_ATTEMPTS = 5
+LEASE_BACKOFF_FACTOR = 2
+# HTTP status codes we treat as transient for the lease POST. 409 is
+# included here (unlike a generic insert) — see module docstring.
+LEASE_TRANSIENT_STATUS = frozenset({408, 409, 429, 500, 502, 503, 504})
+
+
+def _http_status(exc: BaseException) -> int | None:
+    """Return the HTTP status code carried by ``exc``, or None.
+
+    Args:
+        exc: An exception raised by a catalog POST.
+
+    Returns:
+        The integer status code if ``exc`` is a
+        :class:`requests.HTTPError` whose ``response`` carries a
+        status; otherwise ``None`` (e.g. a bare transport error).
+
+    Example:
+        >>> import requests
+        >>> r = requests.Response()
+        >>> r.status_code = 503
+        >>> _http_status(requests.HTTPError(response=r))
+        503
+        >>> _http_status(RuntimeError("boom")) is None
+        True
+    """
+    resp = getattr(exc, "response", None)
+    status = getattr(resp, "status_code", None)
+    return int(status) if status is not None else None
+
+
+def _is_transient_lease_error(exc: BaseException) -> bool:
+    """Classify a lease-POST exception as transient (retry) or terminal.
+
+    Transient: an :class:`requests.HTTPError` whose status is in
+    :data:`LEASE_TRANSIENT_STATUS`, or a non-HTTP exception presumed
+    to be a transport error (timeout, connection reset) with no
+    status attached. Terminal: any other 4xx (e.g. 403 forbidden,
+    404) — re-sending will not help.
+
+    Args:
+        exc: The exception raised by the catalog POST.
+
+    Returns:
+        ``True`` if the caller should retry, ``False`` to raise.
+
+    Example:
+        >>> import requests
+        >>> r = requests.Response(); r.status_code = 409
+        >>> _is_transient_lease_error(requests.HTTPError(response=r))
+        True
+        >>> r2 = requests.Response(); r2.status_code = 403
+        >>> _is_transient_lease_error(requests.HTTPError(response=r2))
+        False
+        >>> _is_transient_lease_error(ConnectionError("reset"))
+        True
+    """
+    status = _http_status(exc)
+    if status is None:
+        # No HTTP status → transport-level error; presume transient.
+        return True
+    return status in LEASE_TRANSIENT_STATUS
+
+
+def _fetch_landed_leases(
+    catalog: "ErmrestCatalog",
+    tokens: list[str],
+) -> dict[str, str]:
+    """Return token→RID for tokens already present in ERMrest_RID_Lease.
+
+    Reconciliation query for the retry path: after a transient POST
+    failure we cannot know which rows landed, so we ask the server.
+    Filters by our client's tokens (the ``ID`` column); the
+    ``(RCB, ID)`` unique key means each token maps to at most one row
+    created by this client.
+
+    Args:
+        catalog: Live ErmrestCatalog to query.
+        tokens: Lease tokens to look up.
+
+    Returns:
+        Mapping of every token found in the lease table to its
+        server-assigned RID. Tokens not yet landed are absent.
+    """
+    found: dict[str, str] = {}
+    if not tokens:
+        return found
+    pb = catalog.getPathBuilder()
+    lease_table = pb.schemas["public"].tables["ERMrest_RID_Lease"]
+    for i in range(0, len(tokens), PENDING_ROWS_LEASE_CHUNK):
+        chunk = tokens[i : i + PENDING_ROWS_LEASE_CHUNK]
+        rows = lease_table.filter(lease_table.ID.in_(chunk)).attributes(lease_table.RID, lease_table.ID).fetch()
+        for row in rows:
+            found[row["ID"]] = row["RID"]
+    return found
+
+
+def _lease_chunk_with_retry(
+    *,
+    catalog: "ErmrestCatalog",
+    tokens: list[str],
+) -> dict[str, str]:
+    """POST one chunk of lease tokens, reconciling+retrying transients.
+
+    Args:
+        catalog: Live ErmrestCatalog to POST against.
+        tokens: The chunk of lease tokens to POST (already sized to
+            :data:`PENDING_ROWS_LEASE_CHUNK`).
+
+    Returns:
+        Mapping of every input token to its leased RID.
+
+    Raises:
+        Exception: The last exception seen, if a terminal (non-
+            transient) error occurs or all attempts are exhausted.
+    """
+    resolved: dict[str, str] = {}
+    last_exc: BaseException | None = None
+
+    for attempt in range(LEASE_MAX_ATTEMPTS):
+        if attempt > 0:
+            delay = LEASE_BACKOFF_FACTOR ** (attempt - 1)
+            logger.debug("lease POST retry %d: sleeping %ss", attempt, delay)
+            time.sleep(delay)
+            # Reconcile: learn which tokens already landed so we
+            # don't re-POST them (that would 409 on (RCB, ID)).
+            landed = _fetch_landed_leases(catalog, tokens)
+            resolved.update(landed)
+
+        missing = [t for t in tokens if t not in resolved]
+        if not missing:
+            return resolved
+
+        try:
+            response = catalog.post(
+                "/entity/public:ERMrest_RID_Lease",
+                json=[{"ID": t} for t in missing],
+            )
+            for row in response.json():
+                # ERMrest echoes both ID (our token) and RID (assigned).
+                resolved[row["ID"]] = row["RID"]
+            return resolved
+        except Exception as exc:  # noqa: BLE001 — reclassified below
+            last_exc = exc
+            if not _is_transient_lease_error(exc):
+                raise
+            logger.warning(
+                "Transient lease-POST failure (attempt %d/%d): %s",
+                attempt + 1,
+                LEASE_MAX_ATTEMPTS,
+                exc,
+            )
+
+    # Exhausted every attempt on transient failures. A final
+    # reconcile may still have completed the batch (e.g. the last
+    # POST landed but its response was lost); check before giving up.
+    resolved.update(_fetch_landed_leases(catalog, tokens))
+    if all(t in resolved for t in tokens):
+        return resolved
+
+    logger.error("Lease POST exhausted %d attempts", LEASE_MAX_ATTEMPTS)
+    assert last_exc is not None  # loop ran at least once with a failure
+    raise last_exc
 
 
 def generate_lease_token() -> str:
@@ -57,10 +257,15 @@ def post_lease_batch(
         Dict mapping each input token to its server-assigned RID.
 
     Raises:
-        Exception: Whatever the catalog raises on POST failure.
-            Partial progress is NOT rolled back — the caller is
-            responsible for recording which tokens landed (via the
-            two-phase SQLite write in Task F2).
+        Exception: Whatever the catalog raises on a *terminal*
+            (non-transient) POST failure, or the last transient
+            error after exhausting :data:`LEASE_MAX_ATTEMPTS`.
+            Transient failures (timeouts, 5xx, spurious 409) are
+            retried with reconcile-based backoff so a single hiccup
+            on this finalize-step POST does not fail an otherwise
+            complete commit (issue #360). Partial progress is not
+            rolled back, but retries reconcile against the server's
+            lease rows, so re-running is idempotent by construction.
 
     Example:
         >>> tokens = [generate_lease_token() for _ in range(100)]  # doctest: +SKIP
@@ -72,14 +277,12 @@ def post_lease_batch(
         return {}
 
     result: dict[str, str] = {}
-    # Chunk to keep URL + body sizes bounded.
+    # Chunk to keep URL + body sizes bounded. Each chunk POST retries
+    # transient failures independently, reconciling against the
+    # server's lease rows so a landed-but-lost POST is not re-sent.
     for i in range(0, len(tokens), PENDING_ROWS_LEASE_CHUNK):
         chunk = tokens[i : i + PENDING_ROWS_LEASE_CHUNK]
-        body = [{"ID": t} for t in chunk]
-        response = catalog.post("/entity/public:ERMrest_RID_Lease", json=body)
-        for row in response.json():
-            # ERMrest echoes both ID (our token) and RID (assigned).
-            result[row["ID"]] = row["RID"]
+        result.update(_lease_chunk_with_retry(catalog=catalog, tokens=chunk))
     return result
 
 

--- a/src/deriva_ml/execution/rid_lease.py
+++ b/src/deriva_ml/execution/rid_lease.py
@@ -125,24 +125,49 @@ def _is_transient_lease_error(exc: BaseException) -> bool:
     return status in LEASE_TRANSIENT_STATUS
 
 
+def _client_rcb(catalog: "ErmrestCatalog") -> str:
+    """Return this client's identity, used as the ``RCB`` scope.
+
+    The reconcile query must be scoped to the rows *this* client
+    created, because the lease table's uniqueness is ``(RCB, ID)`` —
+    ``ID`` alone is not unique. Without the scope, a token value that
+    happens to exist under another client's ``RCB`` could be adopted,
+    returning a RID we never leased.
+
+    Args:
+        catalog: Live ErmrestCatalog whose authenticated session
+            identifies the current client.
+
+    Returns:
+        The client id string that ERMrest records as ``RCB`` on rows
+        this client inserts.
+    """
+    return catalog.get_authn_session().json()["client"]["id"]
+
+
 def _fetch_landed_leases(
     catalog: "ErmrestCatalog",
     tokens: list[str],
+    *,
+    rcb: str,
 ) -> dict[str, str]:
-    """Return token→RID for tokens already present in ERMrest_RID_Lease.
+    """Return token→RID for our tokens already present in ERMrest_RID_Lease.
 
     Reconciliation query for the retry path: after a transient POST
     failure we cannot know which rows landed, so we ask the server.
-    Filters by our client's tokens (the ``ID`` column); the
-    ``(RCB, ID)`` unique key means each token maps to at most one row
-    created by this client.
+    Scoped to ``RCB == rcb`` **and** our token set (the ``ID`` column),
+    matching the ``(RCB, ID)`` unique key — so each token maps to at
+    most one row created by this client, and a colliding token value
+    under a different client is never adopted.
 
     Args:
         catalog: Live ErmrestCatalog to query.
         tokens: Lease tokens to look up.
+        rcb: This client's identity (from :func:`_client_rcb`); rows
+            created by any other client are excluded.
 
     Returns:
-        Mapping of every token found in the lease table to its
+        Mapping of every token found under this client to its
         server-assigned RID. Tokens not yet landed are absent.
     """
     found: dict[str, str] = {}
@@ -152,7 +177,12 @@ def _fetch_landed_leases(
     lease_table = pb.schemas["public"].tables["ERMrest_RID_Lease"]
     for i in range(0, len(tokens), PENDING_ROWS_LEASE_CHUNK):
         chunk = tokens[i : i + PENDING_ROWS_LEASE_CHUNK]
-        rows = lease_table.filter(lease_table.ID.in_(chunk)).attributes(lease_table.RID, lease_table.ID).fetch()
+        rows = (
+            lease_table.filter(lease_table.RCB == rcb)
+            .filter(lease_table.ID.in_(chunk))
+            .attributes(lease_table.RID, lease_table.ID)
+            .fetch()
+        )
         for row in rows:
             found[row["ID"]] = row["RID"]
     return found
@@ -179,16 +209,44 @@ def _lease_chunk_with_retry(
     """
     resolved: dict[str, str] = {}
     last_exc: BaseException | None = None
+    # Resolved lazily on first need (the reconcile / final-sweep paths),
+    # so a happy-path first-try success never pays the whoami round-trip.
+    rcb: str | None = None
+
+    def _reconcile() -> None:
+        """RCB-scoped reconcile, transient failures folded into the loop.
+
+        Both the ``POST`` and this reconcile query can fail transiently;
+        neither should escape until attempts are exhausted (Codex #360
+        follow-up). A transient reconcile failure records ``last_exc``
+        and returns, consuming the current attempt. A terminal reconcile
+        failure propagates immediately.
+        """
+        nonlocal last_exc, rcb
+        try:
+            if rcb is None:
+                rcb = _client_rcb(catalog)
+            resolved.update(_fetch_landed_leases(catalog, tokens, rcb=rcb))
+        except Exception as exc:  # noqa: BLE001 — reclassified below
+            if not _is_transient_lease_error(exc):
+                raise
+            last_exc = exc
+            logger.warning(
+                "Transient lease-reconcile failure (attempt %d/%d): %s",
+                attempt + 1,
+                LEASE_MAX_ATTEMPTS,
+                exc,
+            )
 
     for attempt in range(LEASE_MAX_ATTEMPTS):
         if attempt > 0:
             delay = LEASE_BACKOFF_FACTOR ** (attempt - 1)
-            logger.debug("lease POST retry %d: sleeping %ss", attempt, delay)
+            logger.debug("lease retry %d: sleeping %ss", attempt, delay)
             time.sleep(delay)
-            # Reconcile: learn which tokens already landed so we
-            # don't re-POST them (that would 409 on (RCB, ID)).
-            landed = _fetch_landed_leases(catalog, tokens)
-            resolved.update(landed)
+            # Reconcile: learn which tokens already landed so we don't
+            # re-POST them (that would 409 on (RCB, ID)). A transient
+            # failure here just consumes the attempt.
+            _reconcile()
 
         missing = [t for t in tokens if t not in resolved]
         if not missing:
@@ -214,10 +272,11 @@ def _lease_chunk_with_retry(
                 exc,
             )
 
-    # Exhausted every attempt on transient failures. A final
-    # reconcile may still have completed the batch (e.g. the last
-    # POST landed but its response was lost); check before giving up.
-    resolved.update(_fetch_landed_leases(catalog, tokens))
+    # Exhausted every attempt on transient failures. A final reconcile
+    # may still have completed the batch (e.g. the last POST landed but
+    # its response was lost). If that reconcile itself fails
+    # transiently, we fall through to raising last_exc below.
+    _reconcile()
     if all(t in resolved for t in tokens):
         return resolved
 

--- a/tacit-knowledge.md
+++ b/tacit-knowledge.md
@@ -58,3 +58,22 @@ upstream. Mitigation: the reconcile-retry lives in
 own CI catches a future server/deriva-py change that would break the
 idempotency assumption. Document the ERMrest dependency inline in the
 lease module.
+
+**Codex-review hardening (same day, PR #361):** an independent Codex
+review caught two real gaps in the first cut, both fixed:
+1. **Reconcile must be RCB-scoped.** The first reconcile query filtered
+   on `ID` alone. Since `ID` is unique only within `(RCB, ID)`, a token
+   value colliding under *another* client's RCB could be adopted —
+   returning a RID we never leased. Fixed: scope the reconcile to
+   `RCB == _client_rcb(catalog)` (whoami's `client.id`). UUID4 makes the
+   collision astronomically unlikely, but the query now matches the
+   stated contract instead of relying on that luck.
+2. **The reconcile query itself must tolerate transients.** The retry
+   hardened the POST but left `_fetch_landed_leases` unguarded — a 503/
+   timeout on the reconcile GET propagated straight out, re-introducing
+   the exact false-failure #360 fixes, one call over. Fixed: the
+   reconcile is wrapped so a transient failure consumes a retry attempt
+   (like a POST failure) instead of aborting; terminal reconcile errors
+   still propagate. Lesson: when you add a bookkeeping query *inside* a
+   retry loop to make it safe, that query inherits the same
+   transient-failure obligation as the operation it guards.

--- a/tacit-knowledge.md
+++ b/tacit-knowledge.md
@@ -5,7 +5,7 @@ of each section.
 
 ## Execution / commit
 
-### 2026-07-17 — RID-lease POST retry design (issue #360)
+### 2026-07-17 — RID-lease POST retry design (issue #360, PR #361)
 
 **Bug:** `post_lease_batch` (`execution/rid_lease.py`) issues a bare
 `catalog.post("/entity/public:ERMrest_RID_Lease", ...)` with no retry.

--- a/tacit-knowledge.md
+++ b/tacit-knowledge.md
@@ -1,0 +1,60 @@
+# DerivaML Tacit Knowledge
+
+Rationale that the catalog doesn't capture. Newest entries at the bottom
+of each section.
+
+## Execution / commit
+
+### 2026-07-17 — RID-lease POST retry design (issue #360)
+
+**Bug:** `post_lease_batch` (`execution/rid_lease.py`) issues a bare
+`catalog.post("/entity/public:ERMrest_RID_Lease", ...)` with no retry.
+A *transient* `409 CONFLICT "Schema public does not exist"` on that
+single bookkeeping POST propagated out of `commit_output_assets` and
+marked an otherwise-complete 19-hour, 14k-asset execution **Failed**.
+The data (assets + feature rows + provenance) had all committed; only
+the status was a false negative.
+
+**Why the existing retry machinery didn't cover it:**
+- deriva-py's session-level urllib3 `Retry` (`DEFAULT_SESSION_CONFIG`)
+  has `retry_status_forcelist = [500, 502, 503, 504]` (409 not in it)
+  **and** `allow_retry_on_all_methods = False` — so POSTs get zero
+  transport-level retry, and 409 is excluded even for GETs.
+- deriva-py's app-level `datapath._request_with_retry`
+  (the "loader retry machinery" the issue references) defaults
+  `retry_codes = {408, 429, 500, 502, 503, 504}` — **409 deliberately
+  excluded** because for a normal insert a 409 is a real unique-key
+  conflict, not transient.
+
+**The load-bearing fact (verified against localhost catalog):**
+`ERMrest_RID_Lease` has a **composite unique key `(RCB, ID)`**, where
+`RCB` = row-created-by (authenticated client) and `ID` = our
+client-generated UUID4 lease token. `ID` alone is NOT unique.
+
+Consequence for retry-safety: a naive full-POST retry is **unsafe** —
+if the first POST landed but its response was lost, retrying the same
+tokens hits `(RCB, ID)` and 409s on the rows that actually succeeded.
+So "just wrap the POST in blind retry-on-409" would trade one false
+failure for another.
+
+**Correct design = reconcile, don't blind-retry.** The UUID4 `ID`
+token exists precisely for this (per `generate_lease_token` docstring:
+"so we can look up what we leased after a mid-flight crash") — the
+current code just never used it. On failure, query
+`ERMrest_RID_Lease` for `RCB=me AND ID in (our tokens)` to learn which
+tokens already landed, then POST only the missing ones. Idempotent by
+construction; safe to retry any number of times. Retry transient
+failures (timeouts, 5xx, and 409 where reconciliation shows work
+remains) with bounded exponential backoff; still raise on terminal
+failure.
+
+**Placement decision (Carl, 2026-07-17): keep the whole fix in
+deriva-ml.** The `(RCB, ID)` idempotency is technically an ERMrest
+guarantee, but we chose not to add a deriva-py primitive / pin bump
+for this. Trade-off accepted: faster to land, contract not pinned
+upstream. Mitigation: the reconcile-retry lives in
+`execution/rid_lease.py`, and a deriva-ml test asserts the
+`(RCB, ID)` composite-unique guarantee against a live catalog so our
+own CI catches a future server/deriva-py change that would break the
+idempotency assumption. Document the ERMrest dependency inline in the
+lease module.

--- a/tests/execution/test_rid_lease.py
+++ b/tests/execution/test_rid_lease.py
@@ -5,6 +5,21 @@ from __future__ import annotations
 import uuid
 
 import pytest
+import requests
+
+
+def _terminal_http_error(status: int = 403) -> requests.HTTPError:
+    """A non-transient HTTP error (default 403) for the lease POST.
+
+    Terminal 4xx statuses are NOT retried by ``post_lease_batch``;
+    only transient failures (timeouts, 5xx, spurious 409) are. See
+    ``test_rid_lease_retry.py`` for the transient-path coverage.
+    """
+    resp = requests.Response()
+    resp.status_code = status
+    resp._content = b"forbidden"
+    resp.reason = "Forbidden"
+    return requests.HTTPError(f"{status} error", response=resp)
 
 
 class _MockLeaseCatalog:
@@ -18,7 +33,10 @@ class _MockLeaseCatalog:
 
     def post(self, path: str, json=None, **_kw):
         if self.fail:
-            raise RuntimeError("simulated lease failure")
+            # A terminal (non-transient) error must propagate without
+            # retry; use 403 so the retry classifier treats it as
+            # terminal rather than a transport hiccup.
+            raise _terminal_http_error()
         assert "ERMrest_RID_Lease" in path
         assert isinstance(json, list)
         self.post_calls.append(json)
@@ -83,9 +101,14 @@ def test_post_lease_batch_empty_is_noop():
     assert cat.post_calls == []
 
 
-def test_post_lease_batch_propagates_catalog_error():
+def test_post_lease_batch_propagates_terminal_error():
+    """A terminal (non-transient) catalog error propagates immediately,
+    without burning retry attempts (transient handling is covered in
+    test_rid_lease_retry.py)."""
     from deriva_ml.execution.rid_lease import post_lease_batch
 
     cat = _MockLeaseCatalog(fail=True)
-    with pytest.raises(RuntimeError):
+    with pytest.raises(requests.HTTPError):
         post_lease_batch(catalog=cat, tokens=["T"])
+    # Exactly one POST attempt — no retry on a terminal 4xx.
+    assert len(cat.post_calls) == 0  # POST raised before recording

--- a/tests/execution/test_rid_lease_idempotency_contract.py
+++ b/tests/execution/test_rid_lease_idempotency_contract.py
@@ -1,0 +1,129 @@
+"""Live-catalog contract test for the RID-lease idempotency guarantee.
+
+The reconcile-based retry in :func:`deriva_ml.execution.rid_lease.post_lease_batch`
+(issue #360) depends on an ERMrest guarantee about
+``public:ERMrest_RID_Lease``:
+
+    The table has a composite unique key ``(RCB, ID)``, where ``RCB``
+    is the row-created-by (authenticated client) and ``ID`` is our
+    client-generated UUID4 lease token.
+
+That key is what makes a lease POST *idempotent per client*: a
+partially-landed POST cannot be blindly re-sent (it would 409 on the
+tokens that already succeeded), so the retry reconciles by querying
+which tokens already exist and re-POSTs only the missing ones.
+
+Because we chose to keep the fix downstream (no deriva-py pin for this
+contract — see ``tacit-knowledge.md`` 2026-07-17), these tests are our
+CI's guard: if a future server/deriva-py change drops the ``(RCB, ID)``
+unique key or changes the duplicate-POST behavior, the reconcile logic
+must be revisited and these tests fail loudly.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+import requests
+
+requires_catalog = pytest.mark.skipif(
+    not os.environ.get("DERIVA_HOST"),
+    reason="lease idempotency contract tests require DERIVA_HOST",
+)
+
+
+@requires_catalog
+def test_lease_table_has_composite_rcb_id_unique_key(test_ml):
+    """ERMrest_RID_Lease must carry a unique key on (RCB, ID).
+
+    ``ID`` alone must NOT be the unique key — the guarantee is
+    per-client. This pins the exact model fact the reconcile-retry
+    relies on.
+    """
+    model = test_ml.catalog.getCatalogModel()
+    lease = model.schemas["public"].tables["ERMrest_RID_Lease"]
+
+    unique_col_sets = {frozenset(c.name for c in key.unique_columns) for key in lease.keys}
+    assert frozenset({"RCB", "ID"}) in unique_col_sets, (
+        "ERMrest_RID_Lease lost its (RCB, ID) composite unique key — "
+        "the reconcile-based lease retry (issue #360) is no longer safe. "
+        f"Found unique keys: {sorted(sorted(s) for s in unique_col_sets)}"
+    )
+    assert frozenset({"ID"}) not in unique_col_sets, (
+        "ERMrest_RID_Lease.ID became unique on its own; the reconcile "
+        "logic assumes ID is unique only within a client (RCB, ID)."
+    )
+
+
+@requires_catalog
+def test_duplicate_lease_post_conflicts(test_ml):
+    """Re-POSTing the same token (same client) conflicts.
+
+    Proves the idempotency mechanism the retry defends against: a
+    naive blind re-POST is unsafe, which is *why* the retry reconciles.
+    """
+    from deriva_ml.execution.rid_lease import generate_lease_token
+
+    token = generate_lease_token()
+    body = [{"ID": token}]
+    # First POST lands.
+    first = test_ml.catalog.post("/entity/public:ERMrest_RID_Lease", json=body).json()
+    assert len(first) == 1
+    # Second identical POST (same RCB, same ID) must conflict.
+    with pytest.raises(requests.HTTPError) as ei:
+        test_ml.catalog.post("/entity/public:ERMrest_RID_Lease", json=body)
+    assert ei.value.response is not None
+    assert ei.value.response.status_code == 409
+
+
+@requires_catalog
+def test_reconcile_recovers_leased_rid_after_landed_post(test_ml):
+    """A landed POST is fully recoverable by the reconcile query.
+
+    Simulates the lost-response case: the POST succeeded server-side
+    but the client "didn't see" the response. ``_fetch_landed_leases``
+    must return the token→RID mapping so the retry does not re-POST.
+    """
+    from deriva_ml.execution.rid_lease import (
+        _fetch_landed_leases,
+        generate_lease_token,
+    )
+
+    token = generate_lease_token()
+    posted = test_ml.catalog.post("/entity/public:ERMrest_RID_Lease", json=[{"ID": token}]).json()
+    assert len(posted) == 1
+    leased_rid = posted[0]["RID"]
+
+    recovered = _fetch_landed_leases(test_ml.catalog, [token])
+    assert recovered.get(token) == leased_rid, (
+        "reconcile query failed to recover a landed lease token → RID; the retry would incorrectly re-POST it."
+    )
+
+
+@requires_catalog
+def test_post_lease_batch_is_idempotent_end_to_end(test_ml):
+    """Calling post_lease_batch twice with the same tokens is safe.
+
+    Second call reconciles the already-landed tokens instead of
+    409-ing, returning the same RIDs — the end-to-end property the
+    retry provides.
+    """
+    from deriva_ml.execution.rid_lease import (
+        generate_lease_token,
+        post_lease_batch,
+    )
+
+    tokens = [generate_lease_token() for _ in range(3)]
+    first = post_lease_batch(catalog=test_ml.catalog, tokens=tokens)
+    assert set(first.keys()) == set(tokens)
+
+    # Second call with the same tokens: a blind re-POST would 409, but
+    # the reconcile path recovers every RID. Force the reconcile branch
+    # by clearing nothing — post_lease_batch will POST, hit 409 (a
+    # transient status), then reconcile and return the same RIDs.
+    second = post_lease_batch(catalog=test_ml.catalog, tokens=tokens)
+    assert second == first, (
+        "post_lease_batch was not idempotent across repeated calls with "
+        "the same tokens; reconcile-retry did not recover the RIDs."
+    )

--- a/tests/execution/test_rid_lease_idempotency_contract.py
+++ b/tests/execution/test_rid_lease_idempotency_contract.py
@@ -86,6 +86,7 @@ def test_reconcile_recovers_leased_rid_after_landed_post(test_ml):
     must return the token→RID mapping so the retry does not re-POST.
     """
     from deriva_ml.execution.rid_lease import (
+        _client_rcb,
         _fetch_landed_leases,
         generate_lease_token,
     )
@@ -95,7 +96,8 @@ def test_reconcile_recovers_leased_rid_after_landed_post(test_ml):
     assert len(posted) == 1
     leased_rid = posted[0]["RID"]
 
-    recovered = _fetch_landed_leases(test_ml.catalog, [token])
+    rcb = _client_rcb(test_ml.catalog)
+    recovered = _fetch_landed_leases(test_ml.catalog, [token], rcb=rcb)
     assert recovered.get(token) == leased_rid, (
         "reconcile query failed to recover a landed lease token → RID; the retry would incorrectly re-POST it."
     )

--- a/tests/execution/test_rid_lease_retry.py
+++ b/tests/execution/test_rid_lease_retry.py
@@ -27,20 +27,33 @@ def _http_error(status: int, detail: str = "") -> requests.HTTPError:
     return requests.HTTPError(f"{status} error: {detail}", response=resp)
 
 
+SELF_RCB = "https://example.org/auth/self-client"
+OTHER_RCB = "https://example.org/auth/other-client"
+
+
 class _ReconcileCatalog:
     """Mock catalog that drives the reconcile-retry path.
 
     - ``post`` fails for the first ``fail_times`` calls with the
       configured exception, then succeeds. On success it records
       each row it "persists" (keyed by token ID) so the reconcile
-      query can report already-landed tokens.
+      query can report already-landed tokens. Persisted rows carry
+      an ``RCB`` (this client, ``SELF_RCB``) so the reconcile query
+      can be scoped by creator.
     - ``fail_after_persist``: when True, the failing POST persists
       its rows on the server *before* raising — modelling the
       lost-response case where work landed but the client saw an
       error. The reconcile query then finds those tokens.
+    - ``reconcile_fail_times``: fail the first N reconcile ``fetch``
+      calls with ``reconcile_exc`` (defaults to a transient 503),
+      modelling a transient hiccup on the reconcile query itself.
+    - ``seed_foreign``: dict of {token: rid} rows pre-existing under
+      ``OTHER_RCB`` — used to prove the reconcile query does NOT
+      adopt a lease created by a different client.
     - ``getPathBuilder`` exposes an ``ERMrest_RID_Lease`` table whose
-      ``ID.in_(chunk)`` fetch returns the persisted (token, RID)
-      rows intersecting the chunk.
+      ``RCB == <id>`` + ``ID.in_(chunk)`` fetch returns the matching
+      (token, RID) rows.
+    - ``get_authn_session`` reports this client's id (``SELF_RCB``).
     """
 
     def __init__(
@@ -49,23 +62,50 @@ class _ReconcileCatalog:
         fail_times: int = 0,
         exc: Exception | None = None,
         fail_after_persist: bool = False,
+        reconcile_fail_times: int = 0,
+        reconcile_exc: Exception | None = None,
+        seed_foreign: dict[str, str] | None = None,
         prefix: str = "RID-",
     ):
         self.fail_times = fail_times
         self.exc = exc or _http_error(409, "Schema public does not exist")
         self.fail_after_persist = fail_after_persist
+        self.reconcile_fail_times = reconcile_fail_times
+        self.reconcile_exc = reconcile_exc or _http_error(503, "unavailable")
         self.prefix = prefix
         self.post_calls: list[list[dict]] = []
-        self._persisted: dict[str, str] = {}  # token ID -> RID
+        # rows: token -> (rid, rcb)
+        self._rows: dict[str, tuple[str, str]] = {}
+        for tok, rid in (seed_foreign or {}).items():
+            self._rows[tok] = (rid, OTHER_RCB)
         self._counter = 0
+        self._reconcile_calls = 0
         self._reconcile_chunks: list[list[str]] = []
+
+    # --- auth -----------------------------------------------------
+    def get_authn_session(self):
+        class _R:
+            def json(self):
+                return {"client": {"id": SELF_RCB}}
+
+        return _R()
 
     # --- POST -----------------------------------------------------
     def _assign(self, tokens: list[str]) -> None:
+        """Persist tokens under SELF_RCB, modelling the (RCB, ID) key.
+
+        A token already present under SELF_RCB conflicts (409) — the
+        composite unique key forbids a second row for the same client.
+        A token present only under OTHER_RCB is free to insert for us
+        (different RCB), getting a fresh RID distinct from the foreign
+        row's.
+        """
         for t in tokens:
-            if t not in self._persisted:
-                self._persisted[t] = f"{self.prefix}{self._counter}"
-                self._counter += 1
+            if t in self._rows and self._rows[t][1] == SELF_RCB:
+                # Same (RCB, ID) already exists → real ERMrest 409.
+                raise _http_error(409, f"duplicate (RCB, ID) for {t}")
+            self._rows[t] = (f"{self.prefix}{self._counter}", SELF_RCB)
+            self._counter += 1
 
     def post(self, path: str, json=None, **_kw):
         assert "ERMrest_RID_Lease" in path
@@ -87,37 +127,67 @@ class _ReconcileCatalog:
             def json(self):
                 return self._rows
 
-        return _R([{"RID": self._persisted[t], "ID": t} for t in tokens])
+        return _R([{"RID": self._rows[t][0], "ID": t} for t in tokens])
 
     # --- reconcile query -----------------------------------------
     def getPathBuilder(self):
         outer = self
 
-        class _InPredicate:
-            def __init__(self, chunk):
-                self.chunk = list(chunk)
+        class _Pred:
+            """Either an equality or an in_ predicate; composable via filter()."""
 
-        class _Col:
+            def __init__(self, *, rcb=None, chunk=None):
+                self.rcb = rcb
+                self.chunk = list(chunk) if chunk is not None else None
+
+            def merge(self, other):
+                return _Pred(
+                    rcb=self.rcb if other.rcb is None else other.rcb,
+                    chunk=self.chunk if other.chunk is None else other.chunk,
+                )
+
+        class _RCBCol:
+            def __eq__(self, value):
+                return _Pred(rcb=value)
+
+        class _IDCol:
             def in_(self, chunk):
-                return _InPredicate(chunk)
+                return _Pred(chunk=chunk)
 
         class _Chain:
-            def __init__(self, chunk):
-                self.chunk = chunk
+            def __init__(self, pred: "_Pred"):
+                self.pred = pred
+
+            def filter(self, pred: "_Pred"):
+                return _Chain(self.pred.merge(pred))
 
             def attributes(self, *_cols):
                 return self
 
             def fetch(self):
-                outer._reconcile_chunks.append(list(self.chunk))
-                return [{"RID": outer._persisted[t], "ID": t} for t in self.chunk if t in outer._persisted]
+                outer._reconcile_calls += 1
+                if outer._reconcile_calls <= outer.reconcile_fail_times:
+                    raise outer.reconcile_exc
+                chunk = self.pred.chunk or []
+                rcb = self.pred.rcb
+                outer._reconcile_chunks.append(list(chunk))
+                out = []
+                for t in chunk:
+                    if t not in outer._rows:
+                        continue
+                    rid, row_rcb = outer._rows[t]
+                    if rcb is not None and row_rcb != rcb:
+                        continue  # scoped out — created by another client
+                    out.append({"RID": rid, "ID": t})
+                return out
 
         class _Table:
-            RID = _Col()
-            ID = _Col()
+            RID = _IDCol()  # only .attributes() uses it; shape doesn't matter
+            ID = _IDCol()
+            RCB = _RCBCol()
 
-            def filter(self, pred: _InPredicate):
-                return _Chain(pred.chunk)
+            def filter(self, pred: "_Pred"):
+                return _Chain(pred)
 
         class _Schemas:
             def __getitem__(self, _name):
@@ -224,3 +294,71 @@ def test_backoff_uses_configured_factor(monkeypatch):
     # Two failures → two backoff sleeps before the 2nd and 3rd tries:
     # 2**0 = 1, 2**1 = 2.
     assert sleeps == [1, 2]
+
+
+def test_reconcile_scopes_to_current_client(monkeypatch):
+    """A token that exists ONLY under another client's RCB must not be
+    adopted. The reconcile query is scoped to the current client, so
+    such a token is treated as still-missing and re-POSTed for us.
+
+    (Codex finding 1: ``(RCB, ID)`` is the unique key; ``ID`` alone is
+    not, so reconciling on ``ID`` only could return a foreign RID.)
+    """
+    from deriva_ml.execution import rid_lease
+    from deriva_ml.execution.rid_lease import post_lease_batch
+
+    monkeypatch.setattr(rid_lease.time, "sleep", lambda _s: None)
+    # "FOREIGN" already exists under OTHER_RCB with a RID we must NOT
+    # return. First POST 409s (transient) to force the reconcile path.
+    cat = _ReconcileCatalog(fail_times=1, seed_foreign={"FOREIGN": "NOT-OURS"})
+    result = post_lease_batch(catalog=cat, tokens=["FOREIGN"])
+
+    assert result["FOREIGN"] != "NOT-OURS", "reconcile adopted a lease created by a different client"
+    # We re-POSTed the token for ourselves (the retry's missing set
+    # still contained it after RCB-scoped reconcile found nothing ours).
+    assert len(cat.post_calls) == 2
+
+
+def test_transient_reconcile_query_failure_is_retried(monkeypatch):
+    """A transient failure on the reconcile *query* must not abort the
+    retry — it consumes an attempt and is retried, same as a POST
+    failure.
+
+    (Codex finding 2: the reconcile query was previously unguarded, so
+    a 503/timeout on it re-introduced the exact false-failure #360
+    fixes, just one call over.)
+    """
+    from deriva_ml.execution import rid_lease
+    from deriva_ml.execution.rid_lease import post_lease_batch
+
+    monkeypatch.setattr(rid_lease.time, "sleep", lambda _s: None)
+    monkeypatch.setattr(rid_lease, "LEASE_MAX_ATTEMPTS", 5)
+    # POST fails once (409) → enter reconcile path. The reconcile query
+    # then fails transiently once (503) before succeeding. The batch
+    # must still ultimately succeed rather than propagating the 503.
+    cat = _ReconcileCatalog(
+        fail_times=1,
+        fail_after_persist=True,  # tokens actually landed on the failed POST
+        reconcile_fail_times=1,
+    )
+    tokens = ["R1", "R2"]
+    result = post_lease_batch(catalog=cat, tokens=tokens)
+    assert set(result.keys()) == set(tokens)
+
+
+def test_transient_reconcile_failure_exhaustion_raises(monkeypatch):
+    """If the reconcile query keeps failing transiently until attempts
+    are exhausted, the last error propagates (does not hang or silently
+    return an incomplete map)."""
+    from deriva_ml.execution import rid_lease
+    from deriva_ml.execution.rid_lease import post_lease_batch
+
+    monkeypatch.setattr(rid_lease.time, "sleep", lambda _s: None)
+    monkeypatch.setattr(rid_lease, "LEASE_MAX_ATTEMPTS", 3)
+    cat = _ReconcileCatalog(
+        fail_times=1,
+        fail_after_persist=True,
+        reconcile_fail_times=99,  # reconcile never recovers
+    )
+    with pytest.raises(requests.HTTPError):
+        post_lease_batch(catalog=cat, tokens=["R"])

--- a/tests/execution/test_rid_lease_retry.py
+++ b/tests/execution/test_rid_lease_retry.py
@@ -1,0 +1,226 @@
+"""Tests for reconcile-based retry in post_lease_batch (issue #360).
+
+A transient failure on the lease POST (timeout, 5xx, or a spurious
+409) must not fail an otherwise-complete commit. The retry is
+*reconcile-based*: because ``ERMrest_RID_Lease`` has a composite
+unique key ``(RCB, ID)`` and ``ID`` is our client-generated UUID4
+token, a partially-landed POST cannot simply be re-sent (it would
+409 on the tokens that already succeeded). Instead the retry queries
+which of our tokens already exist and re-POSTs only the missing ones.
+
+See ``tacit-knowledge.md`` (2026-07-17) and the module docstring of
+``deriva_ml.execution.rid_lease`` for the contract.
+"""
+
+from __future__ import annotations
+
+import pytest
+import requests
+
+
+def _http_error(status: int, detail: str = "") -> requests.HTTPError:
+    """Build a requests.HTTPError carrying a Response with ``status``."""
+    resp = requests.Response()
+    resp.status_code = status
+    resp._content = detail.encode()
+    resp.reason = detail
+    return requests.HTTPError(f"{status} error: {detail}", response=resp)
+
+
+class _ReconcileCatalog:
+    """Mock catalog that drives the reconcile-retry path.
+
+    - ``post`` fails for the first ``fail_times`` calls with the
+      configured exception, then succeeds. On success it records
+      each row it "persists" (keyed by token ID) so the reconcile
+      query can report already-landed tokens.
+    - ``fail_after_persist``: when True, the failing POST persists
+      its rows on the server *before* raising — modelling the
+      lost-response case where work landed but the client saw an
+      error. The reconcile query then finds those tokens.
+    - ``getPathBuilder`` exposes an ``ERMrest_RID_Lease`` table whose
+      ``ID.in_(chunk)`` fetch returns the persisted (token, RID)
+      rows intersecting the chunk.
+    """
+
+    def __init__(
+        self,
+        *,
+        fail_times: int = 0,
+        exc: Exception | None = None,
+        fail_after_persist: bool = False,
+        prefix: str = "RID-",
+    ):
+        self.fail_times = fail_times
+        self.exc = exc or _http_error(409, "Schema public does not exist")
+        self.fail_after_persist = fail_after_persist
+        self.prefix = prefix
+        self.post_calls: list[list[dict]] = []
+        self._persisted: dict[str, str] = {}  # token ID -> RID
+        self._counter = 0
+        self._reconcile_chunks: list[list[str]] = []
+
+    # --- POST -----------------------------------------------------
+    def _assign(self, tokens: list[str]) -> None:
+        for t in tokens:
+            if t not in self._persisted:
+                self._persisted[t] = f"{self.prefix}{self._counter}"
+                self._counter += 1
+
+    def post(self, path: str, json=None, **_kw):
+        assert "ERMrest_RID_Lease" in path
+        assert isinstance(json, list)
+        self.post_calls.append(json)
+        tokens = [b["ID"] for b in json]
+
+        if len(self.post_calls) <= self.fail_times:
+            if self.fail_after_persist:
+                self._assign(tokens)
+            raise self.exc
+
+        self._assign(tokens)
+
+        class _R:
+            def __init__(self, rows):
+                self._rows = rows
+
+            def json(self):
+                return self._rows
+
+        return _R([{"RID": self._persisted[t], "ID": t} for t in tokens])
+
+    # --- reconcile query -----------------------------------------
+    def getPathBuilder(self):
+        outer = self
+
+        class _InPredicate:
+            def __init__(self, chunk):
+                self.chunk = list(chunk)
+
+        class _Col:
+            def in_(self, chunk):
+                return _InPredicate(chunk)
+
+        class _Chain:
+            def __init__(self, chunk):
+                self.chunk = chunk
+
+            def attributes(self, *_cols):
+                return self
+
+            def fetch(self):
+                outer._reconcile_chunks.append(list(self.chunk))
+                return [{"RID": outer._persisted[t], "ID": t} for t in self.chunk if t in outer._persisted]
+
+        class _Table:
+            RID = _Col()
+            ID = _Col()
+
+            def filter(self, pred: _InPredicate):
+                return _Chain(pred.chunk)
+
+        class _Schemas:
+            def __getitem__(self, _name):
+                class _S:
+                    tables = {"ERMrest_RID_Lease": _Table()}
+
+                return _S()
+
+        class _PB:
+            schemas = _Schemas()
+
+        return _PB()
+
+
+def test_transient_409_retries_and_succeeds(monkeypatch):
+    """A single transient 409 is retried; the batch ultimately succeeds."""
+    from deriva_ml.execution import rid_lease
+    from deriva_ml.execution.rid_lease import post_lease_batch
+
+    # No real sleeping in tests.
+    monkeypatch.setattr(rid_lease.time, "sleep", lambda _s: None)
+
+    cat = _ReconcileCatalog(fail_times=1)  # first POST 409s, second ok
+    tokens = ["T1", "T2", "T3"]
+    result = post_lease_batch(catalog=cat, tokens=tokens)
+
+    assert set(result.keys()) == set(tokens)
+    assert len(cat.post_calls) == 2  # one failed, one retried
+
+
+def test_transient_5xx_retries_and_succeeds(monkeypatch):
+    from deriva_ml.execution import rid_lease
+    from deriva_ml.execution.rid_lease import post_lease_batch
+
+    monkeypatch.setattr(rid_lease.time, "sleep", lambda _s: None)
+    cat = _ReconcileCatalog(fail_times=1, exc=_http_error(503, "unavailable"))
+    result = post_lease_batch(catalog=cat, tokens=["A", "B"])
+    assert set(result.keys()) == {"A", "B"}
+    assert len(cat.post_calls) == 2
+
+
+def test_lost_response_reconciles_without_duplicate_post(monkeypatch):
+    """If a POST landed on the server but the response was lost, the
+    retry must NOT re-POST the already-landed tokens (that would 409
+    on the composite (RCB, ID) key). It reconciles and re-POSTs only
+    the missing ones."""
+    from deriva_ml.execution import rid_lease
+    from deriva_ml.execution.rid_lease import post_lease_batch
+
+    monkeypatch.setattr(rid_lease.time, "sleep", lambda _s: None)
+    # First POST persists all rows on the server, then raises (lost
+    # response). The retry should discover every token already landed
+    # and re-POST nothing.
+    cat = _ReconcileCatalog(fail_times=1, fail_after_persist=True)
+    tokens = ["X1", "X2", "X3"]
+    result = post_lease_batch(catalog=cat, tokens=tokens)
+
+    assert set(result.keys()) == set(tokens)
+    # The reconcile query ran, and any retried POST carried only
+    # tokens NOT already persisted (here: none).
+    assert cat._reconcile_chunks, "reconcile query was never issued"
+    if len(cat.post_calls) > 1:
+        retried_tokens = {b["ID"] for b in cat.post_calls[1]}
+        assert retried_tokens == set(), f"retry re-POSTed already-landed tokens: {retried_tokens}"
+
+
+def test_terminal_4xx_does_not_retry(monkeypatch):
+    """A non-transient 4xx (e.g. 403 forbidden) raises immediately,
+    without burning retry attempts."""
+    from deriva_ml.execution import rid_lease
+    from deriva_ml.execution.rid_lease import post_lease_batch
+
+    monkeypatch.setattr(rid_lease.time, "sleep", lambda _s: None)
+    cat = _ReconcileCatalog(fail_times=99, exc=_http_error(403, "forbidden"))
+    with pytest.raises(requests.HTTPError):
+        post_lease_batch(catalog=cat, tokens=["T"])
+    assert len(cat.post_calls) == 1  # no retry on terminal error
+
+
+def test_exhausted_retries_raise(monkeypatch):
+    """When every attempt fails transiently, the last error propagates."""
+    from deriva_ml.execution import rid_lease
+    from deriva_ml.execution.rid_lease import post_lease_batch
+
+    monkeypatch.setattr(rid_lease.time, "sleep", lambda _s: None)
+    monkeypatch.setattr(rid_lease, "LEASE_MAX_ATTEMPTS", 3)
+    cat = _ReconcileCatalog(fail_times=99, exc=_http_error(503, "unavailable"))
+    with pytest.raises(requests.HTTPError):
+        post_lease_batch(catalog=cat, tokens=["T"])
+    assert len(cat.post_calls) == 3  # exactly max attempts
+
+
+def test_backoff_uses_configured_factor(monkeypatch):
+    """Retries sleep with exponential backoff between attempts."""
+    from deriva_ml.execution import rid_lease
+    from deriva_ml.execution.rid_lease import post_lease_batch
+
+    sleeps: list[float] = []
+    monkeypatch.setattr(rid_lease.time, "sleep", lambda s: sleeps.append(s))
+    monkeypatch.setattr(rid_lease, "LEASE_MAX_ATTEMPTS", 4)
+    monkeypatch.setattr(rid_lease, "LEASE_BACKOFF_FACTOR", 2)
+    cat = _ReconcileCatalog(fail_times=2)  # fail twice, succeed on 3rd
+    post_lease_batch(catalog=cat, tokens=["A"])
+    # Two failures → two backoff sleeps before the 2nd and 3rd tries:
+    # 2**0 = 1, 2**1 = 2.
+    assert sleeps == [1, 2]


### PR DESCRIPTION
Fixes #360.

## Problem

`post_lease_batch` (`execution/rid_lease.py`) issued a bare
`catalog.post(".../ERMrest_RID_Lease", ...)` with no retry. A **transient**
ERMrest error on that finalize-step bookkeeping POST propagated out of
`commit_output_assets` and marked an otherwise-complete execution **Failed** —
even when every asset, feature row, and provenance link had already committed.

The reported production case: a run that uploaded **14,125 assets + 14,125
feature rows** (all verified present) failed at finalize with a spurious
`409 CONFLICT "Schema public does not exist"` against a healthy 182k-row lease
table. `Upload_Duration` was 1.9 s but `Execution_Duration` was ~19 h — the run
hung on the lease step for hours before the 409 surfaced. Output complete; only
the **status** was a false negative.

### Why the existing retry machinery didn't cover it

- deriva-py's session-level urllib3 `Retry`: `retry_status_forcelist =
  [500,502,503,504]` (409 excluded) **and** `allow_retry_on_all_methods = False`
  (POST not retried at all).
- deriva-py's `datapath._request_with_retry`: `retry_codes = {408,429,500,502,503,504}`
  — **409 deliberately excluded**, because for a normal insert a 409 is a real
  unique-key conflict, not transient.

## Fix

`post_lease_batch` now retries transient failures (timeouts, 5xx, **and 409**)
with bounded exponential backoff. The retry is **reconcile-based**, not blind
re-POST.

The load-bearing fact (verified against a live catalog): `ERMrest_RID_Lease` has
a **composite unique key `(RCB, ID)`**, where `RCB` is the authenticated client
and `ID` is our client-generated UUID4 lease token. So a POST that *landed* but
whose response was lost cannot be blindly re-sent — re-POSTing the same tokens
would 409 on the rows that already succeeded. Before each retry we query which
of our tokens already exist and re-POST only the missing ones. This is exactly
what the UUID4 `ID` token was designed for ("look up what we leased after a
mid-flight crash"); the code just never used it. Idempotent by construction.

## Placement decision

Kept entirely in **deriva-ml** — no deriva-py pin bump. The `(RCB, ID)`
idempotency is an ERMrest guarantee we depend on but don't pin upstream, so a
**live-catalog contract test** asserts it in our CI: if a future server/deriva-py
change drops the composite key, `test_rid_lease_idempotency_contract.py` fails
loudly and this reconcile logic must be revisited.

## Tests

- **`test_rid_lease_retry.py`** (unit): transient 409/5xx retry → success;
  lost-response reconcile re-POSTs nothing; terminal 4xx (403) does NOT retry;
  exhaustion raises the last error; backoff uses the configured factor.
- **`test_rid_lease_idempotency_contract.py`** (live, gated on `DERIVA_HOST`):
  pins the `(RCB, ID)` unique key; duplicate POST 409s; reconcile recovers a
  landed lease; `post_lease_batch` is idempotent across repeated calls.
- **`test_rid_lease.py`**: terminal-error propagation updated for the new
  transient-vs-terminal classification.

Verified: all lease unit tests + module doctests pass; the 4 live contract tests
and the `test_bug_e2_live_smoke.py` commit-path tests pass against localhost.

## Out of scope

The issue's *optional* suggestion — a distinct execution status for
"bookkeeping failed but data committed" vs "data commit failed" — is a larger
status-model change and is left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)