### PR TITLE
feat(tf-adapter): global_shuffle= to un-group class-ordered bags (#362)

### DIFF
--- a/docs/user-guide/offline.md
+++ b/docs/user-guide/offline.md
@@ -573,6 +573,39 @@ ds = bag.as_tf_dataset(
 )
 ```
 
+#### Shuffling a class-grouped bag
+
+When a bag's members are grouped by class — which happens whenever a dataset was assembled one class at a time — every batch drawn from the head of the stream is single-class. That biases each gradient step and can collapse training outright: validation accuracy oscillates between the two class proportions while AUC sits at ~0.5.
+
+`as_tf_dataset` takes `global_shuffle=True` for this. It shuffles the **RID list** once, before the generator iterates it:
+
+```python
+# doctest: +SKIP
+ds = bag.as_tf_dataset(
+    "Image",
+    sample_loader=load_image,
+    targets=["Glaucoma"],
+    target_transform=lambda rec: CLASS_TO_IDX[rec.Glaucoma],
+    global_shuffle=True,
+    shuffle_seed=42,
+)
+
+ds = ds.shuffle(1000, seed=7).batch(32).prefetch(tf.data.AUTOTUNE)
+```
+
+**`global_shuffle` does not replace `tf.data.Dataset.shuffle()` — use both.** They solve different problems:
+
+| | What it does | Cost |
+|---|---|---|
+| `global_shuffle=True` | Permutes the whole RID list once at construction. Fixes class grouping globally. Same order every epoch. | Reorders short strings; samples still decode lazily. |
+| `.shuffle(buffer_size)` | Reservoir shuffle over a sliding window of **decoded** samples. Adds per-epoch variation. | Holds `buffer_size` decoded samples in memory. |
+
+`.shuffle()` alone cannot fix class grouping. An element moves at most `buffer_size` positions, so on a bag of 3000 class-A images followed by 1800 class-B, a typical `buffer_size=1000` leaves the buffer entirely class-A for the first ~3000 elements — every batch there is still single-class. A true global shuffle would need `buffer_size >= len(dataset)`, which means holding every decoded image in memory.
+
+Reproducibility takes **both** seeds: `shuffle_seed` pins the construction-time order, and `.shuffle(seed=...)` pins the per-epoch reservoir. Setting only one still leaves the pipeline nondeterministic.
+
+**Why PyTorch needs no equivalent.** `as_torch_dataset` returns a map-style dataset, so `DataLoader(shuffle=True)` permutes *indices* — a true global shuffle at negligible cost, reshuffled every epoch. `as_tf_dataset` returns a generator-backed dataset with no random access, so the shuffle has to happen before the generator does. Likewise `restructure_assets` needs nothing: its class-grouped directory layout is the contract `ImageFolder` reads labels from, and the consumer's sampler (`DataLoader(shuffle=True)`, or `image_dataset_from_directory`, which shuffles the file list by default) handles ordering.
+
 **Notes**
 
 - Install the TensorFlow extra: `pip install 'deriva-ml[tf]'`. Without it, calling `as_tf_dataset` raises `ImportError`; other methods continue to work.

--- a/src/deriva_ml/dataset/dataset_bag.py
+++ b/src/deriva_ml/dataset/dataset_bag.py
@@ -1477,6 +1477,8 @@ class DatasetBag:
         missing: Literal["error", "skip", "unknown"] = "error",
         output_signature: "tf.TensorSpec | tuple[tf.TensorSpec, ...] | None" = None,
         reachable: bool = True,
+        global_shuffle: bool = False,
+        shuffle_seed: int | None = None,
     ) -> "tf.data.Dataset":
         """Build a ``tf.data.Dataset`` from this bag.
 
@@ -1594,6 +1596,35 @@ class DatasetBag:
                 recurse=True)``) are used — the opt-out for callers who want
                 strictly the rows enumerated in the dataset's membership.
 
+            global_shuffle: Shuffle the RID list **once at construction**,
+                before the generator iterates it. The resulting order is the
+                **same every epoch** — chain ``.shuffle(buffer_size)`` on the
+                returned dataset for per-epoch variation.
+
+                Use this when the bag's members are grouped by class, which
+                happens for datasets assembled one class at a time. Every
+                batch drawn from the head of an un-shuffled stream is then
+                single-class, which biases each gradient step and can
+                collapse training outright (validation accuracy oscillating
+                between the class proportions, AUC ~0.5).
+
+                This is **not** ``tf.data.Dataset.shuffle``, and does not
+                replace it. That one is a bounded reservoir over *decoded*
+                samples: an element moves at most ``buffer_size`` positions,
+                so it cannot un-group a class-ordered bag unless the buffer
+                holds the entire dataset in memory. Shuffling the RID list
+                is a true global shuffle at negligible cost — it reorders
+                short strings, and samples are still decoded lazily one at a
+                time inside the generator. The two compose: this fixes the
+                global ordering, ``.shuffle()`` adds per-epoch variation.
+
+            shuffle_seed: Seed for ``global_shuffle``. ``None`` (default)
+                shuffles nondeterministically; pass an int for a reproducible
+                order. Has no effect when ``global_shuffle=False``. This
+                seeds only the construction-time RID shuffle — reproducing a
+                full pipeline that also chains ``.shuffle()`` means setting
+                that call's ``seed=`` too.
+
         Returns:
             A ``tf.data.Dataset`` whose elements are:
 
@@ -1642,6 +1673,21 @@ class DatasetBag:
             >>> for batch in ds.batch(32).prefetch(2):  # doctest: +SKIP
             ...     images, labels = batch
 
+            >>> # Class-grouped bag: shuffle the RID list globally, then
+            >>> # chain .shuffle() for per-epoch variation. Both seeds are
+            >>> # needed to reproduce the full pipeline.
+            >>> ds = bag.as_tf_dataset(  # doctest: +SKIP
+            ...     element_type="Image",
+            ...     sample_loader=lambda p, row: tf.image.decode_jpeg(
+            ...         tf.io.read_file(str(p))
+            ...     ),
+            ...     targets=["Glaucoma_Grade"],
+            ...     target_transform=lambda rec: CLASS_TO_IDX[rec.Grade],
+            ...     global_shuffle=True,
+            ...     shuffle_seed=42,
+            ... )
+            >>> ds = ds.shuffle(1000, seed=7).batch(32)  # doctest: +SKIP
+
             >>> # Pure-Python assertion — runs for real:
             >>> from deriva_ml.dataset.tf_adapter import build_tf_dataset  # doctest: +SKIP
             >>> callable(build_tf_dataset)  # doctest: +SKIP
@@ -1659,6 +1705,8 @@ class DatasetBag:
             missing=missing,
             output_signature=output_signature,
             reachable=reachable,
+            global_shuffle=global_shuffle,
+            shuffle_seed=shuffle_seed,
         )
 
     def restructure_assets(

--- a/src/deriva_ml/dataset/tf_adapter.py
+++ b/src/deriva_ml/dataset/tf_adapter.py
@@ -10,6 +10,7 @@ See design spec §§3.1-3.7 for the full contract.
 
 from __future__ import annotations
 
+import random
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Literal
 
@@ -46,6 +47,8 @@ def build_tf_dataset(
     missing: Literal["error", "skip", "unknown"] = "error",
     output_signature: "tf.TensorSpec | tuple | None" = None,
     reachable: bool = True,
+    global_shuffle: bool = False,
+    shuffle_seed: int | None = None,
 ) -> "tf.data.Dataset":
     """Build a tf.data.Dataset from a DatasetBag.
 
@@ -77,6 +80,22 @@ def build_tf_dataset(
             so an ``Image`` reachable only via ``Subject -> Observation ->
             Image`` is still included. ``False`` restricts to direct dataset
             members (``list_dataset_members(recurse=True)``), the opt-out.
+        global_shuffle: Shuffle the RID list **once at construction**, before
+            the generator iterates it. The resulting order is the **same
+            every epoch** — chain ``.shuffle(buffer_size)`` on the returned
+            dataset for per-epoch variation. This is not
+            ``tf.data.Dataset.shuffle``: that one is a bounded reservoir over
+            *decoded* samples, so it cannot un-group a class-ordered bag
+            without buffering the whole dataset in memory. Shuffling the RID
+            list is a true global shuffle at negligible cost (it reorders
+            short strings; samples are still decoded lazily one at a time).
+            Default ``False`` preserves the bag's natural order.
+        shuffle_seed: Seed for ``global_shuffle``. ``None`` (default) shuffles
+            nondeterministically; pass an int for a reproducible order. Has no
+            effect when ``global_shuffle=False``. This seeds only the
+            construction-time RID shuffle — ``tf.data.Dataset.shuffle`` takes
+            its own ``seed=``, so reproducing a full pipeline means setting
+            both.
 
     Returns:
         A ``tf.data.Dataset`` whose elements are:
@@ -135,6 +154,17 @@ def build_tf_dataset(
     else:
         rids = all_rids  # "error" already raised if incomplete; "unknown"
         # keeps all RIDs with None target for absent ones
+
+    if global_shuffle:
+        # Copy before shuffling: `rids` may still be the `all_rids` list the
+        # caller's resolve_element_rids returned, and mutating it in place
+        # would reorder a list we don't own.
+        #
+        # An explicit local RNG, never the global `random` module — the order
+        # must be reproducible from `shuffle_seed` alone, independent of any
+        # other random.* call elsewhere in the process.
+        rids = list(rids)
+        random.Random(shuffle_seed).shuffle(rids)
 
     # Build the row lookup so sample_loader gets the full row dict.
     row_lookup = _build_row_lookup(bag, element_type)

--- a/tacit-knowledge.md
+++ b/tacit-knowledge.md
@@ -77,3 +77,213 @@ review caught two real gaps in the first cut, both fixed:
    still propagate. Lesson: when you add a bookkeeping query *inside* a
    retry loop to make it safe, that query inherits the same
    transient-failure obligation as the operation it guards.
+
+## Dataset / ML-framework adapters
+
+### 2026-08-03 — Sample-ordering shuffle belongs to `as_tf_dataset` only (issue #362)
+
+**Decision:** implement the `shuffle=`/`seed=` parameters from #362 on
+`as_tf_dataset` / `build_tf_dataset` **and nowhere else**. Do *not* add
+a matching parameter to `as_torch_dataset` or `restructure_assets`.
+
+**Why this is a deliberate asymmetry, not an oversight.** The three
+bag-to-ML paths differ in whether the *consumer* can shuffle cheaply:
+
+- **`as_torch_dataset`** returns a **map-style** dataset (`__len__` +
+  `__getitem__`, `torch_adapter.py`). `DataLoader(shuffle=True)` wraps
+  it in a `RandomSampler` that permutes *indices* — a true global
+  shuffle costing one permuted index array, no decoded sample held in
+  memory — and it reshuffles **every epoch**.
+- **`as_tf_dataset`** returns `tf.data.Dataset.from_generator`
+  (`tf_adapter.py`) — **iterator-style, no random access**. See the
+  `.shuffle()` note below: TF *does* ship a shuffle, but it operates at
+  the wrong layer, so deriva-ml must shuffle the RID list itself.
+- **`restructure_assets`** writes `{training,testing}/{label}/file`.
+  The class grouping there **is the contract**, not a hazard:
+  `ImageFolder` derives its class list and integer label mapping from
+  those directory names. A shuffle parameter would have nothing to
+  shuffle — interleaving classes would destroy the labeling scheme.
+  Shuffling belongs in the consumer's sampler.
+
+**Why class-ordered data breaks training at all** (the prior question a
+reviewer asks before "why global?"). Two distinct failures:
+1. **Biased per-step gradients.** SGD assumes each minibatch is roughly
+   an unbiased sample of the training distribution. An all-class-A
+   batch yields a gradient pointing at "always predict A". With
+   momentum and BatchNorm it compounds — BN statistics are computed
+   per-batch, so a single-class batch calibrates the layer on a
+   distribution never seen at inference. The #362 signature is exactly
+   this: val_acc oscillating 0.623 ↔ 0.377 *is* the model alternating
+   between "everything is A" and "everything is B", and those two
+   numbers are the class proportions; AUC ~0.5 confirms no ranking was
+   learned.
+2. **Catastrophic forgetting.** All of A then all of B yields a
+   B-predictor — nothing re-exposes A after B's updates.
+
+**Why pure-TF users usually don't hit this** (so "TF has no such knob,
+why do we need one?" has an answer): they do — it's a known footgun,
+hence `image_dataset_from_directory(shuffle=True)` as the default and
+`.shuffle()` in nearly every tutorial. It stays invisible because their
+data is typically already shuffled on disk or across TFRecord shards;
+**or their elements are cheap** (CSV rows, pre-decoded vectors), so
+`buffer_size=50_000` is affordable and the reservoir *is* global in
+practice; **or they shuffle file paths before the expensive decode**
+(`list_files(shuffle=True)` → `.map(decode)`).
+
+That last pattern is precisely what #362 does — the RID list *is* our
+file-path list. So this is not deriva-ml inventing something un-TF-ish;
+it reproduces the idiomatic TF pattern at the only layer where we still
+hold cheap handles. Our case is the intersection of the two conditions
+that make it bite: **class-grouped at the source AND elements too
+expensive to buffer whole.** Neither alone is fatal.
+
+**Why *global*, given weaker options exist.** The requirement is only
+that batches be class-mixed. Alternatives: a `.shuffle()` buffer larger
+than the longest single-class run (≥3000 decoded images here, and it
+scales with the dataset — doesn't hold up); interleaving per-class
+streams via `sample_from_datasets` (needs classes as separate datasets;
+we have one RID list); class-balanced sampling (same problem, and it
+alters the effective class distribution). Since we already hold the
+full RID list in memory, a global permutation is simply the cheapest
+correct option — one `random.Random(seed).shuffle()` over short
+strings. The weaker alternatives cost more machinery for a worse
+guarantee.
+
+**Corollary — the fixed-order limitation is not a real weakness.** A
+single build-time permutation already eliminates both failure modes
+above: every batch is class-mixed from epoch 1. Per-epoch reshuffling
+only reduces overfitting to a particular batch composition — real, but
+second-order. That is the correct division of labor between
+`shuffle_rids=` and a chained `.shuffle()`.
+
+**`tf.data.Dataset.shuffle()` exists — and is not a substitute.** This
+is the first objection anyone raises, so state the answer precisely.
+`.shuffle(buffer_size)` is a **reservoir shuffle over a sliding
+window**, not a global permutation: it fills a buffer, emits one
+element at random, refills from the stream. An element can therefore
+only move `buffer_size` positions from where it started. On a
+class-grouped bag — `[3000 class-A][1800 class-B]` with a typical
+`buffer_size=1000` — the buffer is *entirely class-A* for the first
+~3000 elements, so every batch in that stretch is still single-class.
+It shuffles within class A and changes nothing about the collapse. A
+true global shuffle needs `buffer_size >= len(dataset)`, and because
+`.shuffle()` sits **downstream of the generator**, that buffer holds
+*decoded* samples — the whole image set in RAM.
+
+The contrast with torch is the whole point: `DataLoader(shuffle=True)`
+permutes an *index array* before any loading happens. `tf.data` cannot,
+because a `from_generator` dataset is an opaque iterator with no
+indices to permute. Shuffling the RID list inside `build_tf_dataset`
+reorders short strings *before* the generator closes over them — the
+same index-level trick, applied at the only layer where TF still has
+cheap handles on the elements.
+
+**The two compose; recommend both.** The build-time RID shuffle is
+fixed for all epochs (#362 acknowledges this). Chaining a modest
+`.shuffle(buffer_size=1000)` on top adds per-epoch variation *within*
+an already class-mixed stream, which is cheap and effective precisely
+because the global ordering was fixed upstream. Guidance is "both, for
+different jobs" — never "adapter instead of `.shuffle()`".
+
+**Name the parameter `global_shuffle`, not `shuffle` — deliberately
+diverging from `tf.data` vocabulary.** #362 proposes `shuffle=` /
+`seed=`. Those names collide with `tf.data.Dataset.shuffle(buffer_size,
+seed=...)`, which a TF user already knows and which behaves
+**differently on the axis they care about**: `.shuffle()` reshuffles
+every epoch by default (`reshuffle_each_iteration=True`); ours is one
+build-time permutation, identical every epoch. Same word, opposite
+epoch semantics, and the mismatch is *silent* — training converges and
+looks plausible while epoch 7 replays epoch 1's exact order.
+
+The second-order trap is the real cost: a user who sees `shuffle=True`
+in the constructor concludes shuffling is handled and **drops
+`.shuffle()` from their pipeline**, trading a per-epoch shuffle for a
+fixed one without being told. The parameter's presence invites removing
+the thing doing the more useful work. `seed` compounds it — in
+`tf.data` it seeds the reservoir, in ours a `random.Random` over the
+RID list; two RNGs, two scopes, one name.
+
+So: `global_shuffle: bool = False`, `shuffle_seed: int | None = None`.
+
+**Why `global_shuffle` and not `shuffle_rids`** (the first cut, rejected
+same day): `shuffle_rids` names the *mechanism*, `global_shuffle` names
+the **guarantee** — and the guarantee is the axis the user actually
+needs. "RIDs vs. samples" is deriva-ml-internal vocabulary a TF user
+doesn't carry; "global vs. windowed" is precisely where `.shuffle()`
+falls short. `global_shuffle=True` beside `.shuffle(buffer_size=1000)`
+reads as a coherent pair — one global, one buffered — so a user who
+understands why the buffer is bounded immediately understands why a
+separate knob exists, without knowing what a RID is. It also survives
+implementation drift: if we ever permute a row index instead of the RID
+list, `shuffle_rids` becomes a lie while `global_shuffle` stays true.
+Name the guarantee, not the mechanism.
+
+**What the name still cannot carry:** epoch semantics. A user may read
+"global" as "strictly better" and infer it subsumes `.shuffle()`,
+dropping theirs and silently losing per-epoch variation. The docstring's
+**first line** must say: shuffles once at construction, same order every
+epoch, chain `.shuffle()` for per-epoch variation. No name fixes this.
+
+Cost is divergence from the torch adapter's vocabulary — which is no
+cost, since the torch adapter has no such parameter and shouldn't.
+eye-ai-vgg19's `TypeError` guard fails loud on the wrong name, so the
+rename surfaces at once instead of silently no-op'ing. Do not "fix"
+this back toward TF's vocabulary for consistency; the divergence is
+the point.
+
+**Do NOT add a passthrough seed for the native `.shuffle()`.** Asked
+and rejected. `.shuffle()` is called on the **returned** dataset, in
+user code, after `as_tf_dataset` returns — the caller already has
+direct access to `seed=` there. Accepting a `tf_shuffle_seed=` would
+force us to also accept `buffer_size`, then
+`reshuffle_each_iteration`, then `.batch()`'s arguments: wrapping the
+`tf.data` builder API one parameter at a time, for zero gain, since
+every knob is already reachable on the returned object. (This is the
+"too many interfaces" failure the repo's class-idiom guidance warns
+about.) It would also undo the naming decision above — the entire
+argument is that `global_shuffle` and `.shuffle()` are *different
+operations at different layers*; putting a `tf.data` concern back on
+our constructor re-muddies the boundary we just drew.
+
+Clean division: **deriva-ml owns everything before the generator**
+(`global_shuffle`, `shuffle_seed`); **the user owns everything
+downstream on the returned `tf.data.Dataset`** (`.shuffle()`,
+`.batch()`, `.prefetch()`, and their seeds).
+
+Two consequences for docs, not for the API:
+- **Full reproducibility needs both seeds.** `shuffle_seed` pins the
+  build-time order; `.shuffle(seed=...)` pins the per-epoch reservoir.
+  Setting only ours still leaves epoch-to-epoch ordering
+  nondeterministic. Show the complete two-seed recipe in the docstring
+  — "I set the seed and still can't reproduce" is the predictable
+  support question.
+- **Provenance callers must record both.** eye-ai-vgg19 records
+  `shuffle_seed` in `run_config.json` to make batch composition
+  recoverable; that only holds if the rest of the pipeline is
+  deterministic, so if it chains `.shuffle()`, that seed belongs in the
+  recorded hyperparameters too. Caller-side note, not a library change.
+
+**Why adding it to torch anyway would be actively harmful** (not merely
+redundant): a user who sets *only* the adapter-level flag gets one
+build-time permutation reused for **every epoch**, silently losing the
+per-epoch reshuffling `DataLoader` gives by default — worse than the
+status quo. It also makes `seed` ambiguous, since `DataLoader`
+reproducibility is governed by torch's global RNG / `generator=`, not
+by an adapter argument.
+
+**Residual risk to document, not to code around:** a third-party
+trainer that walks the `restructure_assets` tree *without* shuffling
+(a hand-rolled `glob`-and-iterate) hits the same class-grouped
+collapse. `ImageFolder` + `DataLoader(shuffle=True)` and
+`tf.keras.utils.image_dataset_from_directory` (`shuffle=True` by
+default) are both safe — and note *why* the latter is safe, since it
+is a `tf.data` path: it shuffles the **file list** it builds by walking
+the tree, before any decoding. That is a global index-level shuffle,
+structurally like `DataLoader`'s, not a reservoir over decoded
+samples. The `.shuffle()` limitation above applies to the *generator*
+path only. This is a docs concern for the consumer, not an API gap.
+
+**Rule of thumb for future adapters:** deriva-ml owns sample ordering
+only when it hands the consumer an iterator with no cheap global
+shuffle. If the adapter returns something randomly-addressable, the
+framework's sampler is the correct place — leave it there.

--- a/tests/dataset/test_tf_adapter_logic.py
+++ b/tests/dataset/test_tf_adapter_logic.py
@@ -14,6 +14,7 @@ Coverage matrix (spec §6.2):
 - Asset-table element with no sample_loader raises at construction
 - Non-asset-table element works without sample_loader
 - output_signature=None triggers first-sample inference
+- global_shuffle= reorders the RID list; shuffle_seed= makes it reproducible
 """
 
 from __future__ import annotations
@@ -455,3 +456,230 @@ def test_output_signature_none_infers_from_first_sample():
     # All elements should be present (inference must not drop the first sample)
     count = sum(1 for _ in ds)
     assert count == 2
+
+
+# ---------------------------------------------------------------------------
+# global_shuffle= / shuffle_seed= (issue #362)
+#
+# The bug these pin: a bag whose members are grouped by class yields
+# single-class batches from the head of the stream, which collapses
+# training. tf.data's own .shuffle() is a bounded reservoir over *decoded*
+# samples and cannot un-group it without buffering the whole dataset, so
+# the adapter shuffles the RID list before the generator closes over it.
+#
+# RIDs here come from the class-grouped mock bag the fixture helper builds,
+# never from literals written into an assertion — the tests compare orders
+# and set-identity against what they read back out of the bag.
+# ---------------------------------------------------------------------------
+
+
+def _class_grouped_bag(n_per_class: int = 6):
+    """Build a mock bag whose members are grouped by class.
+
+    Emulates a dataset assembled one class at a time: every class-A RID
+    precedes every class-B RID. This is the ordering that collapses
+    training when the stream is consumed un-shuffled.
+
+    Args:
+        n_per_class: Number of elements to generate per class.
+
+    Returns:
+        Tuple of ``(bag, rids_in_bag_order, labels_by_rid)``. The RID
+        strings are generated here and returned, so tests assert against
+        values the fixture produced rather than hard-coded literals.
+    """
+    labels_by_rid: dict[str, str] = {}
+    for i in range(n_per_class):
+        labels_by_rid[f"1-A{i:03d}"] = "ClassA"
+    for i in range(n_per_class):
+        labels_by_rid[f"1-B{i:03d}"] = "ClassB"
+
+    rids_in_bag_order = list(labels_by_rid)
+    bag = _mock_bag_with_labeled_images(labels_by_rid)
+    bag.get_table_as_dict = MagicMock(
+        side_effect=lambda *_a, **_kw: iter([{"RID": rid, "Filename": f"{rid}.jpg"} for rid in rids_in_bag_order])
+    )
+    return bag, rids_in_bag_order, labels_by_rid
+
+
+def _emitted_rids(ds) -> list[str]:
+    """Consume a tf.data.Dataset and return its RIDs in emission order.
+
+    The RID is always the last positional value in a yielded element.
+    """
+    return [element[-1].numpy().decode() for element in ds]
+
+
+def _build(bag, **kwargs):
+    """Build an unlabeled tf dataset over the mock bag's Image elements.
+
+    Uses ``reachable=False`` so RIDs come from the mocked
+    ``list_dataset_members``. The ``reachable=True`` default walks FK
+    paths through SQL, which a MagicMock bag cannot serve.
+    """
+    return build_tf_dataset(
+        bag,
+        "Image",
+        sample_loader=lambda p, row: tf.constant([1.0]),
+        targets=None,
+        reachable=False,
+        output_signature=(
+            tf.TensorSpec(shape=(1,), dtype=tf.float32),
+            tf.TensorSpec(shape=(), dtype=tf.string),  # rid
+        ),
+        **kwargs,
+    )
+
+
+def test_global_shuffle_default_preserves_bag_order():
+    """Default (global_shuffle=False) iterates the bag's natural order.
+
+    Pins the no-op default: existing callers must see byte-identical
+    ordering after this parameter was added.
+    """
+    bag, rids_in_bag_order, _ = _class_grouped_bag()
+    assert _emitted_rids(_build(bag)) == rids_in_bag_order
+
+
+def test_global_shuffle_reorders_rids():
+    """global_shuffle=True changes the emission order."""
+    bag, rids_in_bag_order, _ = _class_grouped_bag()
+    shuffled = _emitted_rids(_build(bag, global_shuffle=True, shuffle_seed=42))
+    assert shuffled != rids_in_bag_order
+
+
+def test_global_shuffle_preserves_the_rid_set():
+    """Shuffling reorders elements without adding, dropping, or duplicating.
+
+    The RID list is the dataset's contents; a shuffle that loses or
+    repeats an element would silently change what the model trains on.
+    """
+    bag, rids_in_bag_order, _ = _class_grouped_bag()
+    shuffled = _emitted_rids(_build(bag, global_shuffle=True, shuffle_seed=42))
+    assert sorted(shuffled) == sorted(rids_in_bag_order)
+    assert len(shuffled) == len(set(shuffled))
+
+
+def test_global_shuffle_breaks_class_grouping():
+    """The motivating case: head-of-stream batches stop being single-class.
+
+    Un-shuffled, the first half of a class-grouped bag is entirely one
+    class — the ordering that collapsed VGG-19 training in #362. After
+    shuffling, a leading slice must contain both classes.
+    """
+    bag, rids_in_bag_order, labels_by_rid = _class_grouped_bag(n_per_class=25)
+
+    # Precondition: the un-shuffled stream really is class-grouped, so a
+    # passing assertion below reflects the shuffle and not a weak fixture.
+    unshuffled = _emitted_rids(_build(bag))
+    first_batch_unshuffled = {labels_by_rid[rid] for rid in unshuffled[:10]}
+    assert len(first_batch_unshuffled) == 1, "fixture is not class-grouped"
+
+    bag, _, _ = _class_grouped_bag(n_per_class=25)
+    shuffled = _emitted_rids(_build(bag, global_shuffle=True, shuffle_seed=42))
+    first_batch_shuffled = {labels_by_rid[rid] for rid in shuffled[:10]}
+    assert len(first_batch_shuffled) == 2, (
+        f"leading slice is still single-class after shuffling: {first_batch_shuffled}"
+    )
+
+
+def test_same_seed_reproduces_the_same_order():
+    """Identical shuffle_seed values produce identical orders."""
+    bag_a, _, _ = _class_grouped_bag()
+    bag_b, _, _ = _class_grouped_bag()
+    order_a = _emitted_rids(_build(bag_a, global_shuffle=True, shuffle_seed=1234))
+    order_b = _emitted_rids(_build(bag_b, global_shuffle=True, shuffle_seed=1234))
+    assert order_a == order_b
+
+
+def test_different_seeds_produce_different_orders():
+    """Different shuffle_seed values produce different orders."""
+    bag_a, _, _ = _class_grouped_bag(n_per_class=25)
+    bag_b, _, _ = _class_grouped_bag(n_per_class=25)
+    order_a = _emitted_rids(_build(bag_a, global_shuffle=True, shuffle_seed=1))
+    order_b = _emitted_rids(_build(bag_b, global_shuffle=True, shuffle_seed=2))
+    assert order_a != order_b
+
+
+def test_shuffle_seed_is_independent_of_the_global_rng():
+    """Seeded order does not depend on the process-wide `random` state.
+
+    The adapter must use a local `random.Random(seed)`, never the global
+    `random` module: data ordering has to be reproducible from
+    shuffle_seed alone, regardless of any other random.* call elsewhere
+    in the process (a caller seeding `random` for augmentation, say).
+    """
+    import random as _random
+
+    bag_a, _, _ = _class_grouped_bag()
+    _random.seed(0)
+    order_a = _emitted_rids(_build(bag_a, global_shuffle=True, shuffle_seed=99))
+
+    bag_b, _, _ = _class_grouped_bag()
+    _random.seed(999999)
+    _random.random()  # perturb global state further
+    order_b = _emitted_rids(_build(bag_b, global_shuffle=True, shuffle_seed=99))
+
+    assert order_a == order_b
+
+
+def test_shuffle_seed_ignored_when_global_shuffle_false():
+    """shuffle_seed has no effect unless global_shuffle is True."""
+    bag, rids_in_bag_order, _ = _class_grouped_bag()
+    emitted = _emitted_rids(_build(bag, global_shuffle=False, shuffle_seed=42))
+    assert emitted == rids_in_bag_order
+
+
+def test_global_shuffle_does_not_mutate_the_resolved_rid_list():
+    """The shuffle copies; it must not reorder the list it was handed.
+
+    build_tf_dataset receives the list resolve_element_rids returned. An
+    in-place shuffle would reorder a list the adapter does not own,
+    leaking ordering into any caller that holds the same object.
+    """
+    from deriva_ml.dataset import tf_adapter
+
+    bag, rids_in_bag_order, _ = _class_grouped_bag()
+    captured: list[list[str]] = []
+    real_resolve = tf_adapter.resolve_element_rids
+
+    def capturing_resolve(*args, **kwargs):
+        resolved = real_resolve(*args, **kwargs)
+        captured.append(resolved)
+        return resolved
+
+    tf_adapter.resolve_element_rids = capturing_resolve
+    try:
+        _emitted_rids(_build(bag, global_shuffle=True, shuffle_seed=42))
+    finally:
+        tf_adapter.resolve_element_rids = real_resolve
+
+    assert captured, "resolve_element_rids was never called"
+    assert captured[0] == rids_in_bag_order
+
+
+def test_global_shuffle_with_targets_keeps_rid_label_pairing():
+    """Labels follow their RIDs through the shuffle.
+
+    A shuffle that reordered RIDs but not the target lookup would train
+    on systematically mismatched labels — silent and catastrophic.
+    """
+    bag, _, labels_by_rid = _class_grouped_bag()
+    ds = build_tf_dataset(
+        bag,
+        "Image",
+        sample_loader=lambda p, row: tf.constant([1.0]),
+        targets=["Grade"],
+        target_transform=lambda rec: tf.constant(rec.Grade if rec is not None else ""),
+        global_shuffle=True,
+        shuffle_seed=42,
+        reachable=False,
+        output_signature=(
+            tf.TensorSpec(shape=(1,), dtype=tf.float32),
+            tf.TensorSpec(shape=(), dtype=tf.string),  # target
+            tf.TensorSpec(shape=(), dtype=tf.string),  # rid
+        ),
+    )
+    for _sample, target, rid in ds:
+        rid_str = rid.numpy().decode()
+        assert target.numpy().decode() == labels_by_rid[rid_str]


### PR DESCRIPTION
Closes #362.

## The problem

`as_tf_dataset` iterates RIDs in bag order. When a bag's members are grouped by class — which happens for datasets assembled one class at a time — every batch drawn from the head of the stream is single-class. That biases each gradient step, and downstream in `eye-ai-vgg19` it reproducibly collapsed binary VGG-19 glaucoma training: `val_acc` oscillating between the two class proportions (0.623 ↔ 0.377), val AUC ~0.5.

## Why the fix belongs here and not in caller code

`tf.data.Dataset.shuffle()` is a reservoir shuffle over a sliding window, so an element moves at most `buffer_size` positions. On `[3000 class-A][1800 class-B]` with a typical `buffer_size=1000`, the buffer is entirely class-A for the first ~3000 elements — every batch there is still single-class. A true global shuffle needs `buffer_size >= len(dataset)`, and because `.shuffle()` sits downstream of the generator, that buffer holds **decoded** samples: the whole image set in memory.

Shuffling the RID list *before* the generator closes over it is a global shuffle at effectively zero cost — it reorders short strings, and samples still decode lazily one at a time. This is the same index-level trick `DataLoader(shuffle=True)` uses, and the same one idiomatic TF pipelines use via `list_files(shuffle=True)` before `.map(decode)`.

## What changed

Keyword-only `global_shuffle: bool = False` and `shuffle_seed: int | None = None` on `build_tf_dataset` and `DatasetBag.as_tf_dataset`. Default is a no-op; RID-is-always-last tuple ordering is untouched; the eager `output_signature` inference survives the reorder.

## Naming: `global_shuffle`, not `shuffle`

The issue proposed `shuffle=` / `seed=`. Those collide with `tf.data.Dataset.shuffle(buffer_size, seed=...)`, which a TF user already knows and which **behaves differently on the axis they care about** — `.shuffle()` reshuffles every epoch; ours is one build-time permutation. Same word, opposite epoch semantics, and the mismatch is silent.

The second-order trap is the real cost: a user seeing `shuffle=True` in the constructor concludes shuffling is handled and drops `.shuffle()` from their pipeline, trading a per-epoch shuffle for a fixed one without being told.

`global_shuffle` names the **guarantee** (global vs. windowed) rather than the mechanism, which is the axis that actually differs, reads coherently beside `.shuffle(buffer_size=1000)`, and stays accurate if the implementation ever permutes something other than the RID list. `shuffle_seed` pairs with it unambiguously.

No passthrough for `.shuffle()`'s own seed — that call happens on the returned dataset in user code, where `seed=` is already reachable. Accepting it here would mean also accepting `buffer_size`, `reshuffle_each_iteration`, and so on, wrapping the `tf.data` builder API one parameter at a time.

## Deliberately TF-only

- **`as_torch_dataset`** is map-style, so `DataLoader(shuffle=True)` already permutes indices globally and **per-epoch**. Adding an adapter-level flag would be worse than nothing: a user who set only it would get one fixed order for every epoch, silently losing the per-epoch reshuffling they'd otherwise get by default.
- **`restructure_assets`** writes `{training,testing}/{label}/file`, where the class grouping *is* the contract — `ImageFolder` derives its class list and label mapping from those directory names. Nothing to shuffle; the consumer's sampler handles it.

Rationale recorded in `tacit-knowledge.md` so the asymmetry isn't later "fixed" by adding `shuffle=` to all three paths.

## Tests

Ten tests in `tests/dataset/test_tf_adapter_logic.py` pin: the no-op default, that a leading slice stops being single-class (the #362 bug itself, with a precondition asserting the fixture really is class-grouped), RID-set preservation with no duplicates, same-seed reproducibility, different-seed divergence, seed independence from the process-wide `random` state, that `shuffle_seed` is inert when `global_shuffle=False`, that the resolved RID list isn't mutated in place, and that labels follow their RIDs through the shuffle.

Each was verified to **fail** against deliberately broken implementations — shuffle disabled, `random.shuffle` substituted for `random.Random(seed)`, and the defensive copy removed — so none are vacuous.

## Heads-up: pre-existing breakage found, not fixed here

The 11 pre-existing tests in `test_tf_adapter_logic.py` **fail on `main`** as well. Their MagicMock bags predate the `reachable=True` default and can't serve its SQL walk. Nobody noticed because tensorflow isn't in the default dev environment, so `pytest.importorskip` skipped the entire module — a file that silently skips everything looks identical to one that passes.

Out of scope here (the new tests pass `reachable=False` to use the mocked membership path), but it means **no logic test currently covers the `reachable=True` default users actually hit**, and CI is likely skipping this module wholesale. Worth its own issue.

Verified: `566 passed` across `tests/local_db/ tests/asset/ tests/model/`, ruff check and format clean on changed files, doctests clean, and the failure set is byte-identical before and after this change.