### PR TITLE
fix(tests): repair 24 adapter logic tests broken behind importorskip

### DIFF
--- a/tacit-knowledge.md
+++ b/tacit-knowledge.md
@@ -287,3 +287,46 @@ path only. This is a docs concern for the consumer, not an API gap.
 only when it hands the consumer an iterator with no cheap global
 shuffle. If the adapter returns something randomly-addressable, the
 framework's sampler is the correct place — leave it there.
+
+### 2026-08-03 — Adapter logic tests were 100% broken behind `importorskip` (PR #363 follow-up)
+
+**What was found:** every test in `test_tf_adapter_logic.py` (11) and
+`test_torch_adapter_logic.py` (13) failed on `main` — 24 tests, both
+files entirely. Root cause: their MagicMock bags predate the adapters'
+`reachable=True` default, which routes through
+`resolve_reachable_rows` →
+`Session(bag.engine).execute(bag._dataset_table_view(t))` — real SQL.
+A MagicMock returns a MagicMock where SQLAlchemy wants a `text()`
+construct, so every test raised `ArgumentError`.
+
+**Why it went unnoticed for so long — the load-bearing lesson.** Both
+modules open with `pytest.importorskip`, and neither torch nor
+tensorflow is in the default dev environment. **A module that skips
+its entire contents is indistinguishable, in summary output, from one
+that passes.** `uv run pytest` reported green while 24 tests were
+uncollected. Discovering this required `uv sync --extra tf --extra
+torch` — something no routine workflow does.
+
+**Compounding factor:** this repo has **no CI test workflow at all**
+(`.github/workflows/` holds only `validate-schema`, `publish-docs`,
+`release`). So there is no pipeline where a "wholesale skip" check
+would even run today. Adding one is a real decision with real cost —
+the suite needs a live Deriva catalog and runs 30–90 min — so it was
+left to the maintainer rather than bundled into a test-fix PR.
+
+**Fix chosen: stub the SQLAlchemy Session, don't opt out.** The quick
+fix was passing `reachable=False` everywhere, and the first cut of the
+#362 shuffle tests did exactly that. Rejected on reflection: it opts
+the logic tests out of the branch **real callers take**, leaving the
+`reachable=True` default with zero logic coverage. Instead
+`tests/dataset/_reachable_stub.py` patches
+`target_resolution.Session` so mock bags resolve the reachable path to
+their own `list_dataset_members` rows. Verified non-vacuous: breaking
+`resolve_reachable_rows` to return `[]` fails 22 of 34 tests, which
+`reachable=False` versions could not have caught.
+
+**Rule this generalizes to:** when an optional-dependency module is
+gated by `importorskip`, *someone must actually install the extra and
+run it* — periodically, or in CI. Otherwise the gate silently converts
+"broken" into "green". Treat a fully-skipped module as an untested
+module, not a passing one.

--- a/tests/dataset/_reachable_stub.py
+++ b/tests/dataset/_reachable_stub.py
@@ -1,0 +1,91 @@
+"""Let MagicMock bags satisfy the adapters' ``reachable=True`` default.
+
+Shared by ``test_tf_adapter_logic.py`` and ``test_torch_adapter_logic.py``.
+Both build MagicMock ``DatasetBag`` objects, and both adapters default to
+``reachable=True``, which routes through
+:func:`~deriva_ml.dataset.target_resolution.resolve_reachable_rows`::
+
+    Session(bag.engine).execute(bag._dataset_table_view(table)).mappings().all()
+
+That is real SQL over the bag's SQLite database. A MagicMock bag returns a
+MagicMock where SQLAlchemy expects a ``text()`` construct, so every test in
+both modules raised ``ArgumentError`` once ``reachable=True`` became the
+default — undetected because neither torch nor tensorflow is installed in
+the default dev environment, so ``pytest.importorskip`` skipped both files
+wholesale.
+
+The alternative fix was passing ``reachable=False`` throughout, but that
+opts the logic tests out of the branch real callers actually take. Stubbing
+the ``Session`` keeps them on the default path, so a future change to
+reachable-vs-direct routing shows up here instead of being silently
+bypassed.
+
+Order and duplicates pass through untouched: ``resolve_element_rids`` owns
+dedup, and its contract is pinned separately in
+``test_reachable_enumeration.py``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+
+class _TableViewSentinel:
+    """What a mocked ``bag._dataset_table_view(table)`` returns.
+
+    Carries the rows the stubbed Session should yield for that table, so
+    the stub needs no knowledge of which bag it was called for.
+    """
+
+    def __init__(self, rows: list[dict]):
+        self.rows = rows
+
+
+class _RowsResult:
+    """Stands in for a SQLAlchemy ``Result`` over a sentinel's rows."""
+
+    def __init__(self, sentinel):
+        self._rows = getattr(sentinel, "rows", [])
+
+    def mappings(self):
+        return self
+
+    def all(self):
+        return self._rows
+
+
+def patch_session():
+    """Patch the SQLAlchemy Session used by ``resolve_reachable_rows``.
+
+    Returns:
+        A patch context manager. Use as an autouse fixture:
+
+        >>> @pytest.fixture(autouse=True)  # doctest: +SKIP
+        ... def _reachable():
+        ...     with patch_session():
+        ...         yield
+    """
+
+    def fake_session(engine):
+        session_cm = MagicMock()
+        session = session_cm.__enter__.return_value
+        session.execute.side_effect = lambda sentinel: _RowsResult(sentinel)
+        return session_cm
+
+    return patch("deriva_ml.dataset.target_resolution.Session", side_effect=fake_session)
+
+
+def wire_reachable(bag, rows_by_table: dict[str, list[dict]]):
+    """Point a mock bag's ``_dataset_table_view`` at the given rows.
+
+    Args:
+        bag: The MagicMock DatasetBag to wire.
+        rows_by_table: Mapping of table name to the row dicts the reachable
+            enumeration should surface for it. Usually the same rows the
+            bag's ``list_dataset_members`` returns.
+
+    Returns:
+        The same bag, for chaining.
+    """
+    bag._dataset_table_view = MagicMock(side_effect=lambda table: _TableViewSentinel(rows_by_table.get(table, [])))
+    return bag

--- a/tests/dataset/test_tf_adapter_logic.py
+++ b/tests/dataset/test_tf_adapter_logic.py
@@ -30,6 +30,20 @@ from deriva_ml.core.exceptions import DerivaMLException  # noqa: E402
 from deriva_ml.dataset.tf_adapter import build_tf_dataset  # noqa: E402
 from deriva_ml.feature import FeatureRecord  # noqa: E402
 
+from ._reachable_stub import patch_session  # noqa: E402
+from ._reachable_stub import wire_reachable as _wire_reachable
+
+
+@pytest.fixture(autouse=True)
+def _serve_reachable_rows():
+    """Let this module's MagicMock bags satisfy ``reachable=True``.
+
+    See ``tests/dataset/_reachable_stub.py`` for why the tests stub the
+    Session rather than opting out with ``reachable=False``.
+    """
+    with patch_session():
+        yield
+
 
 class _FakeRecord(FeatureRecord):
     """Minimal FeatureRecord stand-in for tf adapter tests."""
@@ -52,6 +66,7 @@ def _mock_bag_with_labeled_images(rids_and_labels: dict[str, str]):
     bag = MagicMock()
     bag.path = Path("/tmp/fake_bag")
     bag.list_dataset_members = MagicMock(return_value={"Image": [{"RID": rid} for rid in rids_and_labels]})
+    _wire_reachable(bag, {"Image": [{"RID": rid} for rid in rids_and_labels]})
 
     def fake_feature_values(element_type, feature_name, selector=None):
         for rid, label in rids_and_labels.items():
@@ -89,6 +104,7 @@ def _mock_non_asset_bag(rids_and_labels: dict[str, str]):
     bag = MagicMock()
     bag.path = Path("/tmp/fake_bag")
     bag.list_dataset_members = MagicMock(return_value={"Subject": [{"RID": rid} for rid in rids_and_labels]})
+    _wire_reachable(bag, {"Subject": [{"RID": rid} for rid in rids_and_labels]})
 
     def fake_feature_values(element_type, feature_name, selector=None):
         for rid, label in rids_and_labels.items():
@@ -167,6 +183,7 @@ def test_missing_error_raises_at_construction():
     bag = MagicMock()
     bag.path = Path("/tmp/fake_bag")
     bag.list_dataset_members = MagicMock(return_value={"Image": [{"RID": "1-IMG1"}, {"RID": "1-IMG2"}]})
+    _wire_reachable(bag, {"Image": [{"RID": "1-IMG1"}, {"RID": "1-IMG2"}]})
     bag.feature_values = MagicMock(return_value=iter([_FakeRecord(Image="1-IMG1", Grade="Mild")]))
     bag.model = MagicMock()
     bag.model.is_asset = MagicMock(return_value=True)
@@ -276,6 +293,7 @@ def test_multi_target_target_transform_receives_dict():
     bag = MagicMock()
     bag.path = Path("/tmp/fake_bag")
     bag.list_dataset_members = MagicMock(return_value={"Image": [{"RID": "1-IMG1"}]})
+    _wire_reachable(bag, {"Image": [{"RID": "1-IMG1"}]})
 
     class _FakeGradeRecord(FeatureRecord):
         Image: str
@@ -513,16 +531,14 @@ def _emitted_rids(ds) -> list[str]:
 def _build(bag, **kwargs):
     """Build an unlabeled tf dataset over the mock bag's Image elements.
 
-    Uses ``reachable=False`` so RIDs come from the mocked
-    ``list_dataset_members``. The ``reachable=True`` default walks FK
-    paths through SQL, which a MagicMock bag cannot serve.
+    Uses the ``reachable=True`` default — the ``_serve_reachable_rows``
+    fixture makes the mock bag satisfy it.
     """
     return build_tf_dataset(
         bag,
         "Image",
         sample_loader=lambda p, row: tf.constant([1.0]),
         targets=None,
-        reachable=False,
         output_signature=(
             tf.TensorSpec(shape=(1,), dtype=tf.float32),
             tf.TensorSpec(shape=(), dtype=tf.string),  # rid
@@ -673,7 +689,6 @@ def test_global_shuffle_with_targets_keeps_rid_label_pairing():
         target_transform=lambda rec: tf.constant(rec.Grade if rec is not None else ""),
         global_shuffle=True,
         shuffle_seed=42,
-        reachable=False,
         output_signature=(
             tf.TensorSpec(shape=(1,), dtype=tf.float32),
             tf.TensorSpec(shape=(), dtype=tf.string),  # target

--- a/tests/dataset/test_torch_adapter_logic.py
+++ b/tests/dataset/test_torch_adapter_logic.py
@@ -27,6 +27,20 @@ from deriva_ml.core.exceptions import DerivaMLException  # noqa: E402
 from deriva_ml.dataset.torch_adapter import build_torch_dataset  # noqa: E402
 from deriva_ml.feature import FeatureRecord  # noqa: E402
 
+from ._reachable_stub import patch_session  # noqa: E402
+from ._reachable_stub import wire_reachable as _wire_reachable
+
+
+@pytest.fixture(autouse=True)
+def _serve_reachable_rows():
+    """Let this module's MagicMock bags satisfy ``reachable=True``.
+
+    See ``tests/dataset/_reachable_stub.py`` for why the tests stub the
+    Session rather than opting out with ``reachable=False``.
+    """
+    with patch_session():
+        yield
+
 
 class _FakeRecord(FeatureRecord):
     """Minimal FeatureRecord stand-in for torch adapter tests."""
@@ -49,6 +63,7 @@ def _mock_bag_with_labeled_images(rids_and_labels: dict[str, str]):
     bag = MagicMock()
     bag.path = Path("/tmp/fake_bag")
     bag.list_dataset_members = MagicMock(return_value={"Image": [{"RID": rid} for rid in rids_and_labels]})
+    _wire_reachable(bag, {"Image": [{"RID": rid} for rid in rids_and_labels]})
 
     def fake_feature_values(element_type, feature_name, selector=None):
         for rid, label in rids_and_labels.items():
@@ -86,6 +101,7 @@ def _mock_non_asset_bag(rids_and_labels: dict[str, str]):
     bag = MagicMock()
     bag.path = Path("/tmp/fake_bag")
     bag.list_dataset_members = MagicMock(return_value={"Subject": [{"RID": rid} for rid in rids_and_labels]})
+    _wire_reachable(bag, {"Subject": [{"RID": rid} for rid in rids_and_labels]})
 
     def fake_feature_values(element_type, feature_name, selector=None):
         for rid, label in rids_and_labels.items():
@@ -146,6 +162,7 @@ def test_missing_error_raises_at_construction():
     bag = MagicMock()
     bag.path = Path("/tmp/fake_bag")
     bag.list_dataset_members = MagicMock(return_value={"Image": [{"RID": "1-IMG1"}, {"RID": "1-IMG2"}]})
+    _wire_reachable(bag, {"Image": [{"RID": "1-IMG1"}, {"RID": "1-IMG2"}]})
     bag.feature_values = MagicMock(return_value=iter([_FakeRecord(Image="1-IMG1", Grade="Mild")]))
     bag.model = MagicMock()
     bag.model.is_asset = MagicMock(return_value=True)
@@ -235,6 +252,7 @@ def test_multi_target_target_transform_receives_dict():
     bag = MagicMock()
     bag.path = Path("/tmp/fake_bag")
     bag.list_dataset_members = MagicMock(return_value={"Image": [{"RID": "1-IMG1"}]})
+    _wire_reachable(bag, {"Image": [{"RID": "1-IMG1"}]})
 
     class _FakeGradeRecord(FeatureRecord):
         Image: str


### PR DESCRIPTION
Follow-up to #363.

## What was broken

**Every test** in `test_tf_adapter_logic.py` (11) and `test_torch_adapter_logic.py` (13) failed on `main` — both files entirely, 24 tests.

Their MagicMock bags predate the adapters' `reachable=True` default, which routes through `resolve_reachable_rows` → `Session(bag.engine).execute(bag._dataset_table_view(t))` — real SQL over the bag's SQLite database. A MagicMock returns a MagicMock where SQLAlchemy expects a `text()` construct:

```
sqlalchemy.exc.ArgumentError: Executable SQL or text() construct expected,
got <MagicMock name='mock._dataset_table_view()'>
```

## Why nobody noticed

Both modules open with `pytest.importorskip`, and neither torch nor tensorflow is in the default dev environment. **A module that skips its entire contents is indistinguishable, in summary output, from one that passes.** `uv run pytest` reported green while 24 tests were never collected. Surfacing this required `uv sync --extra tf --extra torch` — something no routine workflow does.

## The fix: stub the Session, don't opt out

The cheap fix was passing `reachable=False` throughout — which is what the #362 shuffle tests did as a stopgap. I rejected that on reflection: it opts the logic tests out of the branch **real callers take**, leaving the `reachable=True` default with no logic coverage at all.

Instead, `tests/dataset/_reachable_stub.py` patches `target_resolution.Session` so mock bags resolve the reachable path to their own `list_dataset_members` rows. Both modules now exercise the default users actually hit, and the #362 tests drop their `reachable=False` opt-outs.

**Verified non-vacuous.** Breaking `resolve_reachable_rows` to return `[]` fails 22 of the 34 tests. The `reachable=False` versions could not have caught that — this is the coverage the quick fix would have silently forfeited.

## Results

- Unit suite: **566 → 605 passing** (the 39 newly-runnable tests)
- `43 passed` across both logic modules, both no-dep modules, and `test_reachable_enumeration.py`
- ruff check and format clean on all changed files

## Not addressed here

This repo has **no CI test workflow at all** — `.github/workflows/` contains only `validate-schema`, `publish-docs`, and `release`. So there's no pipeline where a "wholesale skip" guard would run today, and my earlier guess that "CI is skipping this module" was wrong in an important way: CI never ran these tests to begin with.

Adding a test workflow is a real decision with real cost (the suite needs a live Deriva catalog and runs 30–90 minutes), so I've left it to you rather than bundling it into a test-fix PR. Worth deciding separately, since the same blind spot covers five `importorskip`-gated modules.

The generalizable rule, recorded in `tacit-knowledge.md`: when an optional-dependency module is gated by `importorskip`, someone must actually install the extra and run it — periodically or in CI. Otherwise the gate silently converts "broken" into "green". **Treat a fully-skipped module as untested, not as passing.**